### PR TITLE
Add validation for invalid open trackers

### DIFF
--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -443,7 +443,7 @@ class TestGenerateSRTNotes:
         """
         flaw = FlawFactory()
         FlawCommentFactory(flaw=flaw)
-        affect = AffectFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
         TrackerFactory(
             affects=[affect],
             external_system_id="PROJECT-1",
@@ -780,7 +780,7 @@ class TestGenerateGroups:
         """
         flaw = FlawFactory(embargoed=False)
         FlawCommentFactory(flaw=flaw)
-        affect = AffectFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
         TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
         PsModuleFactory(
             name=affect.ps_module,
@@ -803,7 +803,7 @@ class TestGenerateGroups:
         """
         flaw = FlawFactory(embargoed=True)
         FlawCommentFactory(flaw=flaw)
-        affect = AffectFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
         TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
         PsModuleFactory(
             name=affect.ps_module,
@@ -830,7 +830,7 @@ class TestGenerateGroups:
         """
         flaw = FlawFactory(embargoed=True)
         FlawCommentFactory(flaw=flaw)
-        affect = AffectFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
         TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
         PsModuleFactory(
             name=affect.ps_module,
@@ -856,7 +856,7 @@ class TestGenerateGroups:
             embargoed=True, meta_attr={"groups": '["private", "qe_staff", "security"]'}
         )
         FlawCommentFactory(flaw=flaw)
-        affect = AffectFactory(flaw=flaw)
+        affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
         TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
         PsModuleFactory(
             name=affect.ps_module,
@@ -890,7 +890,7 @@ class TestGenerateGroups:
             embargoed=True, meta_attr={"groups": '["private", "qe_staff", "security"]'}
         )
         FlawCommentFactory(flaw=flaw)
-        affect1 = AffectFactory(flaw=flaw)
+        affect1 = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
         TrackerFactory(affects=[affect1], embargoed=flaw.is_embargoed)
         PsModuleFactory(
             name=affect1.ps_module,
@@ -905,7 +905,9 @@ class TestGenerateGroups:
         # remove existing affect
         new_flaw.affects.first().delete()
         # and add a newly created affect
-        affect2 = AffectFactory(flaw=new_flaw)
+        affect2 = AffectFactory(
+            flaw=new_flaw, affectedness=Affect.AffectAffectedness.NEW
+        )
         TrackerFactory(affects=[affect2], embargoed=new_flaw.is_embargoed)
         PsModuleFactory(
             name=affect2.ps_module,

--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -191,7 +191,9 @@ class TestBzTrackerCollector:
     def test_sync_with_affect(self, bz_tracker_collector):
         creation_dt = datetime(2011, 1, 1, tzinfo=timezone.utc)
         with freeze_time(creation_dt):
-            affect = AffectFactory.create(flaw__embargoed=False)
+            affect = AffectFactory.create(
+                flaw__embargoed=False, affectedness=Affect.AffectAffectedness.NEW
+            )
             TrackerFactory.create(
                 affects=(affect,),
                 external_system_id="577404",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,11 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for components affected by flaws closed as NOTABUG (OSIDB-363)
 - Implement validation for invalid components in software collection (OSIDB-356)
 - Implement Bugzilla metadata collector
-- Implement validation for for affects with exceptional combination of affectedness and resolution (OSIDB-361)
 - Implement validation for services related products with WONTREPORT resolution (OSIDB-362)
 - Implement validation for combinations of affectedness and resolution (OSIDB-360)
 - Implement a new API for getting a list of all supported products (PSINSIGHTS-593)
 - Implement CC list builder in Bugzilla backwards sync (OSIDB-386)
+- Implement validation for affects with exceptional combination of affectedness and resolution (OSIDB-361)
+- Implement validation for affects marked as WONTFIX or NOTAFFECTED with open trackers (OSIDB-364)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)


### PR DESCRIPTION
This PR implements validation for affects marked as `WONTFIX` or `NOTAFFECTED` with open trackers.

In order to achieve that was created validations in both `Affect` and `Tracker` model preventing user to associate open trackers in affects with invalid properties.

Closes OSIDB-364.