### PR TITLE
Separate community products check

### DIFF
--- a/apps/exploits/query_sets.py
+++ b/apps/exploits/query_sets.py
@@ -10,15 +10,23 @@ class AffectQuerySetExploitExtension(models.QuerySet):
     Additional Affect queries needed for exploit reports.
     """
 
-    def supported(self):
+    def not_community(self):
         """
-        Exclude all affects which Red Hat does not provide ANY security fixes regardless of the
-        flaw impact and affects where we do not particularly care if fix is provided, i.e.
-        community products.
+        Exclude all community products.
         """
         q = self
         q = q.exclude(ps_module__contains="epel")  # Remove EPEL
         q = q.exclude(ps_module__contains="fedora")  # Remove Fedora
+        return q
+
+    def supported(self):
+        """
+        Exclude all affects which Red Hat does not provide ANY security fixes regardless of the
+        flaw impact and affects where we do not particularly care if fix is provided, i.e.
+        community products and EOL products.
+        """
+        q = self
+        q = q.not_community()  # Remove community products
         # Remove products which are not supported anymore. This is a temporary workaround until
         # it is possible to check for products which are completely unsupported (no security fixed
         # ever)


### PR DESCRIPTION
This is helpful for specific queries which want to exclude community products but include all Red Hat products, even the ones which are not supported anymore.