### PR TITLE
Various schema and BBsync fixes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -145,7 +145,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 52,
+        "line_number": 57,
         "is_secret": false
       }
     ],
@@ -191,7 +191,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 102,
         "is_secret": false
       }
     ],
@@ -201,7 +201,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 46,
+        "line_number": 52,
         "is_secret": false
       }
     ],
@@ -235,16 +235,6 @@
         "is_secret": false
       }
     ],
-    "osidb/api_views.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "osidb/api_views.py",
-        "hashed_secret": "79829e87e71dbf51796728a0663ec8483d62d52e",
-        "is_verified": false,
-        "line_number": 377,
-        "is_secret": false
-      }
-    ],
     "osidb/models.py": [
       {
         "type": "Artifactory Credentials",
@@ -261,7 +251,7 @@
         "filename": "osidb/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1062,
+        "line_number": 1067,
         "is_secret": false
       }
     ],
@@ -284,5 +274,5 @@
       }
     ]
   },
-  "generated_at": "2023-03-12T23:38:29Z"
+  "generated_at": "2023-03-20T14:16:49Z"
 }

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -49,9 +49,13 @@ class TestBBSyncIntegration:
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
-        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        response = auth_client.post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+        )
         assert response.status_code == 201
         body = response.json()
         created_uuid = body["uuid"]
