### PR TITLE
basic SRT notes builder for BBSync

### DIFF
--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -653,6 +653,8 @@ class FlawBugConvertor:
         meta_attr["acl_labels"] = self.groups
         meta_attr["task_owner"] = self.task_owner
         meta_attr["groups"] = json.dumps(self.flaw_bug.get("groups", []))
+        # store the original SRT notes string as meta attributes tamper the JSON
+        meta_attr["original_srtnotes"] = self.flaw_bug["cf_srtnotes"]
         return meta_attr
 
     def get_nvd_cvss2(self, cve_id):

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -147,6 +147,7 @@ class TestTrackingMixin:
             "depends_on": [],
             "creation_time": tzdatetime(2020, 12, 24),
             "last_change_time": tzdatetime(2021, 12, 24),
+            "cf_srtnotes": "",
         }
 
     def get_flaw_bug_convertor(self):


### PR DESCRIPTION
this is the first part of BBSync SRT notes builder for now only closing OSIDB-385 so it stores the original SRT notes on the flaw sync and then restores them on the backwards sync

the more complicated logic will come later