### PR TITLE
Bugzilla flaw create and update PoC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ tests/htmlcov
 /venv
 .vscode/
 *.db.gz
+osidb_data_backup_dump*

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Data models, validations, serializers, API, and other vital parts are defined th
 You can find more details [here](osidb/README.md).
 Additional functionality is implemented by specialized [apps](apps/).
 
+* [bbsync](apps/bbsync/) Bugzilla Backwards Synchronization
 * [exploits](apps/exploits/)
 * [osim](apps/osim/) - Open Security Issue Manager
 

--- a/apps/bbsync/README.md
+++ b/apps/bbsync/README.md
@@ -1,0 +1,5 @@
+# Bugzilla Backwards Synchronization
+
+This app implements functionality necessary to synchronize flaws back to Bugzilla.
+The aim is to create it as light dependency as possible so it can be eventually
+easily removed once Bugzilla is finally being deprecated.

--- a/apps/bbsync/apps.py
+++ b/apps/bbsync/apps.py
@@ -1,0 +1,14 @@
+"""
+
+    BBSync - Bugzilla Backwards Synchronization
+        osidb.bbsync to be precise
+
+"""
+
+from django.apps import AppConfig
+
+
+class BBSync(AppConfig):
+    """django name"""
+
+    name = "apps.bbsync"

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -1,0 +1,190 @@
+from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT
+from osidb.models import Flaw, FlawImpact
+
+
+class BugzillaQueryBuilder:
+    """
+    Bugzilla flaw bug query builder
+    to generate general flaw save query
+
+    https://bugzilla.redhat.com/docs/en/html/api/index.html
+    """
+
+    def __init__(self, flaw, old_flaw=None):
+        """
+        init stuff
+        parametr old_flaw is optional as there is no old flaw on creation
+        and if not set we consider the query to be a create query
+        """
+        self.flaw = flaw
+        self.old_flaw = old_flaw
+        self._query = None
+
+    @property
+    def query(self):
+        """
+        query getter shorcut
+        """
+        if self._query is None:
+            self.generate()
+
+        return self._query
+
+    @property
+    def creation(self):
+        return self.old_flaw is None
+
+    def generate(self):
+        """
+        generate query
+        """
+        self.generate_base()
+        self.generate_unconditional()
+        self.generate_description()
+        self.generate_resolution()
+        self.generate_alias()
+        self.generate_keywords()
+        self.generate_flags()
+        self.generate_groups()
+        self.generate_cc()
+        # TODO placeholder + has different groups
+        # TODO SRT notes
+        # TODO tracker links
+        # TODO prestage eligable date - deprecate
+        # TODO checklists
+        # TODO fixed_in
+        # TODO dupe_of
+        # TODO cf_devel_whiteboard
+        # TODO ARRAY_FIELDS_ON_CREATE = ("depends_on", "blocks", "cc", "groups", "keywords")
+        # TODO auto-requires doc text on create
+
+    def generate_base(self):
+        """
+        generate static base of the query
+        """
+        self._query = {
+            "product": ANALYSIS_TASK_PRODUCT,
+            "component": "vulnerability",
+            "op_sys": "Linux",
+            "platform": "All",
+            "version": "unspecified",
+        }
+
+    IMPACT_TO_SEVERITY_PRIORITY = {
+        FlawImpact.CRITICAL: "urgent",
+        FlawImpact.IMPORTANT: "high",
+        FlawImpact.MODERATE: "medium",
+        FlawImpact.LOW: "low",
+        FlawImpact.NOVALUE: "unspecified",
+    }
+
+    def generate_unconditional(self):
+        """
+        generate query attributes not requiring conditional processing
+        """
+        self._query["summary"] = self.flaw.title  # TODO handle prefixes
+        self._query["cf_release_notes"] = self.flaw.summary
+        self._query["status"] = self.flaw.state
+        self._query["severity"] = self.IMPACT_TO_SEVERITY_PRIORITY[self.flaw.impact]
+        self._query["priority"] = self.IMPACT_TO_SEVERITY_PRIORITY[self.flaw.impact]
+
+    def generate_description(self):
+        """
+        generate query for flaw description on create
+        """
+        if self.creation:
+            self._query["description"] = self.flaw.comments.first().text
+            self._query["comment_is_private"] = False
+            # TODO
+            # self._query["comment_is_private"] = True if ... else False
+
+    def generate_resolution(self):
+        """
+        generate resolution query
+        if status is CLOSED
+        """
+        if self.flaw.state == Flaw.FlawState.CLOSED:
+            self._query["resolution"] = self.flaw.resolution
+
+    def generate_alias(self):
+        """
+        generate add or remove CVE alias query
+        conditionally based on the changes and create|update
+        """
+        if self.creation:
+            if self.flaw.cve_id is not None:
+                # create query requires pure list
+                self._query["alias"] = [self.flaw.cve_id]
+
+        elif self.flaw.cve_id != self.old_flaw.cve_id:
+            self._query["alias"] = {}
+
+            if self.flaw.cve_id is not None:
+                self._query["alias"]["add"] = [self.flaw.cve_id]
+
+            if self.old_flaw.cve_id is not None:
+                self._query["alias"]["remove"] = [self.old_flaw.cve_id]
+
+    def generate_keywords(self):
+        """
+        generate keywords query based on creation|update
+        """
+        self._query["keywords"] = (
+            ["Security"] if self.old_flaw is None else {"add": ["Security"]}
+        )
+
+    def generate_flags(self):
+        """
+        generate query for Bugzilla flags
+        """
+        self._query["flags"] = []
+        # TODO needinfo and other flags
+        # hightouch | hightouch-lite | nist_cvss_validation | requires_doc_text
+
+    EMBARGOED_GROUPS = ["qe_staff", "security"]
+    DEADLINE_FORMAT = "%Y-%m-%d"
+
+    def generate_groups(self):
+        """
+        generate query for Bugzilla groups
+        which control the access to the flaw
+        plus eventually set deadline
+        """
+        # TODO groups handling is more complicated and involves
+        # product definitions processing but let us do it simple now
+
+        if self.flaw.embargoed:
+            if self.creation:
+                self._query["groups"] = self.EMBARGOED_GROUPS
+
+            if self.flaw.unembargo_dt:
+                self._query["deadline"] = self.flaw.unembargo_dt.strftime(
+                    self.DEADLINE_FORMAT
+                )
+
+        # unembargo
+        elif not self.creation and self.old_flaw.embargoed:
+            # TODO we have no detailed information on previous groups
+            # so if there were some unusual we cannot guess
+            self._query["groups"] = {"remove": self.EMBARGOED_GROUPS}
+            self._query["deadline"] = ""
+
+        # TODO other case should be theoretically not needed to handle
+        # which is probably quite naive so let us test it extensively
+        #
+        # - embargoing of a public flaw is futile
+        #
+        # - groups should be set to embargoed or none
+        #   but there are definitely some corner cases
+        #
+        # - we need to store them on flaw fetch if we
+        #   want to do something more clever about them
+
+    def generate_cc(self):
+        """
+        generate query for CC list
+        """
+        # TODO now just empty CC list on creation
+        # on update it is more complicated
+        if self.creation:
+            self._query["cc"] = []

