### PR TITLE
make UUID constant whenever possible

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Jira tracker created and updated timestamps (OSIDB-14)
 - Fix errata created and updated timestamps (OSIDB-453)
 - Restrict write operations on placeholder flaws (OSIDB-388)
+- Avoid recreating flaws on CVE ID changes whenever possible (OSIDB-392)
 
 ## [2.3.4] - 2022-12-15
 ### Changed

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -190,7 +190,8 @@ class TestTrackingMixin:
         """
         test Bugzilla flaw bug convertion and save when importing an existing flaw
         """
-        flaw = self.create_flaw(cve_id="CVE-2020-12345")
+        meta_attr = {"bz_id": "12345"}
+        flaw = self.create_flaw(cve_id="CVE-2020-12345", meta_attr=meta_attr)
         flaw.save()
 
         convertor = self.get_flaw_bug_convertor()


### PR DESCRIPTION
This PR changes the behavior of creating and deleting the flaws on Bugzilla sync. Previously we were deleting all the flaws first and then re-creating them. This was resulting in UUID changes as it was always newly generated. It is undesired when not really necessary. Basically whenever we are able to unambiguously map the existing flaws to the new ones we should consider them identical and preserve the UUID.

It the up-to-date workflow where we want to have zero or one CVE for each flaw this really means a constant UUID as the mapping is straightforward. It is problematic for the old multi-CVE flaws where there are cases when we cannot define an unambiguous mapping.

The problematic cases are when we assign multiple CVEs at once to a CVE-less flaw, when we remove one or more CVEs and add multiple CVEs at once, when we remove multiple CVEs and add one or more, and when we remove multiple CVEs at once resulting in a CVE-less flaw. For these cases we simply do not give any UUID guarantees. As it is all quite improbable operations and only applicable to very old flaws it is not a big deal.

Closes OSIDB-392