### PR TITLE
Simplify GitHub Testing workflow

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - master
 jobs:
-  lint:
-    name: Linting
+  changelog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,19 +1,18 @@
 name: Test
-on:
-  workflow_run:
-    workflows: [Lint]
-    types: [completed]
+on: [push]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     container:
+      # Docker-in-docker is not really necessary but helps the network
+      # communication between the runner and the services, and also makes
+      # it much simpler to transition from GitLab to GitHub as we use the
+      # same image and dependencies / setup as before, it should probably
+      # be revisited in the not-so-distant future
       image: quay.io/prodsecdev/fedora-latest:35
       credentials:
         username: ${{ secrets.QUAY_REGISTRY_USERNAME }}
         password: ${{ secrets.QUAY_REGISTRY_TOKEN }}
-    # this is required in order to have the job run only if the dependent
-    # workflow succeeded, see GitHub docs for more info
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     services:
       postgres:
         image: registry.redhat.io/rhel8/postgresql-13:1

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,7 +109,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 21,
+        "line_number": 20,
         "is_secret": false
       },
       {
@@ -117,7 +117,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 39,
+        "line_number": 38,
         "is_secret": false
       }
     ],
@@ -254,5 +254,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-03T16:18:07Z"
+  "generated_at": "2023-02-09T11:41:55Z"
 }


### PR DESCRIPTION
This commit changes the "Testing" GitHub workflow to simply run on push, just like the "Linting" one.

Previously it had been set up to only run after the "Linting" workflow completed and only if it was successful, the idea behind this was to not waste resources on testing (heavy) if the linting (not-so-heavy) failed.

While this is a very noble goal, GH workflows are not really conceived to work this way and thus when pushing the "Testing" workflow wouldn't be attached to any branch, where one would expect it to be attached to the branch that triggered the dependent workflow, this makes it hard to track the result of the "Testing" workflow.

Since we have unlimited resources for GH actions, the benefits of the previous approach do not outweigh the consequences, so we can simply run both workflows in parallel, enjoy a reduction in PR overhead and be able to easily track the result of all workflows.