### PR TITLE
Prevent libpq from attempting GSSAPI authentication

### DIFF
--- a/config/settings_ci.py
+++ b/config/settings_ci.py
@@ -64,6 +64,8 @@ DATABASES = {
         "HOST": "postgres",
         "PORT": "5432",
         "ENGINE": "psqlextra.backend",
+        # prevent libpq from automatically trying to connect to the db via GSSAPI
+        "OPTIONS": {"gssencmode": "disable"},
     }
 }
 

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -64,7 +64,11 @@ DATABASES = {
         "HOST": "osidb-data",
         "PORT": "5432",
         "ENGINE": "psqlextra.backend",
-        "OPTIONS": {"sslmode": "require"},
+        "OPTIONS": {
+            "sslmode": "require",
+            # prevent libpq from automatically trying to connect to the db via GSSAPI
+            "gssencmode": "disable",
+        },
     }
 }
 

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -71,7 +71,11 @@ DATABASES = {
         "HOST": get_env("OSIDB_DB_HOST"),
         "PORT": get_env("OSIDB_DB_PORT", default="5432"),
         "ENGINE": "psqlextra.backend",
-        "OPTIONS": {"sslmode": "require"},
+        "OPTIONS": {
+            "sslmode": "require",
+            # prevent libpq from automatically trying to connect to the db via GSSAPI
+            "gssencmode": "disable",
+        },
     }
 }
 

--- a/config/settings_shell.py
+++ b/config/settings_shell.py
@@ -19,6 +19,10 @@ DATABASES = {
         "HOST": get_env("OSIDB_DB_HOST", default="localhost"),
         "PORT": get_env("OSIDB_DB_PORT", default="5432"),
         "ENGINE": "psqlextra.backend",
-        "OPTIONS": {"sslmode": "require"},
+        "OPTIONS": {
+            "sslmode": "require",
+            # prevent libpq from automatically trying to connect to the db via GSSAPI
+            "gssencmode": "disable",
+        },
     }
 }

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -71,7 +71,11 @@ DATABASES = {
         "HOST": get_env("OSIDB_DB_HOST"),
         "PORT": get_env("OSIDB_DB_PORT", default="5432"),
         "ENGINE": "psqlextra.backend",
-        "OPTIONS": {"sslmode": "require"},
+        "OPTIONS": {
+            "sslmode": "require",
+            # prevent libpq from automatically trying to connect to the db via GSSAPI
+            "gssencmode": "disable",
+        },
     }
 }
 


### PR DESCRIPTION
As it turns out, postgresql 12 introduced support for secure GSS
communication between libpq and pg over TCP/IP if libpq is compiled with
GSSAPI support through an option called gssencmode. This option, by
default, is set to "prefer", meaning that if libpq detects GSSAPI
credentials in the system it's running on, it will attempt to connect to
the database via encrypted GSSAPI connection.

Since we do not have GSSAPI connection properly set up between the OSIDB
service pod and the database pod, this will fail, always, leading to
wasted resources on every request to the database.

https://www.postgresql.org/docs/13/libpq-connect.html#LIBPQ-CONNECT-GSSENCMODE

Closes OSIDB-424