### PR TITLE
Add validation for special handling packages

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement CC list builder in Bugzilla backwards sync (OSIDB-386)
 - Implement validation for affects with exceptional combination of affectedness and resolution (OSIDB-361)
 - Implement validation for affects marked as WONTFIX or NOTAFFECTED with open trackers (OSIDB-364)
+- Implement validation for affected special handled modules without summary or statement (OSIDB-328)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)


### PR DESCRIPTION
This PR adds validation alerting that a `Flaw` affects a `PSModule` with special handling features but misses `summary` or `statement`.

Closes OSIDB-328.