### PR TITLE
implement complete Bugzilla groups handling in Bugzilla sync

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -145,6 +145,19 @@ class BugzillaQueryBuilder:
         # TODO needinfo and other flags
         # hightouch | hightouch-lite | nist_cvss_validation | requires_doc_text
 
+    # Bugzilla groups allowed to be set for Bugzilla Security Response product
+    # https://bugzilla.redhat.com/editproducts.cgi?action=edit&product=Security%20Response
+    # TODO should be ideally synced so they are kept up-to-date but let us start simple
+    ALLOWED_GROUPS = [
+        "cinco",
+        "private",
+        "qe_staff",
+        "redhat",
+        "secalert",
+        "secalert_entry",
+        "security",
+        "team ocp_embargoes",
+    ]
     EMBARGOED_GROUPS = ["qe_staff", "security"]
 
     def generate_groups(self):

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -160,6 +160,21 @@ class BugzillaQueryBuilder:
     ]
     EMBARGOED_GROUPS = ["qe_staff", "security"]
 
+    def _standardize_embargoed_groups(self, groups):
+        """
+        combine groups with default embargoed but make sure all
+        of them are allowed plus always remove redhat group
+
+        this serves as a safegourd ensuring that all embargoed flaws
+        have the embargoed groups and never the redhat group plus we
+        ignore groups which are not allowed to be assigned to flaws
+        in case anyone put them in the product definitions
+        """
+        return list(
+            ((set(groups) | set(self.EMBARGOED_GROUPS)) & set(self.ALLOWED_GROUPS))
+            - {"redhat"}
+        )
+
     def generate_groups(self):
         """
         generate query for Bugzilla groups
@@ -192,8 +207,7 @@ class BugzillaQueryBuilder:
                 ]
             )
 
-            # TODO standardize embargoed groups
-            groups = module_groups
+            groups = self._standardize_embargoed_groups(module_groups)
 
         # TODO we do not account for placeholder flaws
 

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -175,6 +175,15 @@ class BugzillaQueryBuilder:
             - {"redhat"}
         )
 
+    def _lists2diffs(self, new_list, old_list):
+        """
+        take the new and the old list and return
+        the differences to be added and removed
+        """
+        to_add = list(set(new_list) - set(old_list))
+        to_remove = list(set(old_list) - set(new_list))
+        return to_add, to_remove
+
     def generate_groups(self):
         """
         generate query for Bugzilla groups
@@ -218,8 +227,7 @@ class BugzillaQueryBuilder:
         # otherwise we provide the differences
         else:
             old_groups = json.loads(self.old_flaw.meta_attr.get("groups", "[]"))
-            # TODO generate the diffs for update query
-            add_groups, remove_groups = groups, old_groups
+            add_groups, remove_groups = self._lists2diffs(groups, old_groups)
             self._query["groups"] = {
                 "add": add_groups,
                 "remove": remove_groups,

--- a/apps/bbsync/tests/conftest.py
+++ b/apps/bbsync/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -6,6 +6,7 @@ from osidb.tests.factories import (
     AffectFactory,
     FlawCommentFactory,
     FlawFactory,
+    PsModuleFactory,
     TrackerFactory,
 )
 
@@ -22,6 +23,14 @@ class TestGenerateGroups:
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw)
         TrackerFactory(affects=[affect])
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_groups={
+                "embargoed": [
+                    "private",
+                ]
+            },
+        )
 
         bbq = BugzillaQueryBuilder(flaw)
         query = bbq.query
@@ -37,11 +46,21 @@ class TestGenerateGroups:
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw)
         TrackerFactory(affects=[affect])
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_groups={
+                "embargoed": [
+                    "private",
+                ]
+            },
+        )
 
         bbq = BugzillaQueryBuilder(flaw)
         query = bbq.query
 
         groups = query.get("groups", [])
+        assert len(groups) == 3
+        assert "private" in groups
         assert "qe_staff" in groups
         assert "security" in groups
 
