### PR TITLE
Ensure that flake8 exits with non-zero exit code on lint failure

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ commands =
 [testenv:flake8]
 deps = flake8
        flake8-django
-commands = flake8 --exit-zero osidb collectors apps
+commands = flake8 osidb collectors apps
 
 [flake8]
 # E203 - whitespace before ':' -- ignored per Black documentation, non PEP8-compliant


### PR DESCRIPTION
The --exit-zero flag does the opposite of what we want it to do, it should return a non-zero exit code on lint failure so that the CI detects it and prevents a merge.