### PR TITLE
Fix Schema YAML link and missing closing element </div>

### DIFF
--- a/osidb/templates/index.html
+++ b/osidb/templates/index.html
@@ -31,6 +31,7 @@
           {% endif %}
           </li>
         </ul>
+      </div>
     </nav>
     <div class="container-fluid">
       <hr/>

--- a/osidb/templates/index.html
+++ b/osidb/templates/index.html
@@ -40,7 +40,7 @@
       <p>Docs: <a href='https://github.com/RedHatProductSecurity/osidb/blob/master/docs/user/TUTORIAL.md'>OSIDB REST API tutorial</a> |
       <a href='https://github.com/RedHatProductSecurity/osidb-bindings/blob/master/TUTORIAL.md'>OSIDB Bindings Tutorial</a> |
       <a href='/osidb/api/v1/schema/swagger-ui'>API</a></p>
-      <p>Schema <a href='/osidb/api/v1/schema?format=json'>JSON</a>| <a href='/osidb/api/v1/schema?format=json'>YAML</a>| <a href='/osidb/api/v1/schema/swagger-ui/'>Interactive</a></p>
+      <p>Schema <a href='/osidb/api/v1/schema?format=json'>JSON</a>| <a href='/osidb/api/v1/schema?format=yaml'>YAML</a>| <a href='/osidb/api/v1/schema/swagger-ui/'>Interactive</a></p>
     </div>
     <div class="container-fluid footer-pf">
       <div class="text-center" style="font-size:80%; padding-bottom: 5px">


### PR DESCRIPTION
Fixes two small issues in `osid/osidb/templates/index.html` - Schema YAML link pointed to JSON instead of YAML, and closing element `</div>` was missing.