### PR TITLE
SRT notes builder part #1

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -1,8 +1,13 @@
 import json
 from itertools import chain
 
-from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT
+from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT, BZ_DT_FMT_HISTORY
 from osidb.models import Flaw, FlawImpact, PsModule, Tracker
+
+DATE_FMT = "%Y-%m-%d"
+# these two time formats are the same
+# thus spare us defining it again
+DATETIME_FMT = BZ_DT_FMT_HISTORY
 
 
 class SRTNotesBuilder:
@@ -323,17 +328,13 @@ class BugzillaQueryBuilder:
                 "remove": remove_groups,
             }
 
-    DEADLINE_FORMAT = "%Y-%m-%d"
-
     def generate_deadline(self):
         """
         generate query for Bugzilla deadline
         """
         if self.flaw.embargoed:
             if self.flaw.unembargo_dt:
-                self._query["deadline"] = self.flaw.unembargo_dt.strftime(
-                    self.DEADLINE_FORMAT
-                )
+                self._query["deadline"] = self.flaw.unembargo_dt.strftime(DATE_FMT)
 
         # unembargo
         elif not self.creation and self.old_flaw.embargoed:

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -2,7 +2,7 @@ import json
 from itertools import chain
 
 from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT
-from osidb.models import Flaw, FlawImpact, PsModule
+from osidb.models import Flaw, FlawImpact, PsModule, Tracker
 
 
 class SRTNotesBuilder:
@@ -58,6 +58,24 @@ class SRTNotesBuilder:
         generate json content
         """
         self.restore_original()
+        self.generate_jira_trackers()
+
+    def generate_jira_trackers(self):
+        """
+        generate array of Jira tracker identifier pairs
+        consisting of BTS name being Jira instance identifier
+        and Jira issue key in given Jira instance
+        """
+        self.add_conditionally(
+            "jira_trackers",
+            [
+                # BTS name is always jboss which is the
+                # historical naming of the only Jira instance we use
+                {"bts_name": "jboss", "key": tracker.external_system_id}
+                for affect in self.flaw.affects.all()
+                for tracker in affect.trackers.filter(type=Tracker.TrackerType.JIRA)
+            ],
+        )
 
     def restore_original(self):
         """

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -65,6 +65,7 @@ class SRTNotesBuilder:
         self.restore_original()
         self.generate_impact()
         self.generate_jira_trackers()
+        self.generate_public_date()
 
     def generate_impact(self):
         """
@@ -89,6 +90,32 @@ class SRTNotesBuilder:
                 for tracker in affect.trackers.filter(type=Tracker.TrackerType.JIRA)
             ],
         )
+
+    def generate_public_date(self):
+        """
+        generate public date attribute
+        which is abbreviated to public
+
+        it can be either date or datetime so we should check the old
+        value and preserve the format when the value does not change
+        """
+        if not self.flaw.unembargo_dt:
+            self.add_conditionally("public", None)
+            return
+
+        date_str = self.flaw.unembargo_dt.strftime(DATE_FMT)
+        if (
+            "public" in self._original_keys
+            and self.old_flaw
+            and self.flaw.unembargo_dt == self.old_flaw.unembargo_dt
+            and self._json["public"] == date_str
+        ):
+            # we prefer datetime format but if there was just date format
+            # before and the value does not change we keep the old format
+            self._json["public"] = date_str
+
+        else:
+            self._json["public"] = self.flaw.unembargo_dt.strftime(DATETIME_FMT)
 
     def restore_original(self):
         """

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -58,7 +58,15 @@ class SRTNotesBuilder:
         generate json content
         """
         self.restore_original()
+        self.generate_impact()
         self.generate_jira_trackers()
+
+    def generate_impact(self):
+        """
+        generate impact attribute
+        """
+        impact = "none" if not self.flaw.impact else self.flaw.impact.lower()
+        self.add_conditionally("impact", impact, empty_value="none")
 
     def generate_jira_trackers(self):
         """


### PR DESCRIPTION
This is a part of OSIDB-384 but not the whole solution. I am sending it on review to make it shorter and also because I will switch the context for a moment. This part introduces building of
 
- Jira trackers
- impact
- public date

and a bit of helper code. One important concept I would like to use throughout the SRT notes building is that whenever there is no real change we do not introduce anything new to Bugzilla history. Three examples

- the Jira trackers array was not present at all so we could generate `jira_trackers=[]` which has the same meaning but we will rather not generate that attribute at all because changing nothing to `jira_trackers=[]` would be a change
- the impact was not present at all so we could generate `impact=none` which has the same meaning but again ...
- the public date was `2022-12-24` and we could store it as `2022-12-24T00:00:00Z` which has the same meaning (except maybe the denoted timezone?) but again ...

The reasoning is that when the user eg. adds a new comment and touches nothing else the Bugzilla audit with the unexpected changes would be confusing. It would say that the user changed SRT notes in some way while it would be just OSIDB and not the user.

I also try to introduce the code well covered by the tests as this might soon start performing the write changes to the data.

I am using the technical label as I would like to update the changelog with the last part PR.