### PR TITLE
Validate public date

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 159,
+        "line_number": 160,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2022-10-05T14:34:39Z"
+  "generated_at": "2022-11-28T12:12:05Z"
 }

--- a/apps/osim/tests/test_models.py
+++ b/apps/osim/tests/test_models.py
@@ -62,7 +62,6 @@ class CheckDescFactory:
         ("has summary", "summary", ""),
         ("has statement", "statement", ""),
         ("has cwe", "cwe_id", ""),
-        ("has unembargo_dt", "unembargo_dt", None),
         ("has source", "source", ""),
         # ("has reported_dt", "reported_dt", None),
         ("has cvss2", "cvss2", ""),

--- a/apps/osim/tests/test_models.py
+++ b/apps/osim/tests/test_models.py
@@ -211,9 +211,9 @@ class TestCheck:
     @pytest.mark.parametrize("cathegory", ["property", "not_property", "has_property"])
     def test_all_properties_positive(self, cathegory):
         """test all positive properties"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         requirements, flaw_properties = CheckDescFactory.generate(
-            cathegory=cathegory,
-            accepts=True,
+            cathegory=cathegory, accepts=True, exclude=flaw_properties
         )
         flaw = FlawFactory(**flaw_properties)
 
@@ -226,9 +226,9 @@ class TestCheck:
     @pytest.mark.parametrize("cathegory", ["property", "not_property", "has_property"])
     def test_all_properties_negative(self, cathegory):
         """test all negative properties"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         requirements, flaw_properties = CheckDescFactory.generate(
-            cathegory=cathegory,
-            accepts=False,
+            cathegory=cathegory, accepts=False, exclude=flaw_properties
         )
         flaw = FlawFactory(**flaw_properties)
 
@@ -254,8 +254,9 @@ class TestState:
     @pytest.mark.parametrize("count", [1, 2, 3, 4, 5])
     def test_satisfied_requirements(self, count):
         """test that a state accepts a flaw which satisfies its requirements"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         requirements, flaw_properties = CheckDescFactory.generate(
-            accepts=True, count=count
+            accepts=True, count=count, exclude=flaw_properties
         )
         state = State(
             {
@@ -275,8 +276,9 @@ class TestState:
     )
     def test_unsatisfied_requirements(self, positive, negative):
         """test that a state rejects a flaw which does not satisfy its requirements"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         positive_requirements, flaw_properties = CheckDescFactory.generate(
