### PR TITLE
revert problematic tracker component regex refinement

### DIFF
--- a/collectors/tests/test_utils.py
+++ b/collectors/tests/test_utils.py
@@ -1,0 +1,60 @@
+import pytest
+
+from collectors.utils import tracker_parse_update_stream_component
+
+pytestmark = pytest.mark.unit
+
+
+class TestParseUpdateStreamComponent:
+    @pytest.mark.parametrize(
+        "title,stream,component",
+        [
+            ("component: [stream]", "stream", "component"),
+            ("component: random text [stream]", "stream", "component"),
+            ("CVE-123-123 component: random text [stream]", "stream", "component"),
+            (
+                "CVE-123-123,CVE-5-897976 component: random text [stream]",
+                "stream",
+                "component",
+            ),
+            ("CVE-123-123,... component: random text [stream]", "stream", "component"),
+            ("EMBARGOED component: random text [stream]", "stream", "component"),
+            (
+                "EMBARGOED CVE-123-123 component: text [stream]",
+                "stream",
+                "component",
+            ),
+            (
+                "EMBARGOED \tCVE-1-1 \n   component:   \t text    [stream]   ",
+                "stream",
+                "component",
+            ),
+            ("EMBARGOED ... component: random text [stream]", "stream", "component"),
+            (
+                "abc12:::3>12387/.*@#$~đĐ: random text [82sfłvø→{$~|#{]",
+                "82sfłvø→{$~|#{",
+                "abc12:::3>12387/.*@#$~đĐ",
+            ),
+            ("component: anotherone: something: [stream]", "stream", "component"),
+        ],
+    )
+    def test_correct(self, title, stream, component):
+        """
+        test parsing of update stream and component from a correct summary
+        """
+        assert (stream, component) == tracker_parse_update_stream_component(title)
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "component:[stream]",
+            "component:text [stream]",
+            "text [stream]",
+            "component: text",
+        ],
+    )
+    def test_incorrect(self, title):
+        """
+        test parsing of update stream and component from an incorrect summary
+        """
+        assert (None, None) == tracker_parse_update_stream_component(title)

--- a/collectors/utils.py
+++ b/collectors/utils.py
@@ -7,7 +7,7 @@ TRACKER_COMPONENT_UPDATE_STREAM_RE = re.compile(
     r"^(?:\s*EMBARGOED\s+)?"  # Embargoed keyword
     r"(?:CVE-[0-9]+-[0-9]+,?\s*)*"  # list of CVEs
     r"(?:\.+\s+)?"  # dots, when too many CVEs are present
-    r"(?P<component>[^:]+?):\s"  # PSComponent (might contain spaces or rhel module)
+    r"(?P<component>.+?):\s"  # PSComponent (might contain spaces or rhel module)
     r".*"  # text part summary
     r"\[(?P<stream>.*)\]\s*$",  # + PSUpdateStream in brackets
     re.VERBOSE,


### PR DESCRIPTION
an old merge request (228)
introduced a tracker component regex refinement with the following reasoning

    the component is exactly before the first colon (not any)
    I just encountered an exceptional tracker with

            component: something: text

    title which might cause us some troubles when parsing (greedy regex modifier +)

however it causes more troubles than good as it breaks parsing the title with RHEL modules or multiple components so let us just revert it back to SFM2 behavior and eventually deal with it if it is worthy

OSIDB-464