### PR TITLE
Validate combinations of the major incident flags

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - unified logging across the whole OSIDB
+- validate hightouch and hightouch-lite flag value combinations (OSIDB-329)
 
 ## [2.1.0] - 2022-08-02
 ### Changed


### PR DESCRIPTION
Certain combinations of the MAJOR_INCIDENT and MAJOR_INCIDENT_LITE
FlawMeta flags should never be valid, to ensure that this constraint is
enforced a validation method is added on the FlawMeta model and executed
on each save.

Closes OSIDB-329