### PR TITLE
PSINSIGHTS-646: Run CISA collector hourly in production

### DIFF
--- a/collectors/exploits_cisa/tasks.py
+++ b/collectors/exploits_cisa/tasks.py
@@ -4,7 +4,7 @@ CISA exploit data collector
 import logging
 
 import requests
-from celery.schedules import crontab
+from django.conf import settings
 from django.utils import timezone
 from django.utils.dateparse import parse_date
 
@@ -56,8 +56,8 @@ def cisa_collector_main():
 
 
 @collector(
-    # Execute once a day
-    crontab=crontab(minute=0, hour=1),
+    # Execute once an hour in production or stage, otherwise daily
+    crontab=settings.CISA_COLLECTOR_CRONTAB
 )
 def exploit_cisa_collector(collector_obj):
     logger.info(f"Collector {collector_obj.name} is running")

--- a/config/settings.py
+++ b/config/settings.py
@@ -264,3 +264,6 @@ SPECTACULAR_SETTINGS = {
 
 ERRATA_TOOL_SERVER = get_env("ET_URL")
 ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"
+
+# Execute once a day by default
+CISA_COLLECTOR_CRONTAB = crontab(minute=0, hour=1)

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -111,3 +111,6 @@ KRB5_HOSTNAME = get_env("KRB5_HOSTNAME")
 
 ERRATA_TOOL_SERVER = get_env("ET_URL")
 ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"
+
+# Execute once an hour in production
+CISA_COLLECTOR_CRONTAB = crontab(minute=0)

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -108,3 +108,6 @@ AUTHENTICATION_BACKENDS += [
     "django_auth_ldap.backend.LDAPBackend",
 ]
 KRB5_HOSTNAME = get_env("KRB5_HOSTNAME")
+
+# Execute once an hour in stage to be consistent with production
+CISA_COLLECTOR_CRONTAB = crontab(minute=0)


### PR DESCRIPTION
For monitoring purposes make CISA collector run hourly. However, that is only needed in production and stage environment.