### PR TITLE
Jira tracker timestamps

### DIFF
--- a/collectors/jiraffe/core.py
+++ b/collectors/jiraffe/core.py
@@ -90,7 +90,7 @@ def get_field_attr(issue, field, attr):
     return None
 
 
-def upsert_trackers(affect: Affect, dry_run=False) -> None:
+def upsert_trackers(affect: Affect) -> None:
     """
     Creates or updates an affect's trackers.
     """
@@ -128,11 +128,9 @@ def upsert_trackers(affect: Affect, dry_run=False) -> None:
                 ),
             },
         )
-        if not dry_run:
-            tracker.save()
-            tracker.affects.add(affect)
-    if not dry_run:
-        affect.save()
+        tracker.save()
+        tracker.affects.add(affect)
+    affect.save()
 
 
 def get_affects_to_sync(interval: str) -> Union[tuple[UUID], tuple[Any]]:

--- a/collectors/jiraffe/core.py
+++ b/collectors/jiraffe/core.py
@@ -128,9 +128,12 @@ def upsert_trackers(affect: Affect) -> None:
                 ),
             },
         )
-        tracker.save()
-        tracker.affects.add(affect)
-    affect.save()
+        # eventual save inside create_tracker would override the timestamps
+        # so we have to set them here and both ensure save and turn off auto-timestamps
+        # this might be refactored but as separate task as it changes the affect linking
+        tracker.created_dt = issue.fields.created
+        tracker.updated_dt = issue.fields.updated or issue.fields.created
+        tracker.save(auto_timestamps=False)
 
 
 def get_affects_to_sync(interval: str) -> Union[tuple[UUID], tuple[Any]]:

--- a/collectors/jiraffe/tasks.py
+++ b/collectors/jiraffe/tasks.py
@@ -26,7 +26,7 @@ logger = get_task_logger(__name__)
     soft_time_limit=JIRA_SOFT_TIME_LIMIT,
     rate_limit=JIRA_RATE_LIMIT,
 )
-def process_affect(affect_uuid, dry_run, groups_read, groups_write):
+def process_affect(affect_uuid, groups_read, groups_write):
     """
     Fetches an affect and creates or updates any Trackers related to it
     """
@@ -41,7 +41,7 @@ def process_affect(affect_uuid, dry_run, groups_read, groups_write):
         ]
     )
     affect = Affect.objects.get(uuid=affect_uuid)
-    upsert_trackers(affect, dry_run=dry_run)
+    upsert_trackers(affect)
 
 
 @shared_task
@@ -55,7 +55,6 @@ def jiraffe_sync():
             for affect_uuid in affect_uuids:
                 process_affect.delay(
                     affect_uuid=affect_uuid,
-                    dry_run=False,
                     groups_read=settings.PUBLIC_READ_GROUPS,
                     groups_write=[settings.PUBLIC_WRITE_GROUP],
                 )

--- a/collectors/jiraffe/tests/test_core.py
+++ b/collectors/jiraffe/tests/test_core.py
@@ -1,4 +1,6 @@
 import pytest
+from django.utils import timezone
+from freezegun import freeze_time
 
 from osidb.models import Affect, Tracker
 
@@ -45,6 +47,7 @@ class TestJiraTrackerCollection(object):
         assert not trackers
 
     @pytest.mark.vcr
+    @freeze_time(timezone.datetime(2020, 10, 10))
     def test_tracker_creation_from_affect(self, good_flaw, good_jira_trackers):
         """
         Test the creation of Tracker objects from Affect objects by querying the JIRA API.
@@ -66,8 +69,15 @@ class TestJiraTrackerCollection(object):
         assert tracker.meta_attr.get("qe_owner", False) is None
         assert tracker.meta_attr.get("ps_module", False)
         assert tracker.meta_attr.get("ps_component", False)
+        assert tracker.created_dt == timezone.datetime(
+            2018, 4, 24, 1, 2, 47, tzinfo=timezone.utc
+        )
+        assert tracker.updated_dt == timezone.datetime(
+            2018, 6, 5, 16, 2, 24, tzinfo=timezone.utc
+        )
 
     @pytest.mark.vcr
+    @freeze_time(timezone.datetime(2020, 10, 10))
     def test_tracker_update_from_affect(self, good_flaw, good_jira_trackers):
         """
         Test updating an existing Tracker object from an Affect object by querying the JIRA API.
@@ -91,6 +101,12 @@ class TestJiraTrackerCollection(object):
         assert tracker.status == "random_status"
         assert tracker.resolution == "random_resolution"
         assert tracker.ps_update_stream == ""
+        assert tracker.created_dt == timezone.datetime(
+            2020, 10, 10, tzinfo=timezone.utc
+        )
+        assert tracker.updated_dt == timezone.datetime(
+            2020, 10, 10, tzinfo=timezone.utc
+        )
 
         # Should update the previously created tracker, not create a new one
         upsert_trackers(affect)
@@ -101,3 +117,9 @@ class TestJiraTrackerCollection(object):
         assert tracker.status == "Closed"
         assert tracker.resolution == "Done"
         assert tracker.ps_update_stream == "fis-2.0"
+        assert tracker.created_dt == timezone.datetime(
+            2018, 4, 24, 1, 2, 47, tzinfo=timezone.utc
+        )
+        assert tracker.updated_dt == timezone.datetime(
+            2018, 6, 5, 16, 2, 24, tzinfo=timezone.utc
+        )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change logging of celery and django to filesystem (OSIDB-418)
 - Implement validation for CWE ID chain in a Flaw (OSIDB-357)
 - Implement validation for embargoed flaws not be able to have public trackers (OSIDB-350)
+- Fix Jira tracker created and updated timestamps (OSIDB-14)
 
 ## [2.3.4] - 2022-12-15
 ### Changed


### PR DESCRIPTION
The timestamps of the Jira trackers were not explicitly set on the collector sync so they were implicitly assigned to the current time without any relation to the actual tracker creation or update times. This PR fixes this plus extends the collector and the tests accordingly.

Closes OSIDB-14