@@ -93,10 +97,12 @@ class TestBBSyncIntegration:
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
         response = auth_client.put(
-            f"{test_api_uri}/flaws/{flaw.uuid}", flaw_data, format="json"
+            f"{test_api_uri}/flaws/{flaw.uuid}",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 200
 
@@ -131,10 +137,12 @@ class TestBBSyncIntegration:
             "affectedness": "AFFECTED",
             "resolution": "FIX",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
         response = auth_client.post(
-            f"{test_api_uri}/affects", affect_data, format="json"
+            f"{test_api_uri}/affects",
+            affect_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 201
         body = response.json()
@@ -180,10 +188,12 @@ class TestBBSyncIntegration:
             "ps_component": "kernel",
             "resolution": "WONTFIX",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
         response = auth_client.put(
-            f"{test_api_uri}/affects/{affect.uuid}", affect_data, format="json"
+            f"{test_api_uri}/affects/{affect.uuid}",
+            affect_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 200
 
@@ -227,10 +237,10 @@ class TestBBSyncIntegration:
             ps_component="openssl",
         )
 
-        data = {"bz_api_key": "SECRET"}
-
         response = auth_client.delete(
-            f"{test_api_uri}/affects/{affect.uuid}", data, format="json"
+            f"{test_api_uri}/affects/{affect.uuid}",
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 204
 
@@ -251,8 +261,12 @@ class TestBBSyncIntegration:
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
-        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        response = auth_client.post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+        )
         assert response.status_code == 400
         assert "CVSSv3 score is missing" in str(response.content)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -42,7 +42,9 @@ services:
 # #####################
       environment:
         BZIMPORT_BZ_API_KEY: ${BZIMPORT_BZ_API_KEY:?Variable BZIMPORT_BZ_API_KEY must be set.}
+        BZIMPORT_BZ_URL: ${BZIMPORT_BZ_URL}
         JIRA_AUTH_TOKEN: ${JIRA_AUTH_TOKEN:?Variable JIRA_AUTH_TOKEN must be set.}
+        JIRA_URL: ${JIRA_URL}
         ET_URL: ${ET_URL}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
         DASHBOARD_URL: ${DASHBOARD_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,7 +71,9 @@ services:
         OSIDB_DEBUG: ${OSIDB_DEBUG}
         DJANGO_SETTINGS_MODULE: "config.settings_local"
         BZIMPORT_BZ_API_KEY: ${BZIMPORT_BZ_API_KEY:?Variable BZIMPORT_BZ_API_KEY must be set.}
+        BZIMPORT_BZ_URL: ${BZIMPORT_BZ_URL}
         JIRA_AUTH_TOKEN: ${JIRA_AUTH_TOKEN:?Variable JIRA_AUTH_TOKEN must be set.}
+        JIRA_URL: ${JIRA_URL}
         ET_URL: ${ET_URL}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
         DASHBOARD_URL: ${DASHBOARD_URL}
@@ -129,7 +131,9 @@ services:
         DJANGO_SETTINGS_MODULE: "config.settings_local"
         OSIDB_DEBUG: ${OSIDB_DEBUG}
         BZIMPORT_BZ_API_KEY: ${BZIMPORT_BZ_API_KEY:?Variable BZIMPORT_BZ_API_KEY must be set.}
+        BZIMPORT_BZ_URL: ${BZIMPORT_BZ_URL}
         JIRA_AUTH_TOKEN: ${JIRA_AUTH_TOKEN:?Variable JIRA_AUTH_TOKEN must be set.}
+        JIRA_URL: ${JIRA_URL}
         JIRAFFE_AUTO_SYNC: ${JIRAFFE_AUTO_SYNC}
         ET_URL: ${ET_URL}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
@@ -155,7 +159,9 @@ services:
         DJANGO_SETTINGS_MODULE: "config.settings_local"
         OSIDB_DEBUG: ${OSIDB_DEBUG}
         BZIMPORT_BZ_API_KEY: ${BZIMPORT_BZ_API_KEY:?Variable BZIMPORT_BZ_API_KEY must be set.}
+        BZIMPORT_BZ_URL: ${BZIMPORT_BZ_URL}
         JIRA_AUTH_TOKEN: ${JIRA_AUTH_TOKEN:?Variable JIRA_AUTH_TOKEN must be set.}
+        JIRA_URL: ${JIRA_URL}
         JIRAFFE_AUTO_SYNC: ${JIRAFFE_AUTO_SYNC}
         ET_URL: ${ET_URL}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
@@ -181,7 +187,9 @@ services:
         DJANGO_SETTINGS_MODULE: "config.settings_local"
         OSIDB_DEBUG: ${OSIDB_DEBUG}
         BZIMPORT_BZ_API_KEY: ${BZIMPORT_BZ_API_KEY:?Variable BZIMPORT_BZ_API_KEY must be set.}
+        BZIMPORT_BZ_URL: ${BZIMPORT_BZ_URL}
         JIRA_AUTH_TOKEN: ${JIRA_AUTH_TOKEN:?Variable JIRA_AUTH_TOKEN must be set.}
+        JIRA_URL: ${JIRA_URL}
         ET_URL: ${ET_URL}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
         DASHBOARD_URL: ${DASHBOARD_URL}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Integrate Bugzilla backwards sync into the flaw and affect save (OSIDB-240)
 - Introduce Bugzilla API key as a serializer attribute (OSIDB-368)
 - Implement non-empty source validation (OSIDB-759)
+- Local development instance is now able to switch between stage and production easily via env variables
 
 ### Changed
 - Change logging of celery and django to filesystem (OSIDB-418)
@@ -40,6 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unsused data prestage_eligible_date from schemas (OSIDB-695)
 - Revise the allowed API view HTTP methods on models
   restricting flaw deletion and all tracker write methods (OSIDB-748)
+- Bugzilla API key is send via Bugzilla-Api-Key HTTP header
 
 ### Removed
 - Remove deprecated mitigated_by field (OSIDB-753)

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -14,9 +14,15 @@ Create a file named `.env`:
 # Bugzilla REST API key
 BZIMPORT_BZ_API_KEY=####################
 
+# Bugzilla URL (optional, defaults to RedHat production Bugzilla)
+BZIMPORT_BZ_URL="https://foo.bar"
+
 # Enable auto syncing of Jira trackers
 JIRAFFE_AUTO_SYNC=True
 JIRA_AUTH_TOKEN=####################
+
+# Jira URL (optional, defaults to RedHat production Jira)
+JIRA_URL="https://foo.bar"
 
 # Export the default local postgresql password
 OSIDB_DB_PASSWORD=passw0rd

--- a/openapi.yml
+++ b/openapi.yml
@@ -2156,15 +2156,10 @@ components:
           type: string
           readOnly: true
         embargoed:
+          type: boolean
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
-          readOnly: true
-          required: true
-          type: boolean
-        bz_api_key:
-          type: string
-          writeOnly: true
         created_dt:
           type: string
           format: date-time
@@ -2174,7 +2169,6 @@ components:
           format: date-time
           readOnly: true
       required:
-      - bz_api_key
       - created_dt
       - delegated_resolution
       - embargoed
@@ -2510,15 +2504,10 @@ components:
             $ref: '#/components/schemas/CVEv5PackageVersions'
           readOnly: true
         embargoed:
+          type: boolean
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
-          readOnly: true
-          required: true
-          type: boolean
-        bz_api_key:
-          type: string
-          writeOnly: true
         created_dt:
           type: string
           format: date-time
@@ -2544,7 +2533,6 @@ components:
           readOnly: true
       required:
       - affects
-      - bz_api_key
       - classification
       - comments
       - created_dt
@@ -2698,12 +2686,10 @@ components:
             type: string
             nullable: true
         embargoed:
+          type: boolean
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
-          readOnly: true
-          required: true
-          type: boolean
         created_dt:
           type: string
           format: date-time

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -9,7 +9,6 @@ from typing import Dict, List, Tuple
 
 from django.conf import settings
 from django.contrib.auth.models import User
-from django.core.exceptions import ValidationError
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -436,16 +435,24 @@ class BugzillaSyncMixinSerializer(serializers.ModelSerializer):
     which need to perform Bugzilla sync as part of the save procedure
     """
 
-    bz_api_key = serializers.CharField(allow_null=False, required=True, write_only=True)
+    def __get_bz_api_key(self):
+        bz_api_key = self.context["request"].META.get("HTTP_BUGZILLA_API_KEY")
+        if not bz_api_key:
+            raise serializers.ValidationError(
+                {"Bugzilla-Api-Key": "This HTTP header is required."}
+            )
+        return bz_api_key
 
     def create(self, validated_data):
         """
         perform the ordinary instance create
         with providing BZ API key while saving
         """
-        bz_api_key = validated_data.pop("bz_api_key")
+        # NOTE: This won't work for many-to-many fields as
+        # some logic from original .create() was overwritten
+
         instance = self.Meta.model(**validated_data)
-        instance.save(bz_api_key=bz_api_key)
+        instance.save(bz_api_key=self.__get_bz_api_key())
         return instance
 
     def update(self, instance, validated_data):
@@ -453,15 +460,15 @@ class BugzillaSyncMixinSerializer(serializers.ModelSerializer):
         perform the ordinary instance update
         with providing BZ API key while saving
         """
-        bz_api_key = validated_data.pop("bz_api_key")
+        # NOTE: This won't work for many-to-many fields as
+        # some logic from original .create() was overwritten
         for attr, value in validated_data.items():
             setattr(instance, attr, value)
-        instance.save(bz_api_key=bz_api_key)
+        instance.save(bz_api_key=self.__get_bz_api_key())
         return instance
 
     class Meta:
         model = BugzillaSyncMixin
-        fields = ["bz_api_key"]
         abstract = True
 
 
@@ -542,7 +549,6 @@ class AffectSerializer(
                 "delegated_resolution",
             ]
             + ACLMixinSerializer.Meta.fields
-            + BugzillaSyncMixinSerializer.Meta.fields
             + TrackingMixinSerializer.Meta.fields
         )
 
@@ -725,7 +731,6 @@ class FlawSerializer(
                 "package_versions",
             ]
             + ACLMixinSerializer.Meta.fields
-            + BugzillaSyncMixinSerializer.Meta.fields
             + TrackingMixinSerializer.Meta.fields
             + WorkflowModelSerializer.Meta.fields
         )

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -301,31 +301,54 @@ class TrackerSerializer(
         ] + TrackingMixinSerializer.Meta.fields
 
 
+class EmbargoedField(serializers.BooleanField):
+    """The embargoed boolean attribute is technically read-only as it just indirectly
+    modifies the ACLs but is mandatory as it controls the access to the resource."""
+
+    def to_representation(self, value):
+        return value.is_embargoed
+
+    def run_validation(self, data):
+        # Run base Boolean field validation, ACL validation and then
+        # raise SkipField to not include this field in validated data
+        # since we don't have `embargoed` field to write in
+        super().run_validation(data)
+        self.validate_acl(data)
+        raise serializers.SkipField()
+
+    def validate_acl(self, embargoed):
+        acl_read = (
+            settings.EMBARGO_READ_GROUP if embargoed else settings.PUBLIC_READ_GROUPS
+        )
+        acl_write = (
+            settings.EMBARGO_WRITE_GROUP if embargoed else settings.PUBLIC_WRITE_GROUP
+        )
+        acl_read, acl_write = ensure_list(acl_read), ensure_list(acl_write)
+
+        acls = [group.name for group in self.context["request"].user.groups.all()]
+        for acl in acl_read + acl_write:
+            # this is a temporary safeguard with a very simple philosophy that one cannot
+            # give access to something (s)he does not have access to but possibly in the future
+            # we will want some more clever handling like ProdSec can grant anything etc.
+            if acl not in acls:
+                raise serializers.ValidationError(
+                    f"Cannot provide access for the LDAP group without being a member: {acl}"
+                )
+
+
 class ACLMixinSerializer(serializers.ModelSerializer):
     """
     ACLMixin class serializer
     translates embargoed boolean to ACLs
     """
 
-    embargoed = serializers.SerializerMethodField()
-
-    @extend_schema_field(
-        {
-            "description": (
-                "The embargoed boolean attribute is technically read-only as it just indirectly "
-                "modifies the ACLs but is mandatory as it controls the access to the resource."
-            ),
-            # TODO the read-only does not work this way
-            "readOnly": False,
-            "required": True,
-            "type": "boolean",
-        }
+    embargoed = EmbargoedField(
+        source="*",
+        help_text=(
+            "The embargoed boolean attribute is technically read-only as it just indirectly "
+            "modifies the ACLs but is mandatory as it controls the access to the resource."
+        ),
     )
-    def get_embargoed(self, obj):
-        """
-        get embargoed status from ACLMixin
-        """
-        return obj.is_embargoed
 
     class Meta:
         abstract = True
@@ -355,11 +378,8 @@ class ACLMixinSerializer(serializers.ModelSerializer):
         """
         process validated data converting embargoed status into the ACLs
         """
+        # Already validated in EmbargoedField
         embargoed = self.context["request"].data.get("embargoed")
-        # the serializer nativaly considers embargoed as read-only
-        # so we have to explicitely make it required on write
-        if embargoed is None:
-            raise ValidationError({"embargoed": "Field is required"})
 
         acl_read, acl_write = self.get_acls(embargoed)
         validated_data["acl_read"] = acl_read
@@ -374,35 +394,6 @@ class ACLMixinSerializer(serializers.ModelSerializer):
     def update(self, instance, validated_data):
         validated_data = self.embargoed2acls(validated_data)
         return super().update(instance, validated_data)
-
-    def validate(self, data):
-        """
-        validate that the current user is member of all LDAP groups (s)he provides
-        with the access so there is no access expansion beyond the user permissions
-        """
-        data = super().validate(data)
-
-        # get the resulting ACLs from the embargo status
-        embargoed = self.context["request"].data.get("embargoed")
-        acl_read = (
-            settings.EMBARGO_READ_GROUP if embargoed else settings.PUBLIC_READ_GROUPS
-        )
-        acl_write = (
-            settings.EMBARGO_WRITE_GROUP if embargoed else settings.PUBLIC_WRITE_GROUP
-        )
-        acl_read, acl_write = ensure_list(acl_read), ensure_list(acl_write)
-
-        acls = [group.name for group in self.context["request"].user.groups.all()]
-        for acl in acl_read + acl_write:
-            # this is a temporary safeguard with a very simple philosophy that one cannot
-            # give access to something (s)he does not have access to but possibly in the future
-            # we will want some more clever handling like ProdSec can grant anything etc.
-            if acl not in acls:
-                raise serializers.ValidationError(
-                    f"Cannot provide access for the LDAP group without being a member: {acl}"
-                )
-
-        return data
 
 
 class MetaSerializer(ACLMixinSerializer, TrackingMixinSerializer):

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1059,9 +1059,13 @@ class TestEndpoints(object):
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
-        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        response = auth_client.post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+        )
         assert response.status_code == 201
         body = response.json()
         created_uuid = body["uuid"]
@@ -1087,9 +1091,13 @@ class TestEndpoints(object):
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
-        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        response = auth_client.post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+        )
         assert response.status_code == 201
         body = response.json()
         created_uuid = body["uuid"]
