### PR TITLE
Add Summary validation for Major Incident flaws

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -231,10 +231,10 @@
         "filename": "tox.ini",
         "hashed_secret": "5a4fe08359c7f97380e408c717ef42c86939cd86",
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 54,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2022-11-28T12:12:05Z"
+  "generated_at": "2022-12-05T13:01:34Z"
 }

--- a/mk/testrunner.mk
+++ b/mk/testrunner.mk
@@ -28,7 +28,7 @@ testrunner.all-unit-tests:
 testrunner.all-integration-tests:
 	$(podman) exec -it testrunner tox -e integration-tests apps/osim collectors/bzimport collectors/jiraffe collectors/product_definitions osidb
 testrunner.all-tests:
-	$(podman) exec -it testrunner tox -e tests apps/osim collectors/bzimport collectors/jiraffe collectors/product_definitions osidb
+	$(podman) exec -it testrunner tox -e tests
 testrunner.record-new:
 	rm -rf *_cache.sqlite
 	$(podman) exec -it testrunner tox -e record-new osidb/ collectors/jiraffe collectors/bzimport collectors/product_definitions

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -757,6 +757,28 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin):
         if not self.cvss3:
             raise ValidationError("CVSSv3 score is missing")
 
+    def _validate_summary_major_incident(self):
+        """
+        Check that a flaw that is a major incident has a summary
+        """
+        req = self.meta.filter(type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT).last()
+        if not self.is_major_incident or (req and req.meta_attr.get("status") == "-"):
+            return
+
+        if not self.summary:
+            raise ValidationError("Flaw marked as Major Incident does not have Summary")
+
+        if not req or req.meta_attr.get("status") == "?":
+            raise ValidationError(
+                "Flaw marked as Major Incident does not have Summary reviewed"
+            )
+
+        # XXX: In SFM2 we check that the REQUIRES_DOC_TEXT flag is set by
+        # someone who has review access rights, it is uncertain whether
+        # we'd need this in OSIDB as ideally we would block non-authorized
+        # users from reviewing in the first place, in which case we don't
+        # need to perform this validation
+
     # TODO this needs to be refactored
     # but it makes sense only when we are capable of write actions
     # and we may thus actually do some changes to the embargo

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -44,6 +44,11 @@ class FlawFactory(factory.django.DjangoModelFactory):
     description = factory.LazyAttribute(lambda c: f"Description for {c.cve_id}")
     statement = factory.LazyAttribute(lambda c: f"Statement for {c.cve_id}")
     embargoed = factory.Faker("random_element", elements=[False, True])
+    summary = factory.Maybe(
+        "is_major_incident",
+        yes_declaration="I'm a spooky CVE",
+        no_declaration=factory.Faker("random_element", elements=["", "foo"]),
+    )
     unembargo_dt = factory.Maybe(
         "embargoed",
         yes_declaration=factory.Faker("future_datetime", tzinfo=UTC),

--- a/osidb/tests/test_core.py
+++ b/osidb/tests/test_core.py
@@ -5,7 +5,8 @@ from rest_framework.viewsets import ModelViewSet
 from osidb.api_views import get_valid_http_methods
 from osidb.core import set_user_acls
 from osidb.exceptions import OSIDBException
-from osidb.tests.factories import FlawFactory
+from osidb.models import FlawMeta
+from osidb.tests.factories import FlawFactory, FlawMetaFactory
 from osidb.tests.models import TestAlertModel, TestAlertModelBasic
 
 pytestmark = pytest.mark.unit
@@ -18,7 +19,14 @@ class TestCore(object):
 
     def test_flaw_factory(self):
         """test that we can generate a flaw using factory"""
-        flaw1 = FlawFactory(is_major_incident=True)
+        flaw1 = FlawFactory.build(is_major_incident=True)
+        flaw1.save(raise_validation_error=False)
+        FlawMetaFactory(
+            flaw=flaw1,
+            type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT,
+            meta_attr={"status": "+"},
+        )
+        assert flaw1.save() is None
         assert "test" in flaw1.meta_attr
 
     def test_flaw_exceptions(self):

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -84,7 +84,14 @@ class TestEndpoints(object):
     def test_get_flaw(self, auth_client, test_api_uri):
         """retrieve specific flaw from endpoint"""
 
-        flaw1 = FlawFactory(is_major_incident=True)
+        flaw1 = FlawFactory.build(is_major_incident=True)
+        flaw1.save(raise_validation_error=False)
+        FlawMetaFactory(
+            flaw=flaw1,
+            type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT,
+            meta_attr={"status": "+"},
+        )
+        assert flaw1.save() is None
         FlawCommentFactory(flaw=flaw1)
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw1.cve_id}")
         assert response.status_code == 200