-            accepts=True, count=positive
+            accepts=True, count=positive, exclude=flaw_properties
         )
         negative_requirements, flaw_properties = CheckDescFactory.generate(
             accepts=False, count=negative, exclude=flaw_properties
@@ -315,8 +317,9 @@ class TestWorkflow:
     @pytest.mark.parametrize("count", [1, 2, 3, 4, 5])
     def test_satisfied_conditions(self, count):
         """test that a workflow accepts a flaw which satisfies its conditions"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         conditions, flaw_properties = CheckDescFactory.generate(
-            accepts=True, count=count
+            accepts=True, count=count, exclude=flaw_properties
         )
         workflow = Workflow(
             {
@@ -339,8 +342,9 @@ class TestWorkflow:
     )
     def test_unsatisfied_conditions(self, positive, negative):
         """test that a workflow rejects a flaw which does not satisfy its conditions"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         positive_conditions, flaw_properties = CheckDescFactory.generate(
-            accepts=True, count=positive
+            accepts=True, count=positive, exclude=flaw_properties
         )
         negative_conditions, flaw_properties = CheckDescFactory.generate(
             accepts=False, count=negative, exclude=flaw_properties
@@ -366,9 +370,10 @@ class TestWorkflow:
     @pytest.mark.parametrize("count1,count2", [(1, 1), (2, 2), (3, 1), (1, 4)])
     def test_classify(self, count1, count2):
         """test that a flaw is correctly classified in the workflow states"""
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
         state_factory = StateFactory()
         accepting_states, flaw_properties = state_factory.generate(
-            accepts=True, count=count1
+            accepts=True, count=count1, exclude=flaw_properties
         )
         rejecting_states, flaw_properties = state_factory.generate(
             accepts=False, count=1, exclude=flaw_properties
@@ -554,7 +559,7 @@ class TestWorkflowFramework:
         """test flaw classification in both workflow and state"""
         workflow_framework = WorkflowFramework()
 
-        flaw_properties = {}
+        flaw_properties = {"unembargo_dt": None, "embargoed": None}
 
         for name, priority, accepting, accepting_states in workflows:
             workflow = Workflow(

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -735,6 +735,19 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin):
             if self.unembargo_dt > timezone.now():
                 raise ValidationError("Public flaw has a future unembargo_dt")
 
+    def _validate_future_unembargo_date(self):
+        """
+        Check that an enbargoed flaw has an unembargo date in the future
+        """
+        if (
+            self.is_embargoed
+            and self.unembargo_dt is not None
+            and self.unembargo_dt < timezone.now()
+        ):
+            raise ValidationError(
+                "Flaw still embargoed but unembargo date is in the past."
+            )
+
     # TODO this needs to be refactored
     # but it makes sense only when we are capable of write actions
     # and we may thus actually do some changes to the embargo

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -44,6 +44,11 @@ class FlawFactory(factory.django.DjangoModelFactory):
     description = factory.LazyAttribute(lambda c: f"Description for {c.cve_id}")
     statement = factory.LazyAttribute(lambda c: f"Statement for {c.cve_id}")
     embargoed = factory.Faker("random_element", elements=[False, True])
+    unembargo_dt = factory.Maybe(
+        "embargoed",
+        yes_declaration=factory.Faker("future_datetime", tzinfo=UTC),
+        no_declaration=factory.Faker("past_datetime", tzinfo=UTC),
+    )
     # cannot be set to ("random_element", elements=list(FlawSource)) because it could
     # inadvertently trigger validation errors in unrelated tests.
     source = ""

--- a/osidb/tests/test_embargo.py
+++ b/osidb/tests/test_embargo.py
@@ -30,6 +30,7 @@ class TestEmbargo(object):
             title="test",
             description="test",
             reported_dt=timezone.now(),
+            unembargo_dt=timezone.now(),
         )
         flaw.save()
         flaw = Flaw.objects.get(cve_id="CVE-2000-11111")

--- a/osidb/tests/test_embargo.py
+++ b/osidb/tests/test_embargo.py
@@ -1,5 +1,6 @@
 import pytest
 from django.utils import timezone
+from freezegun import freeze_time
 
 from osidb.models import Flaw
 
@@ -17,8 +18,18 @@ class TestEmbargo(object):
         assert flaw.acl_read == embargoed_groups
 
     @pytest.mark.parametrize("embargoed", [False, True])
+    @freeze_time(timezone.datetime(2022, 11, 25))
     def test_embargoed_annotation(self, embargoed_groups, public_groups, embargoed):
-        groups = embargoed_groups if embargoed else public_groups
+        if embargoed:
+            groups = embargoed_groups
+            unembargo_dt = timezone.datetime(
+                2022, 12, 26, tzinfo=timezone.get_current_timezone()
+            )
+        else:
+            groups = public_groups
+            unembargo_dt = timezone.datetime(
+                2022, 11, 24, tzinfo=timezone.get_current_timezone()
+            )
         flaw = Flaw(
             acl_read=groups,
             acl_write=groups,
@@ -30,7 +41,7 @@ class TestEmbargo(object):
             title="test",
             description="test",
             reported_dt=timezone.now(),
-            unembargo_dt=timezone.now(),
+            unembargo_dt=unembargo_dt,
         )
         flaw.save()
         flaw = Flaw.objects.get(cve_id="CVE-2000-11111")

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1010,6 +1010,7 @@ class TestEndpoints(object):
             "impact": "CRITICAL",
             "description": "test",
             "reported_dt": "2022-11-22T15:55:22.830Z",
+            "unembargo_dt": "2000-1-1T22:03:26.065Z",
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201
@@ -1032,6 +1033,7 @@ class TestEndpoints(object):
             "impact": "CRITICAL",
             "description": "test",
             "reported_dt": "2022-11-22T15:55:22.830Z",
+            "unembargo_dt": "2000-1-1T22:03:26.065Z",
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -49,6 +49,7 @@ class TestFlaw:
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
             reported_dt=datetime_with_tz,
+            unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -139,6 +140,7 @@ class TestFlaw:
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
             reported_dt=datetime_with_tz,
+            unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -164,6 +166,7 @@ class TestFlaw:
         Flaw.objects.create_flaw(
             bz_id="12345",
             title="first",
+            unembargo_dt=tzdatetime(2000, 1, 1),
             description="description",
             acl_read=acls,
             acl_write=acls,
@@ -282,6 +285,7 @@ class TestFlaw:
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
             reported_dt=datetime_with_tz,
+            unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -310,6 +314,7 @@ class TestFlaw:
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
             reported_dt=datetime_with_tz,
+            unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -337,6 +342,7 @@ class TestFlaw:
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
             reported_dt=datetime_with_tz,
+            unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
@@ -748,3 +754,22 @@ class TestFlawValidators:
         # whenever we save the flaw which the factory does automatically the validations are run
         # and if there is an exception the test will fail so creating the flaw is enough to test it
         FlawFactory()
+
+    @pytest.mark.parametrize(
+        "embargoed,unembargo_date,error_str",
+        [
+            (False, None, "Public flaw has an empty unembargo_dt"),
+            (False, tzdatetime(2022, 11, 22), "Public flaw has a future unembargo_dt"),
+            (False, tzdatetime(2021, 11, 22), None),
+            (True, None, None),
+            (True, tzdatetime(2021, 11, 22), None),
+        ],
+    )
+    @freeze_time(tzdatetime(2021, 11, 23))
+    def test_validate_public_unembargo_date(self, embargoed, unembargo_date, error_str):
+        if error_str:
+            with pytest.raises(ValidationError) as e:
+                FlawFactory(unembargo_dt=unembargo_date, embargoed=embargoed)
+            assert error_str in str(e)
+        else:
+            assert FlawFactory(unembargo_dt=unembargo_date, embargoed=embargoed)

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -762,7 +762,11 @@ class TestFlawValidators:
             (False, tzdatetime(2022, 11, 22), "Public flaw has a future unembargo_dt"),
             (False, tzdatetime(2021, 11, 22), None),
             (True, None, None),
-            (True, tzdatetime(2021, 11, 22), None),
+            (
+                True,
+                tzdatetime(2021, 11, 22),
+                "Flaw still embargoed but unembargo date is in the past.",
+            ),
         ],
     )
     @freeze_time(tzdatetime(2021, 11, 23))
