### PR TITLE
Unify logging + fix exporting the env variables

### DIFF
--- a/apps/exploits/tests/test_api.py
+++ b/apps/exploits/tests/test_api.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 import pytest
 
@@ -7,7 +6,6 @@ from apps.exploits.helpers import store_or_update_exploits
 from osidb.models import Affect
 from osidb.tests.factories import AffectFactory, FlawFactory
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/apps/exploits/tests/test_parsing.py
+++ b/apps/exploits/tests/test_parsing.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 import pytest
 
@@ -8,7 +7,6 @@ from apps.exploits.models import EPSS, Exploit
 from osidb.models import Flaw
 from osidb.tests.factories import FlawFactory
 
-logger = logging.getLogger("apps.exploits")
 pytestmark = pytest.mark.unit
 
 CISA_TEST_FILE = "apps/exploits/tests/files/CISA/known_exploited_vulnerabilities.json"

--- a/apps/osim/tests/test_core.py
+++ b/apps/osim/tests/test_core.py
@@ -1,8 +1,5 @@
-import logging
-
 import pytest
 
-logger = logging.getLogger("apps.osim")
 pytestmark = pytest.mark.unit
 
 

--- a/apps/osim/tests/test_endpoints.py
+++ b/apps/osim/tests/test_endpoints.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from apps.osim.models import Workflow
@@ -10,7 +8,6 @@ from apps.osim.workflow import WorkflowFramework
 from osidb.models import Flaw
 from osidb.tests.factories import FlawFactory
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/apps/osim/tests/test_integration.py
+++ b/apps/osim/tests/test_integration.py
@@ -9,7 +9,6 @@
 """
 
 import json
-import logging
 import subprocess
 
 import pytest
@@ -20,7 +19,6 @@ from apps.osim.workflow import WorkflowFramework
 
 pytestmark = pytest.mark.integration
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.integration
 
 

--- a/apps/osim/tests/test_workflows.py
+++ b/apps/osim/tests/test_workflows.py
@@ -2,13 +2,10 @@
 workflow definitions validation tests
 """
 
-import logging
-
 import pytest
 
 from apps.osim.workflow import WorkflowFramework, WorkflowModel
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -1,11 +1,11 @@
 """
 transform Bugzilla flaw bug into OSIDB flaw model
 """
+import logging
 import re
 from collections import defaultdict
 from functools import cached_property
 
-from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
@@ -37,7 +37,7 @@ from .constants import BZ_DT_FMT, BZ_DT_FMT_HISTORY, BZ_ENABLE_IMPORT_EMBARGOED
 from .exceptions import NonRecoverableBZImportException
 from .fixups import AffectFixer, FlawFixer
 
-logger = get_task_logger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class TrackerBugConvertor:

--- a/collectors/bzimport/tests/test_fixups.py
+++ b/collectors/bzimport/tests/test_fixups.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 # TODO parsed_fixed_in was turned into FlawBugConvertor.package_versions
@@ -9,7 +7,6 @@ import pytest
 # from collectors.bzimport.fixups import fixup_affect_ps_module, parse_fixed_in
 # from osidb.tests.factories import AffectFactory
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/collectors/epss/tasks.py
+++ b/collectors/epss/tasks.py
@@ -4,10 +4,10 @@ EPSS data collector
 import csv
 import gzip
 import io
-import logging
 
 import requests
 from celery.schedules import crontab
+from celery.utils.log import get_task_logger
 from django.db import transaction
 from django.utils import timezone
 
@@ -15,7 +15,7 @@ from apps.exploits.helpers import set_exploit_collector_acls, update_objects_wit
 from apps.exploits.models import EPSS
 from collectors.framework.models import collector
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 # CSV fields:
 # cve,epss,percentile

--- a/collectors/errata/tests/test_core.py
+++ b/collectors/errata/tests/test_core.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 
 from osidb.models import Erratum, Tracker