@@ -986,7 +993,14 @@ class TestEndpoints(object):
         assert "refresh" in body
         token = body["access"]
 
-        flaw1 = FlawFactory(is_major_incident=True)
+        flaw1 = FlawFactory.build(is_major_incident=True)
+        flaw1.save(raise_validation_error=False)
+        FlawMetaFactory(
+            flaw=flaw1,
+            type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT,
+            meta_attr={"status": "+"},
+        )
+        assert flaw1.save() is None
         FlawCommentFactory(flaw=flaw1)
 
         # attempt to access with unauthenticated client using good token value

--- a/osidb/tests/test_integration.py
+++ b/osidb/tests/test_integration.py
@@ -27,13 +27,12 @@ class TestIntegration(object):
         )
         assert curl_result.returncode == 0
         json_body = json.loads(curl_result.stdout)
-        assert json_body["status"] == "ok"
+        assert json_body["env"] == "local"
 
     def test_status_with_curl(
         self,
         command_curl,
         test_api_uri,
-        tokens,
     ):
         """access status api using curl"""
         cmd = [
@@ -41,8 +40,6 @@ class TestIntegration(object):
             "-v",
             "-H",
             "Content-type: application/json",
-            "-H",
-            f"Authorization: Bearer {tokens['access']}",
             f"{test_api_uri}/status",
         ]
         curl_result = subprocess.run(
@@ -50,13 +47,12 @@ class TestIntegration(object):
         )
         assert curl_result.returncode == 0
         json_body = json.loads(curl_result.stdout)
-        assert json_body["status"] == "ok"
+        assert json_body["env"] == "local"
 
     def test_flaws_with_curl(
         self,
         command_curl,
         test_api_uri,
-        tokens,
     ):
         """access status api using curl"""
         cmd = [
@@ -64,8 +60,6 @@ class TestIntegration(object):
             "-v",
             "-H",
             "Content-type: application/json",
-            "-H",
-            f"Authorization: Bearer {tokens['access']}",
             f"{test_api_uri}/flaws",
         ]
         curl_result = subprocess.run(

--- a/tox.ini
+++ b/tox.ini
@@ -9,6 +9,7 @@ setenv =
     OSIDB_DEBUG = 1
     DJANGO_SETTINGS_MODULE=config.settings_local
     DJANGO_SECRET_KEY = local
+    PYTEST_ADDOPTS = --ignore=apps/osim
 
 [testenv:unit-tests]
 deps = -rdevel-requirements.txt
@@ -51,10 +52,11 @@ setenv =
     OSIDB_DEBUG = 1
     DJANGO_SETTINGS_MODULE=config.settings_ci
     DJANGO_SECRET_KEY = ci
+    PYTEST_ADDOPTS = --ignore=apps/osim
 deps = -rdevel-requirements.txt
        -rrequirements.txt
 commands =
-        pytest -m "unit" apps osidb collectors krb5_auth
+        pytest -m "unit"
 
 [testenv:flake8]
 deps = flake8


### PR DESCRIPTION
This commit adds a Flaw validation method that checks that flaws that are marked as is_major_incident=True have a corresponding FlawMeta object of type REQUIRES_DOC_TEXT linked to them with a correct value.

Closes OSIDB-327