### PR TITLE
remove obsoleted pghistory

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -41,7 +41,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
-    "pgconnection",
     "django.contrib.postgres",
     "psqlextra",
     "rest_framework",

--- a/config/settings.py
+++ b/config/settings.py
@@ -41,8 +41,6 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django_extensions",
-    "pghistory",
-    "pgtrigger",
     "pgconnection",
     "django.contrib.postgres",
     "psqlextra",
@@ -258,6 +256,3 @@ ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"
 
 # Execute once a day by default
 CISA_COLLECTOR_CRONTAB = crontab(minute=0, hour=1)
-
-# Do not reinstall pgtriggers during the migration step
-PGTRIGGER_INSTALL_ON_MIGRATE = False

--- a/requirements.in
+++ b/requirements.in
@@ -5,11 +5,11 @@ django
 django-auth-ldap
 django.contrib.postgres
 django-db
+django-pgconnection
 django-deprecate-fields
 django-extensions
 django-filter
 django-model-utils
-django-pghistory
 django-polymorphic
 django-postgres-extra
 djangorestframework

--- a/requirements.in
+++ b/requirements.in
@@ -5,7 +5,6 @@ django
 django-auth-ldap
 django.contrib.postgres
 django-db
-django-pgconnection
 django-deprecate-fields
 django-extensions
 django-filter

--- a/requirements.txt
+++ b/requirements.txt
@@ -181,8 +181,6 @@ django==3.2.15 \
     #   django-filter
     #   django-model-utils
     #   django-pgconnection
-    #   django-pghistory
-    #   django-pgtrigger
     #   django-polymorphic
     #   django-postgres-extra
     #   djangorestframework
@@ -214,17 +212,7 @@ django-model-utils==4.2.0 \
 django-pgconnection==1.0.2 \
     --hash=sha256:1c012e789cd65bee1d514de6a4b3f90c888e599c3c2be195e7bb3627923bb7f3 \
     --hash=sha256:51ea5943faaa4aa4a2f953586b925ecddec852b009c004ee0b5de93d5ae162f7
-    # via
-    #   django-pghistory
-    #   django-pgtrigger
-django-pghistory==1.2.1 \
-    --hash=sha256:5014cc21cad1615cb78948d614b2c94fca1f8433468a703108df26bfb39f24d4 \
-    --hash=sha256:7b5768096bb45348676d59994e1b50f80683be2b31cb374f15b5863a330c51ff
     # via -r requirements.in
-django-pgtrigger==2.4.0 \
-    --hash=sha256:4515739ade4e1889f86b8ea0ce6fd2be2ed144ed70fa213654935aac050ace8a \
-    --hash=sha256:c3bd10a987d0b05f30425bd48a2218fe0b7d97f440d5bbc4b486c5338527e829
-    # via django-pghistory
 django-polymorphic==3.0.0 \
     --hash=sha256:73b75eb44ea302bd32820f8661e469509d245ce7f7ff09cd2ad149e5c42034ff \
     --hash=sha256:9d886f19f031d26bb1391c055ed9be06fb226a04a4cec1842b372c58873b3caa

--- a/requirements.txt
+++ b/requirements.txt
@@ -180,7 +180,6 @@ django==3.2.15 \
     #   django-extensions
     #   django-filter
     #   django-model-utils
-    #   django-pgconnection
     #   django-polymorphic
     #   django-postgres-extra
     #   djangorestframework
@@ -208,10 +207,6 @@ django-filter==21.1 \
 django-model-utils==4.2.0 \
     --hash=sha256:a768a25c80514e0ad4e4a6f9c02c44498985f36c5dfdea47b5b1e8cf994beba6 \
     --hash=sha256:e7a95e102f9c9653427eadab980d5d59e1dea972913b9c9e01ac37f86bba0ddf
-    # via -r requirements.in
-django-pgconnection==1.0.2 \
-    --hash=sha256:1c012e789cd65bee1d514de6a4b3f90c888e599c3c2be195e7bb3627923bb7f3 \
-    --hash=sha256:51ea5943faaa4aa4a2f953586b925ecddec852b009c004ee0b5de93d5ae162f7
     # via -r requirements.in
 django-polymorphic==3.0.0 \
     --hash=sha256:73b75eb44ea302bd32820f8661e469509d245ce7f7ff09cd2ad149e5c42034ff \


### PR DESCRIPTION
and also the related pgtrigger in hope that it will kill the immortal trigger

depends on https://github.com/RedHatProductSecurity/osidb/pull/52 but first we need to do the release and one more pull request removing the old migrations (to keep n-1 compatibility) and only after that this can come