### PR TITLE
Implement ps_module validation for Affect + small AlertMixin fix

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - validate that flaws from public sources don't contain ack FlawMetas (OSIDB-338)
 - `AlertMixin` for the creation of easily-serializable alerts on a per-record
   basis for any model that inherits from said mixin (OSIDB-324)
+- validate that an Affect's `ps_module` exists in product definitions (OSIDB-342)
 
 ## [2.1.0] - 2022-08-02
 ### Changed

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -36,3 +36,10 @@ CVSS3_SEVERITY_SCALE = {
     "high": (Decimal("7.0"), Decimal("8.9")),
     "critical": (Decimal("9.0"), Decimal("10.0")),
 }
+
+
+# This is a BZ ID used for marking a certain point in time of flaw analysis in BZ
+# any issues before and including this one belong to the "old way" of having
+# update streams instead of ps_modules for affects, any issues after this one
+# belong to the "new way" in which ps_modules are more heavily enforced
+BZ_ID_SENTINEL = 1489716

--- a/osidb/migrations/0058_affect__alerts.py
+++ b/osidb/migrations/0058_affect__alerts.py
@@ -1,0 +1,36 @@
+# This is a MANUAL migration, it overrides Django's default migration
+# to leverage PostgreSQL's fast default values, it will essentially
+# set Affect._alerts to always have a default value of {} in the
+# database instead of python code which would be very slow in a production
+# database.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osidb', '0057_remove_pghistory_event_tables'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            """
+            ALTER TABLE "osidb_affect"
+            ADD COLUMN "_alerts" JSONB
+            NOT NULL
+            DEFAULT '{}'::JSONB
+            """,
+            reverse_sql="""
+            ALTER TABLE "osidb_affect"
+            DROP COLUMN "_alerts"
+            """,
+            state_operations=[
+                migrations.AddField(
+                    model_name='affect',
+                    name='_alerts',
+                    field=models.JSONField(blank=True, default=dict),
+                ),
+            ],
+        ),
+    ]

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -96,7 +96,7 @@ class AlertMixin(models.Model):
     the alerts are somewhat constant in their content.
     """
 
-    _alerts = models.JSONField(default=dict)
+    _alerts = models.JSONField(default=dict, blank=True)
 
     class AlertType(Enum):
         WARNING = "warning"

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -20,9 +20,9 @@ from apps.exploits.mixins import AffectExploitExtensionMixin
 from apps.exploits.query_sets import AffectQuerySetExploitExtension
 from apps.osim.workflow import WorkflowModel
 
-from .constants import CVSS3_SEVERITY_SCALE, OSIDB_API_VERSION
+from .constants import BZ_ID_SENTINEL, CVSS3_SEVERITY_SCALE, OSIDB_API_VERSION
 from .core import generate_acls
-from .mixins import NullStrFieldsMixin, TrackingMixin
+from .mixins import AlertMixin, NullStrFieldsMixin, TrackingMixin
 from .validators import (
     no_future_date,
     validate_cve_id,
@@ -848,7 +848,9 @@ class AffectManager(models.Manager):
         # If search has no results, this will now return an empty queryset
 
 
-class Affect(TrackingMixin, AffectExploitExtensionMixin, NullStrFieldsMixin):
+class Affect(
+    AlertMixin, TrackingMixin, AffectExploitExtensionMixin, NullStrFieldsMixin
+):
     """affect model definition"""
 
     class AffectAffectedness(models.TextChoices):

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -28,6 +28,13 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
+@pytest.fixture(autouse=True)
+def test_ps_module():
+    from osidb.tests.factories import PsModuleFactory
+
+    PsModuleFactory(name="rhel-6")
+
+
 @pytest.fixture
 def root_url():
     return "http://osdib-service:8000"

--- a/osidb/tests/models.py
+++ b/osidb/tests/models.py
@@ -1,6 +1,10 @@
 from osidb.mixins import AlertMixin
 
 
+class TestAlertModelBasic(AlertMixin):
+    pass
+
+
 class TestAlertModel(AlertMixin):
     def save(self, *args, **kwargs):
         self.alert("my_alert", "This alert be danger")

--- a/osidb/tests/test_core.py
+++ b/osidb/tests/test_core.py
@@ -6,7 +6,7 @@ from osidb.api_views import get_valid_http_methods
 from osidb.core import set_user_acls
 from osidb.exceptions import OSIDBException
 from osidb.tests.factories import FlawFactory
-from osidb.tests.models import TestAlertModel
+from osidb.tests.models import TestAlertModel, TestAlertModelBasic
 
 pytestmark = pytest.mark.unit
 
@@ -47,6 +47,13 @@ class TestCore(object):
 
 
 class TestModelDefinitions:
+    @isolate_apps("tests")
+    def test_creation_empty_alerts(self):
+        m = TestAlertModelBasic()
+        m.save()
+
+        assert m._alerts == {}
+
     @isolate_apps("tests")
     def test_alert_inheritance(self):
         m = TestAlertModel()


### PR DESCRIPTION
This PR introduces the following changes:

* A small fix to `AlertMixin` and tests
* Applies the `AlertMixin` to the `Affect` model
* Implements `ps_module` validation to the `Affect` model

Closes OSIDB-342