### PR TITLE
Prevent pgtrigger from recreating triggers

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -258,3 +258,6 @@ ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"
 
 # Execute once a day by default
 CISA_COLLECTOR_CRONTAB = crontab(minute=0, hour=1)
+
+# Do not reinstall pgtriggers during the migration step
+PGTRIGGER_INSTALL_ON_MIGRATE = False


### PR DESCRIPTION
In the version of pgtrigger used by OSIDB, the default way to install triggers is to call some function during the application of migrations, even if there are no migrations to apply.

This happens regardless of whether there's any actual pgtrigger left in the code, it's a pure SQL mechanism, this means that despite us having removed the pgtrigger code from the codebase and removed the relevant tables via a migration, the triggers kept getting recreated and causing issues unless we intervened manually and pruned them, this was particularly frustrating after unexpected pod restarts as that meant that the pod would be in a non-working state for several days without us noticing.

The feature is undocumented for our version of pgtrigger, but its implementation can be seen at
https://github.com/Opus10/django-pgtrigger/blob/2.4.0/pgtrigger/apps.py#L21

Closes OSIDB-429