### PR TITLE
Validate unknown component

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -231,7 +231,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 146,
+        "line_number": 148,
         "is_secret": false
       }
     ],
@@ -254,5 +254,5 @@
       }
     ]
   },
-  "generated_at": "2023-02-09T11:41:55Z"
+  "generated_at": "2023-02-21T00:37:20Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for affects marked as WONTFIX or NOTAFFECTED with open trackers (OSIDB-364)
 - Implement validation for affected special handled modules without summary or statement (OSIDB-328)
 - Implement validation for flaws with private source without ACK (OSIDB-339)
+- Implement validation for unknown component (OSIDB-355)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -19,6 +19,8 @@ from django_deprecate_fields import deprecate_field
 from polymorphic.models import PolymorphicModel
 from psqlextra.fields import HStoreField
 
+from apps.bbsync.constants import RHSCL_BTS_KEY
+from apps.bbsync.models import BugzillaComponent
 from apps.exploits.mixins import AffectExploitExtensionMixin
 from apps.exploits.query_sets import AffectQuerySetExploitExtension
 from apps.osim.workflow import WorkflowModel
@@ -1098,7 +1100,7 @@ class Affect(
         """
         bz_id = self.flaw.meta_attr.get("bz_id")
         if bz_id and int(bz_id) <= BZ_ID_SENTINEL:
-            if not PsModule.objects.filter(name=self.ps_module).exists():
+            if self.is_unknown:
                 self.alert(
                     "old_flaw_affect_ps_module",
                     f"{self.ps_module} is not a valid ps_module "
@@ -1116,7 +1118,7 @@ class Affect(
         """
         bz_id = self.flaw.meta_attr.get("bz_id")
         if bz_id and int(bz_id) > BZ_ID_SENTINEL:
-            if not PsModule.objects.filter(name=self.ps_module).exists():
+            if self.is_unknown:
                 raise ValidationError(
                     f"{self.ps_module} is not a valid ps_module "
                     f"for flaw with bz_id {bz_id}."
@@ -1141,10 +1143,7 @@ class Affect(
         """
         Check that all RHSCL components in flaw's affects start with a valid collection.
         """
-        if (
-            not self.ps_module.startswith("rhscl")
-            or self.ps_component in COMPONENTS_WITHOUT_COLLECTION
-        ):
+        if not self.is_rhscl or self.ps_component in COMPONENTS_WITHOUT_COLLECTION:
             return
 
         streams = PsUpdateStream.objects.filter(ps_module__name=self.ps_module)
@@ -1229,34 +1228,61 @@ class Affect(
                 "WONTFIX but has open tracker(s).",
             )
 
-    @property
-    def delegated_resolution(self):
-        """affect delegated resolution based on resolutions of related trackers"""
-        if not (
-            self.affectedness == Affect.AffectAffectedness.AFFECTED
-            and self.resolution == Affect.AffectResolution.DELEGATED
-        ):
-            return None
+    def _validate_unknown_component(self):
+        """
+        Alerts that a flaw affects a component not tracked in Bugzilla.
+        Alternatively, the PSComponent should have an override set in Product Definitions.
+        The used PSComponent is either misspelled or the override is missing.
+        """
 
-        trackers = self.trackers.all()
-        if not trackers:
-            return Affect.AffectFix.AFFECTED
+        if not self.ps_component:
+            return
 
-        statuses = [tracker.fix_state for tracker in trackers]
-        for status in (
-            Affect.AffectFix.NOTAFFECTED,
-            Affect.AffectFix.AFFECTED,
-            Affect.AffectFix.WONTFIX,
-            Affect.AffectFix.OOSS,
-            Affect.AffectFix.DEFER,
-        ):
-            if status in statuses:
-                return status
+        ps_module = PsModule.objects.filter(name=self.ps_module).first()
+        if not ps_module:
+            # unknown PSModule; should be checked in other function
+            return
 
-        # We don't know. Maybe none of the trackers have a valid resolution; default to "Affected".
-        logger.error("How did we get here??? %s, %s", trackers, statuses)
+        if ps_module.default_component:
+            # PSModule has a default component set; assume all as valid
+            return
 
-        return Affect.AffectFix.AFFECTED
+        if self.is_rhscl:
+            cc_affect = RHSCLAffectCCBuilder(affect=self, embargoed=self.is_embargoed)
+            _, component = cc_affect.collection_component()
+        else:
+            cc_affect = AffectCCBuilder(affect=self, embargoed=self.is_embargoed)
+            component = cc_affect.ps2bz_component()
+
+        if not cc_affect.is_bugzilla:
+            # only Bugzilla BTS is supported
+            return
+
+        if ps_module.component_overrides and component in ps_module.component_overrides:
+            # PSComponent is being overridden for BTS; assume its correct
+            return
+
+        if not BugzillaComponent.objects.filter(name=component).exists():
+            # Components for BTS key does not exist; maybe cache is not populated yet.
+            # Instead of raising warning for all flaw bugs when metadata are not
+            # cache, we will stay quiet.
+            return
+
+        bts_component = BugzillaComponent.objects.filter(
+            name=component, product__name=ps_module.bts_key
+        )
+        if not bts_component.exists():
+            alert_text = (
+                'Component "{}" for {} did not match BTS component (in {}) '
+                "nor component from Product Definitions"
+            )
+            alert_text = alert_text.format(
+                component, self.ps_module, ps_module.bts_name
+            )
+            self.alert(
+                "flaw_affects_unknown_component",
+                alert_text,
+            )
 
     def _validate_wontreport_products(self):
         """
@@ -1311,6 +1337,70 @@ class Affect(
                     f"Affected module ({special_module.first().name}) "
                     "are marked as special handling but flaw does not contain statement.",
                 )
+
+    @property
+    def delegated_resolution(self):
+        """affect delegated resolution based on resolutions of related trackers"""
+        if not (
+            self.affectedness == Affect.AffectAffectedness.AFFECTED
+            and self.resolution == Affect.AffectResolution.DELEGATED
+        ):
+            return None
+
+        trackers = self.trackers.all()
+        if not trackers:
+            return Affect.AffectFix.AFFECTED
+
+        statuses = [tracker.fix_state for tracker in trackers]
+        for status in (
+            Affect.AffectFix.NOTAFFECTED,
+            Affect.AffectFix.AFFECTED,
+            Affect.AffectFix.WONTFIX,
+            Affect.AffectFix.OOSS,
+            Affect.AffectFix.DEFER,
+        ):
+            if status in statuses:
+                return status
+
+        # We don't know. Maybe none of the trackers have a valid resolution; default to "Affected".
+        logger.error("How did we get here??? %s, %s", trackers, statuses)
+
+        return Affect.AffectFix.AFFECTED
+
+    @property
+    def is_community(self) -> bool:
+        """
+        check and return whether the given affect is community one
+        """
+        return PsModule.objects.filter(
+            name=self.ps_module, ps_product__business_unit="Community"
+        ).exists()
+
+    @property
+    def is_notaffected(self) -> bool:
+        """
+        check and return whether the given affect is set as not affected or not to be fixed
+        """
+        return (
+            self.affectedness == Affect.AffectFix.NOTAFFECTED
+            or self.resolution == Affect.AffectResolution.WONTFIX
+        )
+
+    @property
+    def is_rhscl(self) -> bool:
+        """
+        check and return whether the given affect is RHSCL one
+        """
+        return PsModule.objects.filter(
+            name=self.ps_module, bts_key=RHSCL_BTS_KEY
+        ).exists()
+
+    @property
+    def is_unknown(self) -> bool:
+        """
+        check and return whether the given affect has unknown PS module
+        """
+        return not PsModule.objects.filter(name=self.ps_module).exists()
 
 
 class TrackerManager(ACLMixinManager):
@@ -1917,6 +2007,8 @@ class Profile(models.Model):
     def __str__(self):
         return self.username
 
+
+from apps.bbsync.cc import AffectCCBuilder, RHSCLAffectCCBuilder  # noqa: E402
 
 from .constants import (  # noqa: E402
     AFFECTEDNESS_VALID_RESOLUTIONS,

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -6,6 +6,8 @@ from django.core.exceptions import ValidationError
 from django.utils import timezone
 from freezegun import freeze_time
 
+from apps.bbsync.constants import RHSCL_BTS_KEY
+from apps.bbsync.models import BugzillaComponent, BugzillaProduct
 from collectors.bzimport.constants import FLAW_PLACEHOLDER_KEYWORD
 from osidb.constants import BZ_ID_SENTINEL
 from osidb.core import generate_acls
@@ -1182,16 +1184,16 @@ class TestFlawValidators:
         assert should_raise == bool("notabug_affect_ps_component" in flaw._alerts)
 
     @pytest.mark.parametrize(
-        "ps_module,ps_component,alerts",
+        "is_rhscl,ps_component,alerts",
         [
-            ("rhscl-module", "valid-component", []),
-            ("rhscl-module", "source-to-image", []),
-            ("not-rhscl-module", "valid-component", []),
-            ("not-rhscl-module", "valid", []),
-            ("not-rhscl-module", "invalid-component", []),
-            ("not-rhscl-module", "source-to-image", []),
+            (True, "valid-component", []),
+            (True, "source-to-image", []),
+            (False, "valid-component", []),
+            (False, "valid", []),
+            (False, "invalid-component", []),
+            (False, "source-to-image", []),
             (
-                "rhscl-module",
+                True,
                 "valid",
                 [
                     "flaw_affects_rhscl_collection_only",
@@ -1199,19 +1201,20 @@ class TestFlawValidators:
                 ],
             ),
             (
-                "rhscl-module",
+                True,
                 "invalid-component",
                 ["flaw_affects_rhscl_invalid_collection"],
             ),
         ],
     )
     def test_flaw_affects_rhscl_invalid_collection(
-        self, ps_module, ps_component, alerts
+        self, is_rhscl, ps_component, alerts
     ):
         VALID_COLLECTIONS = ["valid"]
-        module_obj = PsModuleFactory(name=ps_module)
+        bts_key = "Not a RHSCL" if not is_rhscl else RHSCL_BTS_KEY
+        module_obj = PsModuleFactory(name="test-module", bts_key=bts_key)
         PsUpdateStreamFactory(collections=VALID_COLLECTIONS, ps_module=module_obj)
-        affect = AffectFactory(ps_module=ps_module, ps_component=ps_component)
+        affect = AffectFactory(ps_module="test-module", ps_component=ps_component)
         if alerts:
             assert set(alerts).issubset(affect._alerts)
 
@@ -1525,3 +1528,44 @@ class TestFlawValidators:
         assert "private_source_no_ack" in flaw2._alerts
         flaw3 = FlawFactory(source=public_source, embargoed=False)
         assert "private_source_no_ack" not in flaw3._alerts
+
+    @pytest.mark.parametrize(
+        "is_same_product_name, should_raise",
+        [
+            (False, True),
+            (True, False),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "ps_component,is_rhscl",
+        [
+            ("test-module", False),
+            ("rhscl-custom-collection-test-module", True),
+        ],
+    )
+    def test_validate_unknown_component(
+        self, is_same_product_name, should_raise, ps_component, is_rhscl
+    ):
+        """
+        Test that a flaw affecting a component not tracked in Bugzilla raises
+        alert if its not an override set in Product Definitions.
+        """
+        bts_key = "Not a RHSCL" if not is_rhscl else RHSCL_BTS_KEY
+        ps_module = PsModuleFactory(
+            name="test-ps-module",
+            bts_name="bugzilla",
+            bts_key=bts_key,
+            default_component="",
+        )
+        PsUpdateStreamFactory(
+            ps_module=ps_module, collections=["rhscl-custom-collection"]
+        )
+        product_name = (
+            ps_module.bts_key if is_same_product_name else "other-test-module"
+        )
+        bz_product = BugzillaProduct(name=product_name)
+        bz_product.save()
+        BugzillaComponent(name="test-module", product=bz_product).save()
+        affect = AffectFactory(ps_module="test-ps-module", ps_component=ps_component)
+
+        assert should_raise == bool("flaw_affects_unknown_component" in affect._alerts)


### PR DESCRIPTION
This PR adds validation for flaws affecting components not tracked in Bugzilla.

This PR also makes CC list the following methods static for reuse purpose, changing some validations that could make uses of them:
- `apps::bbsync::cc.py::CCBuilder::is_community`
- `apps::bbsync::cc.py::CCBuilder::is_notaffected`
- `apps::bbsync::cc.py::CCBuilder::is_rhscl`
- `apps::bbsync::cc.py::CCBuilder::is_unknown`

Closes OSIDB-355.