### PR TITLE
Update overlooked test with wrong HTTP response status code

### DIFF
--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -247,7 +247,7 @@ class TestBBSyncIntegration:
             format="json",
             HTTP_BUGZILLA_API_KEY="SECRET",
         )
-        assert response.status_code == 204
+        assert response.status_code == 200
 
         response = auth_client.get(f"{test_api_uri}/affects/{affect.uuid}")
         assert response.status_code == 404


### PR DESCRIPTION
This PR continues the changes done in #181, and updates overlooked test with wrong HTTP response status code (204 -> 200).