### PR TITLE
Add validation for flaws with prestage eligible dt

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -213,7 +213,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 153,
         "is_secret": false
       }
     ],
@@ -236,5 +236,5 @@
       }
     ]
   },
-  "generated_at": "2023-01-18T23:57:53Z"
+  "generated_at": "2023-02-01T18:38:49Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for invalid components in software collection (OSIDB-356)
 - Implement Bugzilla metadata collector
 - Implement validation for for affects with exceptional combination of affectedness and resolution (OSIDB-361)
+- Implement validation for flaws with pre-stage eligible date (OSIDB-365)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -5,6 +5,7 @@ import json
 import logging
 import re
 import uuid
+from datetime import timedelta
 from decimal import Decimal
 from typing import Union
 
@@ -830,6 +831,21 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin, ACLMixi
                 "notabug_affect_ps_component",
                 f"Module {affected.ps_module} of component "
                 f"{affected.ps_component} is affected by a flaw solved as NOTABUG.",
+            )
+
+    def _validate_prestage_eligible_date(self):
+        """
+        Validates that flaw with a pre-stage eligible date has an
+        unembargo date at maximum 48 hours in future.
+        """
+        prestage_eligible_date = self.meta_attr.get("prestage_eligible_date")
+        if prestage_eligible_date and (
+            not self.unembargo_dt
+            or self.unembargo_dt - prestage_eligible_date > timedelta(hours=48)
+        ):
+            raise ValidationError(
+                "Flaw cannot have pre-stage eligible date without an "
+                "unbembargo date at maximum 48 hours in future."
             )
 
     @property


### PR DESCRIPTION
This PR adds validation for flaws with pre-stage eligible date.

flaws with pre-stage eligible date should always have unembargo date within less than 48 hours in future.
Closes OSIDB-365.