@@ -1100,7 +1108,12 @@ class TestEndpoints(object):
 
         # let's try creating another one without cve_id to make sure the
         # unique=True constraint doesn't jump (I don't trust django)
-        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        response = auth_client.post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+        )
         assert response.status_code == 201
         body = response.json()
         new_uuid = body["uuid"]
@@ -1135,9 +1148,9 @@ class TestEndpoints(object):
                 "impact": flaw.impact,
                 "source": flaw.source,
                 "embargoed": False,
-                "bz_api_key": "SECRET",
             },
             format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 200
         body = response.json()
@@ -1224,10 +1237,12 @@ class TestEndpoints(object):
             "ps_module": "rhacm-2",
             "ps_component": "curl",
             "embargoed": False,
-            "bz_api_key": "SECRET",
         }
         response = auth_client.post(
-            f"{test_api_uri}/affects", affect_data, format="json"
+            f"{test_api_uri}/affects",
+            affect_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 201
         body = response.json()
@@ -1253,9 +1268,9 @@ class TestEndpoints(object):
             {
                 **original_body,
                 "ps_module": f"different {affect.ps_module}",
-                "bz_api_key": "SECRET",
             },
             format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 200
         body = response.json()
@@ -1275,7 +1290,7 @@ class TestEndpoints(object):
         response = auth_client.get(affect_url)
         assert response.status_code == 200
 
-        response = auth_client.delete(affect_url, data={"bz_api_key": "SECRET"})
+        response = auth_client.delete(affect_url, HTTP_BUGZILLA_API_KEY="SECRET")
         assert response.status_code == 204
 
         response = auth_client.get(affect_url)
@@ -1372,9 +1387,13 @@ class TestEndpointsACLs:
             "unembargo_dt": None if embargoed else "2000-1-1T22:03:26.065Z",
             "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
             "embargoed": embargoed,
-            "bz_api_key": "SECRET",
         }
