### PR TITLE
Remove pip-audit checks

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,18 +15,6 @@ check:
   script:
     - dnf install -y openldap-devel python3.9
     - tox --parallel --parallel-live
-  except:
-    refs:
-      - schedules
-
-
-# TODO: There's a better way, will fix this tomorrow if I have time
-pip-audit:
-  stage: check
-  image: quay.io/prodsecdev/fedora-latest:35  # includes tox
-  script:
-    - dnf install -y python3.9
-    - tox -e pip-audit
 
 test:
   stage: test
@@ -59,6 +47,3 @@ test:
     - sleep 60
     - ldapadd -c -H "ldap://testldap:1389" -x -D "cn=admin,dc=redhat,dc=com" -w "adminpassword" -f etc/openldap/local-export.ldif || true
     - tox -e ci-osidb
-  except:
-    refs:
-      - schedules

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,7 +109,7 @@
         "filename": ".gitlab-ci.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 40,
+        "line_number": 28,
         "is_secret": false
       },
       {
@@ -117,7 +117,7 @@
         "filename": ".gitlab-ci.yml",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 35,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2022-07-06T14:40:23Z"
+  "generated_at": "2022-08-04T06:59:54Z"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -106,15 +106,3 @@ skip = migrations,venv,.tox,src
 [testenv:isort]
 deps = isort
 commands = isort --diff --check .
-
-[testenv:pip-audit]
-deps = pip-audit
-allowlist_externals = bash
-commands =
-    # OSV is slow, but sometimes has CVEs that PyPI doesn't. Must check both
-    pip-audit --ignore-vuln 'GHSA-q4qm-xhf9-4p8f' --ignore-vuln 'PYSEC-2017-49' \
-    -r requirements.txt -r devel-requirements.txt --vulnerability-service pypi
-    pip-audit --ignore-vuln 'GHSA-q4qm-xhf9-4p8f' --ignore-vuln 'PYSEC-2017-49' \
-    -r requirements.txt -r devel-requirements.txt --vulnerability-service osv
-    /usr/bin/bash -c 'if [ -f local-requirements.txt ]; then pip-audit --ignore-vuln "GHSA-q4qm-xhf9-4p8f" --ignore-vuln "PYSEC-2017-49" -r local-requirements.txt --vulnerability-service pypi; fi'
-    /usr/bin/bash -c 'if [ -f local-requirements.txt ]; then pip-audit --ignore-vuln "GHSA-q4qm-xhf9-4p8f" --ignore-vuln "PYSEC-2017-49" -r local-requirements.txt --vulnerability-service osv; fi'


### PR DESCRIPTION
After a brief discussion we informally decided to drop pip-audit usage,
the main argument being that whenever a vulnerability was discovered in
one of our packages our entire development process is halted -- CI
cannot pass as long as the pip-audit check is failing, so we must
immediately update to the latest version in order to be able to continue
normal development and often times the vulnerabilities don't even affect
us since we may not use the feature that the security patch fixes.

Since we develop on GitHub now, we can simply defer this job to
Dependabot which can alert us once a week (by default) of potential
security vulnerabilities present in our codebase and let developers
gauge whether it's urgent or not to apply the security patches, without
disrupting workflow.

For reference, Dependabot is highly customizable through a
dependabot.yaml file inside the .github directory of the repository:
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file