### PR TITLE
Assume empty-string environment variables are undefined.

### DIFF
--- a/osidb/signals.py
+++ b/osidb/signals.py
@@ -1,5 +1,4 @@
 import logging
-import os
 
 from bugzilla import Bugzilla
 from django.contrib.auth.models import User
@@ -7,14 +6,15 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from jira import JIRA
 
+from osidb.helpers import get_env
 from osidb.models import Profile
 
 logger = logging.getLogger(__name__)
 
 
 def get_bz_user_id(email: str) -> str:
-    api_key = os.getenv("BZIMPORT_BZ_API_KEY")
-    bz_url = os.getenv("BZIMPORT_BZ_URL", "https://bugzilla.redhat.com")
+    api_key = get_env("BZIMPORT_BZ_API_KEY")
+    bz_url = get_env("BZIMPORT_BZ_URL", "https://bugzilla.redhat.com")
     try:
         bz_api = Bugzilla(
             bz_url,
@@ -34,8 +34,8 @@ def get_bz_user_id(email: str) -> str:
 
 
 def get_jira_user_id(email: str) -> str:
-    auth_token = os.getenv("JIRA_AUTH_TOKEN")
-    jira_url = os.getenv("JIRA_URL", "https://issues.redhat.com")
+    auth_token = get_env("JIRA_AUTH_TOKEN")
+    jira_url = get_env("JIRA_URL", "https://issues.redhat.com")
     try:
         jira_api = JIRA(
             {

--- a/osidb/tests/test_users.py
+++ b/osidb/tests/test_users.py
@@ -1,9 +1,9 @@
-import os
-
 import pytest
 from bugzilla import Bugzilla
 from django.contrib.auth.models import User
 from jira import JIRA
+
+from osidb.helpers import get_env
 
 pytestmark = pytest.mark.unit
 
@@ -28,10 +28,10 @@ class TestUsers:
         assert new_user.profile.jira_user_id == "atorresj@redhat.com"
 
         # verify that the user info can be fetched from bugzilla / jira
-        bz_token = os.getenv("BZIMPORT_BZ_API_KEY")
-        bz_url = os.getenv("BZIMPORT_BZ_URL", "https://bugzilla.redhat.com")
-        jira_token = os.getenv("JIRA_AUTH_TOKEN")
-        jira_url = os.getenv("JIRA_URL", "https://issues.redhat.com")
+        bz_token = get_env("BZIMPORT_BZ_API_KEY")
+        bz_url = get_env("BZIMPORT_BZ_URL", "https://bugzilla.redhat.com")
+        jira_token = get_env("JIRA_AUTH_TOKEN")
+        jira_url = get_env("JIRA_URL", "https://issues.redhat.com")
         bz_api = Bugzilla(bz_url, api_key=bz_token, force_rest=True)
         jira_api = JIRA(
             {


### PR DESCRIPTION
This fixes test regression from commit https://github.com/RedHatProductSecurity/osidb/commit/422a494f6604bf576ad8a79532e526d0c72fcb21 that wasn't caught in CI
because `.github/workflows/test.yml` doesn't set the empty-string variables
`BZIMPORT_BZ_URL` and `JIRA_URL` in `docker-compose*yml`.