### PR TITLE
Add validation for allowed flaw sources

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce mitigation field into Flaw and update SRT notes generator (OSIDB-584)
 - Introduce flaw component attribute
+- Implement validation for allowed flaw sources (OSIDB-73)
 
 ### Changed
 - Rework the mapping from Bugzilla sumary to OSIDB title and vice versa (OSIDB-694)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -279,6 +279,44 @@ class FlawSource(models.TextChoices):
             self.UBUNTU,
         }
 
+    def is_allowed(self):
+        """
+        Returns True if the source is allowed (not historical), False otherwise.
+        """
+        return self in [
+            self.ADOBE,
+            self.APPLE,
+            self.BUGTRAQ,
+            self.CERT,
+            self.CUSTOMER,
+            self.CVE,
+            self.DEBIAN,
+            self.DISTROS,
+            self.FULL_DISCLOSURE,
+            self.GENTOO,
+            self.GIT,
+            self.GOOGLE,
+            self.HW_VENDOR,
+            self.INTERNET,
+            self.LKML,
+            self.MAGEIA,
+            self.MOZILLA,
+            self.OPENSSL,
+            self.ORACLE,
+            self.OSS_SECURITY,
+            self.REDHAT,
+            self.RESEARCHER,
+            self.SECUNIA,
+            self.SKO,
+            self.SUN,
+            self.SUSE,
+            self.TWITTER,
+            self.UBUNTU,
+            self.UPSTREAM,
+            self.VENDOR_SEC,
+            self.XEN,
+        ]
+
 
 class FlawHistory(NullStrFieldsMixin, ValidateMixin, ACLMixin):
     """match existing history table for flaws"""
@@ -834,6 +872,13 @@ class Flaw(
                 "private_source_no_ack",
                 alert_text,
             )
+
+    def _validate_allowed_source(self):
+        """
+        Checks that the flaw source is allowed (not historical).
+        """
+        if self.source and not FlawSource(self.source).is_allowed():
+            raise ValidationError("The flaw has a disallowed (historical) source.")
 
     @property
     def is_placeholder(self):

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -89,9 +89,6 @@ class FlawFactory(factory.django.DjangoModelFactory):
             elements=[
                 FlawSource.GIT,
                 FlawSource.INTERNET,
-                FlawSource.MITRE,
-                FlawSource.PRESS,
-                FlawSource.XCHAT,
             ],
         ),
     )

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1419,6 +1419,14 @@ class TestFlawValidators:
         flaw3 = FlawFactory(source=public_source, embargoed=False)
         assert "private_source_no_ack" not in flaw3._alerts
 
+    def test_validate_allowed_source(self):
+        """
+        Test that a disallowed (historical) flaw source raises an exception.
+        """
+        error_msg = r"The flaw has a disallowed \(historical\) source."
+        with pytest.raises(ValidationError, match=error_msg):
+            FlawFactory(source=FlawSource.ASF)
+
     @pytest.mark.parametrize(
         "is_same_product_name, should_raise",
         [


### PR DESCRIPTION
This PR adds validation for allowed flaw sources. It also updates FlawFactory to use only allowed flaw sources.

Related to "extend and refine flaw model" (OSIDB-73).