### PR TITLE
Remove migration step from run-service script

### DIFF
--- a/scripts/run-service.sh
+++ b/scripts/run-service.sh
@@ -9,9 +9,6 @@ python3 manage.py collectstatic \
     --ignore 'tmp*' \
     --noinput
 
-# apply django db migrations
-python3 manage.py migrate --noinput
-
 # start gunicorn
 pkill gunicorn || true
 exec gunicorn config.wsgi --config gunicorn_config.py


### PR DESCRIPTION
It will no longer be needed as migrations will be henceforth run as an
initContainer step.