### PR TITLE
Remove overlooked deprecated fields from Flaw

### DIFF
--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1195,8 +1195,6 @@ class TestEndpoints(object):
                 "type": flaw.type,
                 "title": f"{flaw.title} appended test title",
                 "description": flaw.description,
-                "state": flaw.state,
-                "resolution": flaw.resolution,
                 "impact": flaw.impact,
                 "source": flaw.source,
                 "embargoed": flaw.embargoed,


### PR DESCRIPTION
This PR continues the changes done in #171, and removes overlooked deprecated "resolution" and "state" fields from Flaw.

Related to "extend and refine flaw model" (OSIDB-73).