@@ -773,3 +777,17 @@ class TestFlawValidators:
             assert error_str in str(e)
         else:
             assert FlawFactory(unembargo_dt=unembargo_date, embargoed=embargoed)
+
+    @freeze_time(tzdatetime(2021, 11, 23))
+    def test_validate_future_unembargo_date(self):
+        """test that unembargo_dt is in future for embargoed flaws"""
+        past_dt = tzdatetime(2021, 11, 18)
+        future_dt = tzdatetime(2021, 11, 27)
+
+        with pytest.raises(ValidationError) as e:
+            FlawFactory(unembargo_dt=past_dt, embargoed=True)
+        assert "Flaw still embargoed but unembargo date is in the past." in str(e)
+
+        with freeze_time(future_dt):
+            FlawFactory(unembargo_dt=future_dt, embargoed=True)
+            # no exception should be raised now

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -126,7 +126,7 @@ class TestTrackingMixin:
         test conflicting model changes
         saving an outdated model instance should fail
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(embargoed=False)
         flaw_copy = Flaw.objects.first()
 
         with freeze_time(tzdatetime(2023, 12, 24)):

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -29,6 +29,7 @@ class TestTrackingMixin:
             acl_read=acls,
             acl_write=acls,
             reported_dt=timezone.now(),
+            unembargo_dt=tzdatetime(2000, 1, 1),
             **kwargs,
         )
 

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -70,6 +70,7 @@ class TestSearch:
             state=Flaw.FlawState.NEW,
             created_dt=datetime_with_tz,
             reported_dt=datetime_with_tz,
+            unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
             title="TITLE",
             description="DESCRIPTION",


### PR DESCRIPTION
This PR validate the if all public Flaws created have an unembargo date closing both OSIDB-344 and OSIDB-345.

To achieve it was create a new model validator and the FlawFactory was extended with `unembargo_dt` attribute and old tests that creates public flaws was edited to support this validation.