### PR TITLE
Remove prestage_eligible_date field from schemas

### DIFF
--- a/apps/bbsync/srtnotes-schema.json
+++ b/apps/bbsync/srtnotes-schema.json
@@ -92,11 +92,6 @@
     "acks_not_needed": {
       "type": ["boolean", "null"],
       "description": "Determine whether an acknowledgment is needed for the flaw or not"
-    },
-    "prestage_eligible_date": {
-      "type": ["string", "null"],
-      "description": "A UTC ISO 8601 formated Date or Datetime of when Flaw and mainly their Trackers can be prestaged in CPaaS environment",
-      "pattern": "^\\d{4}-\\d{2}-\\d{2}(T\\d{2}:\\d{2}:\\d{2}Z)?$"
     }
   },
   "definitions": {

--- a/collectors/bzimport/srtnotes_parser.py
+++ b/collectors/bzimport/srtnotes_parser.py
@@ -55,10 +55,9 @@ FLAW_ATTRIBUTES = [
     "mitigate",
     "classification",
     "jira_trackers",
-    "prestage_eligible_date",
 ]
 
-DATETIME_FIELDS = ["public", "reported", "prestage_eligible_date"]
+DATETIME_FIELDS = ["public", "reported"]
 DATE_FMT = "%Y%m%d"
 DATETIME_FMT = "%Y%m%d:%H%M"
 AFFECTS_STATES = ["new", "affected", "notaffected", "defer", "wontfix"]
@@ -173,7 +172,6 @@ def parse_cf_srtnotes(cf_srtnotes, return_warnings=False, revision=1):
         "mitigation": None,
         "acknowledgments": [],
         "acks_not_needed": None,
-        "prestage_eligible_date": None,
     }
     srtnotes.update(json.loads(cf_srtnotes))
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix errata created and updated timestamps (OSIDB-453)
 - Restrict write operations on placeholder flaws (OSIDB-388)
 - Avoid recreating flaws on CVE ID changes whenever possible (OSIDB-392)
+- Remove unsused data prestage_eligible_date from schemas (OSIDB-695)
 
 ## [2.3.4] - 2022-12-15
 ### Changed

--- a/openapi.yml
+++ b/openapi.yml
@@ -2380,8 +2380,6 @@ components:
               type: string
             mitigation:
               type: string
-            prestage_eligible_date:
-              type: string
             public:
               type: string
             references:

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -460,7 +460,6 @@ class FlawSerializer(
         "jira_trackers",
         "mitigate",
         "mitigation",
-        "prestage_eligible_date",
         "public",
         "references",
         "related_cves",


### PR DESCRIPTION
This PR removes the field `prestage_eligible_date`.

Since this data is not used anymore in any IR process or automated process it has been removed from schemas and internal API.

Closes OSIDB-695.