### PR TITLE
implement non-empty impact validation

### DIFF
--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -389,9 +389,10 @@ class TestGenerateSRTNotes:
         """
         test generating of SRT notes impact attribute
         """
-        flaw = FlawFactory(
+        flaw = FlawFactory.build(
             impact=osidb_impact, meta_attr={"original_srtnotes": srtnotes}
         )
+        flaw.save(raise_validation_error=False)
         FlawCommentFactory(flaw=flaw)
         AffectFactory(flaw=flaw)
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement temporary NVD collector (OSIDB-632)
 - Implement Exploits report data API endpoint (PSINSIGHTS-764)
 - Implement ACL validations (OSIDB-691)
+- Implement non-empty impact validation (OSIDB-758)
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -770,6 +770,16 @@ class Flaw(WorkflowModel, TrackingMixin, NullStrFieldsMixin, AlertMixin, ACLMixi
         if not Affect.objects.filter(flaw=self).exists():
             raise ValidationError("Flaw does not contain any affects.")
 
+    def _validate_nonempty_impact(self):
+        """
+        check that the impact is not empty
+
+        we cannot enforce this by model definition
+        as the old flaws may have no impact
+        """
+        if not self.impact:
+            raise ValidationError("Impact value is required.")
+
     def _validate_unsupported_impact_change(self):
         """
         Check that an update of a flaw with open trackers does not change between

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -46,7 +46,9 @@ class FlawFactory(factory.django.DjangoModelFactory):
     reported_dt = factory.Faker("date_time", tzinfo=UTC)
     state = factory.Faker("random_element", elements=list(Flaw.FlawState))
     resolution = factory.Faker("random_element", elements=list(FlawResolution))
-    impact = factory.Faker("random_element", elements=list(FlawImpact))
+    impact = factory.Faker(
+        "random_element", elements=list(set(FlawImpact) - {FlawImpact.NOVALUE})
+    )
     description = factory.LazyAttribute(lambda c: f"Description for {c.cve_id}")
     title = factory.Maybe(
         "embargoed",

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1347,6 +1347,7 @@ class TestEndpointsACLs:
         flaw_data = {
             "title": "EMBARGOED Foo" if embargoed else "Foo",
             "description": "test",
+            "impact": "LOW",
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": None if embargoed else "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -190,6 +190,7 @@ class TestFlaw:
             title="first",
             unembargo_dt=tzdatetime(2000, 1, 1),
             description="description",
+            impact=FlawImpact.LOW,
             acl_read=self.acl_read,
             acl_write=self.acl_write,
             reported_dt=timezone.now(),
@@ -204,6 +205,7 @@ class TestFlaw:
             bz_id="12345",
             title="second",
             description="description",
+            impact=FlawImpact.LOW,
             acl_read=self.acl_read,
             acl_write=self.acl_write,
             reported_dt=timezone.now(),
@@ -1018,6 +1020,13 @@ class TestFlawValidators:
         with pytest.raises(ValidationError) as e:
             flaw2.save()
         assert "Flaw does not contain any affects." in str(e)
+
+    def test_no_impact(self):
+        """
+        test that flaw cannot have an empty impact
+        """
+        with pytest.raises(ValidationError, match="Impact value is required"):
+            FlawFactory(impact=None)
 
     @pytest.mark.parametrize(
         "start_impact,new_impact,tracker_statuses,should_raise",

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from collectors.bzimport.convertors import FlawBugConvertor
 from osidb.core import generate_acls
 from osidb.exceptions import DataInconsistencyException
-from osidb.models import Flaw
+from osidb.models import Flaw, FlawImpact
 from osidb.tests.factories import AffectFactory, FlawFactory
 
 from .test_flaw import tzdatetime
@@ -194,6 +194,7 @@ class TestTrackingMixin:
             title="title",
             cwe_id="CWE-1",
             description="description",
+            impact=FlawImpact.LOW,
             acl_read=acl_read,
             acl_write=acl_write,
             reported_dt=timezone.now(),


### PR DESCRIPTION
During the two-way sync testing I found out that it is possible to create a flaw with an empty impact. This is not correct and requires an additional validation plus some updates of the existing tests.

Closes OSIDB-758