### PR TITLE
fix bug that Major Incident can be unset by unrelated BZ flag

### DIFF
--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -902,6 +902,8 @@ class FlawBugConvertor:
                     )
                 )
 
+        flaw.is_major_incident = False
+
         for flag in self.flags:
             flag_name = flag["name"]
             if flag_name not in self.FLAGS_META:
@@ -915,10 +917,11 @@ class FlawBugConvertor:
                 )
             )
 
-            flaw.is_major_incident = bool(
-                flag_name in ["hightouch", "hightouch-lite"]
-                and flag["status"] in ["?", "+"]
-            )
+            if flag_name in ["hightouch", "hightouch-lite"] and flag["status"] in [
+                "?",
+                "+",
+            ]:
+                flaw.is_major_incident = True
 
         return meta
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Treat collector failures due to already running collectors or due to
   waiting for dependencies as celery Retry exceptions.
 - OSIDB now uses publicly available images from docker.io (OSIDB-170)
+- fix bug that Major Incident can be unset by unrelated BZ flag (OSIDB-416)
 
 ### Added
 - support for CVE-less flaws (OSIDB-25)


### PR DESCRIPTION
The bogus convertor logic according to Bugzilla flag handling was just setting **is_major_incident** to either True or False on every Bugzilla flag processing which obviously wrong. We should only set it according to **hightouch** and **hightouch-lite** flags.