### PR TITLE
ACL validations

### DIFF
--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -4,6 +4,7 @@ transform Bugzilla flaw bug into OSIDB flaw model
 import json
 import logging
 import re
+import uuid
 from collections import defaultdict
 from functools import cached_property
 
@@ -150,13 +151,27 @@ class TrackerBugConvertor:
 
     @cached_property
     def acl_read(self):
-        """get read ACL based on read groups"""
-        return self._acl_read or generate_acls(self.groups_read)
+        """
+        get read ACL based on read groups
+
+        it is necessary to generete UUIDs and not just hashes
+        so the ACL validations may properly compare the result
+        """
+        return self._acl_read or [
+            uuid.UUID(acl) for acl in generate_acls(self.groups_read)
+        ]
 
     @cached_property
     def acl_write(self):
-        """get write ACL based on write groups"""
-        return self._acl_write or generate_acls(self.groups_write)
+        """
+        get write ACL based on write groups
+
+        it is necessary to generete UUIDs and not just hashes
+        so the ACL validations may properly compare the result
+        """
+        return self._acl_write or [
+            uuid.UUID(acl) for acl in generate_acls(self.groups_write)
+        ]
 
     def _gen_tracker_object(self, affect) -> Tracker:
         # there maybe already existing tracker from the previous sync
@@ -527,13 +542,23 @@ class FlawBugConvertor:
 
     @cached_property
     def acl_read(self):
-        """get read ACL based on read groups"""
-        return generate_acls(self.groups_read)
+        """
+        get read ACL based on read groups
+
+        it is necessary to generete UUIDs and not just hashes
+        so the ACL validations may properly compare the result
+        """
+        return [uuid.UUID(acl) for acl in generate_acls(self.groups_read)]
 
     @cached_property
     def acl_write(self):
-        """get write ACL based on write groups"""
-        return generate_acls(self.groups_write)
+        """
+        get write ACL based on write groups
+
+        it is necessary to generete UUIDs and not just hashes
+        so the ACL validations may properly compare the result
+        """
+        return [uuid.UUID(acl) for acl in generate_acls(self.groups_write)]
 
     @property
     def alias(self):

--- a/collectors/product_definitions/core.py
+++ b/collectors/product_definitions/core.py
@@ -3,7 +3,7 @@ from typing import Tuple
 import requests
 from requests_gssapi import HTTPSPNEGOAuth
 
