### PR TITLE
refactor bugzilla mixin not to save new flaw

### DIFF
--- a/apps/bbsync/cc.py
+++ b/apps/bbsync/cc.py
@@ -355,7 +355,7 @@ class CCBuilder:
             add_cc = all_cc
             remove_cc = []
 
-        elif self.old_flaw.embargoed and not self.flaw.embargoed:
+        elif self.old_flaw.embargoed and not self.flaw.is_embargoed:
             # on unembargo we add and remove all but do not add
             # already existing CCs because they are already there
             add_cc = [cc for cc in all_cc if cc not in self.old_cc]
@@ -394,7 +394,7 @@ class CCBuilder:
 
             # for some reason in SFM2 we ignore affects set as not affected or not to be fixed
             # only for embargoed flaws so to keep the functional parity we continue with it
-            if self.flaw.embargoed and affect.is_notaffected:
+            if self.flaw.is_embargoed and affect.is_notaffected:
                 continue
 
             cc_list.update(self.affect2cc(affect))
@@ -408,5 +408,5 @@ class CCBuilder:
         affect_cc_builder_class = (
             RHSCLAffectCCBuilder if affect.is_rhscl else AffectCCBuilder
         )
-        affect_cc_builder = affect_cc_builder_class(affect, self.flaw.embargoed)
+        affect_cc_builder = affect_cc_builder_class(affect, self.flaw.is_embargoed)
         return affect_cc_builder.cc

--- a/apps/bbsync/mixins.py
+++ b/apps/bbsync/mixins.py
@@ -1,9 +1,9 @@
-from django.db import models
+from osidb.mixins import AlertMixin
 
 from .constants import SYNC_TO_BZ
 
 
-class BugzillaSyncMixin(models.Model):
+class BugzillaSyncMixin(AlertMixin):
     """
     mixin for syncing the model to the Bugzilla
 
@@ -28,14 +28,14 @@ class BugzillaSyncMixin(models.Model):
 
         Bugzilla sync is also conditional based on environment variable
         """
-        # preliminary save to link and annotate and
-        # to make sure the validations are performed
-        super().save(*args, **kwargs)
-        self = self.__class__.objects.get(pk=self.pk)
+        # always perform the validations first
+        self.validate(raise_validation_error=kwargs.get("raise_validation_error", True))
 
         # check BBSync conditions are met
         if SYNC_TO_BZ and bz_api_key is not None:
             self.bzsync(*args, bz_api_key=bz_api_key, **kwargs)
+        else:
+            super().save(*args, **kwargs)
 
     def bzsync(self, *args, bz_api_key, **kwargs):
         """

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -202,7 +202,7 @@ class BugzillaQueryBuilder:
         """
         groups = []
 
-        if self.flaw.embargoed:
+        if self.flaw.is_embargoed:
             # get names of all affected PS modules
             # we care for affects with trackers only
             module_names = [
@@ -236,7 +236,7 @@ class BugzillaQueryBuilder:
         """
         generate query for Bugzilla deadline
         """
-        if self.flaw.embargoed:
+        if self.flaw.is_embargoed:
             if self.flaw.unembargo_dt:
                 self._query["deadline"] = self.flaw.unembargo_dt.strftime(DATE_FMT)
 

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -870,7 +870,7 @@ class TestGenerateGroups:
         )
 
         new_flaw = Flaw.objects.first()
-        new_flaw.embargoed = False
+        new_flaw.acl_read = []  # make it whatever but embargoed
 
         bbq = BugzillaQueryBuilder(new_flaw, old_flaw=flaw)
         query = bbq.query

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -434,7 +434,6 @@ class FlawManager(ACLMixinManager):
 
 class Flaw(
     ACLMixin,
-    AlertMixin,
     BugzillaSyncMixin,
     NullStrFieldsMixin,
     TrackingMixin,
@@ -1000,7 +999,6 @@ class AffectManager(ACLMixinManager):
 
 class Affect(
     ACLMixin,
-    AlertMixin,
     AffectExploitExtensionMixin,
     BugzillaSyncMixin,
     NullStrFieldsMixin,
@@ -1433,6 +1431,7 @@ class Affect(
         """
         Bugzilla sync of the Affect instance
         """
+        self.save()
         # Affect needs to be synced through flaw
         self.flaw.save(*args, bz_api_key=bz_api_key, **kwargs)
 


### PR DESCRIPTION
I would like to perform this refactoring of the `BugzillaSyncMixin` before the freeze. It seems that for now it is not so important but will be for the future. When implementing OSIDB-382 I realized that the current design of the model `save` is not well scalable. The reason is this line

https://github.com/RedHatProductSecurity/osidb/blob/ef88c13c82385bf47eee489f4c25107eb387c360/apps/bbsync/mixins.py#L33

Its purpose was three-fold. One was to get `embargoed` annotation, then to perform the validations, and finally to link the affect to the corresponding flaw. The issue is that it later makes the old and the new flaw in BBSync being the same

https://github.com/RedHatProductSecurity/osidb/blob/ef88c13c82385bf47eee489f4c25107eb387c360/apps/bbsync/save.py#L53

which I unfortunately have not realized as an issue. The reason is that I was taking the data from the stored `meta_attr` wherever possible as I was first not sure whether the new and old flaw will be possible to be kept different.

This PR makes it possible substituting `embargoed` with `is_embargoed` which is not an annotation but just a property, then explicitly performing the validations in the BugzillaSyncMixin instead of the whole `save`, and finally performing the `save` in `Affect.bzsync` to link it. This effectively replaces what the `save` did in BugzillaSyncMixin so the new flaw save is now not necessary and it is kept different from the old flaw.