### PR TITLE
CC BBSync #2 : implement CC builder

### DIFF
--- a/apps/bbsync/cc.py
+++ b/apps/bbsync/cc.py
@@ -1,0 +1,443 @@
+import json
+import logging
+import re
+from functools import cached_property
+from itertools import chain
+from typing import List, Optional, Tuple
+
+from osidb.models import Affect, Flaw, PsContact, PsModule, PsUpdateStream
+
+from .constants import RHSCL_BTS_KEY, USER_BLACKLIST
+from .exceptions import ProductDataError
+from .models import BugzillaComponent
+
+logger = logging.getLogger(__name__)
+
+
+class AffectCCBuilder:
+    """
+    affect CC list builder
+    """
+
+    def __init__(self, affect: Affect, embargoed: bool) -> None:
+        """
+        init stuff
+        expects a valid affect
+        """
+        self.affect = affect
+        self.ps_module = affect.ps_module
+        self.ps_component = affect.ps_component
+        self.ps_module_obj = PsModule.objects.get(name=affect.ps_module)
+        self.embargoed = embargoed
+
+        self.bz_component = self.ps2bz_component() if self.is_bugzilla else None
+
+    @property
+    def is_bugzilla(self) -> bool:
+        """
+        check that this PS module is tracked in Bugzilla
+        """
+        return self.ps_module_obj.bts_name == "bugzilla"
+
+    def ps2bz_component(self) -> str:
+        """
+        translate PS component to Bugzilla one
+
+        there are three posible options how to map to the Bugzilla component
+
+            component overrides: mapping defined in PS module
+            component split-off: container-tools:rhel8/podman -> podman
+            identity:            podman -> podman
+
+        """
+        if (
+            self.ps_module_obj.component_overrides
+            and self.ps_component in self.ps_module_obj.component_overrides
+        ):
+            override = self.ps_module_obj.component_overrides[self.ps_component]
+            if override is not None:
+                return override["component"] if isinstance(override, dict) else override
+
+        elif "/" in self.ps_component:
+            return self.ps_component.split("/")[-1]
+
+        return self.ps_component
+
+    @cached_property
+    def cc(self) -> List[str]:
+        """
+        CC list getter
+        """
+        return self.generate_cc()
+
+    def generate_cc(self) -> List[str]:
+        """
+        CC list generator
+        """
+        # skip modules with private trackers not allowed if embargoed
+        if self.embargoed and not self.ps_module_obj.private_trackers_allowed:
+            return []
+
+        cc_list = self.module_cc() + self.component_cc() + self.bugzilla_cc()
+
+        cc_list = [self.expand_alias(cc) for cc in cc_list]
+        cc_list = [self.append_domain(cc) for cc in cc_list]
+
+        if self.embargoed:
+            # if embargoed we need to additionally ensure that
+            # we do not add non-RH or bot or invalid accounts
+            cc_list = [
+                cc
+                for cc in cc_list
+                if not self.is_blacklisted(cc) and self.is_redhat(cc)
+            ]
+
+        return cc_list
+
+    def append_domain(self, cc: str) -> str:
+        """
+        append @redhat.com domain
+        in case no domain is present
+        """
+        return cc if self.is_email(cc) else f"{cc}@redhat.com"
+
+    def expand_alias(self, cc: str) -> str:
+        """
+        expand an alias to the actual email
+        in the case this is actually an alias
+        """
+        if self.is_email(cc):
+            return cc
+
+        contact = PsContact.objects.filter(username=cc).first()
+        if not contact:
+            return cc
+
+        if self.ps_module_obj.bts_name == "bugzilla":
+            return contact.bz_username
+
+        elif self.ps_module_obj.bts_name == "jboss":
+            return contact.jboss_username
+
+        else:
+            raise ProductDataError(f"Unknown BTS name {self.ps_module_obj.bts_name}")
+
+    def is_blacklisted(self, cc: str) -> bool:
+        """
+        check and return whether the CC is on the blacklist
+        contains mostly bot and invalid Bugzilla accounts
+        """
+        return cc in USER_BLACKLIST
+
+    def is_email(self, cc: str) -> bool:
+        """
+        check and return whether the CC is an email
+
+        this is only an estimation but as there are
+        either emails or aliases it should be correct
+        """
+        return "@" in cc
+
+    def is_redhat(self, cc: str) -> bool:
+        """
+        check and return whether the CC is RH one
+        """
+        return cc.endswith("@redhat.com")
+
+    def module_cc(self) -> List[str]:
+        """
+        generate CCs based on module
+        """
+        cc_list = []
+
+        # default CCs
+        if self.ps_module_obj.default_cc:
+            cc_list.extend(self.ps_module_obj.default_cc)
+
+        # extra CCs if embargoed
+        if self.embargoed and self.ps_module_obj.private_tracker_cc:
+            cc_list.extend(self.ps_module_obj.private_tracker_cc)
+
+        return cc_list
+
+    def component_cc(self) -> List[str]:
+        """
+        generate CCs based on component
+        """
+        # exact match
+        if self.bz_component in self.ps_module_obj.component_cc:
+            return self.ps_module_obj.component_cc[self.bz_component]
+
+        cc_list = []
+        # wildcard match
+        for component_pattern, component_cc in self.ps_module_obj.component_cc.items():
+            if "*" in component_pattern:
+                re_pattern = re.escape(component_pattern).replace("\\*", ".+")
+                if re.match(re_pattern, self.bz_component):
+                    cc_list.extend(component_cc)
+
+        return cc_list
+
+    def bugzilla_cc(self) -> List[str]:
+        """
+        generate CCs based on Bugzilla product and component
+        """
+        if not self.is_bugzilla:
+            return []
+
+        bz_component_obj = BugzillaComponent.objects.filter(
+            product__name=self.ps_module_obj.bts_key, name=self.bz_component
+        ).first()
+
+        if not bz_component_obj:
+            return []
+
+        cc_list = []
+        if bz_component_obj.default_cc:
+            cc_list.extend(bz_component_obj.default_cc)
+        if bz_component_obj.default_owner:
+            cc_list.append(bz_component_obj.default_owner)
+
+        return cc_list
+
+
+class RHSCLAffectCCBuilder(AffectCCBuilder):
+    """
+    Red Hat Software Collections affect CC list builder
+    introduces special differences from the base class
+    """
+
+    collection = None
+
+    def collections(self) -> List[str]:
+        """
+        generate collections for the PS module
+        """
+        return list(
+            set(
+                chain.from_iterable(
+                    PsUpdateStream.objects.filter(
+                        ps_module__name=self.ps_module
+                    ).values_list("collections", flat=True)
+                )
+            )
+        )
+
+    def collection_component(self) -> Tuple[Optional[str], str]:
+        """
+        parse RHSCL PS component into collection and
+        Bugzilla component and return them as a tuple
+
+            ps_component | collection | result
+            ----------------------------------
+            podman         truck        None podman
+            podman         podman       podman podman
+            podman-thing   podman       podman thing
+
+        """
+        matched_collections = [
+            collection
+            for collection in self.collections()
+            if self.ps_component.startswith(collection + "-")
+            or self.ps_component == collection
+        ]
+
+        if not matched_collections or len(matched_collections) > 1:
+            return None, self.ps_component
+
+        collection = matched_collections[0]
+        if collection and self.ps_component != collection:
+            return collection, self.ps_component[len(collection) + 1 :]
+
+        return collection, self.ps_component
+
+    def ps2bz_component(self) -> str:
+        """
+        translate PS component to Bugzilla one
+        RH software collections special case
+        """
+        self.collection, bz_component = self.collection_component()
+        return bz_component
+
+    def component_cc(self) -> List[str]:
+        """
+        generate CCs based on component
+        RH software collections special case
+        """
+        cc_list = self.ps_module_obj.component_cc.get(self.bz_component, [])
+        cc_list.extend(self.ps_module_obj.component_cc.get(self.collection, []))
+
+        return cc_list
+
+
+class CCBuilder:
+    """
+    Bugzilla flaw CC list array builder
+    """
+
+    def __init__(self, flaw: Flaw, old_flaw: Optional[Flaw] = None) -> None:
+        """
+        init stuff
+        parametr old_flaw is optional as there is no old flaw on creation
+        and if not set we consider the query to be a create query
+        """
+        self.flaw = flaw
+        self.old_flaw = old_flaw
+
+        # unless the flaw is being created
+        # we extract the previous data
+        if not old_flaw:
+            return
+
+        self.old_cc = json.loads(self.old_flaw.meta_attr.get("cc", "[]"))
+
+        # IMPORTANT
+        # next we consider only two possible mutually exclusive cases
+        #
+        # 1) flaw is modified through /flaws API endpoint
+        # 2) affect is modified through /affects API endpoint
+        #
+        # if in the future we would enable some bulk change of flaw and its affect(s)
+        # together in one API call we would probably have to refactor the following code
+        #
+        # now the consequences are that in 1) there are no affect changes and in 2) there
+        # are no flaw changes but as in Bugzilla affects are just a part of flaw we do
+        # the save always through the flaw and therefore the affect need to be already
+        # stored in DB before we hit flaw.save() which means there are no old_affects in
+        # the DB as they were already rewritten by the new and we need to use SRT notes
+
+        srtnotes = json.loads(self.old_flaw.meta_attr.get("original_srtnotes", "{}"))
+        old_affects = {
+            (affect["ps_module"], affect["ps_component"]): (
+                affect["affectedness"],
+                affect["resolution"],
+            )
+            for affect in srtnotes.get("affects", [])
+        }
+        self.added_affects = [
+            affect
+            for affect in self.flaw.affects.all()
+            if (affect.ps_module, affect.ps_component) not in old_affects
+        ]
+        self.removed_affects = [
+            # there is probably no old affect model instance
+            # any more so we create dummy temporary one
+            Affect(
+                ps_module=module_component[0],
+                ps_component=module_component[1],
+                affectedness=affectedness_resolution[0],
+                resolution=affectedness_resolution[1],
+            )
+            for module_component, affectedness_resolution in old_affects.items()
+            if not self.flaw.affects.filter(
+                ps_module=module_component[0], ps_component=module_component[1]
+            ).exists()
+        ]
+
+    @property
+    def content(self) -> Tuple[List[str], List[str]]:
+        """
+        content getter shorcut
+        sort result to easy compare
+        """
+        add_cc, remove_cc = self.generate()
+        return sorted(add_cc), sorted(remove_cc)
+
+    def generate(self) -> Tuple[List[str], List[str]]:
+        """
+        generate content
+        """
+        all_cc = self.affect_list2cc(self.flaw.affects.all())
+
+        if not self.old_flaw:
+            # on create we add all
+            # and remove nothing
+            add_cc = all_cc
+            remove_cc = []
+
+        elif self.old_flaw.embargoed and not self.flaw.embargoed:
+            # on unembargo we add and remove all but do not add
+            # already existing CCs because they are already there
+            add_cc = [cc for cc in all_cc if cc not in self.old_cc]
+            remove_cc = self.affect_list2cc(self.removed_affects)
+
+        else:
+            # on update we only add the CCs from new affects
+            # so we do not re-add people who removed themselves
+            # and remove whatever is not needed any more
+            add_cc = self.affect_list2cc(self.added_affects)
+            remove_cc = self.affect_list2cc(self.removed_affects)
+
+        # do not remove CCs which are being added from another source
+        remove_cc = [cc for cc in remove_cc if cc not in add_cc]
+
+        return add_cc, remove_cc
+
+    def affect_list2cc(self, affects: List[Affect]) -> List[str]:
+        """
+        process the list of affects and return the corresponding list of CCs
+        """
+        cc_list = set()
+
+        for affect in affects:
+            # exclude unknown PS modules
+            if self.is_unknown(affect):
+                logger.error(
+                    f"Affect {affect.uuid} contains unknown PS module: {affect.ps_module}"
+                )
+                continue
+
+            # exclude community products
+            # which was requested to reduce the spam to the communities
+            if self.is_community(affect):
+                continue
+
+            # for some reason in SFM2 we ignore affects set as not affected or not to be fixed
+            # only for embargoed flaws so to keep the functional parity we continue with it
+            if self.flaw.embargoed and self.is_notaffected(affect):
+                continue
+
+            cc_list.update(self.affect2cc(affect))
+
+        return list(cc_list)
+
+    def affect2cc(self, affect: Affect) -> List[str]:
+        """
+        process an affect and return the corresponding list of CCs
+        """
+        affect_cc_builder_class = (
+            RHSCLAffectCCBuilder if self.is_rhscl(affect) else AffectCCBuilder
+        )
+        affect_cc_builder = affect_cc_builder_class(affect, self.flaw.embargoed)
+        return affect_cc_builder.cc
+
+    def is_community(self, affect: Affect) -> bool:
+        """
+        check and return whether the given affect is community one
+        """
+        return PsModule.objects.filter(
+            name=affect.ps_module, ps_product__business_unit="Community"
+        ).exists()
+
+    def is_notaffected(self, affect: Affect) -> bool:
+        """
+        check and return whether the given affect is set as not affected or not to be fixed
+        """
+        return (
+            affect.affectedness == Affect.AffectFix.NOTAFFECTED
+            or affect.resolution == Affect.AffectResolution.WONTFIX
+        )
+
+    def is_rhscl(self, affect: Affect) -> bool:
+        """
+        check and return whether the given affect is RHSCL one
+        """
+        return PsModule.objects.filter(
+            name=affect.ps_module, bts_key=RHSCL_BTS_KEY
+        ).exists()
+
+    def is_unknown(self, affect: Affect) -> bool:
+        """
+        check and return whether the given affect has unknown PS module
+        """
+        return not PsModule.objects.filter(name=affect.ps_module).exists()

