### PR TITLE
Verify that public source flaws don't have ack FlawMetas

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - unified logging across the whole OSIDB
 - validate hightouch and hightouch-lite flag value combinations (OSIDB-329)
 - validate differences between Red Hat and NVD CVSS score and severity (OSIDB-333)
+- validate that flaws from public sources don't contain ack FlawMetas (OSIDB-338)
 
 ## [2.1.0] - 2022-08-02
 ### Changed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1220,11 +1220,24 @@ class FlawMeta(TrackingMixin):
                 f"Flaw MAJOR_INCIDENT and MAJOR_INCIDENT_LITE combination cannot be {flag_pair}."
             )
 
+    def _validate_public_source_no_ack(self):
+        """
+        Checks that ACK FlawMetas cannot be linked to flaws with public sources.
+        """
+        if self.type != self.FlawMetaType.ACKNOWLEDGMENT or not self.flaw.source:
+            return
+
+        if FlawSource(self.flaw.source).is_public():
+            raise ValidationError(
+                f"Flaw contains acknowledgments for public source {self.flaw.source}"
+            )
+
     def validate(self, *args, **kwargs):
         """validate model"""
         # add custom validation here
         super().clean_fields(*args, exclude=["meta_attr"], **kwargs)
         self._validate_major_incident_combos()
+        self._validate_public_source_no_ack()
 
     def save(self, *args, **kwargs):
         """save model override"""

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from osidb.constants import OSIDB_API_VERSION
 from osidb.core import generate_acls
 from osidb.helpers import get_env
+from osidb.models import FlawSource
 
 
 @pytest.fixture(autouse=True)
@@ -109,3 +110,13 @@ def test_user_dict_no_account():
         "last_name": "Bar",
         "email": "foobarbaz@example.com",
     }
+
+
+@pytest.fixture
+def public_source():
+    return FlawSource.INTERNET
+
+
+@pytest.fixture
+def private_source():
+    return FlawSource.APPLE

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -609,3 +609,18 @@ class TestFlawValidators:
         assert Flaw.objects.count() == 0
         FlawFactory(embargoed=True, source=source)
         assert Flaw.objects.count() == 1
+
+    def test_public_source_ack(self, public_source, private_source):
+        # test the public source w/ ack
+        flaw = FlawFactory(source=public_source, embargoed=False)
+        assert FlawMeta.objects.count() == 0
+        with pytest.raises(ValidationError) as e:
+            FlawMetaFactory(type=FlawMeta.FlawMetaType.ACKNOWLEDGMENT, flaw=flaw)
+        assert (
+            f"Flaw contains acknowledgments for public source {public_source}" in str(e)
+        )
+        assert FlawMeta.objects.count() == 0
+        # test the private source w/ ack
+        flaw = FlawFactory(source=private_source, embargoed=True)
+        FlawMetaFactory(type=FlawMeta.FlawMetaType.ACKNOWLEDGMENT, flaw=flaw)
+        assert FlawMeta.objects.count() == 1


### PR DESCRIPTION
It doesn't make sense to include acknowledgments for Flaws emanating
from public sources as said sources already include the acknowledgment
information.

Closes OSIDB-338