### PR TITLE
Validate differences between RH CVSS and NVD CVSS

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 153,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2022-08-04T06:59:54Z"
+  "generated_at": "2022-08-04T15:46:15Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - unified logging across the whole OSIDB
 - validate hightouch and hightouch-lite flag value combinations (OSIDB-329)
+- validate differences between Red Hat and NVD CVSS score and severity (OSIDB-333)
 
 ## [2.1.0] - 2022-08-02
 ### Changed

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -7,6 +7,7 @@ these may eventually be refactored into config/settings
 
 import re
 from datetime import timedelta, timezone
+from decimal import Decimal
 
 from .helpers import get_env
 
@@ -27,3 +28,11 @@ ENABLE_EMBARGO_PROCESS: bool = get_env(
 # used by osidb manifest endpoint to parse pypi urls
 PYPI_URL = "https://pypi.org/project/"
 URL_REGEX = re.compile(r"https?://[-a-zA-Z0-9@:%_\\+.~#!?&/=;]*[-a-zA-Z0-9@%_~#?&/]")
+
+CVSS3_SEVERITY_SCALE = {
+    "none": (Decimal("0.0"), Decimal("0.0")),
+    "low": (Decimal("0.1"), Decimal("3.9")),
+    "medium": (Decimal("4.0"), Decimal("6.9")),
+    "high": (Decimal("7.0"), Decimal("8.9")),
+    "critical": (Decimal("9.0"), Decimal("10.0")),
+}


### PR DESCRIPTION
The Red Hat CVSS score can contain certain differences when compared to
the NVD CVSS score as long as these differences are within a certain
threshold.

The constraints are:

* A score difference of less than 1.0 point between the two
* No severity difference between the two

Closes OSIDB-333