### PR TITLE
Properly cleanup all FlawMeta objects on flaw sync

### DIFF
--- a/collectors/bzimport/tests/test_convertors.py
+++ b/collectors/bzimport/tests/test_convertors.py
@@ -99,14 +99,24 @@ class TestFlawSaver:
         minimal meta getter
         """
         return [
-            FlawMeta(
+            FlawMeta.objects.create_flawmeta(
                 flaw=flaw,
-                type=FlawMeta.FlawMetaType.MAJOR_INCIDENT,
+                _type=FlawMeta.FlawMetaType.ACKNOWLEDGMENT,
+                meta={"name": "Lon Wnderer"},
                 created_dt=timezone.now(),
                 updated_dt=timezone.now(),
                 acl_read=self.get_acls(),
                 acl_write=self.get_acls(),
-            )
+            ),
+            FlawMeta.objects.create_flawmeta(
+                flaw=flaw,
+                _type=FlawMeta.FlawMetaType.ACKNOWLEDGMENT,
+                meta={"name": "Lone Wanderer"},
+                created_dt=timezone.now(),
+                updated_dt=timezone.now(),
+                acl_read=self.get_acls(),
+                acl_write=self.get_acls(),
+            ),
         ]
 
     def get_trackers(self, affect):
@@ -201,7 +211,7 @@ class TestFlawSaver:
         assert history.acl_write == acls
 
         assert meta is not None
-        assert meta.type == FlawMeta.FlawMetaType.MAJOR_INCIDENT
+        assert meta.type == FlawMeta.FlawMetaType.ACKNOWLEDGMENT
         assert meta.acl_read == acls
         assert meta.acl_write == acls
         assert meta.flaw == flaw
@@ -291,7 +301,7 @@ class TestFlawSaver:
 
         assert flaw is not None
         assert meta is not None
-        assert flaw.meta.count() == 1
+        assert flaw.meta.count() == 2
         assert flaw.meta.first() == meta
         assert meta.flaw == flaw
 
@@ -300,7 +310,9 @@ class TestFlawSaver:
             [],
             [],
             [],
-            [],
+            [
+                self.get_meta(flaw)[1],
+            ],
             [],
             {},
         ).save()
@@ -309,8 +321,9 @@ class TestFlawSaver:
         meta = FlawMeta.objects.first()
 
         assert flaw is not None
-        assert meta is None
-        assert flaw.meta.count() == 0
+        assert flaw.meta.count() == 1
+        assert flaw.meta.first() == self.get_meta(flaw)[1]
+        assert flaw.meta.first().meta_attr["name"] == "Lone Wanderer"
 
     def test_trackers_removed(self):
         """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - change the way that data is synchronized to be more fault-tolerant,
   things like tracker fetching will no longer make the entire flaw
   sync fail.
+- fix a bug where only certain metadata were being correctly synchronized
+  between BZ and OSIDB which resulted in things like typos in acknowledgments
+  persisting in OSIDB despite being removed from BZ.
 
 ### Removed
 - remove audit mechanisms and tables from main models.


### PR DESCRIPTION
Before this commit, only certain types of FlawMeta objects were being
cleaned up / synchronized between OSIDB and upstream (BZ).

This led to issues such as typos in acknowledgments not being properly
corrected, as instead of acks with typos being replaced by acks without
typos all acks would be kept and displayed on CVE pages, including those
with typos.

This commit changes the behavior so that all types of FlawMeta are kept
in sync by removing any existing FlawMeta with a given flaw id, type and
meta_attr if it no longer exists upstream.

Closes OSIDB-315