-from osidb.helpers import get_model_fields
+from osidb.helpers import ensure_list, get_model_fields
 from osidb.models import PsContact, PsModule, PsProduct, PsUpdateStream
 
 from .constants import (
@@ -95,13 +95,6 @@ def sync_ps_update_streams(data: dict):
         PsUpdateStream.objects.update_or_create(
             name=stream_name, defaults=filtered_stream_data
         )
-
-
-def ensure_list(item):
-    """
-    helper to ensure that the item is list
-    """
-    return item if isinstance(item, list) else [item]
 
 
 def sync_ps_products_modules(ps_products_data: dict, ps_modules_data: dict):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for unknown component (OSIDB-355)
 - Implement temporary NVD collector (OSIDB-632)
 - Implement Exploits report data API endpoint (PSINSIGHTS-764)
+- Implement ACL validations (OSIDB-691)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2035,6 +2035,13 @@ components:
         delegated_resolution:
           type: string
           readOnly: true
+        embargoed:
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+          readOnly: true
+          required: true
+          type: boolean
         created_dt:
           type: string
           format: date-time
@@ -2046,6 +2053,7 @@ components:
       required:
       - created_dt
       - delegated_resolution
+      - embargoed
       - flaw
       - meta_attr
       - ps_component
@@ -2263,9 +2271,6 @@ components:
         cwe_id:
           type: string
           maxLength: 50
-        embargoed:
-          type: boolean
-          readOnly: true
         unembargo_dt:
           type: string
           format: date-time
@@ -2384,6 +2389,13 @@ components:
           items:
             $ref: '#/components/schemas/CVEv5PackageVersions'
           readOnly: true
+        embargoed:
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+          readOnly: true
+          required: true
+          type: boolean
         created_dt:
           type: string
           format: date-time
@@ -2562,6 +2574,13 @@ components:
           additionalProperties:
             type: string
             nullable: true
+        embargoed:
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+          readOnly: true
+          required: true
+          type: boolean
         created_dt:
           type: string
           format: date-time
@@ -2572,6 +2591,7 @@ components:
           readOnly: true
       required:
       - created_dt
+      - embargoed
       - type
       - updated_dt
       - uuid

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -19,7 +19,6 @@ from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet, ReadOnlyModelViewSet, ViewSet
 
 from .constants import OSIDB_API_VERSION, PYPI_URL, URL_REGEX
-from .core import generate_acls
 from .filters import AffectFilter, FlawFilter, TrackerFilter
 from .models import Affect, Flaw, Tracker
 from .serializer import (
@@ -317,11 +316,6 @@ class FlawView(ModelViewSet):
         response["Location"] = f"/api/{OSIDB_API_VERSION}/flaws/{response.data['uuid']}"
         return response
 
-    def perform_create(self, serializer):
-        # NOTE: this is incorrect, but will be fixed properly later
-        acls = generate_acls(self.request.user.groups.all())
-        serializer.save(acl_read=acls, acl_write=acls)
-
 
 @extend_schema(
     responses={
@@ -358,11 +352,6 @@ class AffectView(ModelViewSet):
     filterset_class = AffectFilter
     http_method_names = get_valid_http_methods(ModelViewSet)
     permission_classes = [IsAuthenticatedOrReadOnly]
-
-    def perform_create(self, serializer):
-        # NOTE: this is incorrect, but will be fixed properly later
-        acls = generate_acls(self.request.user.groups.all())
-        serializer.save(acl_read=acls, acl_write=acls)
 
 
 # until we implement tracker write operations

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -14,6 +14,13 @@ from django.db import models
 from .exceptions import OSIDBException
 
 
+def ensure_list(item):
+    """
+    helper to ensure that the item is list
+    """
+    return item if isinstance(item, list) else [item]
+
+
 def get_env(
     key: str,
     default: Union[None, str] = None,

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -90,13 +90,33 @@ def embargo_read_group():
 
 
 @pytest.fixture
-def public_groups(public_read_group):
+def public_read_groups(public_read_group):
     return [uuid.UUID(acl) for acl in public_read_group]
 
 
 @pytest.fixture
-def embargoed_groups(embargo_read_group):
+def embargoed_read_groups(embargo_read_group):
     return [uuid.UUID(acl) for acl in embargo_read_group]
+
+
+@pytest.fixture
+def public_write_group():
+    return generate_acls([settings.PUBLIC_WRITE_GROUP])
+
+
+@pytest.fixture
+def embargo_write_group():
+    return generate_acls([settings.EMBARGO_WRITE_GROUP])
+
+
+@pytest.fixture
+def public_write_groups(public_write_group):
+    return [uuid.UUID(acl) for acl in public_write_group]
+
+
+@pytest.fixture
+def embargoed_write_groups(embargo_write_group):
+    return [uuid.UUID(acl) for acl in embargo_write_group]
 
 
 @pytest.fixture

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -25,9 +25,13 @@ from osidb.models import (
     VersionStatus,
 )
 
-DATA_PRODSEC_ACL = uuid.uuid5(
+DATA_PRODSEC_ACL_READ = uuid.uuid5(
     uuid.NAMESPACE_URL,
     "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
+)
+DATA_PRODSEC_ACL_WRITE = uuid.uuid5(
+    uuid.NAMESPACE_URL,
+    "https://osidb.prod.redhat.com/ns/acls#data-prodsec-write",
 )
 
 
@@ -178,8 +182,8 @@ class AffectFactory(factory.django.DjangoModelFactory):
 
     flaw = factory.SubFactory(FlawFactory)
 
-    acl_read = [DATA_PRODSEC_ACL]
-    acl_write = acl_read
+    acl_read = [DATA_PRODSEC_ACL_READ]
+    acl_write = [DATA_PRODSEC_ACL_WRITE]
     meta_attr = factory.Dict({"test": "1"})
 
     # @factory.post_generation
@@ -292,11 +296,11 @@ class FlawCommentFactory(factory.django.DjangoModelFactory):
     type = "BUGZILLA"
     created_dt = factory.Faker("date_time", tzinfo=UTC)
     external_system_id = factory.sequence(lambda n: f"fake-external-id{n}")
-    acl_read = factory.List([DATA_PRODSEC_ACL])
+    acl_read = [DATA_PRODSEC_ACL_READ]
+    acl_write = [DATA_PRODSEC_ACL_WRITE]
 
     flaw = factory.SubFactory(FlawFactory)
 
-    acl_write = acl_read
     meta_attr = {
         "id": "1285930",
         "tags": "[]",
@@ -317,8 +321,8 @@ class FlawMetaFactory(factory.django.DjangoModelFactory):
 
     type = "REFERENCE"
     created_dt = factory.Faker("date_time", tzinfo=UTC)
-    acl_read = factory.List([DATA_PRODSEC_ACL])
-    acl_write = acl_read
+    acl_read = [DATA_PRODSEC_ACL_READ]
+    acl_write = [DATA_PRODSEC_ACL_WRITE]
     meta_attr = {
         "url": "http://nonexistenturl.example.com/1285930",
         "type": "external",

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1,13 +1,17 @@
+import uuid
 from datetime import timedelta
 from typing import Set, Union
 
 import pytest
+from django.conf import settings
 from django.utils import timezone
 from django.utils.timezone import datetime
 from freezegun import freeze_time
 
 from osidb.filters import FlawFilter
 
+from ..core import generate_acls
+from ..helpers import ensure_list
 from ..models import Affect, Flaw, FlawMeta, Tracker
 from .factories import (
     AffectFactory,
@@ -1052,8 +1056,7 @@ class TestEndpoints(object):
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "acl_read": ["data-prodsec"],
-            "acl_write": ["data-prodsec-write"],
+            "embargoed": False,
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201
@@ -1079,8 +1082,7 @@ class TestEndpoints(object):
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
-            "acl_read": ["data-prodsec"],
-            "acl_write": ["data-prodsec-write"],
+            "embargoed": False,
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201
@@ -1126,9 +1128,9 @@ class TestEndpoints(object):
                 "state": flaw.state,
                 "resolution": flaw.resolution,
                 "impact": flaw.impact,
-                "acl_read": ["data-prodsec"],
-                "acl_write": ["data-prodsec-write"],
+                "embargoed": False,
             },
+            format="json",
         )
         assert response.status_code == 200
         body = response.json()
@@ -1214,8 +1216,7 @@ class TestEndpoints(object):
             "resolution": Affect.AffectResolution.NOVALUE,
             "ps_module": "rhacm-2",
             "ps_component": "curl",
-            "acl_read": ["data-prodsec"],
-            "acl_write": ["data-prodsec-write"],
+            "embargoed": False,
         }
         response = auth_client.post(
             f"{test_api_uri}/affects", affect_data, format="json"
@@ -1237,8 +1238,7 @@ class TestEndpoints(object):
         response = auth_client.get(f"{test_api_uri}/affects/{affect.uuid}")
         assert response.status_code == 200
         original_body = response.json()
-        original_body["acl_read"] = ["data-prodsec"]
-        original_body["acl_write"] = ["data-prodsec-write"]
+        original_body["embargoed"] = False
 
         response = auth_client.put(
             f"{test_api_uri}/affects/{affect.uuid}",
@@ -1318,3 +1318,119 @@ class TestEndpoints(object):
         # this HTTP method is not allowed until we integrate
         # with the authoritative sources of the tracker data
         assert response.status_code == 405
+
+
+class TestEndpointsACLs:
+    """
+    ACL specific tests
+    """
+
+    def hash_acl(self, acl):
+        """
+        shortcut to get ACL from the group(s)
+        """
+        return [uuid.UUID(ac) for ac in generate_acls(ensure_list(acl))]
+
+    @pytest.mark.parametrize(
+        "embargoed,acl_read,acl_write",
+        [
+            (False, settings.PUBLIC_READ_GROUPS, settings.PUBLIC_WRITE_GROUP),
+            (True, settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP),
+        ],
+    )
+    def test_flaw_create(
+        self, auth_client, test_api_uri, embargoed, acl_read, acl_write
+    ):
+        """
+        test proper embargo status and ACLs when creating a flaw by sending a POST request
+        """
+        flaw_data = {
+            "title": "EMBARGOED Foo" if embargoed else "Foo",
+            "description": "test",
+            "reported_dt": "2022-11-22T15:55:22.830Z",
+            "unembargo_dt": None if embargoed else "2000-1-1T22:03:26.065Z",
+            "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "embargoed": embargoed,
+        }
+        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        assert response.status_code == 201
+        body = response.json()
+        created_uuid = body["uuid"]
+
+        flaw = Flaw.objects.first()
+        assert flaw.acl_read == self.hash_acl(acl_read)
+        assert flaw.acl_write == self.hash_acl(acl_write)
+
+        response = auth_client.get(f"{test_api_uri}/flaws/{created_uuid}")
+        assert response.status_code == 200
+        assert response.json()["embargoed"] == embargoed
+
+    @pytest.mark.parametrize(
+        "embargoed,acl_read,acl_write",
+        [
+            (False, settings.PUBLIC_READ_GROUPS, settings.PUBLIC_WRITE_GROUP),
+            (True, settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP),
+        ],
+    )
+    def test_flaw_update(
+        self, auth_client, test_api_uri, embargoed, acl_read, acl_write
+    ):
+        """
+        test proper embargo status and ACLs when updating a flaw by sending a PUT request
+        while the embargo status and ACLs itself are not being changed
+        """
+        flaw = FlawFactory(embargoed=embargoed)
+        AffectFactory(flaw=flaw)
+
+        response = auth_client.get(f"{test_api_uri}/flaws/{flaw.uuid}")
+        assert response.status_code == 200
+        original_body = response.json()
+        assert original_body["embargoed"] == embargoed
+
+        response = auth_client.put(
+            f"{test_api_uri}/flaws/{flaw.uuid}",
+            {
+                "title": f"{flaw.title} appended test title",
+                "description": flaw.description,
+                "embargoed": embargoed,
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert original_body["title"] != body["title"]
+        assert "appended test title" in body["title"]
+        assert original_body["embargoed"] == body["embargoed"]
+
+        flaw = Flaw.objects.first()
+        assert flaw.acl_read == self.hash_acl(acl_read)
+        assert flaw.acl_write == self.hash_acl(acl_write)
+
+    @freeze_time(datetime(2021, 11, 23, tzinfo=timezone.get_current_timezone()))
+    def test_flaw_unembargo(self, auth_client, test_api_uri):
+        """
+        test proper embargo status and ACLs when unembargoing a flaw by sending a PUT request
+        """
+        future_dt = datetime(2021, 11, 27, tzinfo=timezone.get_current_timezone())
+        flaw = FlawFactory(
+            embargoed=True,
+            unembargo_dt=future_dt,
+        )
+        AffectFactory(flaw=flaw)
+
+        # the unembargo must happen after the unembargo moment passed
+        with freeze_time(future_dt):
+            response = auth_client.put(
+                f"{test_api_uri}/flaws/{flaw.uuid}",
+                {
+                    "title": flaw.title.replace("EMBARGOED", "").strip(),
+                    "description": flaw.description,
+                    "embargoed": False,
+                },
+                format="json",
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["embargoed"] is False
+        assert Flaw.objects.first().embargoed is False

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1052,6 +1052,8 @@ class TestEndpoints(object):
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "acl_read": ["data-prodsec"],
+            "acl_write": ["data-prodsec-write"],
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201
@@ -1077,6 +1079,8 @@ class TestEndpoints(object):
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
+            "acl_read": ["data-prodsec"],
+            "acl_write": ["data-prodsec-write"],
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 201
@@ -1105,7 +1109,7 @@ class TestEndpoints(object):
         """
         Test that updating a Flaw by sending a PUT request works.
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(embargoed=False)
         AffectFactory(flaw=flaw)
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw.uuid}")
         assert response.status_code == 200
@@ -1122,8 +1126,8 @@ class TestEndpoints(object):
                 "state": flaw.state,
                 "resolution": flaw.resolution,
                 "impact": flaw.impact,
-                "acl_read": flaw.acl_read,
-                "acl_write": flaw.acl_write,
+                "acl_read": ["data-prodsec"],
+                "acl_write": ["data-prodsec-write"],
             },
         )
         assert response.status_code == 200
@@ -1210,6 +1214,8 @@ class TestEndpoints(object):
             "resolution": Affect.AffectResolution.NOVALUE,
             "ps_module": "rhacm-2",
             "ps_component": "curl",
+            "acl_read": ["data-prodsec"],
+            "acl_write": ["data-prodsec-write"],
         }
         response = auth_client.post(
             f"{test_api_uri}/affects", affect_data, format="json"
@@ -1231,6 +1237,8 @@ class TestEndpoints(object):
         response = auth_client.get(f"{test_api_uri}/affects/{affect.uuid}")
         assert response.status_code == 200
         original_body = response.json()
+        original_body["acl_read"] = ["data-prodsec"]
+        original_body["acl_write"] = ["data-prodsec-write"]
 
         response = auth_client.put(
             f"{test_api_uri}/affects/{affect.uuid}",

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -41,15 +41,26 @@ def tzdatetime(*args):
 
 
 class TestFlaw:
-    def test_create(self, datetime_with_tz, good_cve_id):
-        """test raw flaw creation"""
-
-        acls = [
+    @property
+    def acl_read(self):
+        return [
             uuid.uuid5(
                 uuid.NAMESPACE_URL,
                 "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
             )
         ]
+
+    @property
+    def acl_write(self):
+        return [
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                "https://osidb.prod.redhat.com/ns/acls#data-prodsec-write",
+            )
+        ]
+
+    def test_create(self, datetime_with_tz, good_cve_id):
+        """test raw flaw creation"""
         meta_attr = {}
         meta_attr["test"] = 1
         vuln_1 = FlawFactory.build(
@@ -65,8 +76,8 @@ class TestFlaw:
             statement="statement",
             resolution=FlawResolution.NOVALUE,
             is_major_incident=True,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             # META
             meta_attr=meta_attr,
@@ -91,8 +102,8 @@ class TestFlaw:
             affectedness=Affect.AffectAffectedness.NEW,
             resolution=Affect.AffectResolution.NOVALUE,
             impact=Affect.AffectImpact.NOVALUE,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
         )
         affect2.save()
         tracker1 = TrackerFactory(
@@ -123,8 +134,8 @@ class TestFlaw:
                 "creation_time": "2006-03-30T11:56:45Z",
             },
             type=FlawComment.FlawCommentType.BUGZILLA,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
         )
         comment2.save()
         all_comments = vuln_1.comments.all()
@@ -140,8 +151,8 @@ class TestFlaw:
                 "url": "http://nonexistenturl.example.com/99999",
                 "type": "external",
             },
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
         )
         meta2.save()
         all_meta = vuln_1.meta.all()
@@ -162,8 +173,8 @@ class TestFlaw:
             impact=FlawImpact.CRITICAL,
             statement="statement",
             resolution=FlawResolution.NOVALUE,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         )
         assert vuln_2.validate() is None
@@ -172,12 +183,6 @@ class TestFlaw:
         # assert vuln_2.delete()
 
     def test_create_flaw_method(self):
-        acls = [
-            uuid.uuid5(
-                uuid.NAMESPACE_URL,
-                "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
-            )
-        ]
         Flaw.objects.all().delete()
         flaw1 = Flaw.objects.create_flaw(
             bz_id="12345",
@@ -185,8 +190,8 @@ class TestFlaw:
             title="first",
             unembargo_dt=tzdatetime(2000, 1, 1),
             description="description",
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             reported_dt=timezone.now(),
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         )
@@ -199,8 +204,8 @@ class TestFlaw:
             bz_id="12345",
             title="second",
             description="description",
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             reported_dt=timezone.now(),
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         ).save()
@@ -290,8 +295,8 @@ class TestFlaw:
             flaw=flaw,
             _type=FlawMeta.FlawMetaType.MAJOR_INCIDENT,
             meta={},
-            acl_read=[uuid.uuid4()],
-            acl_write=[uuid.uuid4()],
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
         )
         meta.save()
         old_updated_dt = meta.updated_dt
@@ -310,13 +315,6 @@ class TestFlaw:
 
     def test_objects_create_flaw(self, datetime_with_tz, good_cve_id):
         """test creating with manager .create_flow()"""
-
-        acls = [
-            uuid.uuid5(
-                uuid.NAMESPACE_URL,
-                "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
-            )
-        ]
         meta_attr = {}
         meta_attr["test"] = 1
         vuln_1 = Flaw(
@@ -332,8 +330,8 @@ class TestFlaw:
             impact=FlawImpact.CRITICAL,
             statement="statement",
             resolution=FlawResolution.NOVALUE,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             # META
             meta_attr=meta_attr,
@@ -343,13 +341,6 @@ class TestFlaw:
 
     def test_flaw_queryset(self, datetime_with_tz):
         """retrieve flaw manager queryset"""
-        acls = [
-            uuid.uuid5(
-                uuid.NAMESPACE_URL,
-                "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
-            )
-        ]
-
         flaw = Flaw(
             cve_id="CVE-1970-12345",
             cwe_id="CWE-1",
@@ -363,8 +354,8 @@ class TestFlaw:
             impact=FlawImpact.CRITICAL,
             statement="statement",
             resolution=FlawResolution.NOVALUE,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         )
         assert Flaw.objects.get_queryset().count() == 0
@@ -373,13 +364,6 @@ class TestFlaw:
 
     def test_fts_search(self, datetime_with_tz, good_cve_id):
         """check fts search is working"""
-        acls = [
-            uuid.uuid5(
-                uuid.NAMESPACE_URL,
-                "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
-            )
-        ]
-
         flaw = Flaw(
             cve_id=good_cve_id,
             cwe_id="CWE-1",
@@ -393,8 +377,8 @@ class TestFlaw:
             impact=FlawImpact.CRITICAL,
             statement="statement",
             resolution=FlawResolution.NOVALUE,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=self.acl_read,
+            acl_write=self.acl_write,
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         )
 
@@ -943,6 +927,9 @@ class TestFlawValidators:
             flaw.title = "EMBARGOED foo bar baz"
             flaw.acl_read = [
                 uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])
+            ]
+            flaw.acl_write = [
+                uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])
             ]
             flaw.unembargo_dt = tzdatetime(2022, 1, 1)
             flaw.save()

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -1,10 +1,12 @@
 import uuid
 
 import pytest
+from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun import freeze_time
 
 from collectors.bzimport.convertors import FlawBugConvertor
+from osidb.core import generate_acls
 from osidb.exceptions import DataInconsistencyException
 from osidb.models import Flaw
 from osidb.tests.factories import AffectFactory, FlawFactory
@@ -14,21 +16,186 @@ from .test_flaw import tzdatetime
 pytestmark = pytest.mark.unit
 
 
+class TestACLMixin:
+    """
+    negative tests of ACL validations
+    the positive tests are all over the test suite
+    """
+
+    def group2acl(self, group):
+        """
+        translate the human-readable LDAP group
+        name to the corresponding UUID ACL hash
+        """
+        return uuid.UUID(generate_acls([group])[0])
+
+    def create_flaw(self, acl_read=None, acl_write=None, save=True):
+        """
+        shortcut for creating a flaw with the given ACLs
+        """
+        kwargs = {}
+        if acl_read is not None:
+            kwargs["acl_read"] = [self.group2acl(group) for group in acl_read]
+        if acl_write is not None:
+            kwargs["acl_write"] = [self.group2acl(group) for group in acl_write]
+        return FlawFactory(**kwargs) if save else FlawFactory.build(**kwargs)
+
+    def test_empty_acl_read(self):
+        """
+        test that an empty read ACL is not allowed
+        """
+        with pytest.raises(
+            ValidationError, match="acl_read.....This field cannot be blank"
+        ):
+            FlawFactory(acl_read=[])
+
+    def test_empty_acl_write(self):
+        """
+        test that an empty write ACL is not allowed
+        """
+        with pytest.raises(
+            ValidationError, match="acl_write.....This field cannot be blank"
+        ):
+            FlawFactory(acl_write=[])
+
+    @pytest.mark.parametrize(
+        "acl_read,acl_write",
+        [
+            (["data-prodsec", "unknown-group"], ["data-prodsec-write"]),
+            (["date-topsecret"], ["data-topsecret-write", "unknown-group"]),
+            (
+                ["date-topsecret", "unknown-group"],
+                ["data-topsecret-write", "unknown-group"],
+            ),
+        ],
+    )
+    def test_known_acls(self, acl_read, acl_write):
+        """
+        test that both ACLs contains identical LDAP groups
+        of course with respect to read|write difference
+        """
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "Unknown ACL group given - known are: data-prodsec, "
+                "data-prodsec-write, data-topsecret, data-topsecret-write"
+            ),
+        ):
+            flaw = self.create_flaw(acl_read=acl_read, acl_write=acl_write, save=False)
+            flaw._validate_acls_known()
+
+    @pytest.mark.parametrize(
+        "acl_read",
+        [
+            (["data-prodsec-write"]),
+            (["data-prodsec-write", "data-topsecret-write"]),
+            (["data-prodsec", "data-prodsec-write"]),
+            (["data-topsecret", "data-topsecret-write"]),
+        ],
+    )
+    def test_meaningful_acl_read(self, acl_read):
+        """
+        test that read ACL contains only read LDAP groups
+        """
+        with pytest.raises(
+            ValidationError, match="Read ACL contains non-read ACL group:"
+        ):
+            flaw = self.create_flaw(acl_read=acl_read, save=False)
+            flaw._validate_acl_read_meaningful()
+
+    @pytest.mark.parametrize(
+        "acl_write",
+        [
+            (["data-prodsec"]),
+            (["data-prodsec", "data-topsecret"]),
+            (["data-prodsec", "data-prodsec-write"]),
+            (["data-topsecret", "data-topsecret-write"]),
+        ],
+    )
+    def test_meaningful_acl_write(self, acl_write):
+        """
+        test that write ACL contains only read LDAP groups
+        """
+        with pytest.raises(
+            ValidationError, match="Write ACL contains non-write ACL group:"
+        ):
+            flaw = self.create_flaw(acl_write=acl_write, save=False)
+            flaw._validate_acl_write_meaningful()
+
+    @pytest.mark.parametrize(
+        "acl_write",
+        [
+            (["data-prodsec-write"]),
+            (["data-prodsec-write", "data-topsecret-write"]),
+        ],
+    )
+    def test_unexpected_embargoed_acl(self, acl_write):
+        """
+        test that embargoed ACL contains only expected LDAP groups
+        which means the embaroed LDAP groups only
+        """
+        with pytest.raises(
+            ValidationError, match="Unexpected ACL group in embargoed ACLs:"
+        ):
+            # the read ACL is given as it defines the embargo
+            self.create_flaw(acl_read=["data-topsecret"], acl_write=acl_write)
+
+    @pytest.mark.parametrize(
+        "acl_read,acl_write",
+        [
+            (["data-prodsec", "data-topsecret"], ["data-prodsec-write"]),
+            (["data-prodsec"], ["data-prodsec-write", "data-topsecret-write"]),
+        ],
+    )
+    def test_unexpected_non_embargoed_acl(self, acl_read, acl_write):
+        """
+        test that non-embargoed ACL contains only expected LDAP groups
+        which means the public LDAP groups only
+        """
+        with pytest.raises(
+            ValidationError, match="Unexpected ACL group in non-embargoed ACLs:"
+        ):
+            self.create_flaw(acl_read=acl_read, acl_write=acl_write)
+
+    @pytest.mark.parametrize(
+        "acl_read,acl_write",
+        [
+            (["data-prodsec", "data-prodsec"], ["data-prodsec-write"]),
+            (["data-topsecret"], ["data-topsecret-write", "data-topsecret-write"]),
+        ],
+    )
+    def test_duplicite_acl(self, acl_read, acl_write):
+        """
+        test that non-embargoed ACL contains only expected LDAP groups
+        which means the public LDAP groups only
+        """
+        with pytest.raises(
+            ValidationError, match="ACLs must not contain duplicit ACL groups"
+        ):
+            self.create_flaw(acl_read=acl_read, acl_write=acl_write)
+
+
 class TestTrackingMixin:
     def create_flaw(self, **kwargs):
         """shortcut to create minimal flaw"""
-        acls = [
+        acl_read = [
             uuid.uuid5(
                 uuid.NAMESPACE_URL,
                 "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
+            )
+        ]
+        acl_write = [
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                "https://osidb.prod.redhat.com/ns/acls#data-prodsec-write",
             )
         ]
         return Flaw(
             title="title",
             cwe_id="CWE-1",
             description="description",
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=acl_read,
+            acl_write=acl_write,
             reported_dt=timezone.now(),
             unembargo_dt=tzdatetime(2000, 1, 1),
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -58,10 +58,16 @@ class TestSearch:
         body = response.json()
         assert body["count"] == 0
 
-        acls = [
+        acl_read = [
             uuid.uuid5(
                 uuid.NAMESPACE_URL,
                 "https://osidb.prod.redhat.com/ns/acls#data-prodsec",
+            )
+        ]
+        acl_write = [
+            uuid.uuid5(
+                uuid.NAMESPACE_URL,
+                "https://osidb.prod.redhat.com/ns/acls#data-prodsec-write",
             )
         ]
         meta_attr = {"test": 1}
@@ -80,8 +86,8 @@ class TestSearch:
             summary="SUMMARY",
             statement="STATEMENT",
             resolution=FlawResolution.NOVALUE,
-            acl_read=acls,
-            acl_write=acls,
+            acl_read=acl_read,
+            acl_write=acl_write,
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             # META
             meta_attr=meta_attr,


### PR DESCRIPTION
This MR implements ACL validation mixin class. It also makes the ACLs set-able through the API and serializers (so I can make the integration tests passing the ACL validations). There are also a lot of modified tests to pass the new validations and some new tests validating the validations themselves.

I also incorporated a few suggestions from https://github.com/RedHatProductSecurity/osidb/pull/145 so that one will probably be rebased on this one.

Closes OSIDB-691
Closes OSIDB-692