### PR TITLE
Ensure that the deprecated mitaged_by field always returns a string

### DIFF
--- a/osidb/models.py
+++ b/osidb/models.py
@@ -604,7 +604,9 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin):
 
     # , from srtnotes "mitigate"
     mitigated_by = deprecate_field(
-        models.CharField(choices=FlawMitigate.choices, max_length=10, blank=True)
+        models.CharField(choices=FlawMitigate.choices, max_length=10, blank=True),
+        # required to keep backwards compatibility
+        return_instead="",
     )
 
     # , from srtnotes "cvss2"


### PR DESCRIPTION
This field had been returning null ever since 2.3.0 which is API breakage.

Closes OSIDB-614