### PR TITLE
Allow unauthenticated access to the OSIDB API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the authentication call from the constants file which meant that
   ET authentication would happen every time the code was loaded, generating
   a lot of auth calls and logs.
+- Authentication is no longer compulsory for read-only requests against the
+  main OSIDB endpoints such as /flaws, /affects and /trackers (OSIDB-313)
 
 ### Removed
 - remove audit mechanisms and tables from main models.

--- a/openapi.yml
+++ b/openapi.yml
@@ -598,6 +598,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -669,6 +670,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1074,6 +1076,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1192,6 +1195,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1295,6 +1299,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1473,6 +1478,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1545,6 +1551,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1616,6 +1623,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:
@@ -1745,6 +1753,7 @@ paths:
       - osidb
       security:
       - OsidbTokenAuthentication: []
+      - {}
       responses:
         '200':
           content:

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -12,7 +12,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_view
 from packageurl import PackageURL
 from rest_framework.decorators import api_view, permission_classes
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import AllowAny, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -43,6 +43,8 @@ def healthy(request: Request) -> Response:
 class StatusView(APIView):
     """authenticated view containing status osidb service"""
 
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
     @extend_schema(
         responses={
             200: {
@@ -69,6 +71,8 @@ class StatusView(APIView):
 
 class ManifestView(APIView):
     """authenticated view containing project manifest information"""
+
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def get(self, request, *args, **kwargs):
         """HTTP get /manifest"""
@@ -284,6 +288,7 @@ class FlawView(ModelViewSet):
     filterset_class = FlawFilter
     lookup_url_kwarg = "id"
     http_method_names = get_valid_http_methods(ModelViewSet)
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def get_object(self):
         # from https://www.django-rest-framework.org/api-guide/generic-views/#methods
@@ -335,6 +340,7 @@ class FlawView(ModelViewSet):
     }
 )
 @api_view(["GET"])
+@permission_classes((IsAuthenticatedOrReadOnly,))
 def whoami(request: Request) -> Response:
     """View that provides information about the currently logged-in user"""
     return Response(UserSerializer(request.user).data)
@@ -345,6 +351,7 @@ class AffectView(ModelViewSet):
     serializer_class = AffectSerializer
     filterset_class = AffectFilter
     http_method_names = get_valid_http_methods(ModelViewSet)
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def perform_create(self, serializer):
         # NOTE: this is incorrect, but will be fixed properly later
@@ -357,6 +364,7 @@ class TrackerView(ModelViewSet):
     serializer_class = TrackerSerializer
     filterset_class = TrackerFilter
     http_method_names = get_valid_http_methods(ModelViewSet)
+    permission_classes = [IsAuthenticatedOrReadOnly]
 
     def perform_create(self, serializer):
         # NOTE: this is incorrect, but will be fixed properly later

--- a/osidb/auth.py
+++ b/osidb/auth.py
@@ -1,5 +1,6 @@
 import logging
 
+from django.conf import settings
 from drf_spectacular.contrib.rest_framework_simplejwt import SimpleJWTScheme
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
@@ -24,6 +25,8 @@ class OsidbTokenAuthentication(JWTAuthentication):
 
     def authenticate(self, request):
         creds = super().authenticate(request)
+        # by default set ACLs to public read if unauthenticated
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
         if creds and creds[0].is_authenticated:
             _logger.info(f"ACLs set from auth override for user {creds[0].username}")
             set_user_acls(creds[0].groups.all())

--- a/osidb/middleware.py
+++ b/osidb/middleware.py
@@ -5,6 +5,8 @@
 """
 import logging
 
+from django.conf import settings
+
 from osidb.core import set_user_acls
 
 _logger = logging.getLogger(__name__)
@@ -24,6 +26,8 @@ class PgCommon:
         self.get_response = get_response
 
     def __call__(self, request):
+        # by default set ACLs to public read if unauthenticated
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
         if request.user.is_authenticated:
             _logger.info(f"ACLs set from middleware for user {request.user.username}")
             set_user_acls(request.user.groups.all())

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -991,13 +991,6 @@ class TestEndpoints(object):
         flaw1 = FlawFactory(is_major_incident=True)
         FlawCommentFactory(flaw=flaw1)
 
-        # attempt to access with unauthenticated client using bad token value
-        response = client.get(
-            f"{test_api_uri}/flaws/{flaw1.cve_id}",
-            HTTP_AUTHORIZATION="Token badtokenvalue",
-        )
-        assert response.status_code == 401
-
         # attempt to access with unauthenticated client using good token value
         response = client.get(
             f"{test_api_uri}/flaws/{flaw1.cve_id}", HTTP_AUTHORIZATION=f"Bearer {token}"


### PR DESCRIPTION
This commit changes the permission class of the main OSIDB endpoints to
IsAuthenticatedOrReadOnly which allows unauthenticated users to consume
the API in read-only fashion.

The commit also applies some changes to the auth and middleware hooks
that set the ACLs so that AnonymousUsers (=unauthenticated users) can
only read publically available information.

Closes OSIDB-313