-        response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
+        response = auth_client.post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+        )
         assert response.status_code == 201
         body = response.json()
         created_uuid = body["uuid"]
@@ -1420,9 +1439,9 @@ class TestEndpointsACLs:
                 "title": f"{flaw.title} appended test title",
                 "description": flaw.description,
                 "embargoed": embargoed,
-                "bz_api_key": "SECRET",
             },
             format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 200
         body = response.json()
@@ -1454,9 +1473,9 @@ class TestEndpointsACLs:
                     "title": flaw.title.replace("EMBARGOED", "").strip(),
                     "description": flaw.description,
                     "embargoed": False,
-                    "bz_api_key": "SECRET",
                 },
                 format="json",
+                HTTP_BUGZILLA_API_KEY="SECRET",
             )
 
         assert response.status_code == 200
@@ -1540,7 +1559,9 @@ class TestEndpointsBZAPIKey:
         }
         response = auth_client.post(f"{test_api_uri}/flaws", flaw_data, format="json")
         assert response.status_code == 400
-        assert '"bz_api_key":["This field is required."]' in str(response.content)
+        assert '"Bugzilla-Api-Key":"This HTTP header is required."' in str(
+            response.content
+        )
 
     def test_flaw_update_no_bz_api_key(self, auth_client, test_api_uri):
         """
@@ -1561,4 +1582,6 @@ class TestEndpointsBZAPIKey:
             format="json",
         )
         assert response.status_code == 400
-        assert '"bz_api_key":["This field is required."]' in str(response.content)
+        assert '"Bugzilla-Api-Key":"This HTTP header is required."' in str(
+            response.content
+        )


### PR DESCRIPTION
This PR introduces several important fixes and some minor things:

- minor - BZ/Jira URLs are now injected into the all relevant containers which eases local development during instance switching
- `embargoed` field in `ACLMixinSerializer` was changed from `SerializerMethodField`  to custom `EmbargoedField` this allows to mimic readOnly with write that modifies ACLs and also generate the proper schema
- Bugzilla API key was removed from serializer fields of `BugzillaSyncMixinSerializer` as sending the api key in body was not possible for the DELETE method, we now send the BZ API key inside `Bugzilla-Api-key` HTTP header