### PR TITLE
Add validation for components from software collection

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 147,
+        "line_number": 152,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-12T10:04:51Z"
+  "generated_at": "2023-01-18T23:57:53Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for flaw without affect (OSIDB-353)
 - Implement validation for changes in flaws with high criticicity with open tracker (OSIDB-347)
 - Implement validation for components affected by flaws closed as NOTABUG (OSIDB-363)
+- Implement validation for invalid components in software collection (OSIDB-356)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -43,3 +43,6 @@ CVSS3_SEVERITY_SCALE = {
 # update streams instead of ps_modules for affects, any issues after this one
 # belong to the "new way" in which ps_modules are more heavily enforced
 BZ_ID_SENTINEL = 1489716
+
+# Lists of components from RHSCL without collection
+COMPONENTS_WITHOUT_COLLECTION = ["source-to-image", "scl-utils"]


### PR DESCRIPTION
This PR adds validation for components from software collection (RHSCL).

This PR also creates a constant in osidb/constants.py listing the components that does not follow the same naming rule of RHSCL component names.
Closes OSIDB-356.