### PR TITLE
Add reference to all CISA exploits

### DIFF
--- a/apps/exploits/migrations/0004_update_cisa_references.py
+++ b/apps/exploits/migrations/0004_update_cisa_references.py
@@ -1,0 +1,14 @@
+# Update references for all CISA exploits
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exploits', '0003_alter_epss_options'),
+    ]
+
+    operations = [
+        migrations.RunSQL("UPDATE exploits_exploit SET reference='https://www.cisa.gov/known-exploited-vulnerabilities-catalog' WHERE source='CISA'"),
+    ]

--- a/apps/exploits/tests/test_api.py
+++ b/apps/exploits/tests/test_api.py
@@ -77,19 +77,39 @@ class TestAPI(object):
         assert body["results"] == {
             "cves": {
                 "CVE-2222-0001": [
-                    {"date": "2222-01-01", "reference": "N/A", "source": "CISA"}
+                    {
+                        "date": "2222-01-01",
+                        "reference": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+                        "source": "CISA",
+                    }
                 ],
                 "CVE-2222-0002": [
-                    {"date": "2222-01-02", "reference": "N/A", "source": "CISA"}
+                    {
+                        "date": "2222-01-02",
+                        "reference": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+                        "source": "CISA",
+                    }
                 ],
                 "CVE-2222-0003": [
-                    {"date": "2222-01-03", "reference": "N/A", "source": "CISA"}
+                    {
+                        "date": "2222-01-03",
+                        "reference": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+                        "source": "CISA",
+                    }
                 ],
                 "CVE-2222-0004": [
-                    {"date": "2222-01-04", "reference": "N/A", "source": "CISA"}
+                    {
+                        "date": "2222-01-04",
+                        "reference": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+                        "source": "CISA",
+                    }
                 ],
                 "CVE-2222-0005": [
-                    {"date": "2222-01-05", "reference": "N/A", "source": "CISA"}
+                    {
+                        "date": "2222-01-05",
+                        "reference": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+                        "source": "CISA",
+                    }
                 ],
             },
             "page_size": 5,

--- a/collectors/exploits_cisa/tasks.py
+++ b/collectors/exploits_cisa/tasks.py
@@ -18,6 +18,7 @@ from collectors.framework.models import collector
 logger = get_task_logger(__name__)
 
 CISA_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+CISA_CATALOG_URL = "https://www.cisa.gov/known-exploited-vulnerabilities-catalog"
 
 
 def download():
@@ -37,7 +38,8 @@ def process_data(exploit_data):
             source=Exploit.ExploitSource.CISA,
             flaw=None,  # Preliminary set to None, make links later
             date=date,
-            reference="N/A",  # CISA does not provide exploit link or evidence
+            # CISA does not provide exploit link or evidence, so link to their catalog
+            reference=CISA_CATALOG_URL,
             # CISA claims that the exploit is used in the wild
             maturity_preliminary=Exploit.ExploitMaturity.H,
         )


### PR DESCRIPTION
Always provide exploit reference link. For CISA, who do not provide link, use generic link to CISA exploit catalog.

PSINSIGHTS-674