### PR TITLE
Add validation on flaw title format

### DIFF
--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -33,7 +33,7 @@ pytestmark = pytest.mark.unit
 class TestBugzillaQuerier:
     def test_remove_testing(self):
         flaw1 = FlawFactory(
-            title="regular flaw", embargoed=False, meta_attr={"bz_id": "321"}
+            title="regular: flaw", embargoed=False, meta_attr={"bz_id": "321"}
         )
         flaw2 = FlawFactory(
             title="testing: flaw", embargoed=False, meta_attr={"bz_id": "123"}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for for affects with exceptional combination of affectedness and resolution (OSIDB-361)
 - Implement validation for services related products with WONTREPORT resolution (OSIDB-362)
 - Implement validation for combinations of affectedness and resolution (OSIDB-360)
+- Implement validation for flaw title format (OSIDB-331)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1030,7 +1030,7 @@ class TestEndpoints(object):
         flaw_data = {
             "cve_id": "CVE-2021-0666",
             "cwe_id": "CWE-1",
-            "title": "Foo",
+            "title": "CVE-2021-0666 kernel: some description",
             "type": "VULNERABILITY",
             "state": "NEW",
             "impact": "CRITICAL",
@@ -1055,7 +1055,7 @@ class TestEndpoints(object):
         # a flaw draft essentially has no CVE
         flaw_data = {
             "cwe_id": "CWE-1",
-            "title": "Foo",
+            "title": "kernel: some description",
             "type": "VULNERABILITY",
             "state": "NEW",
             "impact": "CRITICAL",

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -24,7 +24,7 @@ class TestTrackingMixin:
             )
         ]
         return Flaw(
-            title="title",
+            title="kernel: some description",
             cwe_id="CWE-1",
             description="description",
             acl_read=acls,

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -95,7 +95,7 @@ class TestSearch:
         body = response.json()
         assert body["count"] == 1
 
-        flaw.title = "NOMORETITLE"
+        flaw.title = "CVE-2022-1234 kernel: NOTFOUND"
         assert flaw.save() is None
 
         response = auth_client.get(f"{test_api_uri}/flaws?search=title")
@@ -194,7 +194,7 @@ class TestSearch:
         assert body["count"] == 0
 
         FlawFactory(
-            title="title",
+            title="kernel: title",
             description="description",
             summary="summary",
             embargoed=False,


### PR DESCRIPTION
This PR adds validation on flaw title format.

This PR enforces all flaws to have a title formatted in the following pattern: 
`[EMBARGOED] [CVE IDs [...]] <component name>: <description of vulnerability nature>`.
In order to achieve that some tests were edited to use the correct format.

Closes OSIDB-331.