### PR TITLE
validate reported date

### DIFF
--- a/apps/osim/tests/test_models.py
+++ b/apps/osim/tests/test_models.py
@@ -64,7 +64,7 @@ class CheckDescFactory:
         ("has cwe", "cwe_id", ""),
         ("has unembargo_dt", "unembargo_dt", None),
         ("has source", "source", ""),
-        ("has reported_dt", "reported_dt", None),
+        # ("has reported_dt", "reported_dt", None),
         ("has cvss2", "cvss2", ""),
         ("has cvss2_score", "cvss2_score", None),
         ("has cvss3", "cvss3", ""),

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -716,6 +716,13 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin):
                     f"Flaw is embargoed but contains public source: {self.source}"
                 )
 
+    def _validate_reported_date(self):
+        """
+        Checks that the flaw has non-empty reported_dt
+        """
+        if self.reported_dt is None:
+            raise ValidationError("Flaw has an empty reported_dt")
+
     # TODO this needs to be refactored
     # but it makes sense only when we are capable of write actions
     # and we may thus actually do some changes to the embargo

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -36,6 +36,7 @@ class FlawFactory(factory.django.DjangoModelFactory):
     cve_id = factory.sequence(lambda n: f"CVE-2020-000{n}")
     type = factory.Faker("random_element", elements=list(FlawType))
     created_dt = factory.Faker("date_time", tzinfo=UTC)
+    reported_dt = factory.Faker("date_time", tzinfo=UTC)
     state = factory.Faker("random_element", elements=list(Flaw.FlawState))
     resolution = factory.Faker("random_element", elements=list(FlawResolution))
     impact = factory.Faker("random_element", elements=list(FlawImpact))

--- a/osidb/tests/test_embargo.py
+++ b/osidb/tests/test_embargo.py
@@ -1,4 +1,5 @@
 import pytest
+from django.utils import timezone
 
 from osidb.models import Flaw
 
@@ -28,6 +29,7 @@ class TestEmbargo(object):
             impact="LOW",
             title="test",
             description="test",
+            reported_dt=timezone.now(),
         )
         flaw.save()
         flaw = Flaw.objects.get(cve_id="CVE-2000-11111")
@@ -47,6 +49,7 @@ class TestEmbargo(object):
                 title="test",
                 description="test",
                 embargoed=embargoed,
+                reported_dt=timezone.now(),
             )
             flaw.save()
         assert "Flaw() got an unexpected keyword argument 'embargoed'" in str(ex)

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1009,6 +1009,7 @@ class TestEndpoints(object):
             "state": "NEW",
             "impact": "CRITICAL",
             "description": "test",
+            "reported_dt": "2022-11-22T15:55:22.830Z",
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201
@@ -1030,6 +1031,7 @@ class TestEndpoints(object):
             "state": "NEW",
             "impact": "CRITICAL",
             "description": "test",
+            "reported_dt": "2022-11-22T15:55:22.830Z",
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -725,3 +725,19 @@ class TestFlawValidators:
         else:
             affect = AffectFactory(flaw=flaw, ps_module=ps_module)
             assert affect
+
+    def test_validate_reported_date_empty(self):
+        """
+        test that the ValidationError is raised when the flaw has an empty reported_dt
+        """
+        with pytest.raises(ValidationError) as e:
+            FlawFactory(reported_dt=None)
+        assert "Flaw has an empty reported_dt" in str(e)
+
+    def test_validate_reported_date_non_empty(self):
+        """
+        test that the ValidationError is not raised when the flaw the reported_dt provided
+        """
+        # whenever we save the flaw which the factory does automatically the validations are run
+        # and if there is an exception the test will fail so creating the flaw is enough to test it
+        FlawFactory()

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -48,6 +48,7 @@ class TestFlaw:
             cve_id=good_cve_id,
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
+            reported_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -137,6 +138,7 @@ class TestFlaw:
             cve_id="CVE-1970-12345",
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
+            reported_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -165,6 +167,7 @@ class TestFlaw:
             description="description",
             acl_read=acls,
             acl_write=acls,
+            reported_dt=timezone.now(),
         ).save()
         assert Flaw.objects.count() == 1
         assert Flaw.objects.first().meta_attr["bz_id"] == "12345"
@@ -174,6 +177,7 @@ class TestFlaw:
             description="description",
             acl_read=acls,
             acl_write=acls,
+            reported_dt=timezone.now(),
         ).save()
         # no new flaw should be created
         assert Flaw.objects.count() == 1
@@ -277,6 +281,7 @@ class TestFlaw:
             cve_id=good_cve_id,
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
+            reported_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -304,6 +309,7 @@ class TestFlaw:
             cve_id="CVE-1970-12345",
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
+            reported_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -330,6 +336,7 @@ class TestFlaw:
             cve_id=good_cve_id,
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
+            reported_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -1,6 +1,7 @@
 import uuid
 
 import pytest
+from django.utils import timezone
 from freezegun import freeze_time
 
 from collectors.bzimport.convertors import FlawBugConvertor
@@ -27,6 +28,7 @@ class TestTrackingMixin:
             description="description",
             acl_read=acls,
             acl_write=acls,
+            reported_dt=timezone.now(),
             **kwargs,
         )
 

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -69,6 +69,7 @@ class TestSearch:
             cve_id=good_cve_id,
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
+            reported_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="TITLE",
             description="DESCRIPTION",


### PR DESCRIPTION
This PR closes OSIDB-332. The reported date validation has two parts. One is that it cannot be set in the future. This one is already present in OSIDB. It is not done by the validation framework but a simple strict Django validation but it seems to cause no issues (no collector data are restricted by it) so we can leave it as it is. One is that reported date (reported_dt attribute) should not be empty. The second is what this PR introduces.

Also the FlawFactory was extended with this attribute (was missing for some reason) and a number of old tests creating flaws with empty reported date has to be adjusted to comply with the new validation.