### PR TITLE
Add Global CA certificate for AWS RDS database connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,11 @@ ARG RH_CERT_URL=""
 COPY ./scripts /opt/app-root/src/scripts
 RUN ./scripts/install-certs.sh $RH_CERT_URL
 
+# Download and install AWS RDS cert chain in order to connect to the DB via SSL
+RUN curl "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
+    -o /etc/pki/ca-trust/source/anchors/aws-rds.pem && \
+    update-ca-trust
+
 # install dependencies and security updates
 RUN dnf --nodocs --setopt install_weak_deps=false -y install \
         cargo \


### PR DESCRIPTION
This is a required change in order to migrate from a self-hosted PostgreSQL instance to AWS RDS while still keeping Encryption-in-Transit active.

The certificate is downloaded and installed per the instructions at https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html