### PR TITLE
Add validation for affectedness and resolution

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 153,
+        "line_number": 146,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-26T19:32:46Z"
+  "generated_at": "2023-01-26T20:24:57Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement Bugzilla metadata collector
 - Implement validation for for affects with exceptional combination of affectedness and resolution (OSIDB-361)
 - Implement validation for services related products with WONTREPORT resolution (OSIDB-362)
+- Implement validation for combinations of affectedness and resolution (OSIDB-360)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -10,6 +10,7 @@ from datetime import timedelta, timezone
 from decimal import Decimal
 
 from .helpers import get_env
+from .models import Affect
 
 OSIDB_API_VERSION: str = "v1"
 
@@ -58,3 +59,27 @@ SERVICES_PRODUCTS = [
     "openshift-hosted",
     "hostedservices",
 ]
+
+AFFECTEDNESS_VALID_RESOLUTIONS = {
+    Affect.AffectAffectedness.NEW: [
+        Affect.AffectResolution.NOVALUE,
+        Affect.AffectResolution.DEFER,
+        Affect.AffectResolution.WONTFIX,
+        Affect.AffectResolution.OOSS,
+    ],
+    Affect.AffectAffectedness.AFFECTED: [
+        Affect.AffectResolution.FIX,
+        Affect.AffectResolution.DEFER,
+        Affect.AffectResolution.DELEGATED,
+        Affect.AffectResolution.WONTREPORT,
+        Affect.AffectResolution.WONTFIX,
+        Affect.AffectResolution.OOSS,
+    ],
+    Affect.AffectAffectedness.NOTAFFECTED: [
+        Affect.AffectResolution.NOVALUE,
+    ],
+    Affect.AffectAffectedness.NOVALUE: [
+        Affect.AffectResolution.DEFER,
+        Affect.AffectResolution.WONTFIX,
+    ],
+}

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -24,13 +24,6 @@ from apps.exploits.query_sets import AffectQuerySetExploitExtension
 from apps.osim.workflow import WorkflowModel
 from collectors.bzimport.constants import FLAW_PLACEHOLDER_KEYWORD
 
-from .constants import (
-    BZ_ID_SENTINEL,
-    COMPONENTS_WITHOUT_COLLECTION,
-    CVSS3_SEVERITY_SCALE,
-    OSIDB_API_VERSION,
-    SERVICES_PRODUCTS,
-)
 from .mixins import (
     ACLMixin,
     ACLMixinManager,
@@ -1152,6 +1145,15 @@ class Affect(
                 "a exceptional state having no affectedness.",
             )
 
+    def _validate_affect_status_resolution(self):
+        """
+        Validates that affected product have a valid combination of affectedness and resolution
+        """
+        if self.resolution not in AFFECTEDNESS_VALID_RESOLUTIONS[self.affectedness]:
+            raise ValidationError(
+                f"{self.resolution} is not a valid resolution for {self.affectedness}."
+            )
+
     @property
     def delegated_resolution(self):
         """affect delegated resolution based on resolutions of related trackers"""
@@ -1785,3 +1787,13 @@ class Profile(models.Model):
 
     def __str__(self):
         return self.username
+
+
+from .constants import (  # noqa: E402
+    AFFECTEDNESS_VALID_RESOLUTIONS,
+    BZ_ID_SENTINEL,
+    COMPONENTS_WITHOUT_COLLECTION,
+    CVSS3_SEVERITY_SCALE,
+    OSIDB_API_VERSION,
+    SERVICES_PRODUCTS,
+)

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -6,6 +6,7 @@ import factory.fuzzy
 from django.conf import settings
 from pytz import UTC
 
+from osidb.constants import AFFECTEDNESS_VALID_RESOLUTIONS
 from osidb.models import (
     Affect,
     CVEv5PackageVersions,
@@ -168,15 +169,8 @@ class AffectFactory(factory.django.DjangoModelFactory):
             Affect.AffectAffectedness.NOTAFFECTED,
         ]
     )
-    resolution = factory.fuzzy.FuzzyChoice(
-        [
-            Affect.AffectResolution.NOVALUE,
-            Affect.AffectResolution.FIX,
-            Affect.AffectResolution.DEFER,
-            Affect.AffectResolution.WONTFIX,
-            Affect.AffectResolution.OOSS,
-            Affect.AffectResolution.DELEGATED,
-        ]
+    resolution = factory.LazyAttribute(
+        lambda a: AFFECTEDNESS_VALID_RESOLUTIONS[a.affectedness][0]
     )
     ps_module = factory.sequence(lambda n: f"ps-module-{n}")
     ps_component = factory.sequence(lambda n: f"ps-component-{n}")


### PR DESCRIPTION
This PR adds validation on affect and flaw to ensure the right combination of affectedness and resolution.

This PR also changes `AffectFactory` to be able to generate, by default, right combinations of affectedness and resolutions.
This PR also creates the class `AffectAffectednessResolution`, a constant list of valid combinations of affectedness and resolutions. It is created in `models.py` instead of `constants.py` to avoid cycle reference.

Closes OSIDB-360.