### PR TITLE
minor fix - Define default PGPASSWORD

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,8 +94,10 @@ services:
         POSTGRES_DB: osidb
         POSTGRES_USER: osidb_admin_user
         POSTGRES_PASSWORD: passw0rd
-        PGUSER: osidb_admin_user
+        # Default connection parameter values
         PGDATABASE: osidb
+        PGUSER: osidb_admin_user
+        PGPASSWORD: passw0rd
       volumes:
         - pg-data:/var/lib/postgresql/data
         - ${PWD}/etc/pg/postgresql.conf:/etc/postgresql/postgresql.conf:z


### PR DESCRIPTION
Define PGPASSWORD default value so the developers don't have to type it manually always.

Minor fix for OSIDB-170.