@@ -15,7 +13,6 @@ from ..core import (
 BZ_CASSETTE = "TestErrataToolCollection.test_get_bz_trackers_for_erratum.yaml"
 JIRA_CASSETTE = "TestErrataToolCollection.test_get_jira_trackers_for_erratum.yaml"
 
-logger = logging.getLogger("collectors.errata")
 pytestmark = pytest.mark.unit
 
 

--- a/collectors/exploits_cisa/tasks.py
+++ b/collectors/exploits_cisa/tasks.py
@@ -1,9 +1,8 @@
 """
 CISA exploit data collector
 """
-import logging
-
 import requests
+from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_date
@@ -16,7 +15,7 @@ from apps.exploits.helpers import (
 from apps.exploits.models import Exploit
 from collectors.framework.models import collector
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 CISA_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
 

--- a/collectors/exploits_exploitdb/tasks.py
+++ b/collectors/exploits_exploitdb/tasks.py
@@ -2,13 +2,13 @@
 Exploit-DB exploit data collector
 """
 import io
-import logging
 import re
 import zipfile
 from os import path
 
 import requests
 from celery.schedules import crontab
+from celery.utils.log import get_task_logger
 from django.utils import timezone
 
 from apps.exploits.helpers import (
@@ -20,7 +20,7 @@ from apps.exploits.models import Exploit
 from collectors.framework.models import collector
 from osidb.validators import CVE_RE_STR
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 EXPLOITDB_URL = (
     "https://github.com/offensive-security/exploitdb/archive/refs/heads/master.zip"

--- a/collectors/exploits_metasploit/tasks.py
+++ b/collectors/exploits_metasploit/tasks.py
@@ -1,10 +1,9 @@
 """
 Metasploit exploit data collector
 """
-import logging
-
 import requests
 from celery.schedules import crontab
+from celery.utils.log import get_task_logger
 from django.utils import timezone
 
 from apps.exploits.helpers import (
@@ -15,7 +14,7 @@ from apps.exploits.helpers import (
 from apps.exploits.models import Exploit
 from collectors.framework.models import collector
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 METASPLOIT_URL = "https://raw.githubusercontent.com/rapid7/metasploit-framework/master/db/modules_metadata_base.json"
 METASPLOIT_REFERENCE = "https://github.com/rapid7/metasploit-framework/blob/master"

--- a/collectors/framework/README.md
+++ b/collectors/framework/README.md
@@ -24,14 +24,14 @@ and `tasks.py` where Celery is going to look for the task definitions
 """
 example collector
 """
-import logging
 
 from celery.schedules import crontab
+from celery.utils.log import get_task_logger
 from django.utils import timezone
 
 from collectors.framework.models import collector
 
-logger = logging.getLogger(__name__)
+logger = get_task_logger(__name__)
 
 
 @collector(
@@ -53,6 +53,9 @@ def example_collector(collector_obj):
 Then, you need to register your Django application to `INSTALLED_APPS`
 in [settings](../../config/settings.py). Compose your OSIDB instance down and start again so the
 Celery hosts are up-to-date. Now you should see a new collector status being reported when running
+
+To enable logs, you need to register new logger for the Collector in [settings](../../config/settings.py)
+under the `LOGGING`.
 
 ```bash
 # provide credentials and optionally set URL and port appropriately

--- a/collectors/jiraffe/tasks.py
+++ b/collectors/jiraffe/tasks.py
@@ -2,6 +2,7 @@
 Celery tasks for the JIRA Collector
 """
 from celery import shared_task
+from celery.utils.log import get_task_logger
 from django.conf import settings
 
 from config.celery import app
@@ -16,6 +17,8 @@ from .constants import (
     JIRAFFE_AUTO_SYNC,
 )
 from .core import get_affects_to_sync, upsert_trackers
+
+logger = get_task_logger(__name__)
 
 
 @app.task(

--- a/collectors/product_definitions/tests/test_core.py
+++ b/collectors/product_definitions/tests/test_core.py
@@ -1,4 +1,3 @@
-import logging
 from typing import Type
 
 import pytest
@@ -16,7 +15,6 @@ from ..core import (
     sync_ps_update_streams,
 )
 
-logger = logging.getLogger("collectors.bzimport")
 pytestmark = pytest.mark.unit
 
 PRODUCT_DEFINITIONS_CASSETTE = (

--- a/config/settings.py
+++ b/config/settings.py
@@ -164,9 +164,13 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
+        "verbose_celery": {
+            "()": "osidb.helpers.TaskFormatter",
+            "format": "%(asctime)s [%(levelname)s] %(task_name)s%(task_id)s: %(message)s",
+        },
         "verbose": {
             # exact format is not important, this is the minimum information
-            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"
+            "format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s",
         },
     },
     "handlers": {
@@ -174,7 +178,7 @@ LOGGING = {
         "celery": {
             "level": "WARNING",
             "class": "logging.StreamHandler",
-            "formatter": "verbose",
+            "formatter": "verbose_celery",
         },
     },
     "loggers": {
@@ -188,54 +192,32 @@ LOGGING = {
         },
         "celery": {"handlers": ["celery"], "level": "INFO", "propagate": True},
         "osidb": {"level": "WARNING", "handlers": ["console"], "propagate": False},
-        "collectors.bzimport": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        "collectors.bzimport.tasks": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        # TODO this is all repeated
-        # can it be defined just once ?
-        "collectors.errata": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        "collectors.example": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        "collectors.framework": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        "collectors.jiraffe": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        "collectors.jiraffe.tasks": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
-        "collectors.product_definitions": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
         "apps.osim": {
             "level": "WARNING",
             "handlers": ["console"],
             "propagate": True,
         },
         "django_auth_ldap": {"level": "WARNING", "handlers": ["console"]},
+        # Collectors loggers
+        **{
+            collector_name: {
+                "level": "WARNING",
+                "handlers": ["celery"],
+                "propagate": True,
+            }
+            for collector_name in [
+                "collectors.bzimport",
+                "collectors.epss",
+                "collectors.errata",
+                "collectors.example",
+                "collectors.exploits_cisa",
+                "collectors.exploits_exploitdb",
+                "collectors.exploits_metasploit",
+                "collectors.framework",
+                "collectors.jiraffe",
+                "collectors.product_definitions",
+            ]
+        },
     },
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Authentication is no longer compulsory for read-only requests against the
   main OSIDB endpoints such as /flaws, /affects and /trackers (OSIDB-313)
 
+### Added
+- unified logging across the whole OSIDB
+
 ## [2.1.0] - 2022-08-02
 ### Changed
 - disable krb5 log redirection in stage and production playbooks.

--- a/osidb/tests/test_core.py
+++ b/osidb/tests/test_core.py
@@ -1,5 +1,3 @@
-import logging
-
 import pytest
 from rest_framework.viewsets import ModelViewSet
 
@@ -8,7 +6,6 @@ from osidb.core import set_user_acls
 from osidb.exceptions import OSIDBException
 from osidb.tests.factories import FlawFactory
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/osidb/tests/test_embargo.py
+++ b/osidb/tests/test_embargo.py
@@ -1,12 +1,9 @@
-import logging
-
 import pytest
 
 from osidb.models import Flaw
 
 from .factories import FlawFactory
 
-logger: logging = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import timedelta
 from typing import Set, Union
 
@@ -17,7 +16,6 @@ from .factories import (
     TrackerFactory,
 )
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 
 import pytest
@@ -24,7 +23,6 @@ from osidb.tests.factories import (
     TrackerFactory,
 )
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/osidb/tests/test_integration.py
+++ b/osidb/tests/test_integration.py
@@ -5,13 +5,11 @@
 
 """
 import json
-import logging
 import subprocess
 
 import pytest
 
 pytestmark = pytest.mark.integration
-logger = logging.getLogger(__name__)
 
 
 class TestIntegration(object):

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -1,4 +1,3 @@
-import logging
 import uuid
 
 import pytest
@@ -7,7 +6,6 @@ from osidb.models import Flaw, FlawImpact, FlawResolution, FlawType
 
 from .factories import FlawFactory
 
-logger = logging.getLogger(__name__)
 pytestmark = pytest.mark.unit
 
 

--- a/osidb/views.py
+++ b/osidb/views.py
@@ -8,7 +8,7 @@ from django.views.generic import TemplateView
 
 from osidb import __version__
 
-logger: logging = logging.getLogger(__name__)
+logger = logging.getLogger(__name__)
 
 
 class index(TemplateView):


### PR DESCRIPTION
Unified logging across the OSIDB:
* Created custom formatter for the celery tasks to inject celery specific info. 
* separation of the `get_task_logger` and `logging.getLogger`
* unified logging inside the tests

minor: fixed exporting variables into containers


Closes https://issues.redhat.com/browse/OSIDB-33