### PR TITLE
Add validation for no ACKed Flaw with private src

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement validation for affects with exceptional combination of affectedness and resolution (OSIDB-361)
 - Implement validation for affects marked as WONTFIX or NOTAFFECTED with open trackers (OSIDB-364)
 - Implement validation for affected special handled modules without summary or statement (OSIDB-328)
+- Implement validation for flaws with private source without ACK (OSIDB-339)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -856,6 +856,29 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin, ACLMixi
                     "are marked as special handling but flaw does not contain statement.",
                 )
 
+    def _validate_private_source_no_ack(self):
+        """
+        Checks that flaws with private sources have ACK.
+        """
+        if (source := FlawSource(self.source)) and source.is_private():
+            if self.meta.filter(type=FlawMeta.FlawMetaType.ACKNOWLEDGMENT).exists():
+                return
+
+            if source.is_public():
+                alert_text = (
+                    f"Flaw source of type {source} can be public or private, "
+                    "ensure that it is public since the Flaw has no acknowledgments."
+                )
+            else:
+                alert_text = (
+                    f"Flaw has no acknoledgments but source of type {source} is private, "
+                    "include them in acknowledgments."
+                )
+            self.alert(
+                "private_source_no_ack",
+                alert_text,
+            )
+
     @property
     def is_placeholder(self):
         """

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1512,3 +1512,16 @@ class TestFlawValidators:
 
         assert "special_handling_flaw_missing_summary" in flaw2._alerts
         assert "special_handling_flaw_missing_statement" in flaw2._alerts
+
+    def test_validate_private_source_no_ack(
+        self, private_source, public_source, both_source
+    ):
+        """
+        Test that flaw with private source without acknoledgments raises alert
+        """
+        flaw1 = FlawFactory(source=private_source, embargoed=True)
+        assert "private_source_no_ack" in flaw1._alerts
+        flaw2 = FlawFactory(source=both_source, embargoed=True)
+        assert "private_source_no_ack" in flaw2._alerts
+        flaw3 = FlawFactory(source=public_source, embargoed=False)
+        assert "private_source_no_ack" not in flaw3._alerts


### PR DESCRIPTION
This PR implements validation for flaws with private source without acknowledgment.
 
Closes OSIDB-339.