--- a/apps/bbsync/save.py
+++ b/apps/bbsync/save.py
@@ -1,0 +1,59 @@
+from collectors.bzimport.collectors import BugzillaConnector
+from osidb.models import Flaw
+
+from .query import BugzillaQueryBuilder
+
+
+class BugzillaSaver(BugzillaConnector):
+    """
+    Bugzilla flaw bug save handler
+    flaw validity is assumed and not checked
+    """
+
+    class UnsaveableFlaw(Exception):
+        """
+        error caused by attempt to save a flaw which cannot be saved
+        either by its nature or due to the current saver capabilities
+        """
+
+        pass
+
+    def __init__(self, flaw):
+        """
+        init stuff
+        """
+        self.flaw = flaw
+
+    def save(self):
+        """
+        generic save serving as class entry point
+        which calls create or update handler to continue
+        returns an updated flaw instance (without saving)
+        """
+        return self.create() if self.flaw.bz_id is None else self.update()
+
+    def create(self):
+        """
+        create flaw in Bugilla
+        """
+        bugzilla_query_builder = BugzillaQueryBuilder(self.flaw)
+        response = self.bz_conn.createbug(bugzilla_query_builder.query)
+        self.flaw.meta_attr["bz_id"] = response.id
+        return self.flaw
+
+    def update(self):
+        """
+        update flaw in Bugzilla
+        """
+        # TODO flaws with multiple CVEs are non-trivial to update
+        # and save back to Bugzilla so let us restrict this for now
+        if Flaw.objects.filter(meta_attr__bz_id=self.flaw.bz_id).count() > 1:
+            raise self.UnsaveableFlaw(
+                "Unable to save a flaw with multiple CVEs to Bugzilla "
+                "due to an ambigous N to 1 OSIDB to Buzilla flaw mapping"
+            )
+
+        old_flaw = Flaw.objects.get(uuid=self.flaw.uuid)
+        bugzilla_query_builder = BugzillaQueryBuilder(self.flaw, old_flaw)
+        self.bz_conn.update_bugs([self.flaw.bz_id], bugzilla_query_builder.query)
+        return self.flaw

