### PR TITLE
Fix retry logic

### DIFF
--- a/collectors/utils.py
+++ b/collectors/utils.py
@@ -20,10 +20,10 @@ def fatal_code(e):
     """Do not retry on 4xx responses."""
     # Handle requests.exceptions.RequestException
     # 408 is "Request Timeout" that Brew sometimes returns, which can be retried safely
-    if getattr(e, "response", None):
+    if hasattr(e, "response"):
         return 400 <= e.response.status_code < 500 and e.response.status_code != 408
     # Handle xmlrpc.client.ProtocolError
-    elif getattr(e, "errcode", None):
+    elif hasattr(e, "errcode"):
         return 400 <= e.errcode < 500 and e.errcode != 408
 
 


### PR DESCRIPTION
@osidb-dev getattr will return the requests.response object, and it will be evaluated as a boolean. If the response had a 200ish code, it evaluates to True. If the code was 400ish or similar, it evaluates to False.

So any failed request will not enter the if block I changed in the diff, and we skip checking whether the code is retryable or not. Instead we just retry all requests, which is dangerous.