### PR TITLE
Validate empty affects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Implement Bugzilla SRT notes builder in Bugzilla Backwards Sync (OSIDB-384)
+- Implement validation for flaw without affect (OSIDB-353)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -754,6 +754,17 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin, ACLMixi
             if not re.match(r"^(CWE-[0-9]+|\(CWE-[0-9]+(\|CWE-[0-9]+)*\))$", element):
                 raise ValidationError("CWE IDs is not well formated.")
 
+    def _validate_flaw_without_affect(self):
+        """
+        Check if flaw have at least one affect
+        """
+        # Skip validation at creation allowing to draft a Flaw
+        if self._state.adding:
+            return
+
+        if not Affect.objects.filter(flaw=self).exists():
+            raise ValidationError("Flaw does not contain any affects.")
+
     def _validate_no_placeholder(self):
         """
         restrict any write operations on placeholder flaws

--- a/osidb/tests/test_core.py
+++ b/osidb/tests/test_core.py
@@ -6,7 +6,7 @@ from osidb.api_views import get_valid_http_methods
 from osidb.core import set_user_acls
 from osidb.exceptions import OSIDBException
 from osidb.models import FlawMeta
-from osidb.tests.factories import FlawFactory, FlawMetaFactory
+from osidb.tests.factories import AffectFactory, FlawFactory, FlawMetaFactory
 from osidb.tests.models import TestAlertModel, TestAlertModelBasic
 
 pytestmark = pytest.mark.unit
@@ -26,6 +26,7 @@ class TestCore(object):
             type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT,
             meta_attr={"status": "+"},
         )
+        AffectFactory(flaw=flaw1)
         assert flaw1.save() is None
         assert "test" in flaw1.meta_attr
 

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -91,6 +91,7 @@ class TestEndpoints(object):
             type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT,
             meta_attr={"status": "+"},
         )
+        AffectFactory(flaw=flaw1)
         assert flaw1.save() is None
         FlawCommentFactory(flaw=flaw1)
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw1.cve_id}")
@@ -1008,6 +1009,8 @@ class TestEndpoints(object):
             type=FlawMeta.FlawMetaType.REQUIRES_DOC_TEXT,
             meta_attr={"status": "+"},
         )
+        AffectFactory(flaw=flaw1)
+
         assert flaw1.save() is None
         FlawCommentFactory(flaw=flaw1)
 
@@ -1089,6 +1092,7 @@ class TestEndpoints(object):
         Test that updating a Flaw by sending a PUT request works.
         """
         flaw = FlawFactory()
+        AffectFactory(flaw=flaw)
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw.uuid}")
         assert response.status_code == 200
         original_body = response.json()

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -7,7 +7,7 @@ from freezegun import freeze_time
 from collectors.bzimport.convertors import FlawBugConvertor
 from osidb.exceptions import DataInconsistencyException
 from osidb.models import Flaw
-from osidb.tests.factories import FlawFactory
+from osidb.tests.factories import AffectFactory, FlawFactory
 
 from .test_flaw import tzdatetime
 
@@ -79,6 +79,7 @@ class TestTrackingMixin:
         """
         flaw = self.create_flaw()
         flaw.save()
+        AffectFactory(flaw=flaw)
 
         assert flaw.created_dt == tzdatetime(2022, 12, 24)
         assert flaw.updated_dt == tzdatetime(2022, 12, 24)
@@ -97,6 +98,7 @@ class TestTrackingMixin:
         """
         flaw = self.create_flaw()
         flaw.save()
+        AffectFactory(flaw=flaw)
 
         assert flaw.created_dt == tzdatetime(2022, 12, 24)
         assert flaw.updated_dt == tzdatetime(2022, 12, 24)
@@ -129,6 +131,8 @@ class TestTrackingMixin:
         saving an outdated model instance should fail
         """
         flaw = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw)
+
         flaw_copy = Flaw.objects.first()
 
         with freeze_time(tzdatetime(2023, 12, 24)):

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -4,7 +4,7 @@ import pytest
 
 from osidb.models import Flaw, FlawImpact, FlawResolution, FlawType
 
-from .factories import FlawFactory
+from .factories import AffectFactory, FlawFactory
 
 pytestmark = pytest.mark.unit
 
@@ -88,6 +88,7 @@ class TestSearch:
         )
 
         assert flaw.save() is None
+        AffectFactory(flaw=flaw)
 
         response = auth_client.get(f"{test_api_uri}/flaws?search=title")
         assert response.status_code == 200


### PR DESCRIPTION
This PR validates that flaws have an affect related.

To achieve it this PR adds a validation that allows Flaw creation without affect but raises error for any edition in flaw without affect, it also changes some tests enforcing the association of a new affect with flaw

Closes OSIDB-353.