### PR TITLE
Improve memory footprint for flaw linking

### DIFF
--- a/apps/exploits/helpers.py
+++ b/apps/exploits/helpers.py
@@ -8,15 +8,21 @@ from osidb.models import Flaw
 def update_objects_with_flaws(exploit_objects):
     """
     Take a list of exploit like objects (Exploit or EPSS) which need to be linked with Flaw
-    objects. Make a one optimized query to the database instead of N queries (~180k for EPSS).
-    Create a link to Flaw object if it exists for the relevant CVE, otherwise set it to None.
+    objects. Create a link to Flaw object if it exists for the relevant CVE, otherwise set it to
+    None.
+
+    Optimizations:
+    * Make a one optimized query to the database instead of N queries (~180k for EPSS).
+    * Store just uuid (primary key) instead of whole object in the intermediate map, that saves
+      about 500 MB of RAM in case of EPSS and makes it faster
+    * Linking is done using 'flaw_id' instead of 'flaw' attribute, which accepts Flaw primary key
+      (uuid) instead of Flaw object
     """
     cves = set(exploit.cve for exploit in exploit_objects)
-    flaws = Flaw.objects.filter(cve_id__in=cves)
-    flaw_map = {flaw.cve_id: flaw for flaw in flaws}
-
+    flaws = Flaw.objects.filter(cve_id__in=cves).values("cve_id", "uuid")
+    flaw_map = {flaw["cve_id"]: flaw["uuid"] for flaw in flaws}
     for one_object in exploit_objects:
-        one_object.flaw = flaw_map.get(one_object.cve, None)
+        one_object.flaw_id = flaw_map.get(one_object.cve, None)
 
 
 def store_or_update_exploits(exploit_objects):


### PR DESCRIPTION
When EPSS objects are linked with flaws, intermediate map needs 500 MB of RAM. This change reduces memory footprint to ~1 MB.