### PR TITLE
Preparation for using Flower in stage / production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ tests/htmlcov
 .tox/
 /venv
 .vscode/
+*.db.gz

--- a/collectors/framework/models.py
+++ b/collectors/framework/models.py
@@ -9,7 +9,7 @@ from typing import Dict, List, Optional, Type
 
 import celery.states as celery_states
 import inflection
-from celery import Task
+from celery import Task, exceptions
 from celery.schedules import crontab
 from django.contrib.postgres import fields
 from django.db import models
@@ -426,7 +426,7 @@ class Collector(Task):
     # EXECEPTIONS #
     ###############
 
-    class CollectorRunning(Exception):
+    class CollectorRunning(exceptions.Retry):
         """
         exception raised when this collector is already running
         to prevent duplicit run before the previous one finished
@@ -434,7 +434,7 @@ class Collector(Task):
 
         pass
 
-    class CollectorBlocked(Exception):
+    class CollectorBlocked(exceptions.Retry):
         """
         exception raised when this collector is blocked by unsatisfied dependencies
         to prevent undefined behavior with some required data not yet collected

--- a/collectors/framework/tests/test_core.py
+++ b/collectors/framework/tests/test_core.py
@@ -2,7 +2,7 @@ import pytest
 from celery.schedules import crontab
 from django.utils import timezone
 
-from collectors.framework.models import Collector, CollectorMetadata, collector
+from collectors.framework.models import CollectorMetadata, collector
 from osidb.models import Affect, Flaw, Tracker
 
 pytestmark = pytest.mark.unit
@@ -118,9 +118,7 @@ class TestCollectorFramework:
             collector6_metadata.data_state = incomplete_data_state
             collector6_metadata.save()
 
-            with pytest.raises(Collector.CollectorBlocked) as exc_info:
-                test_collector5.apply().get()
-            assert "Dependent collector data are not complete" in str(exc_info.value)
+            assert test_collector5.apply().state == "RETRY"
 
         collector6_metadata.data_state = CollectorMetadata.DataState.COMPLETE
         collector6_metadata.save()
@@ -144,6 +142,4 @@ class TestCollectorFramework:
         metadata.save()
 
         for _ in range(5):
-            with pytest.raises(Collector.CollectorRunning) as exc_info:
-                test_collector7.apply().get()
-            assert "Collector is already running" in str(exc_info.value)
+            assert test_collector7.apply().state == "RETRY"

--- a/collectors/jiraffe/core.py
+++ b/collectors/jiraffe/core.py
@@ -151,5 +151,6 @@ def get_affects_to_sync(interval: str) -> Union[tuple[UUID], tuple[Any]]:
         trackers = Tracker.objects.filter(
             external_system_id=issue.key, type=Tracker.TrackerType.JIRA
         )
-        affect_uuids_to_sync |= {tracker.affect.uuid for tracker in trackers}
+        for tracker in trackers:
+            affect_uuids_to_sync |= set(affect.uuid for affect in tracker.affects.all())
     return tuple(affect_uuids_to_sync)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix an issue in which the Jiraffe collector was calling Tracker.affect
   instead of Tracker.affects (ManyToMany field) which resulted in some
   failed JIRA tracker synchronizations.
+- Treat collector failures due to already running collectors or due to
+  waiting for dependencies as celery Retry exceptions.
 
 ### Added
 - unified logging across the whole OSIDB

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Authentication is no longer compulsory for read-only requests against the
   main OSIDB endpoints such as /flaws, /affects and /trackers (OSIDB-313)
+- Fix an issue in which the Jiraffe collector was calling Tracker.affect
+  instead of Tracker.affects (ManyToMany field) which resulted in some
+  failed JIRA tracker synchronizations.
 
 ### Added
 - unified logging across the whole OSIDB


### PR DESCRIPTION
This PR includes some necessary changes to start using Flower in a meaningful way in stage / production, mainly as a way to see any errors emanating from collector runs, but also as a way to provide an API from which a myriad of things can be achieved (such as stats).

The main change is setting the collector exceptions to be of type `Retry`, which remove a lot of the noise from the Flower UI:

![Screenshot from 2022-08-02 17-39-14](https://user-images.githubusercontent.com/4931545/182416277-bfcb6a46-119b-4340-90fb-f0446f16066f.png)
![Screenshot from 2022-08-02 17-39-24](https://user-images.githubusercontent.com/4931545/182416273-707e435c-b765-47a9-be47-996a8e77537a.png)
![Screenshot from 2022-08-02 17-39-36](https://user-images.githubusercontent.com/4931545/182416270-3602aa04-79a8-4426-8d66-af9c8fbdec18.png)

It also includes a small fix to the Jiraffe collector that I discovered while using Flower (proving that it works, huzzah!)