--- a/apps/bbsync/constants.py
+++ b/apps/bbsync/constants.py
@@ -10,5 +10,8 @@ DATE_FMT = "%Y-%m-%d"
 # thus spare us defining it again
 DATETIME_FMT = BZ_DT_FMT_HISTORY
 
+# RHSCL Bugzilla project key
+RHSCL_BTS_KEY = "Red Hat Software Collections"
+
 # JSON schema for SRT notes flaw metadata
 SRTNOTES_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "./srtnotes-schema.json")

--- a/apps/bbsync/constants.py
+++ b/apps/bbsync/constants.py
@@ -4,6 +4,7 @@ BBSync constants
 import os
 
 from collectors.bzimport.constants import BZ_DT_FMT_HISTORY
+from osidb.helpers import get_env
 
 DATE_FMT = "%Y-%m-%d"
 # these two time formats are the same
@@ -15,3 +16,9 @@ RHSCL_BTS_KEY = "Red Hat Software Collections"
 
 # JSON schema for SRT notes flaw metadata
 SRTNOTES_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "./srtnotes-schema.json")
+
+# in SFM2 there are Bugzilla bot accounts and invalid users being filtered out from the CC lists
+# however the list of the corresponding emails is being pulled from VDB by the old vdbqb library
+# and we definitelly do not want such a dependence in OSIDB so I am adding the list statically
+# here as the best we can do now and a motivation to leave Bugzilla as soon as possible
+USER_BLACKLIST: str = get_env("BZ_USER_BLACKLIST", default="[]", is_json=True)

