### PR TITLE
Add validation for affects without affectedness

### DIFF
--- a/collectors/jiraffe/tests/test_core.py
+++ b/collectors/jiraffe/tests/test_core.py
@@ -14,7 +14,7 @@ class TestJiraTrackerCollection(object):
     def _gen_affect(flaw, module, component):
         affect = Affect.objects.create_affect(
             flaw,
-            affectedness=Affect.AffectAffectedness.NOVALUE,
+            affectedness=Affect.AffectAffectedness.NEW,
             resolution=Affect.AffectResolution.NOVALUE,
             impact=Affect.AffectImpact.NOVALUE,
             ps_module=module,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for components affected by flaws closed as NOTABUG (OSIDB-363)
 - Implement validation for invalid components in software collection (OSIDB-356)
 - Implement Bugzilla metadata collector
+- Implement validation for for affects with exceptional combination of affectedness and resolution (OSIDB-361)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1128,6 +1128,25 @@ class Affect(
                 "does not match any valid collection",
             )
 
+    def _validate_exceptional_affectedness_resolution(self):
+        """
+        Alerts that an old flaw have empty affectedness.
+        (Only accepts WONTFIX and DEFER as resolution, validated by other validation)
+        """
+        valid_resolutions = [
+            Affect.AffectResolution.WONTFIX,
+            Affect.AffectResolution.DEFER,
+        ]
+        if (
+            self.affectedness == Affect.AffectAffectedness.NOVALUE
+            and self.resolution in valid_resolutions
+        ):
+            self.alert(
+                "flaw_exceptional_affect_status",
+                f"Affect for {self.ps_module}/{self.ps_component} is in "
+                "a exceptional state having no affectedness.",
+            )
+
     @property
     def delegated_resolution(self):
         """affect delegated resolution based on resolutions of related trackers"""

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -2,6 +2,7 @@ import uuid
 from random import choice
 
 import factory
+import factory.fuzzy
 from django.conf import settings
 from pytz import UTC
 
@@ -160,8 +161,12 @@ class AffectFactory(factory.django.DjangoModelFactory):
         django_get_or_create = ("flaw", "ps_module", "ps_component")
 
     type = factory.Faker("random_element", elements=list(Affect.AffectType))
-    affectedness = factory.Faker(
-        "random_element", elements=list(Affect.AffectAffectedness)
+    affectedness = factory.fuzzy.FuzzyChoice(
+        [
+            Affect.AffectAffectedness.NEW,
+            Affect.AffectAffectedness.AFFECTED,
+            Affect.AffectAffectedness.NOTAFFECTED,
+        ]
     )
     resolution = factory.Faker("random_element", elements=list(Affect.AffectResolution))
     ps_module = factory.sequence(lambda n: f"ps-module-{n}")

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1193,7 +1193,7 @@ class TestEndpoints(object):
         flaw = FlawFactory()
         affect_data = {
             "flaw": str(flaw.uuid),
-            "affectedness": Affect.AffectAffectedness.NOVALUE,
+            "affectedness": Affect.AffectAffectedness.NEW,
             "resolution": Affect.AffectResolution.NOVALUE,
             "ps_module": "rhacm-2",
             "ps_component": "curl",

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1194,3 +1194,37 @@ class TestFlawValidators:
         affect = AffectFactory(ps_module=ps_module, ps_component=ps_component)
         if alerts:
             assert set(alerts).issubset(affect._alerts)
+
+    @pytest.mark.parametrize(
+        "affectedness,resolution,should_raise",
+        [
+            (
+                Affect.AffectAffectedness.NOVALUE,
+                Affect.AffectResolution.DEFER,
+                True,
+            ),
+            (
+                Affect.AffectAffectedness.NOVALUE,
+                Affect.AffectResolution.WONTFIX,
+                True,
+            ),
+            (
+                Affect.AffectAffectedness.NEW,
+                Affect.AffectResolution.DEFER,
+                False,
+            ),
+            (
+                Affect.AffectAffectedness.NEW,
+                Affect.AffectResolution.WONTFIX,
+                False,
+            ),
+        ],
+    )
+    def test_validate_exceptional_affectedness_resolution(
+        self, affectedness, resolution, should_raise
+    ):
+        """
+        Test that old flaw with empty affect raises alert
+        """
+        affect = AffectFactory(resolution=resolution, affectedness=affectedness)
+        assert should_raise == bool("flaw_exceptional_affect_status" in affect._alerts)


### PR DESCRIPTION
This PR adds validation for affects in exceptional state without affectedness.

Closes OSIDB-361.