### PR TITLE
Add validations for flaw title

### DIFF
--- a/apps/osim/tests/test_models.py
+++ b/apps/osim/tests/test_models.py
@@ -185,6 +185,7 @@ class TestCheck:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         requirements, flaw_properties = CheckDescFactory.generate(
             cathegory=cathegory, accepts=True, count=1, exclude=flaw_properties
@@ -203,6 +204,7 @@ class TestCheck:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         requirements, flaw_properties = CheckDescFactory.generate(
             cathegory=cathegory,
@@ -224,6 +226,7 @@ class TestCheck:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         requirements, flaw_properties = CheckDescFactory.generate(
             cathegory=cathegory, accepts=True, exclude=flaw_properties
@@ -243,6 +246,7 @@ class TestCheck:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         requirements, flaw_properties = CheckDescFactory.generate(
             cathegory=cathegory, accepts=False, exclude=flaw_properties
@@ -275,6 +279,7 @@ class TestState:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         requirements, flaw_properties = CheckDescFactory.generate(
             accepts=True, count=count, exclude=flaw_properties
@@ -301,6 +306,7 @@ class TestState:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         positive_requirements, flaw_properties = CheckDescFactory.generate(
             accepts=True, count=positive, exclude=flaw_properties
@@ -346,6 +352,7 @@ class TestWorkflow:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         conditions, flaw_properties = CheckDescFactory.generate(
             accepts=True, count=count, exclude=flaw_properties
@@ -375,6 +382,7 @@ class TestWorkflow:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         positive_conditions, flaw_properties = CheckDescFactory.generate(
             accepts=True, count=positive, exclude=flaw_properties
@@ -407,6 +415,7 @@ class TestWorkflow:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
         state_factory = StateFactory()
         accepting_states, flaw_properties = state_factory.generate(
@@ -600,7 +609,9 @@ class TestWorkflowFramework:
             "unembargo_dt": None,
             "embargoed": None,
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "title": "EMBARGOED CVE-2022-1234 kernel: some description",
         }
+
         for name, priority, accepting, accepting_states in workflows:
             workflow = Workflow(
                 {

--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -30,8 +30,12 @@ pytestmark = pytest.mark.unit
 
 class TestBugzillaQuerier:
     def test_remove_testing(self):
-        flaw1 = FlawFactory(title="regular flaw", meta_attr={"bz_id": "321"})
-        flaw2 = FlawFactory(title="testing: flaw", meta_attr={"bz_id": "123"})
+        flaw1 = FlawFactory(
+            title="regular flaw", embargoed=False, meta_attr={"bz_id": "321"}
+        )
+        flaw2 = FlawFactory(
+            title="testing: flaw", embargoed=False, meta_attr={"bz_id": "123"}
+        )
         AffectFactory(flaw=flaw2)
         CVEv5PackageVersionsFactory(flaw=flaw2)
         FlawCommentFactory(flaw=flaw2)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -779,6 +779,24 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin):
         # users from reviewing in the first place, in which case we don't
         # need to perform this validation
 
+    def _validate_public_flaw_title(self):
+        """
+        Check that the flaw's title does not contain the word "EMBARGOED" if the flaw is public.
+        """
+        if not self.is_embargoed and "EMBARGOED" in self.title:
+            raise ValidationError(
+                'Flaw title contains "EMBARGOED" despite being public.'
+            )
+
+    def _validate_embargoed_flaw_title(self):
+        """
+        Check that the flaw's title does contain the word "EMBARGOED" if the flaw is embargoed.
+        """
+        if self.is_embargoed and "EMBARGOED" not in self.title:
+            raise ValidationError(
+                'Flaw title does not contains "EMBARGOED" despite being embargoed.'
+            )
+
     # TODO this needs to be refactored
     # but it makes sense only when we are capable of write actions
     # and we may thus actually do some changes to the embargo

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -40,8 +40,16 @@ class FlawFactory(factory.django.DjangoModelFactory):
     state = factory.Faker("random_element", elements=list(Flaw.FlawState))
     resolution = factory.Faker("random_element", elements=list(FlawResolution))
     impact = factory.Faker("random_element", elements=list(FlawImpact))
-    title = factory.LazyAttribute(lambda c: f"Title for {c.cve_id}")
     description = factory.LazyAttribute(lambda c: f"Description for {c.cve_id}")
+    title = factory.Maybe(
+        "embargoed",
+        yes_declaration=factory.LazyAttribute(
+            lambda c: f"EMBARGOED {c.cve_id} kernel: some description"
+        ),
+        no_declaration=factory.LazyAttribute(
+            lambda c: f"{c.cve_id} kernel: some description"
+        ),
+    )
     statement = factory.LazyAttribute(lambda c: f"Statement for {c.cve_id}")
     embargoed = factory.Faker("random_element", elements=[False, True])
     summary = factory.Maybe(

--- a/osidb/tests/test_embargo.py
+++ b/osidb/tests/test_embargo.py
@@ -22,11 +22,13 @@ class TestEmbargo(object):
     def test_embargoed_annotation(self, embargoed_groups, public_groups, embargoed):
         if embargoed:
             groups = embargoed_groups
+            title = "EMBARGOED CVE-2022-1234 kernel: some description"
             unembargo_dt = timezone.datetime(
                 2022, 12, 26, tzinfo=timezone.get_current_timezone()
             )
         else:
             groups = public_groups
+            title = "CVE-2022-1234 kernel: some description"
             unembargo_dt = timezone.datetime(
                 2022, 11, 24, tzinfo=timezone.get_current_timezone()
             )
@@ -38,7 +40,7 @@ class TestEmbargo(object):
             state="NEW",
             resolution="",
             impact="LOW",
-            title="test",
+            title=title,
             description="test",
             reported_dt=timezone.now(),
             unembargo_dt=unembargo_dt,

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1089,7 +1089,7 @@ class TestEndpoints(object):
                 "uuid": flaw.uuid,
                 "cve_id": flaw.cve_id,
                 "type": flaw.type,
-                "title": "This is a test",
+                "title": f"{flaw.title} appended test title",
                 "description": flaw.description,
                 "state": flaw.state,
                 "resolution": flaw.resolution,
@@ -1101,7 +1101,7 @@ class TestEndpoints(object):
         assert response.status_code == 200
         body = response.json()
         assert original_body["title"] != body["title"]
-        assert body["title"] == "This is a test"
+        assert "appended test title" in body["title"]
         assert original_body["description"] == body["description"]
 
     def test_flaw_delete(self, auth_client, test_api_uri):

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -866,3 +866,38 @@ class TestFlawValidators:
                 flaw1.save()
         else:
             assert flaw1.save() is None
+
+    @pytest.mark.parametrize(
+        "title,should_raise",
+        [
+            ("CVE-2022-1234 kernel: some description", False),
+            ("EMBARGOED CVE-2022-1234 kernel: some description", True),
+        ],
+    )
+    def test_validate_public_flaw_title(self, title, should_raise):
+        """test that public flaws only accepts a valid title without the "EMBARGOED" word"""
+        if should_raise:
+            with pytest.raises(ValidationError) as e:
+                FlawFactory(embargoed=False, title=title)
+            assert 'Flaw title contains "EMBARGOED" despite being public.' in str(e)
+        else:
+            assert FlawFactory(embargoed=False, title=title)
+
+    @pytest.mark.parametrize(
+        "title,should_raise",
+        [
+            ("EMBARGOED CVE-2022-1234 kernel: some description", False),
+            ("CVE-2022-1234 kernel: some description", True),
+        ],
+    )
+    def test_validate_embargoed_flaw_title(self, title, should_raise):
+        """test that embargoed flaws only accepts a valid title containing the "EMBARGOED" word"""
+        if should_raise:
+            with pytest.raises(ValidationError) as e:
+                FlawFactory(embargoed=True, title=title)
+            assert (
+                'Flaw title does not contains "EMBARGOED" despite being embargoed.'
+                in str(e)
+            )
+        else:
+            assert FlawFactory(embargoed=True, title=title)

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -18,10 +18,11 @@ class TestSearch:
         assert body["count"] == 0
 
         FlawFactory(
-            title="TITLE",
+            title="CVE-2022-1234 kernel: TITLE",
             description="DESCRIPTION",
             summary="SUMMARY",
             statement="STATEMENT",
+            embargoed=False,
         )
 
         response = auth_client.get(f"{test_api_uri}/flaws?search=title")
@@ -72,7 +73,7 @@ class TestSearch:
             reported_dt=datetime_with_tz,
             unembargo_dt=datetime_with_tz,
             type=FlawType.VULNERABILITY,
-            title="TITLE",
+            title="CVE-2022-1234 kernel: TITLE",
             description="DESCRIPTION",
             impact=FlawImpact.CRITICAL,
             summary="SUMMARY",
@@ -147,15 +148,16 @@ class TestSearch:
         assert body["count"] == 0
 
         FlawFactory(
-            title="words",
+            title="CVE-2022-1234 kernel: words",
             description="words",
             summary="words",
             statement="words",
+            embargoed=False,
         )
 
-        FlawFactory(title="words")
+        FlawFactory(embargoed=False, title="CVE-2022-1234 kernel: words")
 
-        FlawFactory(description="words")
+        FlawFactory(description="words", embargoed=False)
 
         FlawFactory(summary="words")
 
@@ -170,14 +172,14 @@ class TestSearch:
             body["count"] == 5
         )  # 5 Flaws have "words" in a text field, "word" should match due to stemming
         # First / most relevant match should be the Flaw with "words" in every field (most number of matches)
-        assert body["results"][0]["title"] == "words"
+        assert body["results"][0]["title"] == "CVE-2022-1234 kernel: words"
         assert body["results"][0]["description"] == "words"
         assert body["results"][0]["summary"] == "words"
         assert body["results"][0]["statement"] == "words"
 
         # Following results are ranked based on what field "word" appears in
         # Matches in title are weighted highest (1.0), followed by description (0.4), summary (0.2), and statement (0.1)
-        assert body["results"][1]["title"] == "words"
+        assert body["results"][1]["title"] == "CVE-2022-1234 kernel: words"
         assert body["results"][2]["description"] == "words"
         assert body["results"][3]["summary"] == "words"
         assert body["results"][4]["statement"] == "words"
@@ -193,6 +195,7 @@ class TestSearch:
             title="title",
             description="description",
             summary="summary",
+            embargoed=False,
             statement="statement",
         )
 


### PR DESCRIPTION
This PR add validations for flaw title.

This PR checks if all embargoed flaws have the word "EMBARGOED" in its title and also validates if public flaws does not have it. This PR also change `FlawFactory` and multiple tests to adhere into this new validation.
This PR closes OSIDB-348 and OSIDB-349.