### PR TITLE
serializers and api fixes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make API requests transactional (OSIDB-232)
 - Rename REQUIRES_DOC_TEXT to REQUIRES_SUMMARY in FlawMeta (OSIDB-73)
 - Minimize mid-air collisions (OSIDB-765)
+- API delete methods now returns HTTP 200 status instead of 204
+  upon succesful delete
 
 ### Removed
 - Remove "state" and "resolution" from FlawHistory (OSIDB-73)

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -17,7 +17,7 @@ from rest_framework.decorators import api_view, permission_classes
 from rest_framework.permissions import AllowAny, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework.status import HTTP_204_NO_CONTENT
+from rest_framework.status import HTTP_200_OK
 from rest_framework.views import APIView
 from rest_framework.viewsets import (
     ModelViewSet,
@@ -380,7 +380,7 @@ class AffectView(ModelViewSet):
             raise ValidationError({"Bugzilla-Api-Key": "This HTTP header is required."})
         instance = self.get_object()
         self.perform_destroy(instance, bz_api_key=bz_api_key)
-        return Response(status=HTTP_204_NO_CONTENT)
+        return Response(status=HTTP_200_OK)
 
     def perform_destroy(self, instance, bz_api_key):
         """

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -5,6 +5,7 @@
 import logging
 import uuid
 from collections import defaultdict
+from distutils.util import strtobool
 from typing import Dict, List, Tuple
 
 from django.conf import settings
@@ -328,7 +329,7 @@ class EmbargoedField(serializers.BooleanField):
         # Run base Boolean field validation, ACL validation and then
         # raise SkipField to not include this field in validated data
         # since we don't have `embargoed` field to write in
-        super().run_validation(data)
+        data = super().run_validation(data)
         self.validate_acl(data)
         raise serializers.SkipField()
 
@@ -396,6 +397,8 @@ class ACLMixinSerializer(serializers.ModelSerializer):
         """
         # Already validated in EmbargoedField
         embargoed = self.context["request"].data.get("embargoed")
+        if isinstance(embargoed, str):
+            embargoed = bool(strtobool(embargoed))
 
         acl_read, acl_write = self.get_acls(embargoed)
         validated_data["acl_read"] = acl_read

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -212,7 +212,7 @@ class UpdatedDateTimeField(serializers.DateTimeField):
         """
         skip updated timestamp validation on create
         """
-        if self.context["request"].stream.method == "POST":
+        if self.context["request"].method == "POST":
             return (True, None)
         return super().validate_empty_values(data)
 

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1347,7 +1347,7 @@ class TestEndpoints(object):
         assert response.status_code == 200
 
         response = auth_client.delete(affect_url, HTTP_BUGZILLA_API_KEY="SECRET")
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         response = auth_client.get(affect_url)
         assert response.status_code == 404


### PR DESCRIPTION
This PR brings couple of fixes to serializers and API:

- it changes HTTP status code returned from DELETE method from 204 to 200 becuase 204 has no content and thus no body and thus we fail to return injected info about OSIDB instance
- it adds custom conversion from str to bool for embargoed field (see the commit description for more info)
- fixed method HTTP method check in serializer