--- a/apps/bbsync/exceptions.py
+++ b/apps/bbsync/exceptions.py
@@ -7,3 +7,10 @@ class SRTNotesValidationError(Exception):
     """
     SRT notes JSON valition error exception class
     """
+
+
+class ProductDataError(Exception):
+    """
+    product data error exception class
+    for error in either the data or the product definitions
+    """

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -4,6 +4,7 @@ from itertools import chain
 from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT
 from osidb.models import Flaw, FlawImpact, PsModule
 
+from .cc import CCBuilder
 from .constants import DATE_FMT
 from .srtnotes import SRTNotesBuilder
 
@@ -247,10 +248,17 @@ class BugzillaQueryBuilder:
         """
         generate query for CC list
         """
-        # TODO now just empty CC list on creation
-        # on update it is more complicated
+        cc_builder = CCBuilder(self.flaw, self.old_flaw)
+        add_cc, remove_cc = cc_builder.content
+
         if self.creation:
-            self._query["cc"] = []
+            self._query["cc"] = add_cc
+
+        else:
+            self._query["cc"] = {
+                "add": add_cc,
+                "remove": remove_cc,
+            }
 
     def generate_srt_notes(self):
         """

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -56,12 +56,10 @@ class BugzillaQueryBuilder:
         self.generate_cc()
         self.generate_srt_notes()
         # TODO tracker links
-        # TODO prestage eligable date - deprecate
-        # TODO checklists
         # TODO fixed_in
         # TODO dupe_of
         # TODO cf_devel_whiteboard
-        # TODO ARRAY_FIELDS_ON_CREATE = ("depends_on", "blocks", "cc", "groups", "keywords")
+        # TODO ARRAY_FIELDS_ON_CREATE = ("depends_on", "blocks")
         # TODO auto-requires doc text on create
 
     def generate_base(self):

--- a/apps/bbsync/tests/factories.py
+++ b/apps/bbsync/tests/factories.py
@@ -1,0 +1,30 @@
+import factory
+
+from apps.bbsync.models import BugzillaComponent, BugzillaProduct
+
+
+class BugzillaProductFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = BugzillaProduct
+
+    name = factory.sequence(lambda n: f"bz_product{n}")
+
+
+class BugzillaComponentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = BugzillaComponent
+
+    name = factory.sequence(lambda n: f"bz_component{n}")
+    default_owner = factory.Faker(
+        "random_element",
+        elements=["contributor@fedora.org", "owner@redhat.com", "user@redhat.com"],
+    )
+    default_cc = factory.List(
+        [
+            f"email{i}@{domain}"
+            for i in range(3)
+            for domain in ["fedora.org", "redhat.com"]
+        ]
+    )
+
+    product = factory.SubFactory(BugzillaProductFactory)

--- a/apps/bbsync/tests/test_cc.py
+++ b/apps/bbsync/tests/test_cc.py
@@ -1,0 +1,880 @@
+import json
+
+import pytest
+
+from apps.bbsync.cc import CCBuilder, RHSCLAffectCCBuilder
+from apps.bbsync.constants import RHSCL_BTS_KEY, USER_BLACKLIST
+from apps.bbsync.tests.factories import BugzillaComponentFactory, BugzillaProductFactory
+from osidb.models import Affect, Flaw, PsModule
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsContactFactory,
+    PsModuleFactory,
+    PsProductFactory,
+    PsUpdateStreamFactory,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestCCBuilder:
+    def prepare_flaw(
+        self,
+        affects=None,
+        embargoed=False,
+        old_affects=None,
+        old_cc=None,
+    ):
+        """
+        helper to initialize flaw with affects
+        provided only abbreviated definitions
+        """
+
+        def prepare_affect(affect):
+            """
+            helper to initialize affect
+            """
+            if isinstance(affect, tuple):
+                if not PsModule.objects.filter(name=affect[0]).exists():
+                    PsModuleFactory(
+                        name=affect[0],
+                        default_cc=[f"{affect[0]}.{affect[1]}@redhat.com"],
+                    )
+                return {
+                    "ps_module": affect[0],
+                    "ps_component": affect[1],
+                    "affectedness": affect[2]
+                    if len(affect) > 2
+                    else Affect.AffectAffectedness.AFFECTED,
+                    "resolution": affect[3]
+                    if len(affect) > 3
+                    else Affect.AffectResolution.FIX,
+                }
+            else:
+                return affect
+
+        affects = (
+            [] if affects is None else [prepare_affect(affect) for affect in affects]
+        )
+        old_affects = (
+            []
+            if old_affects is None
+            else [prepare_affect(affect) for affect in old_affects]
+        )
+
+        meta_attr = {}
+        if old_cc is not None:
+            meta_attr["cc"] = '["' + '", "'.join(old_cc) + '"]'
+        if old_affects is not None:
+            meta_attr["original_srtnotes"] = (
+                '{"affects": ' + json.dumps(old_affects) + "}"
+            )
+
+        flaw = FlawFactory(
+            embargoed=embargoed,
+            meta_attr=meta_attr,
+        )
+        for affect in affects:
+            AffectFactory(flaw=flaw, **affect)
+
+        return flaw
+
+    def test_prepare(self):
+        self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_affects=[
+                ("rhel-6", "kernel"),
+            ],
+            old_cc=[
+                "email@redhat.com",
+                "someone@gmail.com",
+            ],
+        )
+        flaw = Flaw.objects.first()
+        assert flaw
+        assert flaw.embargoed is False
+        assert flaw.meta_attr["cc"] == '["email@redhat.com", "someone@gmail.com"]'
+        assert (
+            flaw.meta_attr["original_srtnotes"]
+            == '{"affects": [{"ps_module": "rhel-6", "ps_component": "kernel", "affectedness": "AFFECTED", "resolution": "FIX"}]}'
+        )
+        assert flaw.affects.count() == 2
+        assert flaw.affects.filter(ps_module="rhel-6", ps_component="kernel").exists()
+        assert flaw.affects.filter(ps_module="rhel-7", ps_component="openssl").exists()
+        assert PsModule.objects.get(name="rhel-6").default_cc == [
+            "rhel-6.kernel@redhat.com"
+        ]
+        assert PsModule.objects.get(name="rhel-7").default_cc == [
+            "rhel-7.openssl@redhat.com"
+        ]
+
+    ###############
+    # FLAW CREATE #
+    ###############
+
+    def test_empty(self):
+        """
+        test that no affects result in empty CCs
+        """
+        flaw = FlawFactory()
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert not remove_cc
+
+    def test_unknown(self):
+        """
+        test that affect with an unknown PS module results in empty CCs
+        """
+        flaw = FlawFactory()
+        AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert not remove_cc
+
+    def test_community(self):
+        """
+        test that community affect results in empty CCs
+        """
+        flaw = FlawFactory()
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        ps_product = PsProductFactory(business_unit="Community")
+        PsModuleFactory(
+            name=affect.ps_module,
+            default_cc=["me@redhat.com"],
+            ps_product=ps_product,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert not remove_cc
+
+    @pytest.mark.parametrize(
+        "cc,embargoed",
+        [
+            ([], True),
+            (["me@redhat.com", "you@redhat.com"], False),
+        ],
+    )
+    def test_notaffected(self, cc, embargoed):
+        """
+        test that notaffected affects result in empty CCs
+        however this restriction only applies to embargoed flaws
+        """
+        flaw = FlawFactory(embargoed=embargoed)
+        affect1 = AffectFactory(
+            flaw=flaw, affectedness=Affect.AffectAffectedness.NOTAFFECTED
+        )
+        affect2 = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.WONTFIX,
+        )
+        PsModuleFactory(
+            name=affect1.ps_module,
+            default_cc=["me@redhat.com"],
+        )
+        PsModuleFactory(
+            name=affect2.ps_module,
+            default_cc=["you@redhat.com"],
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == cc
+        assert not remove_cc
+
+    ###############
+    # FLAW UPDATE #
+    ###############
+
+    def test_no_change(self):
+        """
+        test that no change means no change
+        """
+        flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_cc=[
+                "rhel-6.kernel@redhat.com",
+                "rhel-7.openssl@redhat.com",
+            ],
+        )
+
+        cc_builder = CCBuilder(flaw, old_flaw=flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert not remove_cc
+
+    def test_no_change_removed(self):
+        """
+        test that no change means no change
+        even when someone has been manually removed
+        """
+        flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_cc=[
+                "rhel-6.kernel@redhat.com",
+                # rhel-7 CC is missing here
+            ],
+        )
+
+        cc_builder = CCBuilder(flaw, old_flaw=flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert not remove_cc
+
+    def test_no_change_extra(self):
+        """
+        test that no change means no change
+        even when someone has been manually added
+        """
+        flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_cc=[
+                "rhel-6.kernel@redhat.com",
+                "rhel-7.openssl@redhat.com",
+                "random.user@email.com",
+            ],
+        )
+
+        cc_builder = CCBuilder(flaw, old_flaw=flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert not remove_cc
+
+    def test_add_affect(self):
+        """
+        test that adding an affect results in adding the corresponding CCs
+        """
+        new_flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+        )
+        old_flaw = self.prepare_flaw(
+            old_affects=[
+                ("rhel-6", "kernel"),
+            ],
+            old_cc=[
+                "rhel-6.kernel@redhat.com",
+            ],
+        )
+
+        cc_builder = CCBuilder(new_flaw, old_flaw=old_flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == ["rhel-7.openssl@redhat.com"]
+        assert not remove_cc
+
+    def test_remove_affect(self):
+        """
+        test that removing an affect results in removing the corresponding CCs
+        """
+        new_flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+            ],
+        )
+        old_flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_cc=[
+                "rhel-6.kernel@redhat.com",
+                "rhel-7.openssl@redhat.com",
+            ],
+        )
+
+        cc_builder = CCBuilder(new_flaw, old_flaw=old_flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert not add_cc
+        assert remove_cc == ["rhel-7.openssl@redhat.com"]
+
+    def test_unembargo(self):
+        """
+        test that unembargo results in adding all possible CCs
+        even when some of them were manually removed before
+        """
+        new_flaw = self.prepare_flaw(
+            affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            embargoed=False,
+        )
+        old_flaw = self.prepare_flaw(
+            embargoed=True,
+            old_affects=[
+                ("rhel-6", "kernel"),
+                ("rhel-7", "openssl"),
+            ],
+            old_cc=[
+                "rhel-6.kernel@redhat.com",
+            ],
+        )
+
+        cc_builder = CCBuilder(new_flaw, old_flaw=old_flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == ["rhel-7.openssl@redhat.com"]
+        assert not remove_cc
+
+
+class TestAffectCCBuilder:
+    @pytest.mark.parametrize(
+        "cc,private_trackers_allowed",
+        [
+            (["me@redhat.com", "you@redhat.com"], True),
+            ([], False),
+        ],
+    )
+    def test_private_trackers_allowed(self, cc, private_trackers_allowed):
+        """
+        test that the CCs are empty if embargoed
+        when private trackers are not allowed
+        """
+        flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            default_cc=["me@redhat.com"],
+            private_tracker_cc=["you@redhat.com"],
+            private_trackers_allowed=private_trackers_allowed,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == cc
+        assert not remove_cc
+
+    def test_embargoed_nonredhat(self):
+        """
+        test that non-RH CC is not added when the flaw is embargoed
+        """
+        flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            default_cc=["me@fedora.org"],
+            private_tracker_cc=["you@redhat.com"],
+            private_trackers_allowed=True,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == ["you@redhat.com"]
+        assert not remove_cc
+
+    def test_embargoed_blacklist(self):
+        """
+        test that blacklisted CC is not added when the flaw is embargoed
+        """
+        flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            default_cc=USER_BLACKLIST[:10],
+            private_tracker_cc=["you@redhat.com"],
+            private_trackers_allowed=True,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == ["you@redhat.com"]
+        assert not remove_cc
+
+    def test_append_domain(self):
+        """
+        test that RH domain is added to CC without a domain
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            default_cc=["cat", "dog", "duck@fedora.org"],
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == [
+            "cat@redhat.com",
+            "dog@redhat.com",
+            "duck@fedora.org",
+        ]
+        assert not remove_cc
+
+    def test_expand_alias(self):
+        """
+        test that CC aliases are correctly expanded
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect1 = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            bts_name="bugzilla",
+            name=affect1.ps_module,
+            default_cc=["cat", "duck@fedora.org"],
+        )
+        PsContactFactory(
+            username="cat",
+            bz_username="catfish@email.org",
+            jboss_username="tomcat@domain.de",
+        )
+        affect2 = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            bts_name="jboss",
+            name=affect2.ps_module,
+            default_cc=["dog", "horse@redhat.com"],
+        )
+        PsContactFactory(
+            username="dog",
+            bz_username="puppy@domain.au",
+            jboss_username="hotdog@email.org",
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == [
+            "catfish@email.org",
+            "duck@fedora.org",
+            "horse@redhat.com",
+            "hotdog@email.org",
+        ]
+        assert not remove_cc
+
+    @pytest.mark.parametrize(
+        "default_cc,private_tracker_cc,embargoed,expected_cc",
+        [
+            ([], [], False, []),
+            (["me@redhat.com"], [], False, ["me@redhat.com"]),
+            ([], ["you@redhat.com"], False, []),
+            (["me@redhat.com"], ["you@redhat.com"], False, ["me@redhat.com"]),
+            ([], [], True, []),
+            (["me@redhat.com"], [], True, ["me@redhat.com"]),
+            ([], ["you@redhat.com"], True, ["you@redhat.com"]),
+            (
+                ["me@redhat.com"],
+                ["you@redhat.com"],
+                True,
+                ["me@redhat.com", "you@redhat.com"],
+            ),
+        ],
+    )
+    def test_module_cc(self, default_cc, private_tracker_cc, embargoed, expected_cc):
+        """
+        test that PS module CCs are correctly added
+        """
+        flaw = FlawFactory(embargoed=embargoed)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            default_cc=default_cc,
+            private_tracker_cc=private_tracker_cc,
+            private_trackers_allowed=True,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == expected_cc
+        assert not remove_cc
+
+    @pytest.mark.parametrize(
+        "ps_component,component_overrides,component_cc",
+        [
+            ("cup", {}, {}),
+            (
+                "cup",
+                {},
+                {
+                    "fork": ["you@fedora.org"],
+                    "spoon": ["me@redhat.com"],
+                },
+            ),
+            (
+                "cup",
+                {
+                    "cup": "spoon",
+                    "fork": "knife",
+                },
+                {},
+            ),
+            (
+                "cup",
+                {
+                    "banana": "cup",
+                    "cup": "spoon",
+                },
+                {
+                    "cup": ["her@redhat.com", "you@fedora.org"],
+                    "spoon": ["me@redhat.com"],
+                },
+            ),
+            # override preceeds slash
+            (
+                "cup/plate",
+                {
+                    "cup": "spoon",
+                    "cup/plate": "fork",
+                    "plate": "spoon",
+                },
+                {
+                    "cup": ["her@redhat.com"],
+                    "fork": ["me@redhat.com"],
+                    "plate": ["you@fedora.org"],
+                    "spoon": ["her@redhat.com", "you@fedora.org"],
+                },
+            ),
+            (
+                "cup/plate",
+                {
+                    "cup": "spoon",
+                    "plate": "spoon",
+                },
+                {
+                    "cup": ["her@redhat.com"],
+                    "plate": ["me@redhat.com"],
+                    "spoon": ["you@fedora.org"],
+                },
+            ),
+            (
+                "cup/fork/plate",
+                {
+                    "cup": "spoon",
+                    "plate": "spoon",
+                },
+                {
+                    "cup": ["her@redhat.com"],
+                    "plate": ["me@redhat.com"],
+                    "spoon": ["you@fedora.org"],
+                },
+            ),
+        ],
+    )
+    def test_ps2bz_component(self, ps_component, component_overrides, component_cc):
+        """
+        test that PS component is correctly mapped to
+        the Bugzilla one while generating the CCs
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_component=ps_component,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_name="bugzilla",
+            component_cc=component_cc,
+            component_overrides=component_overrides,
+            default_cc=[],
+            private_tracker_cc=[],
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == (
+            ["me@redhat.com"] if component_overrides and component_cc else []
+        )
+        assert not remove_cc
+
+    @pytest.mark.parametrize(
+        "component_cc,expected_cc",
+        [
+            ({}, []),
+            (
+                {
+                    "stick": ["me@redhat.com"],
+                },
+                [],
+            ),
+            (
+                {
+                    "brick": ["me@redhat.com", "you@fedora.org"],
+                    "stick": ["her@redhat.com"],
+                },
+                ["me@redhat.com", "you@fedora.org"],
+            ),
+            # wildcard match
+            (
+                {
+                    "br*": ["him@redhat.com"],
+                },
+                ["him@redhat.com"],
+            ),
+            (
+                {
+                    "b*ck": ["her@redhat.com", "him@fedora.org"],
+                    "s*": ["him@redhat.com"],
+                },
+                ["her@redhat.com", "him@fedora.org"],
+            ),
+            (
+                {
+                    "br*": ["her@redhat.com", "him@redhat.com"],
+                    "b*ck": ["her@redhat.com", "him@fedora.org"],
+                },
+                ["her@redhat.com", "him@fedora.org", "him@redhat.com"],
+            ),
+        ],
+    )
+    def test_component_cc(self, component_cc, expected_cc):
+        """
+        test that CCs based on Bugzilla component are correctly added
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_component="brick",
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_name="bugzilla",
+            component_cc=component_cc,
+            default_cc=[],
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == expected_cc
+        assert not remove_cc
+
+    @pytest.mark.parametrize(
+        "default_cc,expected_cc",
+        [
+            ([], ["me@redhat.com"]),
+            (["you@redhat.com"], ["me@redhat.com", "you@redhat.com"]),
+        ],
+    )
+    def test_bugzilla_cc(self, default_cc, expected_cc):
+        """
+        test that CCs based on Bugzilla product and component are correctly added
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+        bz_product = BugzillaProductFactory()
+        BugzillaComponentFactory(
+            name=affect.ps_component,
+            default_cc=default_cc,
+            default_owner="me@redhat.com",
+            product=bz_product,
+        )
+        PsModuleFactory(
+            name=affect.ps_module,
+            bts_name="bugzilla",
+            bts_key=bz_product.name,
+            component_cc={},
+            default_cc=[],
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == expected_cc
+        assert not remove_cc
+
+
+class TestRHSCLAffectCCBuilder:
+    def test_component_cc(self):
+        """
+        test that CCs based on Bugzilla component are correctly added
+        even in the case of RHSCL where the mechanism is different
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect1 = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_component="brick-collection",
+        )
+        ps_module1 = PsModuleFactory(
+            name=affect1.ps_module,
+            bts_key=RHSCL_BTS_KEY,
+            bts_name="bugzilla",
+            component_cc={
+                "brick": ["me@redhat.com"],
+                "collection": ["you@redhat.com"],
+                "stick": ["her@redhat.com"],
+            },
+            default_cc=[],
+        )
+        PsUpdateStreamFactory(
+            collections=[
+                "brick",
+                "stick",
+            ],
+            ps_module=ps_module1,
+        )
+        affect2 = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_component="apple-juice",
+        )
+        ps_module2 = PsModuleFactory(
+            name=affect2.ps_module,
+            bts_key=RHSCL_BTS_KEY,
+            bts_name="bugzilla",
+            component_cc={
+                "apple": ["cat@redhat.com"],
+                "apple-juice": ["dog@redhat.com"],
+                "juice": ["hamster@redhat.com"],
+            },
+            default_cc=[],
+        )
+        PsUpdateStreamFactory(
+            collections=[
+                "apple-juice",
+                "juice",
+            ],
+            ps_module=ps_module2,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert add_cc == ["dog@redhat.com", "me@redhat.com", "you@redhat.com"]
+        assert not remove_cc
+
+    def test_no_collection_match(self):
+        """
+        test that RHSCL CCs are correctly processed
+        even when no collection is matched
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_component="stick",
+        )
+        ps_module = PsModuleFactory(
+            name=affect.ps_module,
+            bts_key=RHSCL_BTS_KEY,
+            bts_name="bugzilla",
+            component_cc={
+                "brick": ["me@redhat.com"],
+                "stick": ["her@redhat.com"],
+            },
+            default_cc=["you@redhat.com"],
+        )
+        PsUpdateStreamFactory(
+            collections=[
+                "brick",
+            ],
+            ps_module=ps_module,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert RHSCLAffectCCBuilder(affect, flaw.embargoed).collection is None
+        assert add_cc == ["her@redhat.com", "you@redhat.com"]
+        assert not remove_cc
+
+    def test_extra_collection_match(self):
+        """
+        test that RHSCL CCs are correctly processed
+        even when extra collection is matched
+        """
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_component="stick-brick",
+        )
+        ps_module = PsModuleFactory(
+            name=affect.ps_module,
+            bts_key=RHSCL_BTS_KEY,
+            bts_name="bugzilla",
+            component_cc={
+                "brick": ["me@redhat.com"],
+                "stick": ["her@redhat.com"],
+            },
+            default_cc=["you@redhat.com"],
+        )
+        PsUpdateStreamFactory(
+            collections=[
+                "stick",
+                "stick-brick",
+            ],
+            ps_module=ps_module,
+        )
+
+        cc_builder = CCBuilder(flaw)
+        add_cc, remove_cc = cc_builder.content
+        assert RHSCLAffectCCBuilder(affect, flaw.embargoed).collection is None
+        assert add_cc == ["you@redhat.com"]
+        assert not remove_cc

