### PR TITLE
fix incorrect errata collector design

### DIFF
--- a/collectors/errata/tasks.py
+++ b/collectors/errata/tasks.py
@@ -20,12 +20,17 @@ logger = get_task_logger(__name__)
 
 
 @collector(
-    # Execute this every 4 hours
-    crontab=crontab(hour="*/4"),
+    # execute this every 5 minutes
+    crontab=crontab(minute="*/5"),
     data_models=[Erratum],
+    depends_on=[
+        "collectors.bzimport.tasks.bztracker_collector",
+        # TODO Jiraffe is not a collector but should be
+        # "collectors.jiraffe.tasks.jiraffe_collector",
+    ],
 )
-def errata_tool_initial_sync(collector_obj) -> str:
-    """Initial sync for Errata Tool collector"""
+def errata_collector(collector_obj) -> str:
+    """Errata Tool collector"""
 
     logger.info(f"Fetching Errata from '{settings.ERRATA_TOOL_SERVER}'")
     start_time = timezone.now()
@@ -34,34 +39,7 @@ def errata_tool_initial_sync(collector_obj) -> str:
     if not collector_obj.is_complete:
         # Fetch all Errata that have CVEs from Errata Tool, since collector has never run.
         # This endpoint doesn't support searching for only errata updated after some date.
-        # This takes about 84 minutes, but the collector framework doesn't prevent duplicate runs.
-        # TODO: How do we check for an already-running task, and avoid starting a new one?
-        #  Should we also batch below into multiple independent Celery tasks?
-        #  Parallelization might help it run faster, it can also be refactored to be more efficient
-        # For now, just run initial sync every 4 hours. Older tasks should finish before next is started
-        # After first finishes, this task should become a no-op and periodic sync will take over
         erratum_id_name_pairs = get_all_errata()
-    else:
-        return f"The initial run of {collector_obj.name} already finished."
-
-    errata_tool_collector(collector_obj, erratum_id_name_pairs, start_time)
-    return f"The initial run of {collector_obj.name} finished with {len(erratum_id_name_pairs)} errata synced."
-
-
-@collector(
-    # Execute this every 5 minutes
-    crontab=crontab(minute="*/5"),
-    data_models=[Erratum],
-)
-def errata_tool_periodic_sync(collector_obj) -> str:
-    """Periodic sync for Errata Tool collector"""
-
-    logger.info(f"Fetching Errata from '{settings.ERRATA_TOOL_SERVER}'")
-    start_time = timezone.now()
-    set_acls_for_et_collector()
-
-    if not collector_obj.is_complete:
-        return f"The periodic run of {collector_obj.name} did not start because the initial run is not finished."
     else:
         # Fetch all errata changed after last collector start time, even errata with no CVEs we don't care about.
         # This endpoint doesn't support searching for only errata with CVEs, non-None security impact, etc.
@@ -70,7 +48,10 @@ def errata_tool_periodic_sync(collector_obj) -> str:
         )
 
     errata_tool_collector(collector_obj, erratum_id_name_pairs, start_time)
-    return f"The periodic run of {collector_obj.name} finished with {len(erratum_id_name_pairs)} errata synced."
+    return (
+        f"Collector {collector_obj.name} finished with {len(erratum_id_name_pairs)} "
+        f"errata synced and is updated until {start_time}."
+    )
 
 
 def errata_tool_collector(collector_obj, erratum_id_name_pairs, start_time) -> None:


### PR DESCRIPTION
errata collector was implemented as two independent collectors one for the initial sync and the other for the periodic one which however results in two independent CollectorMetadata instances and as a result the data completeness context was not shared between the two and based on this the periodic run never started to run after the initial one as it kept thinking that the initial has not run yet despite it actually has

Fixes OSIDB-433