@@ -51,11 +70,19 @@ class TestGenerateGroups:
         removes groups in BZ query
         """
         flaw = FlawFactory(
-            embargoed=True, meta_attr={"groups": ["qe_staff", "security"]}
+            embargoed=True, meta_attr={"groups": '["private", "qe_staff", "security"]'}
         )
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw)
         TrackerFactory(affects=[affect])
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_groups={
+                "embargoed": [
+                    "private",
+                ]
+            },
+        )
 
         new_flaw = Flaw.objects.first()
         new_flaw.embargoed = False
@@ -64,6 +91,51 @@ class TestGenerateGroups:
         query = bbq.query
 
         groups = query.get("groups", [])
+        assert not groups.get("add")
         remove = groups.get("remove", [])
+        assert len(remove) == 3
+        assert "private" in remove
         assert "qe_staff" in remove
         assert "security" in remove
+
+    def test_affect_change(self):
+        """
+        test that affect change is properly reflected
+        in added and removed groups in BZ query
+        """
+        flaw = FlawFactory(
+            embargoed=True, meta_attr={"groups": '["private", "qe_staff", "security"]'}
+        )
+        FlawCommentFactory(flaw=flaw)
+        affect1 = AffectFactory(flaw=flaw)
+        TrackerFactory(affects=[affect1])
+        PsModuleFactory(
+            name=affect1.ps_module,
+            bts_groups={
+                "embargoed": [
+                    "private",
+                ]
+            },
+        )
+
+        new_flaw = Flaw.objects.first()
+        # remove existing affect
+        new_flaw.affects.first().delete()
+        # and add a newly created affect
+        affect2 = AffectFactory(flaw=new_flaw)
+        TrackerFactory(affects=[affect2])
+        PsModuleFactory(
+            name=affect2.ps_module,
+            bts_groups={
+                "embargoed": [
+                    "secalert",
+                ]
+            },
+        )
+
+        bbq = BugzillaQueryBuilder(new_flaw, old_flaw=flaw)
+        query = bbq.query
+
+        groups = query.get("groups", [])
+        assert ["secalert"] == groups.get("add", [])
+        assert ["private"] == groups.get("remove", [])

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -64,6 +64,30 @@ class TestGenerateGroups:
         assert "qe_staff" in groups
         assert "security" in groups
 
+    def test_create_embargoed_no_redhat(self):
+        """
+        test that when creating an embargoed flaw
+        the redhat group is never being added
+        """
+        flaw = FlawFactory(embargoed=True)
+        FlawCommentFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw)
+        TrackerFactory(affects=[affect])
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_groups={
+                "embargoed": [
+                    "redhat",
+                ]
+            },
+        )
+
+        bbq = BugzillaQueryBuilder(flaw)
+        query = bbq.query
+
+        groups = query.get("groups", [])
+        assert "redhat" not in groups
+
     def test_unembargo(self):
         """
         test that unembargoeing flaw

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -1,0 +1,69 @@
+import pytest
+
+from apps.bbsync.query import BugzillaQueryBuilder
+from osidb.models import Flaw
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawCommentFactory,
+    FlawFactory,
+    TrackerFactory,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestGenerateGroups:
+    def test_create_public(self):
+        """
+        test that when creating a public flaw
+        there are no or empty groups in BZ query
+        """
+        flaw = FlawFactory(embargoed=False)
+        FlawCommentFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw)
+        TrackerFactory(affects=[affect])
+
+        bbq = BugzillaQueryBuilder(flaw)
+        query = bbq.query
+
+        assert not query.get("groups", [])
+
+    def test_create_embargoed(self):
+        """
+        test that when creating an embargoed flaw
+        there are expected groups in BZ query
+        """
+        flaw = FlawFactory(embargoed=True)
+        FlawCommentFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw)
+        TrackerFactory(affects=[affect])
+
+        bbq = BugzillaQueryBuilder(flaw)
+        query = bbq.query
+
+        groups = query.get("groups", [])
+        assert "qe_staff" in groups
+        assert "security" in groups
+
+    def test_unembargo(self):
+        """
+        test that unembargoeing flaw
+        removes groups in BZ query
+        """
+        flaw = FlawFactory(
+            embargoed=True, meta_attr={"groups": ["qe_staff", "security"]}
+        )
+        FlawCommentFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw)
+        TrackerFactory(affects=[affect])
+
+        new_flaw = Flaw.objects.first()
+        new_flaw.embargoed = False
+
+        bbq = BugzillaQueryBuilder(new_flaw, old_flaw=flaw)
+        query = bbq.query
+
+        groups = query.get("groups", [])
+        remove = groups.get("remove", [])
+        assert "qe_staff" in remove
+        assert "security" in remove

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -1,6 +1,7 @@
 """
 transform Bugzilla flaw bug into OSIDB flaw model
 """
+import json
 import logging
 import re
 from collections import defaultdict
@@ -651,6 +652,7 @@ class FlawBugConvertor:
         meta_attr["last_imported_dt"] = timezone.now()
         meta_attr["acl_labels"] = self.groups
         meta_attr["task_owner"] = self.task_owner
+        meta_attr["groups"] = json.dumps(self.flaw_bug.get("groups", []))
         return meta_attr
 
     def get_nvd_cvss2(self, cve_id):

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -80,12 +80,29 @@ class FlawFactory(factory.django.DjangoModelFactory):
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
-        """instance creation"""
+        """
+        instance creation
+        with saving to DB
+        """
         # embargoed is not a real model attribute but annotation so it is read-only
         # but we want preserve it as writable factory attribute as it is easier to work with
         # than with ACLs so we need to remove it for the flaw creation and emulate annotation
         embargoed = kwargs.pop("embargoed")
         flaw = super()._create(model_class, *args, **kwargs)
+        flaw.embargoed = embargoed
+        return flaw
+
+    @classmethod
+    def _build(cls, model_class, *args, **kwargs):
+        """
+        instance build
+        without saving to DB
+        """
+        # embargoed is not a real model attribute but annotation so it is read-only
+        # but we want preserve it as writable factory attribute as it is easier to work with
+        # than with ACLs so we need to remove it for the flaw creation and emulate annotation
+        embargoed = kwargs.pop("embargoed")
+        flaw = super()._build(model_class, *args, **kwargs)
         flaw.embargoed = embargoed
         return flaw
 


### PR DESCRIPTION
This pull request extends the bzimport and BBSync groups handling. First it extends the collector to store the Bugzilla groups so OSIDB knows the current state. Then it extends the BugzillaQueryBuilder so it so it accounts for the embargo configuration in product definitions and generate the appropriate query according to possible affectedness changes. It also implements unit tests for the group related query generation logic.

There are two TODOs left. First the allowed Bugzilla flaw groups are not being synced now and just hardcoded. It would require a new collector otherwise and I am not sure it is worthy. Second we do not account for placeholder flaws with respect to the correct Bugzilla group setting. The agreement now is that we will set placeholder flaws as non-editable but it is a matter of a different task.

Closes OSIDB-387