### PR TITLE
restrict write operations on placeholder flaws

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 145,
+        "line_number": 147,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2022-12-15T13:37:32Z"
+  "generated_at": "2023-01-11T10:11:27Z"
 }

--- a/collectors/bzimport/constants.py
+++ b/collectors/bzimport/constants.py
@@ -27,3 +27,5 @@ ANALYSIS_TASK_PRODUCT = "Security Response"
 # Bugzilla datetime format strings
 BZ_DT_FMT = "%Y-%m-%dT%H:%M:%S%z"
 BZ_DT_FMT_HISTORY = "%Y-%m-%dT%H:%M:%SZ"
+
+FLAW_PLACEHOLDER_KEYWORD = "Tracking"

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -653,6 +653,7 @@ class FlawBugConvertor:
         meta_attr["acl_labels"] = self.groups
         meta_attr["task_owner"] = self.task_owner
         meta_attr["groups"] = json.dumps(self.flaw_bug.get("groups", []))
+        meta_attr["keywords"] = json.dumps(self.flaw_bug.get("keywords", []))
         # store the original SRT notes string as meta attributes tamper the JSON
         meta_attr["original_srtnotes"] = self.flaw_bug["cf_srtnotes"]
         return meta_attr

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for embargoed flaws not be able to have public trackers (OSIDB-350)
 - Fix Jira tracker created and updated timestamps (OSIDB-14)
 - Fix errata created and updated timestamps (OSIDB-453)
+- Restrict write operations on placeholder flaws (OSIDB-388)
 
 ## [2.3.4] - 2022-12-15
 ### Changed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -401,50 +401,6 @@ class FlawHistory(NullStrFieldsMixin, ValidateMixin, ACLMixin):
 
     objects = FlawHistoryManager()
 
-    # TODO this needs to be refactored
-    # but it makes sense only when we are capable of write actions
-    # and we may thus actually do some changes to the embargo
-    #
-    # def process_embargo_state(self):
-    #     """TBD - this is process related so deactivating it
-
-    #     explicitly set embargoed based on co-constraints
-
-    #     embargoed = (True|False|None)
-    #     unembargo_dt = (Past date|Future date | None)
-    #     # permutations = 9
-
-    #     | embargoed | unembargo_dt | embargoed set value |
-    #     |-----------|--------------|---------------------|
-    #     | True      | None         | True                |
-    #     | False     | None         | False               |
-    #     | None      | None         | False               |
-
-    #     | True      | Future date  | True                |
-    #     | False     | Future date  | True                |
-    #     | None      | Future date  | True                |
-
-    #     | True      | Past date    | True                | no trust defensive - in the future we may change
-    #     | False     | Past date    | False               |
-    #     | None      | Past date    | False               |
-
-    #     corner case(s) = [ unembargo_dt = now() ]
-
-    #     TBD -  process with respect to perms access
-
-    #     """
-    #     if self.embargoed and self.unembargo_dt is None:
-    #         pass
-    #     elif self.embargoed and self.unembargo_dt < datetime.now():
-    #         pass
-    #     elif self.unembargo_dt is None:
-    #         self.embargoed = False
-    #     else:
-    #         if self.unembargo_dt > datetime.now():
-    #             self.embargoed = True
-    #         if self.unembargo_dt < datetime.now():
-    #             self.embargoed = False
-
 
 class FlawManager(ACLMixinManager):
     """flaw manager"""
@@ -797,50 +753,6 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin, ACLMixi
         for element in parsed_elements:
             if not re.match(r"^(CWE-[0-9]+|\(CWE-[0-9]+(\|CWE-[0-9]+)*\))$", element):
                 raise ValidationError("CWE IDs is not well formated.")
-
-    # TODO this needs to be refactored
-    # but it makes sense only when we are capable of write actions
-    # and we may thus actually do some changes to the embargo
-    #
-    # def process_embargo_state(self):
-    #     """TBD - this is process related so deactivating it
-
-    #     explicitly set embargoed based on co-constraints
-
-    #     embargoed = (True|False|None)
-    #     unembargo_dt = (Past date|Future date | None)
-    #     # permutations = 9
-
-    #     | embargoed | unembargo_dt | embargoed set value |
-    #     |-----------|--------------|---------------------|
-    #     | True      | None         | True                |
-    #     | False     | None         | False               |
-    #     | None      | None         | False               |
-
-    #     | True      | Future date  | True                |
-    #     | False     | Future date  | True                |
-    #     | None      | Future date  | True                |
-
-    #     | True      | Past date    | True                | no trust defensive - in the future we may change
-    #     | False     | Past date    | False               |
-    #     | None      | Past date    | False               |
-
-    #     corner case(s) = [ unembargo_dt = now() ]
-
-    #     TBD -  process with respect to perms access
-
-    #     """
-    #     if self.embargoed and self.unembargo_dt is None:
-    #         pass
-    #     elif self.embargoed and self.unembargo_dt < datetime.now():
-    #         pass
-    #     elif self.unembargo_dt is None:
-    #         self.embargoed = False
-    #     else:
-    #         if self.unembargo_dt > datetime.now():
-    #             self.embargoed = True
-    #         if self.unembargo_dt < datetime.now():
-    #             self.embargoed = False
 
     def _validate_no_placeholder(self):
         """

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -6,6 +6,7 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun import freeze_time
 
+from collectors.bzimport.constants import FLAW_PLACEHOLDER_KEYWORD
 from osidb.constants import BZ_ID_SENTINEL
 from osidb.core import generate_acls
 from osidb.models import (
@@ -989,3 +990,18 @@ class TestFlawValidators:
                 TrackerFactory(affects=affects, embargoed=embargoed_tracker)
         else:
             assert TrackerFactory(affects=affects, embargoed=embargoed_tracker)
+
+    def test_validate_no_placeholder(self):
+        """
+        test that placeholder flaw cannot be saved
+        unless it is performed by the collector
+        """
+        flaw = FlawFactory.build(
+            meta_attr={"keywords": '["' + FLAW_PLACEHOLDER_KEYWORD + '"]'}
+        )
+
+        with pytest.raises(ValidationError):
+            flaw.save()
+
+        # exclude collectors from restriction
+        flaw.save(raise_validation_error=False)


### PR DESCRIPTION
The placeholder flaws handling is non-standard (mainly due to visibility differences) and this concept is being deprecated. Currently there are 154 such flaws according to SFM2 central which is marginal.

Closes OSIDB-388