### PR TITLE
Add alerts for components affected by NOTABUG flaw

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement Bugzilla SRT notes builder in Bugzilla Backwards Sync (OSIDB-384)
 - Implement validation for flaw without affect (OSIDB-353)
 - Implement validation for changes in flaws with high criticicity with open tracker (OSIDB-347)
+- Implement validation for components affected by flaws closed as NOTABUG (OSIDB-363)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1083,3 +1083,78 @@ class TestFlawValidators:
         flaw.save()
 
         assert should_raise == bool("unsupported_impact_change" in flaw._alerts)
+
+    @pytest.mark.parametrize(
+        "state,resolution,affectedness,should_raise",
+        [
+            (
+                Flaw.FlawState.CLOSED,
+                FlawResolution.NOTABUG,
+                Affect.AffectAffectedness.AFFECTED,
+                True,
+            ),
+            (
+                Flaw.FlawState.NEW,
+                FlawResolution.NOTABUG,
+                Affect.AffectAffectedness.AFFECTED,
+                False,
+            ),
+            (
+                Flaw.FlawState.CLOSED,
+                FlawResolution.NEXTRELEASE,
+                Affect.AffectAffectedness.AFFECTED,
+                False,
+            ),
+            (
+                Flaw.FlawState.CLOSED,
+                FlawResolution.NOTABUG,
+                Affect.AffectAffectedness.NOTAFFECTED,
+                False,
+            ),
+        ],
+    )
+    def test_validate_affect_in_notabug_flaw(
+        self, state, resolution, affectedness, should_raise
+    ):
+        flaw = FlawFactory(resolution=resolution, state=state)
+        AffectFactory(flaw=flaw, affectedness=affectedness)
+
+        assert should_raise == bool("notabug_affect_ps_component" in flaw._alerts)
+
+    @pytest.mark.parametrize(
+        "state,resolution,affectedness,should_raise",
+        [
+            (
+                Flaw.FlawState.CLOSED,
+                FlawResolution.NOTABUG,
+                Affect.AffectAffectedness.AFFECTED,
+                True,
+            ),
+            (
+                Flaw.FlawState.NEW,
+                FlawResolution.NOTABUG,
+                Affect.AffectAffectedness.AFFECTED,
+                False,
+            ),
+            (
+                Flaw.FlawState.CLOSED,
+                FlawResolution.NEXTRELEASE,
+                Affect.AffectAffectedness.AFFECTED,
+                False,
+            ),
+            (
+                Flaw.FlawState.CLOSED,
+                FlawResolution.NOTABUG,
+                Affect.AffectAffectedness.NOTAFFECTED,
+                False,
+            ),
+        ],
+    )
+    def test_validate_notabug_flaw_affected(
+        self, state, resolution, affectedness, should_raise
+    ):
+        affect = AffectFactory(affectedness=affectedness)
+        flaw = FlawFactory(resolution=resolution, state=state)
+        flaw.affects.add(affect)
+        flaw.save()
+        assert should_raise == bool("notabug_affect_ps_component" in flaw._alerts)


### PR DESCRIPTION
This PR add validation alerting in case a component is being affected by a flaw closed as NOTABUG.

Closes OSIDB-363.