--- a/collectors/bzimport/collectors.py
+++ b/collectors/bzimport/collectors.py
@@ -31,20 +31,8 @@ from .exceptions import RecoverableBZImportException
 logger = get_task_logger(__name__)
 
 
-class BugzillaQuerier:
-    """Bugzilla query handler"""
-
-    # Bugzilla API limit - 20 is default
-    # query result is cut when exceeding the limit
-    #
-    # 20 is the default but we set the limit to the maximum
-    # by explicitely giving it 0 value and the maximum is 1000
-    # this enhances the queries significantly
-    BZ_API_LIMIT = 1000
-
-    #######################
-    # BUGZILLA CONNECTION #
-    #######################
+class BugzillaConnector:
+    """Bugzilla connection handler"""
 
     _bz_conn = None
 
@@ -62,6 +50,18 @@ class BugzillaQuerier:
             self._bz_conn = self.create_bz_conn()
 
         return self._bz_conn
+
+
+class BugzillaQuerier(BugzillaConnector):
+    """Bugzilla query handler"""
+
+    # Bugzilla API limit - 20 is default
+    # query result is cut when exceeding the limit
+    #
+    # 20 is the default but we set the limit to the maximum
+    # by explicitely giving it 0 value and the maximum is 1000
+    # this enhances the queries significantly
+    BZ_API_LIMIT = 1000
 
     ######################
     # SINGLE BUG QUERIES #

--- a/collectors/bzimport/tests/test_convertors.py
+++ b/collectors/bzimport/tests/test_convertors.py
@@ -773,4 +773,4 @@ class TestFlawBugConvertor:
 
         assert Flaw.objects.count() == 1
         flaw = Flaw.objects.first()
-        assert flaw.is_major_incident == True
+        assert flaw.is_major_incident is True

--- a/config/settings.py
+++ b/config/settings.py
@@ -49,16 +49,17 @@ INSTALLED_APPS = [
     "rest_framework",
     "django_filters",
     "osidb",
+    "apps.bbsync",
+    "apps.exploits",
+    "apps.osim",
     "collectors.bzimport",
     "collectors.errata",
     "collectors.framework",
     "collectors.jiraffe",
     "collectors.product_definitions",
-    "apps.osim",
     "drf_spectacular",
     "polymorphic",
     "rest_framework_simplejwt",
-    "apps.exploits",
     "collectors.epss",
     "collectors.exploits_cisa",
     "collectors.exploits_exploitdb",
@@ -192,12 +193,20 @@ LOGGING = {
         },
         "celery": {"handlers": ["celery"], "level": "INFO", "propagate": True},
         "osidb": {"level": "WARNING", "handlers": ["console"], "propagate": False},
-        "apps.osim": {
-            "level": "WARNING",
-            "handlers": ["console"],
-            "propagate": True,
-        },
         "django_auth_ldap": {"level": "WARNING", "handlers": ["console"]},
+        # app loggers
+        **{
+            app_name: {
+                "level": "WARNING",
+                "handlers": ["console"],
+                "propagate": True,
+            }
+            for app_name in [
+                "apps.bbsync",
+                "apps.exploits",
+                "apps.osim",
+            ]
+        },
         # Collectors loggers
         **{
             collector_name: {

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -763,6 +763,10 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin):
     #             self.embargoed = False
 
     @property
+    def bz_id(self):
+        return self.meta_attr.get("bz_id", None)
+
+    @property
     def api_url(self):
         """return osidb api url"""
         return f"/api/{OSIDB_API_VERSION}/{self.uuid}"


### PR DESCRIPTION
This pull request introduces PoC of Bugzilla flaw create and update functionality (plus some other minor changes). It is not yet integrated into OSIDB as it is just a PoC but it was successfully tested to create and update flaws. I am sending it on the review rather earlier so it is not so much stuff to look into and we can shape it soon enough. It is far from being complete as it does not handle some Bugzilla flaw attributes fully or at all. It can be tested in the OSIDB shell which something like

```
from osidb.models import Flaw
from apps.bbsync.save import BugzillaSaver

f = Flaw.objects.filter(cve_id__isnull=False).first()
bs = BugzillaSaver(f)
flaw = bs.create()
flaw.bz_id  # ID of newly created flaw in Bugzilla

f.title = "cool title"
bs = BugzillaSaver(f)
bs.save()
```

**Always switch to Bugzilla stage when testing write operations!**

Closes OSIDB-367