### PR TITLE
Setup logging to filesystem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN dnf --nodocs --setopt install_weak_deps=false -y install \
         krb5-devel \
         krb5-workstation \
         libffi-devel \
+        logrotate \
         make \
         openldap-devel \
         openssl-devel \

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -118,3 +118,34 @@ ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"
 
 # Execute once an hour in production
 CISA_COLLECTOR_CRONTAB = crontab(minute=0)
+
+# Setup rotation logging into filesystem
+LOG_FILE_SIZE = 1024 * 1024 * 10  # 10mb
+LOG_FILE_COUNT = 3
+
+# To not disrupt the logging of OSIDB instance running in PSI
+# this guard ensures that only OSIDB running in MPP logs to filesystem
+# TODO: Remove after OSIDB is fully migrated to MPP
+if get_env("MPP", is_bool=True, default="False"):
+    LOGGING.update(
+        {
+            "handlers": {
+                "celery": {
+                    "level": "WARNING",
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "formatter": "verbose_celery",
+                    "filename": "/var/log/prod-celery.log",
+                    "maxBytes": LOG_FILE_SIZE,
+                    "backupCount": LOG_FILE_COUNT,
+                },
+                "console": {
+                    "level": "WARNING",
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "formatter": "verbose",
+                    "filename": "/var/log/prod-django.log",
+                    "maxBytes": LOG_FILE_SIZE,
+                    "backupCount": LOG_FILE_COUNT,
+                },
+            }
+        }
+    )

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -115,3 +115,34 @@ KRB5_HOSTNAME = get_env("KRB5_HOSTNAME")
 
 # Execute once an hour in stage to be consistent with production
 CISA_COLLECTOR_CRONTAB = crontab(minute=0)
+
+# Setup rotation logging into filesystem
+LOG_FILE_SIZE = 1024 * 1024 * 10  # 10mb
+LOG_FILE_COUNT = 3
+
+# To not disrupt the logging of OSIDB instance running in PSI
+# this guard ensures that only OSIDB running in MPP logs to filesystem
+# TODO: Remove after OSIDB is fully migrated to MPP
+if get_env("MPP", is_bool=True, default="False"):
+    LOGGING.update(
+        {
+            "handlers": {
+                "celery": {
+                    "level": "WARNING",
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "formatter": "verbose_celery",
+                    "filename": "/var/log/stage-celery.log",
+                    "maxBytes": LOG_FILE_SIZE,
+                    "backupCount": LOG_FILE_COUNT,
+                },
+                "console": {
+                    "level": "WARNING",
+                    "class": "logging.handlers.RotatingFileHandler",
+                    "formatter": "verbose",
+                    "filename": "/var/log/stage-django.log",
+                    "maxBytes": LOG_FILE_SIZE,
+                    "backupCount": LOG_FILE_COUNT,
+                },
+            }
+        }
+    )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Change logging of celery and django to filesystem (OSIDB-418)
+
 ## [2.3.2] - 2022-11-28
 ### Changed
 - Catch tracker sync exceptions individually (OSIDB-580)


### PR DESCRIPTION
Setup django and celery to log to filesystem on stage and production. Logging uses logrotation so we should not run out of space. Also added `logrotate` as dependency in `Dockerfile` for OSIDB image build since we need that for Flower.

Flower and redis logging to filesystem will be done in a k8s and templates in ops repository.



This PR partially addresses OSIDB-418.