### PR TITLE
Disable osim tests in testrunner.all-tests

### DIFF
--- a/mk/testrunner.mk
+++ b/mk/testrunner.mk
@@ -28,7 +28,7 @@ testrunner.all-unit-tests:
 testrunner.all-integration-tests:
 	$(podman) exec -it testrunner tox -e integration-tests collectors/bzimport collectors/jiraffe collectors/product_definitions osidb
 testrunner.all-tests:
-	$(podman) exec -it testrunner tox -e tests
+	$(podman) exec -it testrunner tox -e tests -- --ignore=apps/osim
 testrunner.record-new:
 	rm -rf *_cache.sqlite
 	$(podman) exec -it testrunner tox -e record-new osidb/ collectors/jiraffe collectors/bzimport collectors/product_definitions


### PR DESCRIPTION
Updates testrunner.all-tests to be compliant with tests in GitHub's CI.