### PR TITLE
Add validation for affects with wontreport status

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 153,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-18T23:57:53Z"
+  "generated_at": "2023-01-26T19:32:46Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for invalid components in software collection (OSIDB-356)
 - Implement Bugzilla metadata collector
 - Implement validation for for affects with exceptional combination of affectedness and resolution (OSIDB-361)
+- Implement validation for services related products with WONTREPORT resolution (OSIDB-362)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -46,3 +46,15 @@ BZ_ID_SENTINEL = 1489716
 
 # Lists of components from RHSCL without collection
 COMPONENTS_WITHOUT_COLLECTION = ["source-to-image", "scl-utils"]
+
+# List of ps_product that are classified as services
+SERVICES_PRODUCTS = [
+    "ansible-services",
+    "cloud-redhat-com",
+    "hosted-openshift",
+    "insights",
+    "managed-application-services",
+    "other-services",
+    "openshift-hosted",
+    "hostedservices",
+]

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -168,7 +168,16 @@ class AffectFactory(factory.django.DjangoModelFactory):
             Affect.AffectAffectedness.NOTAFFECTED,
         ]
     )
-    resolution = factory.Faker("random_element", elements=list(Affect.AffectResolution))
+    resolution = factory.fuzzy.FuzzyChoice(
+        [
+            Affect.AffectResolution.NOVALUE,
+            Affect.AffectResolution.FIX,
+            Affect.AffectResolution.DEFER,
+            Affect.AffectResolution.WONTFIX,
+            Affect.AffectResolution.OOSS,
+            Affect.AffectResolution.DELEGATED,
+        ]
+    )
     ps_module = factory.sequence(lambda n: f"ps-module-{n}")
     ps_component = factory.sequence(lambda n: f"ps-component-{n}")
     impact = factory.Faker("random_element", elements=list(Affect.AffectImpact))


### PR DESCRIPTION
This PR adds validation for services related products with WONTREPORT resolution.

Closes OSIDB-362.