### PR TITLE
revise the allowed API view HTTP methods on models

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Restrict write operations on placeholder flaws (OSIDB-388)
 - Avoid recreating flaws on CVE ID changes whenever possible (OSIDB-392)
 - Remove unsused data prestage_eligible_date from schemas (OSIDB-695)
+- Revise the allowed API view HTTP methods on models
+  restricting flaw deletion and all tracker write methods (OSIDB-748)
 
 ## [2.3.4] - 2022-12-15
 ### Changed

--- a/openapi.yml
+++ b/openapi.yml
@@ -1334,37 +1334,6 @@ paths:
                     version:
                       type: string
           description: ''
-    delete:
-      operationId: osidb_api_v1_flaws_destroy
-      parameters:
-      - in: path
-        name: id
-        schema:
-          type: string
-        description: A string representing either the internal OSIDB UUID of the Flaw
-          resource or the CVE number corresponding to a Flaw
-        required: true
-      tags:
-      - osidb
-      security:
-      - OsidbTokenAuthentication: []
-      responses:
-        '204':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  dt:
-                    type: string
-                    format: date-time
-                  env:
-                    type: string
-                  revision:
-                    type: string
-                  version:
-                    type: string
-          description: ''
   /osidb/api/v1/manifest:
     get:
       operationId: osidb_api_v1_manifest_retrieve
@@ -1645,43 +1614,6 @@ paths:
                     version:
                       type: string
           description: ''
-    post:
-      operationId: osidb_api_v1_trackers_create
-      tags:
-      - osidb
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Tracker'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Tracker'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Tracker'
-        required: true
-      security:
-      - OsidbTokenAuthentication: []
-      responses:
-        '201':
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/Tracker'
-                - type: object
-                  properties:
-                    dt:
-                      type: string
-                      format: date-time
-                    env:
-                      type: string
-                    revision:
-                      type: string
-                    version:
-                      type: string
-          description: ''
   /osidb/api/v1/trackers/{uuid}:
     get:
       operationId: osidb_api_v1_trackers_retrieve
@@ -1716,82 +1648,6 @@ paths:
                       type: string
                     version:
                       type: string
-          description: ''
-    put:
-      operationId: osidb_api_v1_trackers_update
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Tracker.
-        required: true
-      tags:
-      - osidb
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Tracker'
-          application/x-www-form-urlencoded:
-            schema:
-              $ref: '#/components/schemas/Tracker'
-          multipart/form-data:
-            schema:
-              $ref: '#/components/schemas/Tracker'
-        required: true
-      security:
-      - OsidbTokenAuthentication: []
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                allOf:
-                - $ref: '#/components/schemas/Tracker'
-                - type: object
-                  properties:
-                    dt:
-                      type: string
-                      format: date-time
-                    env:
-                      type: string
-                    revision:
-                      type: string
-                    version:
-                      type: string
-          description: ''
-    delete:
-      operationId: osidb_api_v1_trackers_destroy
-      parameters:
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this Tracker.
-        required: true
-      tags:
-      - osidb
-      security:
-      - OsidbTokenAuthentication: []
-      responses:
-        '204':
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  dt:
-                    type: string
-                    format: date-time
-                  env:
-                    type: string
-                  revision:
-                    type: string
-                  version:
-                    type: string
           description: ''
   /osidb/healthy:
     get:

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1141,10 +1141,9 @@ class TestEndpoints(object):
         assert response.status_code == 200
 
         response = auth_client.delete(f"{test_api_uri}/flaws/{flaw.uuid}")
-        assert response.status_code == 204
-
-        response = auth_client.get(f"{test_api_uri}/flaws/{flaw.uuid}")
-        assert response.status_code == 404
+        # this HTTP method is not allowed until we leave Bugzilla and
+        # define the conditions under which a flaw can be deleted
+        assert response.status_code == 405
 
     def test_list_flaws_tracker_ids(self, auth_client, test_api_uri):
         """
@@ -1273,15 +1272,9 @@ class TestEndpoints(object):
         response = auth_client.post(
             f"{test_api_uri}/trackers", tracker_data, format="json"
         )
-        assert response.status_code == 201
-        body = response.json()
-        created_uuid = body["uuid"]
-
-        response = auth_client.get(f"{test_api_uri}/trackers/{created_uuid}")
-        assert response.status_code == 200
-        body = response.json()
-        assert body["status"] == "foo"
-        assert body["resolution"] == "bar"
+        # this HTTP method is not allowed until we integrate
+        # with the authoritative sources of the tracker data
+        assert response.status_code == 405
 
     def test_tracker_update(self, auth_client, test_api_uri):
         """
@@ -1300,9 +1293,9 @@ class TestEndpoints(object):
             },
             format="json",
         )
-        assert response.status_code == 200
-        body = response.json()
-        assert original_body["resolution"] != body["resolution"]
+        # this HTTP method is not allowed until we integrate
+        # with the authoritative sources of the tracker data
+        assert response.status_code == 405
 
     def test_tracker_delete(self, auth_client, test_api_uri):
         """
@@ -1314,7 +1307,6 @@ class TestEndpoints(object):
         assert response.status_code == 200
 
         response = auth_client.delete(tracker_url)
-        assert response.status_code == 204
-
-        response = auth_client.get(tracker_url)
-        assert response.status_code == 404
+        # this HTTP method is not allowed until we integrate
+        # with the authoritative sources of the tracker data
+        assert response.status_code == 405


### PR DESCRIPTION
as the OSIDB is still not an authoritative source and therefore the flaws cannot really be deleted in Bugzilla and for the trackers we do not have any write integration with the backends at all

this is a part of OSIDB-240 and re-introduces part of https://github.com/RedHatProductSecurity/osidb/pull/145 in a better way

Closing OSIDB-748