### PR TITLE
Pin black dependency when running via tox (CI)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
     -   id: black
         language_version: python3.9

--- a/tox.ini
+++ b/tox.ini
@@ -71,7 +71,7 @@ jobs = 4
 max-line-length=88
 
 [testenv:black]
-deps = black
+deps = black==22.12.0
 commands = black --extend-exclude src --extend-exclude openshift --extend-exclude ^.*\b(migrations)\b.*$ --check .
 
 [testenv:bandit]


### PR DESCRIPTION
The dependency on black defined in tox.ini was not pinned, this meant that when running on CI the latest version of Black was always being pulled whereas the version was pinned to major version 22.3.0 in the pre-commit hook.

Black major version 23 was recently released meaning that there are some backwards-incompatible changes, this together with the CI and local version desyncs meant that all CI runs would fail on the black step.