### PR TITLE
support (CISA) Major Incident label in tracker description (OSIDB-579)

### DIFF
--- a/collectors/tests/test_utils.py
+++ b/collectors/tests/test_utils.py
@@ -36,6 +36,16 @@ class TestParseUpdateStreamComponent:
                 "abc12:::3>12387/.*@#$~đĐ",
             ),
             ("component: anotherone: something: [stream]", "stream", "component"),
+            (
+                "[Major Incident] CVE-2222-1111 component: text [stream]",
+                "stream",
+                "component",
+            ),
+            (
+                "[CISA Major Incident] CVE-2222-1111 component: another: text [stream]",
+                "stream",
+                "component",
+            ),
         ],
     )
     def test_correct(self, title, stream, component):

--- a/collectors/utils.py
+++ b/collectors/utils.py
@@ -5,6 +5,7 @@ from osidb.models import PsUpdateStream
 
 TRACKER_COMPONENT_UPDATE_STREAM_RE = re.compile(
     r"^(?:\s*EMBARGOED\s+)?"  # Embargoed keyword
+    r"(?:\[(?:CISA\s)?Major\sIncident\]\s+)?"  # Major Incident
     r"(?:CVE-[0-9]+-[0-9]+,?\s*)*"  # list of CVEs
     r"(?:\.+\s+)?"  # dots, when too many CVEs are present
     r"(?P<component>.+?):\s"  # PSComponent (might contain spaces or rhel module)


### PR DESCRIPTION
was recently added to SFM2 but not OSIDB which causes tracker linking issues https://git.prodsec.redhat.com/devops/sfm2/-/blob/master/sfm2/helpers.py#L91

closing OSIDB-579