--- a/collectors/product_definitions/constants.py
+++ b/collectors/product_definitions/constants.py
@@ -22,7 +22,7 @@ PROPERTIES_MAP = {
         },
         "components": {
             "default": "default_component",
-            "override": "components_override",
+            "override": "component_overrides",
         },
     }
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for services related products with WONTREPORT resolution (OSIDB-362)
 - Implement validation for combinations of affectedness and resolution (OSIDB-360)
 - Implement a new API for getting a list of all supported products (PSINSIGHTS-593)
+- Implement CC list builder in Bugzilla backwards sync (OSIDB-386)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)


### PR DESCRIPTION
This is the second and final part of the BBSync CC list functionality. It is quite huge and complicated but I would say ten times simpler than the SFM2 implementation of the same thing :smile: About two thirds of this are the tests and I think the number of the test cases necessary to cover the functionality enough speaks the best about the complexity. Hopefully we can do this much better with the LDAP groups in the future.

I am not even sure where to start describing it. Hopefully the code is readable and commented enough. There is number of conditions OSIDB has to take into account when building the CC lists.

- one is whether we create a new flaw or modify the existing when in the later case we have to parse the old flaw to retrieve the previous case
- unembargo is a special case here
- then we split the building into individual affects (unlike the dumb SFM2) and filter out some
- we have either regular or RHSCL affects with some special handling
- in the case of Bugzilla we have to do some mapping from PS to Bugzilla component
- we compose the CCs from the ones based on the module, based on component in product definitions, and based on component in Bugzilla
- we expand potential aliases, append domain if not present, remove blacklisted addresses ...
- plus there are various special cases for embargo or wildcards etc.
- it is one big mess I tried to sort out as best as I could :smile_cat: 

Closes OSIDB-386