### PR TITLE
Add php-pear to package exclusion list

### DIFF
--- a/apps/exploits/constants.py
+++ b/apps/exploits/constants.py
@@ -34,6 +34,7 @@ NOT_INCLUSION_LIST_COMPONENTS = [
     "firefox",
     "thunderbird",
     "flash-plugin",
+    "php-pear",
 ]
 
 


### PR DESCRIPTION
"php-pear" package needs to be added to an exclusion list until better mechanism is created.