### PR TITLE
Add database options to support managed databases + misc fixes

### DIFF
--- a/config/settings_ci.py
+++ b/config/settings_ci.py
@@ -64,8 +64,13 @@ DATABASES = {
         "HOST": "postgres",
         "PORT": "5432",
         "ENGINE": "psqlextra.backend",
-        # prevent libpq from automatically trying to connect to the db via GSSAPI
-        "OPTIONS": {"gssencmode": "disable"},
+        "OPTIONS": {
+            # prevent libpq from automatically trying to connect to the db via GSSAPI
+            "gssencmode": "disable",
+            # this is a hack due to our inability to set a custom parameter either at
+            # the database or role level in managed databases such as AWS RDS
+            "options": "-c osidb.acl=''",
+        },
     }
 }
 

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -68,6 +68,9 @@ DATABASES = {
             "sslmode": "require",
             # prevent libpq from automatically trying to connect to the db via GSSAPI
             "gssencmode": "disable",
+            # this is a hack due to our inability to set a custom parameter either at
+            # the database or role level in managed databases such as AWS RDS
+            "options": "-c osidb.acl=''",
         },
     }
 }

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -75,6 +75,9 @@ DATABASES = {
             "sslmode": "require",
             # prevent libpq from automatically trying to connect to the db via GSSAPI
             "gssencmode": "disable",
+            # this is a hack due to our inability to set a custom parameter either at
+            # the database or role level in managed databases such as AWS RDS
+            "options": "-c osidb.acl=''",
         },
     }
 }

--- a/config/settings_shell.py
+++ b/config/settings_shell.py
@@ -23,6 +23,9 @@ DATABASES = {
             "sslmode": "require",
             # prevent libpq from automatically trying to connect to the db via GSSAPI
             "gssencmode": "disable",
+            # this is a hack due to our inability to set a custom parameter either at
+            # the database or role level in managed databases such as AWS RDS
+            "options": "-c osidb.acl=''",
         },
     }
 }

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -75,6 +75,9 @@ DATABASES = {
             "sslmode": "require",
             # prevent libpq from automatically trying to connect to the db via GSSAPI
             "gssencmode": "disable",
+            # this is a hack due to our inability to set a custom parameter either at
+            # the database or role level in managed databases such as AWS RDS
+            "options": "-c osidb.acl=''",
         },
     }
 }

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,16 +20,6 @@ services:
       #   osidb-data:
       #     condition: service_healthy
 
-    phpldapadmin:
-      image: docker.io/osixia/phpldapadmin:latest
-      container_name: phpldapadmin
-      environment:
-        PHPLDAPADMIN_LDAP_HOSTS: "ldap://testldap:1389"
-        PHPLDAPADMIN_HTTPS: "false"
-      ports:
-        - "${OSIDB_TESTRUNNER_PORT-8080}:80"
-      depends_on: ["testldap"]
-
     testrunner:
       container_name: testrunner
       build:

--- a/etc/pg/postgresql.conf
+++ b/etc/pg/postgresql.conf
@@ -777,4 +777,3 @@ default_text_search_config = 'pg_catalog.english'
 #------------------------------------------------------------------------------
 
 # Add settings for extensions here
-osidb.acl = ''

--- a/osidb/migrations/0001_initial_squashed_0059_flaw__alerts.py
+++ b/osidb/migrations/0001_initial_squashed_0059_flaw__alerts.py
@@ -1347,8 +1347,6 @@ class Migration(migrations.Migration):
 --enable row based security for following tables
 ALTER TABLE osidb_flaw ENABLE ROW LEVEL SECURITY;
 ALTER TABLE osidb_flaw FORCE ROW LEVEL SECURITY;
---set default value for osidb.acl parameter
-SET osidb.acl TO '';
 --following policies define fine grained read/write control on osidb_flaw entity
 --policy for entity insert (eg. create)
 DROP policy if exists acl_policy_flaw_create on osidb_flaw;


### PR DESCRIPTION
This PR changes the way that the custom osidb.acl parameter is initialized to be more managed database friendly and also removes an unused image from the local dev environment compose file.

Closes OSIDB-639