### PR TITLE
AlertMixin and small flake8 invocation improvement

### DIFF
--- a/config/settings_ci.py
+++ b/config/settings_ci.py
@@ -73,3 +73,5 @@ LOGIN_REDIRECT_URL = "/"  # this is the name of the url
 
 STATIC_ROOT = "/var/www/osidb/static/"
 STATIC_URL = "/static/"
+
+INSTALLED_APPS += ["osidb.tests"]

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -73,3 +73,5 @@ LOGIN_REDIRECT_URL = "/"  # this is the name of the url
 
 STATIC_ROOT = "/var/www/osidb/static/"
 STATIC_URL = "/static/"
+
+INSTALLED_APPS += ["osidb.tests"]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - validate hightouch and hightouch-lite flag value combinations (OSIDB-329)
 - validate differences between Red Hat and NVD CVSS score and severity (OSIDB-333)
 - validate that flaws from public sources don't contain ack FlawMetas (OSIDB-338)
+- `AlertMixin` for the creation of easily-serializable alerts on a per-record
+  basis for any model that inherits from said mixin (OSIDB-324)
 
 ## [2.1.0] - 2022-08-02
 ### Changed

--- a/osidb/tests/models.py
+++ b/osidb/tests/models.py
@@ -1,0 +1,7 @@
+from osidb.mixins import AlertMixin
+
+
+class TestAlertModel(AlertMixin):
+    def save(self, *args, **kwargs):
+        self.alert("my_alert", "This alert be danger")
+        super().save(*args, **kwargs)

--- a/tox.ini
+++ b/tox.ini
@@ -59,7 +59,7 @@ commands =
 [testenv:flake8]
 deps = flake8
        flake8-django
-commands = flake8 osidb collectors apps
+commands = flake8 --exit-zero osidb collectors apps
 
 [flake8]
 # E203 - whitespace before ':' -- ignored per Black documentation, non PEP8-compliant


### PR DESCRIPTION
This PR introduces two changes:

* The addition of `AlertMixin` which allows the usage of alerts on any model that inherits from said mixin.
* A small fix to `flake8` so that failures are clearer

Closes OSIDB-324