### PR TITLE
Add task ownership assignment

### DIFF
--- a/apps/taskman/api.py
+++ b/apps/taskman/api.py
@@ -223,3 +223,44 @@ class task_status(GenericAPIView):
         ).update_task_status(
             issue_key=task_key, status=serializer.validated_data["status"]
         )
+
+
+@jira_token_description
+class task_assignee(GenericAPIView):
+    @extend_schema(
+        responses=JiraIssueQueryResultSerializer,
+    )
+    def get(self, request, user):
+        """Get a list of tasks from a user"""
+        return JiraTaskmanQuerier(
+            token=request.headers.get("JiraAuthentication")
+        ).search_tasks_by_assignee(user)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(name="task_key", required=True, type=str),
+        ],
+        description="Assign a task to a user",
+        responses={204: OpenApiResponse(description="Modified.")},
+    )
+    def put(self, request, user):
+        """Assign a user for a task"""
+        serializer = TaskKeySerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        issue_key = serializer.validated_data["task_key"]
+
+        return JiraTaskmanQuerier(
+            token=request.headers.get("JiraAuthentication")
+        ).assign_task(task_key=issue_key, assignee=user)
+
+
+@jira_token_description
+class task_unassigneed(GenericAPIView):
+    @extend_schema(
+        responses=JiraIssueQueryResultSerializer,
+    )
+    def get(self, request):
+        """Get a list of tasks without an user assigned"""
+        return JiraTaskmanQuerier(
+            token=request.headers.get("JiraAuthentication")
+        ).search_tasks_by_assignee(None)

--- a/apps/taskman/jira_serializer.py
+++ b/apps/taskman/jira_serializer.py
@@ -33,6 +33,8 @@ class JiraIssueFieldsSerializer(serializers.Serializer):
     summary = serializers.CharField()
     description = serializers.CharField()
     assignee = JiraUserSerializer()
+    reporter = JiraUserSerializer()
+    creator = JiraUserSerializer()
     customfield_12311140 = serializers.CharField(help_text="Task group key")
 
 

--- a/apps/taskman/service.py
+++ b/apps/taskman/service.py
@@ -178,3 +178,28 @@ class JiraTaskmanQuerier(JiraQuerier):
             )
         except JIRAError as e:
             return Response(data=e.response.json(), status=e.status_code)
+
+    def assign_task(self, task_key: str, assignee: str) -> Response:
+        """set Jira task assignee"""
+        try:
+            self.jira_conn.assign_issue(task_key, assignee)
+            return Response(
+                data={},
+                status=204,
+            )
+        except JIRAError as e:
+            return Response(data=e.response.json(), status=e.status_code)
+
+    def search_tasks_by_assignee(self, assignee: str) -> Response:
+        """search Jira task by its assignee"""
+        user_query = f'assignee="{assignee}"' if assignee else "assignee is EMPTY"
+        jql_query = f'PROJECT={JIRA_TASKMAN_PROJECT_KEY} \
+                AND {user_query} \
+                AND type="Story"'
+        try:
+            return Response(
+                data=self.jira_conn.search_issues(jql_query, json_result=True),
+                status=200,
+            )
+        except JIRAError as e:
+            return Response(data=e.response.json(), status=e.status_code)

--- a/apps/taskman/tests/cassettes/test_integration/TestIntegration.test_assignment.yaml
+++ b/apps/taskman/tests/cassettes/test_integration/TestIntegration.test_assignment.yaml
@@ -893,9 +893,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:17 GMT
+      - Tue, 18 Apr 2023 22:12:43 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:17 GMT
+      - Tue, 18 Apr 2023 22:12:43 GMT
       Pragma:
       - no-cache
       Vary:
@@ -908,11 +908,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44543x1
+      - 1332x51962x1
       x-asessionid:
-      - 1h6xm8a
+      - 19hgkc6
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -920,9 +920,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851497.5305286b
+      - 0.a6912f17.1681855963.2e750246
       x-rh-edge-request-id:
-      - 5305286b
+      - 2e750246
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -948,7 +948,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A5a1a57e0-5b32-40e0-bc6d-c47995692ff1%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
   response:
     body:
       string: '{"startAt": 0, "maxResults": 50, "total": 0, "issues": []}'
@@ -962,9 +962,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:12:43 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:12:43 GMT
       Pragma:
       - no-cache
       Vary:
@@ -977,11 +977,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44544x1
+      - 1332x51963x1
       x-asessionid:
-      - 11ddnnb
+      - x7xvzk
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -989,9 +989,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851498.53052957
+      - 0.a6912f17.1681855963.2e7502d9
       x-rh-edge-request-id:
-      - '53052957'
+      - 2e7502d9
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1141,9 +1141,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:12:43 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:12:43 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1156,11 +1156,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44545x1
+      - 1332x51964x1
       x-asessionid:
-      - nmyxpx
+      - t0gu1a
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1168,9 +1168,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851498.53052a51
+      - 0.a6912f17.1681855963.2e750390
       x-rh-edge-request-id:
-      - 53052a51
+      - 2e750390
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1249,9 +1249,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1264,11 +1264,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44546x1
+      - 1332x51965x1
       x-asessionid:
-      - b7q6rj
+      - pot48q
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1276,9 +1276,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851498.53052df3
+      - 0.a6912f17.1681855964.2e750429
       x-rh-edge-request-id:
-      - 53052df3
+      - 2e750429
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1289,7 +1289,7 @@ interactions:
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12336420"}, "summary":
       "CVE-2020-0000 kernel: some description", "description": "Description for CVE-2020-0000",
-      "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"]}}'
+      "labels": ["flawuuid:5a1a57e0-5b32-40e0-bc6d-c47995692ff1"]}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1311,7 +1311,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: '{"id": "14943813", "key": "OSIM-248", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813"}'
+      string: '{"id": "14943751", "key": "OSIM-263", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943751"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1322,9 +1322,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1337,11 +1337,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44547x1
+      - 1332x51966x1
       x-asessionid:
-      - 1rwj4wq
+      - 1pzxsuk
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1349,9 +1349,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851499.53052fce
+      - 0.a6912f17.1681855964.2e7504ae
       x-rh-edge-request-id:
-      - 53052fce
+      - 2e7504ae
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1377,12 +1377,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-263
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943751", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943751",
+        "key": "OSIM-263", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -1396,28 +1396,28 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5c48499c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f6172ca[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6e4d6d0[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@461a0f45[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@514f8a6c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@658c55ad[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6a2619a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@ce092e4[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21d165fe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@26f77d54[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7cc6a31e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@74b979d0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5eed0c2c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@436dc778[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1ea062ce[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@8562678[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66e2ec11[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4b114f2e[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@56baf290[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6fe66bd9[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e959050[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5fbcc493[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e939386[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2f7832e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.002+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-263/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:12:44.111+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:5a1a57e0-5b32-40e0-bc6d-c47995692ff1"],
         "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:19.002+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T22:12:44.111+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
@@ -1452,10 +1452,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-263/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za105g:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za108s:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1466,26 +1466,26 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8634'
+      - '8632'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44548x1
+      - 1332x51967x1
       x-asessionid:
-      - 1q1kgxj
+      - 1tp4a36
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1493,9 +1493,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851499.530537ff
+      - 0.a6912f17.1681855964.2e75082e
       x-rh-edge-request-id:
-      - 530537ff
+      - 2e75082e
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1521,13 +1521,13 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+assignee+is+EMPTY+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
   response:
     body:
       string: '{"expand": "names,schema", "startAt": 0, "maxResults": 50, "total":
         1, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943751", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943751",
+        "key": "OSIM-263", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -1541,28 +1541,28 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6d03f9d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4ad52b2[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@142507a3[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7241d0a7[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6be75e7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@68e89f40[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4a5b0b74[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@67979546[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12f3d51e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3e4d4a9f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2cdfe689[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@77b96bf1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7bee0b3d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2fa3bf6d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49586da1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@356048c5[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@400edf2a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5641faed[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5cfeb0e1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6b6ffddb[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d2e9813[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@46197c9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2db1461c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@39a4e754[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.000+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-263/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:12:44.000+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:5a1a57e0-5b32-40e0-bc6d-c47995692ff1"],
         "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:19.000+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T22:12:44.000+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
@@ -1595,9 +1595,9 @@ interactions:
         "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
+        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-263/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za105g:"}}]}'
+        null, "customfield_12311940": "1|za108s:"}}]}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1608,151 +1608,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:20 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:20 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '8495'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44549x1
-      x-asessionid:
-      - dtp8t9
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851500.53053aa0
-      x-rh-edge-request-id:
-      - 53053aa0
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
-  response:
-    body:
-      string: '{"expand": "names,schema", "startAt": 0, "maxResults": 50, "total":
-        1, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@64a87aef[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e624046[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7b34c386[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3718ccd6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@ab5bf5d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@33cfe8f8[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6eba25f4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1fb53a89[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38dd3175[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@749986be[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4b33985c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7d6482c1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.000+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:19.000+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
-        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za105g:"}}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:20 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:20 GMT
+      - Tue, 18 Apr 2023 22:12:44 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1765,11 +1623,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44550x1
+      - 1332x51968x1
       x-asessionid:
-      - 1vefw7c
+      - 8b0e32
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1777,9 +1635,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851500.53053df6
+      - 0.a6912f17.1681855964.2e7508fc
       x-rh-edge-request-id:
-      - 53053df6
+      - 2e7508fc
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1788,8 +1646,77 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fields": {"summary": "CVE-2020-0000 kernel: some description modified",
-      "description": "Description for CVE-2020-0000"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/user/search?includeActive=True&includeInactive=False&maxResults=1&username=concosta%40redhat.com
+  response:
+    body:
+      string: '[{"self":"https://issues.stage.redhat.com/rest/api/2/user?username=concosta@redhat.com","key":"JIRAUSER196381","name":"concosta@redhat.com","emailAddress":"concosta+stage@redhat.com","avatarUrls":{"48x48":"https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326","24x24":"https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326","16x16":"https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326","32x32":"https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},"displayName":"Conrado
+        Costa","active":true,"deleted":false,"timeZone":"GMT","locale":"en_US"}]'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:12:44 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:12:44 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '720'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-1
+      x-arequestid:
+      - 1332x51969x1
+      x-asessionid:
+      - 1btuf1h
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.a6912f17.1681855964.2e750ab9
+      x-rh-edge-request-id:
+      - 2e750ab9
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "concosta@redhat.com"}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1800,7 +1727,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '122'
+      - '31'
       Content-Type:
       - application/json
       User-Agent:
@@ -1808,7 +1735,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248
+    uri: https://squid.corp.redhat.com:3128/rest/api/latest/issue/OSIM-263/assignee
   response:
     body:
       string: ''
@@ -1822,9 +1749,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:21 GMT
+      - Tue, 18 Apr 2023 22:12:45 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:21 GMT
+      - Tue, 18 Apr 2023 22:12:45 GMT
       Pragma:
       - no-cache
       referrer-policy:
@@ -1832,11 +1759,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44551x1
+      - 1332x51970x1
       x-asessionid:
-      - 1hgxqa5
+      - 7tq659
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1844,9 +1771,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851501.53054096
+      - 0.a6912f17.1681855965.2e750bb4
       x-rh-edge-request-id:
-      - '53054096'
+      - 2e750bb4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1872,13 +1799,13 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+assignee%3D%22concosta%40redhat.com%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
   response:
     body:
       string: '{"expand": "names,schema", "startAt": 0, "maxResults": 50, "total":
         1, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943751", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943751",
+        "key": "OSIM-263", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -1892,29 +1819,36 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2f7ab70c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@42fd4a4a[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@95a73de[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6c5ef66a[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38afd5a8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@102867ed[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2bc8727d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@57e2e1f5[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@11a66c34[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@42e266e2[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a51bf59[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6a7c1eaf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48190818[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@191da28f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@719f90f5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6a69c50a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7059fac7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@55eb7186[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@58fe5bf6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7c1b8476[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@43abd6f0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4dc2e842[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67493be7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@47513b4c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.000+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-263/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:12:44.000+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:5a1a57e0-5b32-40e0-bc6d-c47995692ff1"],
         "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:20.000+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "updated":
+        "2023-04-18T22:12:44.000+0000", "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
@@ -1927,8 +1861,7 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description modified", "creator": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1947,9 +1880,9 @@ interactions:
         "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
+        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-263/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za105g:"}}]}'
+        null, "customfield_12311940": "1|za108s:"}}]}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1960,26 +1893,26 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:21 GMT
+      - Tue, 18 Apr 2023 22:12:45 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:21 GMT
+      - Tue, 18 Apr 2023 22:12:45 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8507'
+      - '9180'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-0
+      - rh1-jira-dc-stg-1
       x-arequestid:
-      - 1258x44552x1
+      - 1332x51971x1
       x-asessionid:
-      - siv3rv
+      - 1m2dyco
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1987,308 +1920,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851501.5305455a
+      - 0.a6912f17.1681855965.2e750ec1
       x-rh-edge-request-id:
-      - 5305455a
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248/transitions
-  response:
-    body:
-      string: '{"expand": "transitions", "transitions": [{"id": "31", "name": "In
-        Progress", "opsbarSequence": 2147483647, "to": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10018",
-        "description": "Work has started", "iconUrl": "https://issues.stage.redhat.com/images/icons/status_generic.gif",
-        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
-        {"id": "41", "name": "Closed", "opsbarSequence": 2147483647, "to": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/status/6", "description": "The
-        issue is closed. See the resolution for context regarding why (for example
-        Done, Abandoned, Duplicate, etc)", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/closed.png",
-        "name": "Closed", "id": "6", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/3",
-        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}, {"id":
-        "51", "name": "New", "opsbarSequence": 2147483647, "to": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "61", "name": "Refinement", "opsbarSequence": 2147483647, "to": {"self": "https://issues.stage.redhat.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '1952'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44553x1
-      x-asessionid:
-      - 145gvs1
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851501.5305475b
-      x-rh-edge-request-id:
-      - 5305475b
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"transition": {"id": "31"}, "fields": {}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '42'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: POST
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248/transitions
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:22 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:22 GMT
-      Pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44554x1
-      x-asessionid:
-      - ywswpd
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851502.53054845
-      x-rh-edge-request-id:
-      - '53054845'
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@77b76e20[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@63eb827c[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@44d55720[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7b92c5a4[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a59a97a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@d824c02[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@630076c5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@ed230e4[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@39774a3d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@268af34d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@46dc1f07[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@59964228[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.002+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:21.658+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10018",
-        "description": "Work has started", "iconUrl": "https://issues.stage.redhat.com/images/icons/status_generic.gif",
-        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}},
-        "components": [], "timeoriginalestimate": null, "description": "Description
-        for CVE-2020-0000", "customfield_12314040": null, "customfield_12320844":
-        null, "timetracking": {}, "customfield_12320842": null, "archiveddate": null,
-        "customfield_12310243": null, "attachment": [], "aggregatetimeestimate": null,
-        "customfield_12316542": {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description modified", "creator": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
-        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
-        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za105g:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:22 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:22 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '8576'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44555x1
-      x-asessionid:
-      - 1295qe9
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851502.53054e1c
-      x-rh-edge-request-id:
-      - 53054e1c
+      - 2e750ec1
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/apps/taskman/tests/cassettes/test_integration/TestIntegration.test_comment.yaml
+++ b/apps/taskman/tests/cassettes/test_integration/TestIntegration.test_comment.yaml
@@ -17,937 +17,6 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/field
-  response:
-    body:
-      string: "[{\"id\":\"customfield_12322243\",\"name\":\"Release Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322243]\",\"Release
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322243}},{\"id\":\"customfield_12322244\",\"name\":\"PX
-        Impact Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322244]\",\"PX
-        Impact Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlynumber\",\"customId\":12322244}},{\"id\":\"customfield_12322240\",\"name\":\"Staffing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322240]\",\"Staffing\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12322240}},{\"id\":\"customfield_12322241\",\"name\":\"Gating
-        Tests\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322241]\",\"Gating
-        Tests\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12322241}},{\"id\":\"resolution\",\"name\":\"Resolution\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolution\"],\"schema\":{\"type\":\"resolution\",\"system\":\"resolution\"}},{\"id\":\"customfield_12310022\",\"name\":\"SVN
-        / CVS Isolated Branch\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310022]\",\"SVN
-        / CVS Isolated Branch\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12310022}},{\"id\":\"customfield_12314742\",\"name\":\"Percent
-        confident\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314742]\",\"Percent
-        confident\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12314742}},{\"id\":\"customfield_12310021\",\"name\":\"Support
-        Case Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310021]\",\"Support
-        Case Reference\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12310021}},{\"id\":\"customfield_12312441\",\"name\":\"Affects
-        Build\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affects
-        Build\",\"cf[12312441]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312441}},{\"id\":\"customfield_12314741\",\"name\":\"Percent
-        complete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314741]\",\"Percent
-        complete\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12314741}},{\"id\":\"customfield_12314740\",\"name\":\"Development\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314740]\",\"Development\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:devsummary\",\"customId\":12314740}},{\"id\":\"customfield_12312442\",\"name\":\"Fix
-        Build\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312442]\",\"Fix
-        Build\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312442}},{\"id\":\"customfield_12312440\",\"name\":\"Deployment
-        Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312440]\",\"Deployment
-        Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12312440}},{\"id\":\"customfield_12315950\",\"name\":\"Contributors\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315950]\",\"Contributors\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12315950}},{\"id\":\"lastViewed\",\"name\":\"Last
-        Viewed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"lastViewed\"],\"schema\":{\"type\":\"datetime\",\"system\":\"lastViewed\"}},{\"id\":\"customfield_12321040\",\"name\":\"Internal
-        Target Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321040]\",\"Internal
-        Target Milestone\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321040}},{\"id\":\"customfield_12311244\",\"name\":\"CDW
-        qa_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        qa_ack\",\"cf[12311244]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagqa\",\"customId\":12311244}},{\"id\":\"customfield_12311245\",\"name\":\"CDW
-        blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        blocker\",\"cf[12311245]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagprogman\",\"customId\":12311245}},{\"id\":\"customfield_12315842\",\"name\":\"PX
-        Priority Data_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315842]\",\"PX
-        Priority Data_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12315842}},{\"id\":\"customfield_12311242\",\"name\":\"CDW
-        pm_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        pm_ack\",\"cf[12311242]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagpm\",\"customId\":12311242}},{\"id\":\"customfield_12315841\",\"name\":\"PX
-        Scheduling Request - OLD\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315841]\",\"PX
-        Scheduling Request - OLD\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12315841}},{\"id\":\"customfield_12311243\",\"name\":\"CDW
-        devel_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        devel_ack\",\"cf[12311243]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagdevel\",\"customId\":12311243}},{\"id\":\"customfield_12313541\",\"name\":\"Epic
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313541]\",\"Epic
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313541}},{\"id\":\"customfield_12315840\",\"name\":\"PX
-        Impact Score_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315840]\",\"PX
-        Impact Score_Old\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12315840}},{\"id\":\"aggregatetimeoriginalestimate\",\"name\":\"\u03A3
-        Original Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeoriginalestimate\"}},{\"id\":\"customfield_12310150\",\"name\":\"Defect
-        Tracker URL\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310150]\",\"Defect
-        Tracker URL\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12310150}},{\"id\":\"customfield_12311240\",\"name\":\"Target
-        Release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311240]\",\"Target
-        Release\"],\"schema\":{\"type\":\"version\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwtargetreleasebyversion\",\"customId\":12311240}},{\"id\":\"customfield_12311241\",\"name\":\"CDW
-        release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        release\",\"cf[12311241]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagrelease\",\"customId\":12311241}},{\"id\":\"customfield_12310031\",\"name\":\"Affects\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affects\",\"cf[12310031]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310031}},{\"id\":\"issuelinks\",\"name\":\"Linked
-        Issues\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"issuelinks\"}},{\"id\":\"assignee\",\"name\":\"Assignee\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"assignee\"],\"schema\":{\"type\":\"user\",\"system\":\"assignee\"}},{\"id\":\"customfield_12311246\",\"name\":\"CDW
-        exception\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        exception\",\"cf[12311246]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagprogman\",\"customId\":12311246}},{\"id\":\"customfield_12320041\",\"name\":\"Escape
-        Reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320041]\",\"Escape
-        Reason\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320041}},{\"id\":\"customfield_12319294\",\"name\":\"QE
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319294]\",\"QE
-        Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319294}},{\"id\":\"customfield_12319293\",\"name\":\"Affected
-        Groups\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affected
-        Groups\",\"cf[12319293]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319293}},{\"id\":\"customfield_12320040\",\"name\":\"Work
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320040]\",\"Work
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320040}},{\"id\":\"customfield_12319297\",\"name\":\"BZ
-        Partner_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Partner_Old\",\"cf[12319297]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319297}},{\"id\":\"customfield_12320043\",\"name\":\"Corrective
-        Measures\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320043]\",\"Corrective
-        Measures\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320043}},{\"id\":\"customfield_12320042\",\"name\":\"Escape
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320042]\",\"Escape
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320042}},{\"id\":\"customfield_12319299\",\"name\":\"SME\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319299]\",\"SME\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12319299}},{\"id\":\"customfield_12319290\",\"name\":\"Training
-        Opportunity\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319290]\",\"Training
-        Opportunity\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319290}},{\"id\":\"customfield_12319292\",\"name\":\"Testing
-        Instructions\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319292]\",\"Testing
-        Instructions\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319292}},{\"id\":\"customfield_12319291\",\"name\":\"Training
-        Opportunity Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319291]\",\"Training
-        Opportunity Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319291}},{\"id\":\"customfield_12310120\",\"name\":\"Help
-        Desk Ticket Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310120]\",\"Help
-        Desk Ticket Reference\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiurl\",\"customId\":12310120}},{\"id\":\"customfield_12314840\",\"name\":\"Doc
-        Version/s\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314840]\",\"Doc
-        Version/s\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiversion\",\"customId\":12314840}},{\"id\":\"customfield_12310243\",\"name\":\"Story
-        Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310243]\",\"Story
-        Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12310243}},{\"id\":\"subtasks\",\"name\":\"Sub-Tasks\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"subtasks\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"subtasks\"}},{\"id\":\"customfield_12321140\",\"name\":\"GtmhubObjectID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321140]\",\"GtmhubObjectID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321140}},{\"id\":\"customfield_12322356\",\"name\":\"Begin
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Begin
-        Date\",\"cf[12322356]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12322356}},{\"id\":\"customfield_12322357\",\"name\":\"End
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322357]\",\"End
-        Date\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12322357}},{\"id\":\"customfield_12322358\",\"name\":\"Revision\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322358]\",\"Revision\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322358}},{\"id\":\"customfield_12315943\",\"name\":\"Ready-Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315943]\",\"Ready-Ready\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12315943}},{\"id\":\"customfield_12310010\",\"name\":\"Forum
-        Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310010]\",\"Forum
-        Reference\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12310010}},{\"id\":\"customfield_12315944\",\"name\":\"Planned
-        End\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315944]\",\"Planned
-        End\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12315944}},{\"id\":\"customfield_12315948\",\"name\":\"QA
-        Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315948]\",\"QA
-        Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12315948}},{\"id\":\"customfield_12315949\",\"name\":\"Product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315949]\",\"Product\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315949}},{\"id\":\"votes\",\"name\":\"Votes\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"votes\"],\"schema\":{\"type\":\"votes\",\"system\":\"votes\"}},{\"id\":\"worklog\",\"name\":\"Log
-        Work\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"worklog\",\"system\":\"worklog\"}},{\"id\":\"customfield_12315940\",\"name\":\"Acceptance
-        Criteria\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Acceptance
-        Criteria\",\"cf[12315940]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12315940}},{\"id\":\"customfield_12315941\",\"name\":\"Backlogs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Backlogs\",\"cf[12315941]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12315941}},{\"id\":\"issuetype\",\"name\":\"Issue
-        Type\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issuetype\",\"type\"],\"schema\":{\"type\":\"issuetype\",\"system\":\"issuetype\"}},{\"id\":\"customfield_12322040\",\"name\":\"Internal
-        Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322040]\",\"Internal
-        Whiteboard\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlytext\",\"customId\":12322040}},{\"id\":\"customfield_12310181\",\"name\":\"Engineering
-        Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310181]\",\"Engineering
-        Response\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310181}},{\"id\":\"customfield_12310060\",\"name\":\"Patch
-        Visibility\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310060]\",\"Patch
-        Visibility\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310060}},{\"id\":\"customfield_12310180\",\"name\":\"Background
-        and Context\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Background
-        and Context\",\"cf[12310180]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310180}},{\"id\":\"customfield_12316845\",\"name\":\"5-Acks
-        Check\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"5-Acks
-        Check\",\"cf[12316845]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316845}},{\"id\":\"customfield_12316846\",\"name\":\"GitHub
-        Issue\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316846]\",\"GitHub
-        Issue\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316846}},{\"id\":\"customfield_12316847\",\"name\":\"Developer
-        Comment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316847]\",\"Developer
-        Comment\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316847}},{\"id\":\"customfield_12316848\",\"name\":\"ODC
-        Planning\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316848]\",\"ODC
-        Planning\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316848}},{\"id\":\"customfield_12312241\",\"name\":\"Code
-        Sample\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312241]\",\"Code
-        Sample\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12312241}},{\"id\":\"customfield_12316849\",\"name\":\"ODC
-        Planning Ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316849]\",\"ODC
-        Planning Ack\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316849}},{\"id\":\"customfield_12310183\",\"name\":\"Steps
-        to Reproduce\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310183]\",\"Steps
-        to Reproduce\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310183}},{\"id\":\"customfield_12310182\",\"name\":\"Product
-        Management Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310182]\",\"Product
-        Management Response\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310182}},{\"id\":\"customfield_12312240\",\"name\":\"QE
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312240]\",\"QE
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312240}},{\"id\":\"customfield_12316840\",\"name\":\"Bugzilla
-        Bug\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug\",\"cf[12316840]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12316840}},{\"id\":\"customfield_12316841\",\"name\":\"Sync
-        Failure Flag\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316841]\",\"Sync
-        Failure Flag\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12316841}},{\"id\":\"customfield_12316842\",\"name\":\"Sync
-        Failure Message\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316842]\",\"Sync
-        Failure Message\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316842}},{\"id\":\"customfield_12316843\",\"name\":\"Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316843]\",\"Whiteboard\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316843}},{\"id\":\"customfield_12316844\",\"name\":\"Subcomponent\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316844]\",\"Subcomponent\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316844}},{\"id\":\"customfield_12310071\",\"name\":\"Patch
-        Repository Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310071]\",\"Patch
-        Repository Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12310071}},{\"id\":\"customfield_12310070\",\"name\":\"Patch
-        Instructions\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310070]\",\"Patch
-        Instructions\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310070}},{\"id\":\"customfield_12315640\",\"name\":\"Doc
-        Required\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315640]\",\"Doc
-        Required\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315640}},{\"id\":\"customfield_12313340\",\"name\":\"Stackoverflow
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313340]\",\"Stackoverflow
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12313340}},{\"id\":\"customfield_12316850\",\"name\":\"Service
-        Delivery Planning ACK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316850]\",\"Service
-        Delivery Planning ACK\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316850}},{\"id\":\"customfield_12317940\",\"name\":\"Funding
-        State\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317940]\",\"Funding
-        State\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317940}},{\"id\":\"customfield_12317941\",\"name\":\"Funding
-        Strategy\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317941]\",\"Funding
-        Strategy\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317941}},{\"id\":\"customfield_12322143\",\"name\":\"PX
-        Impact Range\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322143]\",\"PX
-        Impact Range\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12322143}},{\"id\":\"customfield_12322144\",\"name\":\"Risk
-        Identified Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322144]\",\"Risk
-        Identified Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322144}},{\"id\":\"customfield_12322145\",\"name\":\"Additional
-        Approvers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Additional
-        Approvers\",\"cf[12322145]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12322145}},{\"id\":\"customfield_12322146\",\"name\":\"Security
-        Approvals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322146]\",\"Security
-        Approvals\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12322146}},{\"id\":\"customfield_12322140\",\"name\":\"PX
-        Review Complete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322140]\",\"PX
-        Review Complete\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12322140}},{\"id\":\"customfield_12322141\",\"name\":\"PX
-        Technical Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322141]\",\"PX
-        Technical Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12322141}},{\"id\":\"customfield_12322142\",\"name\":\"PX
-        Priority Data\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322142]\",\"PX
-        Priority Data\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12322142}},{\"id\":\"customfield_12322147\",\"name\":\"External
-        QA Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322147]\",\"External
-        QA Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12322147}},{\"id\":\"customfield_12322148\",\"name\":\"Development
-        Complete Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322148]\",\"Development
-        Complete Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322148}},{\"id\":\"customfield_12322149\",\"name\":\"Project
-        Target Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322149]\",\"Project
-        Target Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322149}},{\"id\":\"timetracking\",\"name\":\"Time
-        Tracking\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"timetracking\",\"system\":\"timetracking\"}},{\"id\":\"customfield_12312340\",\"name\":\"GSS
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312340]\",\"GSS
-        Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12312340}},{\"id\":\"customfield_12314640\",\"name\":\"Upstream
-        Jira\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314640]\",\"Upstream
-        Jira\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12314640}},{\"id\":\"customfield_12310160\",\"name\":\"Customer
-        Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310160]\",\"Customer
-        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12310160}},{\"id\":\"customfield_12316940\",\"name\":\"Team
-        Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316940]\",\"Team
-        Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316940}},{\"id\":\"customfield_12316941\",\"name\":\"QE
-        Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316941]\",\"QE
-        Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316941}},{\"id\":\"customfield_12316942\",\"name\":\"Doc
-        Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316942]\",\"Doc
-        Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316942}},{\"id\":\"customfield_12316943\",\"name\":\"Business
-        Value\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Business
-        Value\",\"cf[12316943]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12316943}},{\"id\":\"customfield_12322150\",\"name\":\"Exception
-        Count\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322150]\",\"Exception
-        Count\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12322150}},{\"id\":\"customfield_12322151\",\"name\":\"Security
-        Controls\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322151]\",\"Security
-        Controls\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12322151}},{\"id\":\"customfield_12322152\",\"name\":\"Blocked
-        by Bugzilla Bug\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Blocked
-        by Bugzilla Bug\",\"cf[12322152]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12322152}},{\"id\":\"customfield_12310170\",\"name\":\"Affects
-        Testing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affects
-        Testing\",\"cf[12310170]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310170}},{\"id\":\"environment\",\"name\":\"Environment\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"environment\"],\"schema\":{\"type\":\"string\",\"system\":\"environment\"}},{\"id\":\"customfield_12313443\",\"name\":\"Affected
-        Jars\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affected
-        Jars\",\"cf[12313443]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12313443}},{\"id\":\"customfield_12311143\",\"name\":\"Epic
-        Colour\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311143]\",\"Epic
-        Colour\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-color\",\"customId\":12311143}},{\"id\":\"customfield_12313442\",\"name\":\"PDD
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313442]\",\"PDD
-        Priority\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12313442}},{\"id\":\"customfield_12311141\",\"name\":\"Epic
-        Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311141]\",\"Epic
-        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-label\",\"customId\":12311141}},{\"id\":\"customfield_12313441\",\"name\":\"SFDC
-        Cases Links\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313441]\",\"SFDC
-        Cases Links\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.redhat.engineering.step.step-sfdc-plugin:sfdc_cases\",\"customId\":12313441}},{\"id\":\"customfield_12315740\",\"name\":\"issueFunction\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315740]\",\"issueFunction\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:jqlFunctionsCustomFieldType\",\"customId\":12315740}},{\"id\":\"customfield_12311142\",\"name\":\"Epic
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311142]\",\"Epic
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-status\",\"customId\":12311142}},{\"id\":\"customfield_12313440\",\"name\":\"SFDC
-        Cases Counter\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313440]\",\"SFDC
-        Cases Counter\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.redhat.engineering.step.step-sfdc-plugin:sfdc_cases_counter\",\"customId\":12313440}},{\"id\":\"duedate\",\"name\":\"Due
-        Date\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"due\",\"duedate\"],\"schema\":{\"type\":\"date\",\"system\":\"duedate\"}},{\"id\":\"customfield_12310173\",\"name\":\"Component
-        Fix Version(s)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310173]\",\"Component
-        Fix Version(s)\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12310173}},{\"id\":\"customfield_12311140\",\"name\":\"Epic
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311140]\",\"Epic
-        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-link\",\"customId\":12311140}},{\"id\":\"customfield_12314340\",\"name\":\"cee_cir\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cee_cir\",\"cf[12314340]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cirflag\",\"customId\":12314340}},{\"id\":\"customfield_12318940\",\"name\":\"Workstream
-        (OLD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318940]\",\"Workstream
-        (OLD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318940}},{\"id\":\"customfield_12313140\",\"name\":\"Parent
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313140]\",\"Parent
-        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-parent\",\"customId\":12313140}},{\"id\":\"customfield_12313145\",\"name\":\"QE
-        Estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313145]\",\"QE
-        Estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12313145}},{\"id\":\"timeestimate\",\"name\":\"Remaining
-        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"remainingEstimate\",\"timeestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeestimate\"}},{\"id\":\"customfield_12313143\",\"name\":\"EAP
-        PT Community Docs (CD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313143]\",\"EAP
-        PT Community Docs (CD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313143}},{\"id\":\"customfield_12313144\",\"name\":\"EAP
-        PT Test Dev (TD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313144]\",\"EAP
-        PT Test Dev (TD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313144}},{\"id\":\"customfield_12315440\",\"name\":\"Verified-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315440]\",\"Verified-delete\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12315440}},{\"id\":\"customfield_12317740\",\"name\":\"Planning
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317740]\",\"Planning
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317740}},{\"id\":\"status\",\"name\":\"Status\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"status\"],\"schema\":{\"type\":\"status\",\"system\":\"status\"}},{\"id\":\"customfield_12310080\",\"name\":\"Tester\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310080]\",\"Tester\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12310080}},{\"id\":\"archiveddate\",\"name\":\"Archived\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"datetime\",\"system\":\"archiveddate\"}},{\"id\":\"customfield_12316747\",\"name\":\"Support
-        Exception Account Number\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316747]\",\"Support
-        Exception Account Number\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316747}},{\"id\":\"customfield_12316749\",\"name\":\"Architect\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Architect\",\"cf[12316749]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316749}},{\"id\":\"aggregatetimeestimate\",\"name\":\"\u03A3
-        Remaining Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeestimate\"}},{\"id\":\"customfield_12312142\",\"name\":\"Class
-        of work\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312142]\",\"Class
-        of work\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312142}},{\"id\":\"customfield_12314440\",\"name\":\"cee_docs_prio-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cee_docs_prio-delete\",\"cf[12314440]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:ccsprioflag\",\"customId\":12314440}},{\"id\":\"customfield_12316740\",\"name\":\"Prod
-        build version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316740]\",\"Prod
-        build version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316740}},{\"id\":\"customfield_12316745\",\"name\":\"QE
-        ACK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316745]\",\"QE
-        ACK\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12316745}},{\"id\":\"creator\",\"name\":\"Creator\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"creator\"],\"schema\":{\"type\":\"user\",\"system\":\"creator\"}},{\"id\":\"customfield_12323041\",\"name\":\"Domain
-        Pool\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12323041]\",\"Domain
-        Pool\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:multiple-ldap-picker-cf\",\"customId\":12323041}},{\"id\":\"customfield_12310091\",\"name\":\"Workaround
-        Description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310091]\",\"Workaround
-        Description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310091}},{\"id\":\"customfield_12310090\",\"name\":\"Workaround\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310090]\",\"Workaround\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310090}},{\"id\":\"customfield_12310092\",\"name\":\"Estimated
-        Difficulty\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310092]\",\"Estimated
-        Difficulty\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12310092}},{\"id\":\"customfield_12315542\",\"name\":\"Flagged\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315542]\",\"Flagged\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12315542}},{\"id\":\"customfield_12315541\",\"name\":\"Regression
-        Test\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315541]\",\"Regression
-        Test\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315541}},{\"id\":\"customfield_12315540\",\"name\":\"EAP
-        Docs SME\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315540]\",\"EAP
-        Docs SME\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315540}},{\"id\":\"customfield_12313240\",\"name\":\"Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313240]\",\"Team\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.teams:rm-teams-custom-field-team\",\"customId\":12313240}},{\"id\":\"customfield_12316750\",\"name\":\"Technical
-        Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316750]\",\"Technical
-        Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316750}},{\"id\":\"customfield_12316751\",\"name\":\"Designer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316751]\",\"Designer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316751}},{\"id\":\"customfield_12317841\",\"name\":\"Fuse
-        Progress Bar\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317841]\",\"Fuse
-        Progress Bar\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317841}},{\"id\":\"customfield_12316752\",\"name\":\"Product
-        Manager\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316752]\",\"Product
-        Manager\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316752}},{\"id\":\"customfield_12317842\",\"name\":\"Fuse
-        Progress\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317842]\",\"Fuse
-        Progress\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317842}},{\"id\":\"customfield_12316753\",\"name\":\"Manager\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316753]\",\"Manager\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316753}},{\"id\":\"customfield_12317843\",\"name\":\"BZ
-        Partner\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Partner\",\"cf[12317843]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317843}},{\"id\":\"timespent\",\"name\":\"Time
-        Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"timespent\"],\"schema\":{\"type\":\"number\",\"system\":\"timespent\"}},{\"id\":\"customfield_12320940\",\"name\":\"Test
-        Coverage\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320940]\",\"Test
-        Coverage\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320940}},{\"id\":\"aggregatetimespent\",\"name\":\"\u03A3
-        Time Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimespent\"}},{\"id\":\"customfield_12320944\",\"name\":\"Test
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320944]\",\"Test
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12320944}},{\"id\":\"customfield_12320943\",\"name\":\"Pervasiveness\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320943]\",\"Pervasiveness\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320943}},{\"id\":\"customfield_12320941\",\"name\":\"Willingness
-        to Pay\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320941]\",\"Willingness
-        to Pay\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320941}},{\"id\":\"customfield_12316441\",\"name\":\"Work
-        Source\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316441]\",\"Work
-        Source\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316441}},{\"id\":\"workratio\",\"name\":\"Work
-        Ratio\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"workratio\"],\"schema\":{\"type\":\"number\",\"system\":\"workratio\"}},{\"id\":\"customfield_12316442\",\"name\":\"Customer
-        Cloud Subscription (CCS)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316442]\",\"Customer
-        Cloud Subscription (CCS)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316442}},{\"id\":\"customfield_12318740\",\"name\":\"Portfolio
-        Solutions\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318740]\",\"Portfolio
-        Solutions\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12318740}},{\"id\":\"customfield_12316443\",\"name\":\"Cluster
-        Admin Enabled\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316443]\",\"Cluster
-        Admin Enabled\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316443}},{\"id\":\"customfield_12316444\",\"name\":\"Cloud
-        Platform\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316444]\",\"Cloud
-        Platform\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316444}},{\"id\":\"customfield_12317540\",\"name\":\"Support
-        Scope\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317540]\",\"Support
-        Scope\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317540}},{\"id\":\"customfield_12315240\",\"name\":\"EAP
-        Testing By\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315240]\",\"EAP
-        Testing By\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315240}},{\"id\":\"customfield_12320948\",\"name\":\"Experience\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320948]\",\"Experience\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320948}},{\"id\":\"customfield_12317307\",\"name\":\"Original
-        Estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317307]\",\"Original
-        Estimate\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317307}},{\"id\":\"customfield_12320947\",\"name\":\"Market\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320947]\",\"Market\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12320947}},{\"id\":\"customfield_12317308\",\"name\":\"QA
-        Contacts\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317308]\",\"QA
-        Contacts\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317308}},{\"id\":\"customfield_12317309\",\"name\":\"BZ
-        URL\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        URL\",\"cf[12317309]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317309}},{\"id\":\"customfield_12320946\",\"name\":\"Intelligence
-        Requested\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320946]\",\"Intelligence
-        Requested\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320946}},{\"id\":\"customfield_12320945\",\"name\":\"Risk
-        Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320945]\",\"Risk
-        Category\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320945}},{\"id\":\"customfield_12319840\",\"name\":\"External
-        issue ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319840]\",\"External
-        issue ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319840}},{\"id\":\"customfield_12317300\",\"name\":\"Risk
-        Category - Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317300]\",\"Risk
-        Category - Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317300}},{\"id\":\"customfield_12317301\",\"name\":\"Risk
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317301]\",\"Risk
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317301}},{\"id\":\"customfield_12317302\",\"name\":\"Risk
-        Probability\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317302]\",\"Risk
-        Probability\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317302}},{\"id\":\"customfield_12317303\",\"name\":\"Risk
-        Proximity\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317303]\",\"Risk
-        Proximity\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317303}},{\"id\":\"customfield_12317304\",\"name\":\"Risk
-        Impact Level\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317304]\",\"Risk
-        Impact Level\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317304}},{\"id\":\"customfield_12317305\",\"name\":\"Risk
-        impact description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317305]\",\"Risk
-        impact description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317305}},{\"id\":\"customfield_12317306\",\"name\":\"Risk
-        mitigation/contingency\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317306]\",\"Risk
-        mitigation/contingency\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317306}},{\"id\":\"customfield_12316548\",\"name\":\"Actual
-        Effort\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Actual
-        Effort\",\"cf[12316548]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12316548}},{\"id\":\"customfield_12316549\",\"name\":\"CRT
-        Milestone Estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316549]\",\"CRT
-        Milestone Estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12316549}},{\"id\":\"customfield_12314245\",\"name\":\"EAP
-        PT Pre-Checked (PC)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314245]\",\"EAP
-        PT Pre-Checked (PC)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314245}},{\"id\":\"customfield_12314244\",\"name\":\"EAP
-        PT Product Docs (PD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314244]\",\"EAP
-        PT Product Docs (PD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314244}},{\"id\":\"customfield_12314243\",\"name\":\"EAP
-        PT Docs Analysis (DA)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314243]\",\"EAP
-        PT Docs Analysis (DA)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314243}},{\"id\":\"customfield_12314242\",\"name\":\"EAP
-        PT Test Plan (TP)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314242]\",\"EAP
-        PT Test Plan (TP)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314242}},{\"id\":\"customfield_12314241\",\"name\":\"EAP
-        PT Analysis Document (AD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314241]\",\"EAP
-        PT Analysis Document (AD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314241}},{\"id\":\"customfield_12318840\",\"name\":\"Marketing
-        Info\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318840]\",\"Marketing
-        Info\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12318840}},{\"id\":\"customfield_12316540\",\"name\":\"Reviewer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316540]\",\"Reviewer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316540}},{\"id\":\"customfield_12316541\",\"name\":\"T-Shirt
-        Size\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316541]\",\"T-Shirt
-        Size\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316541}},{\"id\":\"customfield_12316542\",\"name\":\"Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316542]\",\"Ready\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316542}},{\"id\":\"customfield_12316543\",\"name\":\"Blocked\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Blocked\",\"cf[12316543]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316543}},{\"id\":\"customfield_12318841\",\"name\":\"Marketing
-        Info Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318841]\",\"Marketing
-        Info Ready\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318841}},{\"id\":\"customfield_12316544\",\"name\":\"Blocked
-        Reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Blocked
-        Reason\",\"cf[12316544]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316544}},{\"id\":\"customfield_12316545\",\"name\":\"Owner\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316545]\",\"Owner\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316545}},{\"id\":\"customfield_12316546\",\"name\":\"Evidence
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316546]\",\"Evidence
-        Score\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316546}},{\"id\":\"customfield_12316547\",\"name\":\"Discussed
-        with Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316547]\",\"Discussed
-        with Team\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12316547}},{\"id\":\"customfield_12313040\",\"name\":\"Test
-        Plan\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313040]\",\"Test
-        Plan\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12313040}},{\"id\":\"customfield_12313041\",\"name\":\"Analysis
-        Document\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Analysis
-        Document\",\"cf[12313041]\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12313041}},{\"id\":\"customfield_12313042\",\"name\":\"Microrelease
-        version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313042]\",\"Microrelease
-        version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12313042}},{\"id\":\"customfield_12317640\",\"name\":\"DevTestDoc\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317640]\",\"DevTestDoc\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317640}},{\"id\":\"customfield_12319940\",\"name\":\"Target
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319940]\",\"Target
-        Version\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiversion\",\"customId\":12319940}},{\"id\":\"customfield_12317401\",\"name\":\"EXD-Service\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317401]\",\"EXD-Service\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12317401}},{\"id\":\"customfield_12317403\",\"name\":\"EXD-WorkType\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317403]\",\"EXD-WorkType\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317403}},{\"id\":\"customfield_12317404\",\"name\":\"Commitment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317404]\",\"Commitment\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12317404}},{\"id\":\"customfield_12317405\",\"name\":\"Requesting
-        Teams\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317405]\",\"Requesting
-        Teams\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317405}},{\"id\":\"customfield_12316240\",\"name\":\"Planning\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316240]\",\"Planning\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316240}},{\"id\":\"customfield_12317330\",\"name\":\"BZ
-        needinfo\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        needinfo\",\"cf[12317330]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317330}},{\"id\":\"customfield_12316241\",\"name\":\"Design
-        Doc\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316241]\",\"Design
-        Doc\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316241}},{\"id\":\"customfield_12319751\",\"name\":\"Risk
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319751]\",\"Risk
-        Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319751}},{\"id\":\"customfield_12317331\",\"name\":\"BZ
-        rhel-8.0.z\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        rhel-8.0.z\",\"cf[12317331]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317331}},{\"id\":\"customfield_12318540\",\"name\":\"Message
-        For OHSS Project\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318540]\",\"Message
-        For OHSS Project\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:messagecustomfield\",\"customId\":12318540}},{\"id\":\"customfield_12316242\",\"name\":\"QEStatus\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316242]\",\"QEStatus\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316242}},{\"id\":\"customfield_12319750\",\"name\":\"WSJF\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319750]\",\"WSJF\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319750}},{\"id\":\"customfield_12320741\",\"name\":\"Urgency\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320741]\",\"Urgency\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320741}},{\"id\":\"customfield_12320740\",\"name\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320740]\",\"Impact\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320740}},{\"id\":\"customfield_12316243\",\"name\":\"QE
-        Assignee\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316243]\",\"QE
-        Assignee\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316243}},{\"id\":\"customfield_12317332\",\"name\":\"ZStream
-        Target Release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317332]\",\"ZStream
-        Target Release\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317332}},{\"id\":\"customfield_12317333\",\"name\":\"BZ
-        blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        blocker\",\"cf[12317333]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317333}},{\"id\":\"customfield_12316245\",\"name\":\"Needs
-        Product Docs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316245]\",\"Needs
-        Product Docs\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316245}},{\"id\":\"customfield_12319755\",\"name\":\"PX
-        Review Complete_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319755]\",\"PX
-        Review Complete_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319755}},{\"id\":\"customfield_12317334\",\"name\":\"zstream\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317334]\",\"zstream\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317334}},{\"id\":\"customfield_12317335\",\"name\":\"BZ
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Version\",\"cf[12317335]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317335}},{\"id\":\"customfield_12317336\",\"name\":\"BZ
-        Docs Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Docs Contact\",\"cf[12317336]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317336}},{\"id\":\"customfield_12317337\",\"name\":\"BZ
-        requires_doc_text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        requires_doc_text\",\"cf[12317337]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317337}},{\"id\":\"customfield_12319756\",\"name\":\"PX
-        Scheduling Request - SV-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319756]\",\"PX
-        Scheduling Request - SV-delete\"],\"schema\":{\"type\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:version\",\"customId\":12319756}},{\"id\":\"customfield_12317338\",\"name\":\"Doc
-        Commitment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317338]\",\"Doc
-        Commitment\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317338}},{\"id\":\"customfield_12317339\",\"name\":\"Hardware_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317339]\",\"Hardware_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317339}},{\"id\":\"customfield_12310940\",\"name\":\"Sprint\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310940]\",\"Sprint\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-sprint\",\"customId\":12310940}},{\"id\":\"customfield_12316250\",\"name\":\"Link
-        to documentation\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316250]\",\"Link
-        to documentation\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316250}},{\"id\":\"customfield_12317340\",\"name\":\"OS\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317340]\",\"OS\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317340}},{\"id\":\"customfield_12317341\",\"name\":\"Public
-        Target Launch Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317341]\",\"Public
-        Target Launch Date\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317341}},{\"id\":\"customfield_12319640\",\"name\":\"Contributing
-        Groups\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319640]\",\"Contributing
-        Groups\"],\"schema\":{\"type\":\"array\",\"items\":\"group\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multigrouppicker\",\"customId\":12319640}},{\"id\":\"customfield_12317342\",\"name\":\"Onsite
-        Hardware Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317342]\",\"Onsite
-        Hardware Date\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317342}},{\"id\":\"customfield_12315043\",\"name\":\"3scale
-        PT Verified Product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Verified Product\",\"cf[12315043]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315043}},{\"id\":\"customfield_12315042\",\"name\":\"3scale
-        PT Released In Saas\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Released In Saas\",\"cf[12315042]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315042}},{\"id\":\"customfield_12315041\",\"name\":\"3scale
-        PT Docs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Docs\",\"cf[12315041]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315041}},{\"id\":\"customfield_12315040\",\"name\":\"3scale
-        PT Product Specs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Product Specs\",\"cf[12315040]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315040}},{\"id\":\"customfield_12321840\",\"name\":\"Supply
-        Chain STI\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321840]\",\"Supply
-        Chain STI\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12321840}},{\"id\":\"customfield_12321841\",\"name\":\"Offerings\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321841]\",\"Offerings\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12321841}},{\"id\":\"labels\",\"name\":\"Labels\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"labels\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"system\":\"labels\"}},{\"id\":\"customfield_12321842\",\"name\":\"External
-        issue ID_Old12\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321842]\",\"External
-        issue ID_Old12\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321842}},{\"id\":\"customfield_12315044\",\"name\":\"3scale
-        PT Product Update Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Product Update Ready\",\"cf[12315044]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315044}},{\"id\":\"customfield_12317343\",\"name\":\"Target
-        Upstream Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317343]\",\"Target
-        Upstream Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317343}},{\"id\":\"customfield_12317344\",\"name\":\"Close
-        Duplicate Candidate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317344]\",\"Close
-        Duplicate Candidate\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317344}},{\"id\":\"customfield_12317345\",\"name\":\"Partner
-        Requirement State\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317345]\",\"Partner
-        Requirement State\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317345}},{\"id\":\"customfield_12317346\",\"name\":\"BZ
-        Target Release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Target Release\",\"cf[12317346]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317346}},{\"id\":\"customfield_12317347\",\"name\":\"Upstream
-        Kernel Target\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317347]\",\"Upstream
-        Kernel Target\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317347}},{\"id\":\"customfield_12317348\",\"name\":\"EPM
-        priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317348]\",\"EPM
-        priority\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317348}},{\"id\":\"customfield_12317349\",\"name\":\"Case
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Case
-        Link\",\"cf[12317349]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317349}},{\"id\":\"components\",\"name\":\"Component/s\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"component\"],\"schema\":{\"type\":\"array\",\"items\":\"component\",\"system\":\"components\"}},{\"id\":\"customfield_12318640\",\"name\":\"BZ
-        Flags\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Flags\",\"cf[12318640]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12318640}},{\"id\":\"customfield_12316340\",\"name\":\"Service
-        / (sub)product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316340]\",\"Service
-        / (sub)product\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316340}},{\"id\":\"customfield_12316341\",\"name\":\"Department\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316341]\",\"Department\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316341}},{\"id\":\"customfield_12320841\",\"name\":\"Status
-        Summary\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320841]\",\"Status
-        Summary\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12320841}},{\"id\":\"customfield_12320840\",\"name\":\"Release
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320840]\",\"Release
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320840}},{\"id\":\"customfield_12314040\",\"name\":\"Original
-        story points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314040]\",\"Original
-        story points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-original-story-points\",\"customId\":12314040}},{\"id\":\"customfield_12320845\",\"name\":\"Color
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320845]\",\"Color
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320845}},{\"id\":\"customfield_12320844\",\"name\":\"Customer
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320844]\",\"Customer
-        Impact\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12320844}},{\"id\":\"customfield_12320843\",\"name\":\"UX
-        Designer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320843]\",\"UX
-        Designer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12320843}},{\"id\":\"customfield_12320842\",\"name\":\"Documentation
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320842]\",\"Documentation
-        Type\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320842}},{\"id\":\"customfield_12317318\",\"name\":\"BZ
-        Keywords\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Keywords\",\"cf[12317318]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317318}},{\"id\":\"customfield_12317319\",\"name\":\"BZ
-        exception\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        exception\",\"cf[12317319]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317319}},{\"id\":\"customfield_12316342\",\"name\":\"Additional
-        Assignees\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Additional
-        Assignees\",\"cf[12316342]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12316342}},{\"id\":\"customfield_12317310\",\"name\":\"BZ
-        Doc Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Doc Type\",\"cf[12317310]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317310}},{\"id\":\"customfield_12317311\",\"name\":\"BZ
-        QA Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        QA Whiteboard\",\"cf[12317311]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317311}},{\"id\":\"customfield_12316343\",\"name\":\"OpenShift
-        Planning Ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316343]\",\"OpenShift
-        Planning Ack\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316343}},{\"id\":\"customfield_12317312\",\"name\":\"BZ
-        Internal Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Internal Whiteboard\",\"cf[12317312]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317312}},{\"id\":\"customfield_12316344\",\"name\":\"External
-        issue ID_Old14\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316344]\",\"External
-        issue ID_Old14\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316344}},{\"id\":\"customfield_12317313\",\"name\":\"Release
-        Note Text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317313]\",\"Release
-        Note Text\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317313}},{\"id\":\"customfield_12317314\",\"name\":\"Quarter\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317314]\",\"Quarter\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317314}},{\"id\":\"customfield_12317315\",\"name\":\"release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317315]\",\"release\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317315}},{\"id\":\"customfield_12316348\",\"name\":\"Architecture\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Architecture\",\"cf[12316348]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12316348}},{\"id\":\"customfield_12317317\",\"name\":\"BZ
-        Target Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Target Milestone\",\"cf[12317317]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317317}},{\"id\":\"customfield_12316349\",\"name\":\"Cluster
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316349]\",\"Cluster
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316349}},{\"id\":\"customfield_12316350\",\"name\":\"CRT
-        Acceptance Critera\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316350]\",\"CRT
-        Acceptance Critera\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316350}},{\"id\":\"customfield_12319740\",\"name\":\"Approved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approved\",\"cf[12319740]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319740}},{\"id\":\"customfield_12316351\",\"name\":\"CRT
-        Completion Steps\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316351]\",\"CRT
-        Completion Steps\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316351}},{\"id\":\"customfield_12317320\",\"name\":\"Current
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317320]\",\"Current
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317320}},{\"id\":\"customfield_12317441\",\"name\":\"Satellite
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317441]\",\"Satellite
-        Team\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317441}},{\"id\":\"customfield_12320852\",\"name\":\"Size\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320852]\",\"Size\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320852}},{\"id\":\"customfield_12315141\",\"name\":\"Developer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315141]\",\"Developer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12315141}},{\"id\":\"customfield_12320851\",\"name\":\"Sub-System
-        Group\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320851]\",\"Sub-System
-        Group\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320851}},{\"id\":\"reporter\",\"name\":\"Reporter\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"reporter\"],\"schema\":{\"type\":\"user\",\"system\":\"reporter\"}},{\"id\":\"customfield_12315140\",\"name\":\"3Scale
-        PT Tested upstream\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3Scale
-        PT Tested upstream\",\"cf[12315140]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315140}},{\"id\":\"customfield_12320850\",\"name\":\"Release
-        Note Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320850]\",\"Release
-        Note Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320850}},{\"id\":\"customfield_12321940\",\"name\":\"Supply
-        Chain Program\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321940]\",\"Supply
-        Chain Program\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321940}},{\"id\":\"customfield_12317329\",\"name\":\"PM
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317329]\",\"PM
-        Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12317329}},{\"id\":\"customfield_12320849\",\"name\":\"RICE
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320849]\",\"RICE
-        Score\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12320849}},{\"id\":\"customfield_12319749\",\"name\":\"Cost
-        of Delay\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319749]\",\"Cost
-        of Delay\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319749}},{\"id\":\"customfield_12320848\",\"name\":\"Effort\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320848]\",\"Effort\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320848}},{\"id\":\"customfield_12320847\",\"name\":\"Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320847]\",\"Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320847}},{\"id\":\"customfield_12320846\",\"name\":\"Reach\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320846]\",\"Reach\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320846}},{\"id\":\"customfield_12317321\",\"name\":\"BZ
-        Assignee\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Assignee\",\"cf[12317321]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317321}},{\"id\":\"customfield_12319742\",\"name\":\"Release
-        Commit Exception\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319742]\",\"Release
-        Commit Exception\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319742}},{\"id\":\"customfield_12317442\",\"name\":\"Upstream
-        Discussion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317442]\",\"Upstream
-        Discussion\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317442}},{\"id\":\"progress\",\"name\":\"Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"progress\"],\"schema\":{\"type\":\"progress\",\"system\":\"progress\"}},{\"id\":\"customfield_12317322\",\"name\":\"BZ
-        Doc Text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Doc Text\",\"cf[12317322]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317322}},{\"id\":\"customfield_12319741\",\"name\":\"Market
-        Intelligence Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319741]\",\"Market
-        Intelligence Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12319741}},{\"id\":\"customfield_12319744\",\"name\":\"Responsible\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319744]\",\"Responsible\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319744}},{\"id\":\"customfield_12317324\",\"name\":\"BZ
-        Product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Product\",\"cf[12317324]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317324}},{\"id\":\"customfield_12319743\",\"name\":\"Release
-        Blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319743]\",\"Release
-        Blocker\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319743}},{\"id\":\"customfield_12317325\",\"name\":\"BZ
-        URL_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        URL_Old\",\"cf[12317325]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317325}},{\"id\":\"customfield_12319746\",\"name\":\"Risk
-        Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319746]\",\"Risk
-        Response\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319746}},{\"id\":\"archivedby\",\"name\":\"Archiver\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"user\",\"system\":\"archivedby\"}},{\"id\":\"customfield_12317326\",\"name\":\"Hold\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317326]\",\"Hold\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12317326}},{\"id\":\"customfield_12319745\",\"name\":\"Watch
-        List\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319745]\",\"Watch
-        List\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12319745}},{\"id\":\"customfield_12317327\",\"name\":\"RHEL
-        Sub Components\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317327]\",\"RHEL
-        Sub Components\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317327}},{\"id\":\"customfield_12317328\",\"name\":\"BZ
-        Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Whiteboard\",\"cf[12317328]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317328}},{\"id\":\"customfield_12317370\",\"name\":\"Need
-        Info Requestees\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317370]\",\"Need
-        Info Requestees\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317370}},{\"id\":\"customfield_12316040\",\"name\":\"PX
-        Technical Impact_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316040]\",\"PX
-        Technical Impact_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316040}},{\"id\":\"customfield_12317250\",\"name\":\"Product
-        Affects Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317250]\",\"Product
-        Affects Version\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317250}},{\"id\":\"customfield_12318341\",\"name\":\"Feature
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318341]\",\"Feature
-        Link\"],\"schema\":{\"type\":\"issuelinks\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12318341}},{\"id\":\"customfield_12317372\",\"name\":\"Git
-        Commit\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317372]\",\"Git
-        Commit\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317372}},{\"id\":\"customfield_12320540\",\"name\":\"Major
-        Project\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320540]\",\"Major
-        Project\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320540}},{\"id\":\"customfield_12316041\",\"name\":\"PX
-        Impact Range_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316041]\",\"PX
-        Impact Range_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12316041}},{\"id\":\"customfield_12317251\",\"name\":\"Target
-        Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317251]\",\"Target
-        Milestone\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317251}},{\"id\":\"customfield_12318340\",\"name\":\"Cross
-        Team Epic\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318340]\",\"Cross
-        Team Epic\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12318340}},{\"id\":\"customfield_12317252\",\"name\":\"In
-        Portfolio\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317252]\",\"In
-        Portfolio\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317252}},{\"id\":\"customfield_12316042\",\"name\":\"MoSCoW\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316042]\",\"MoSCoW\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12316042}},{\"id\":\"customfield_12317374\",\"name\":\"Ack'd
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Ack'd
-        Status\",\"cf[12317374]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317374}},{\"id\":\"customfield_12316043\",\"name\":\"Brief\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Brief\",\"cf[12316043]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316043}},{\"id\":\"customfield_12317253\",\"name\":\"EXD-Watchlist\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317253]\",\"EXD-Watchlist\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317253}},{\"id\":\"customfield_12317375\",\"name\":\"Block/Fail
-        - Additional Details\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Block/Fail
-        - Additional Details\",\"cf[12317375]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317375}},{\"id\":\"customfield_12317254\",\"name\":\"Watchlist
-        Proposed Solution\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317254]\",\"Watchlist
-        Proposed Solution\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317254}},{\"id\":\"customfield_12322844\",\"name\":\"Product
-        Experience Engineering Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322844]\",\"Product
-        Experience Engineering Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12322844}},{\"id\":\"customfield_12320544\",\"name\":\"Shepherd\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320544]\",\"Shepherd\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12320544}},{\"id\":\"project\",\"name\":\"Project\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"project\"],\"schema\":{\"type\":\"project\",\"system\":\"project\"}},{\"id\":\"customfield_12320543\",\"name\":\"Automated
-        Test\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Automated
-        Test\",\"cf[12320543]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320543}},{\"id\":\"customfield_12320542\",\"name\":\"Test
-        Plan Created\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320542]\",\"Test
-        Plan Created\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320542}},{\"id\":\"customfield_12320541\",\"name\":\"Design
-        Doc Created\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320541]\",\"Design
-        Doc Created\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320541}},{\"id\":\"customfield_12320548\",\"name\":\"Committed
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320548]\",\"Committed
-        Version\"],\"schema\":{\"type\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:version\",\"customId\":12320548}},{\"id\":\"customfield_12322840\",\"name\":\"Partner
-        Fixed Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322840]\",\"Partner
-        Fixed Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322840}},{\"id\":\"customfield_12322841\",\"name\":\"Partner
-        Affects Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322841]\",\"Partner
-        Affects Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322841}},{\"id\":\"customfield_12320547\",\"name\":\"Product
-        Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320547]\",\"Product
-        Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12320547}},{\"id\":\"customfield_12320546\",\"name\":\"Level
-        of Effort\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320546]\",\"Level
-        of Effort\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320546}},{\"id\":\"customfield_12322843\",\"name\":\"Customer
-        Affects Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322843]\",\"Customer
-        Affects Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322843}},{\"id\":\"customfield_12320545\",\"name\":\"Eng
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320545]\",\"Eng
-        Team\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320545}},{\"id\":\"resolutiondate\",\"name\":\"Resolved\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolutiondate\",\"resolved\"],\"schema\":{\"type\":\"datetime\",\"system\":\"resolutiondate\"}},{\"id\":\"customfield_12317376\",\"name\":\"Interop
-        Bug ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317376]\",\"Interop
-        Bug ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317376}},{\"id\":\"customfield_12317255\",\"name\":\"Watchlist
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317255]\",\"Watchlist
-        Impact\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317255}},{\"id\":\"customfield_12317256\",\"name\":\"PM
-        Business Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317256]\",\"PM
-        Business Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317256}},{\"id\":\"customfield_12317377\",\"name\":\"Request
-        Description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317377]\",\"Request
-        Description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317377}},{\"id\":\"customfield_12317257\",\"name\":\"Customers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317257]\",\"Customers\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317257}},{\"id\":\"customfield_12317258\",\"name\":\"Experience_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317258]\",\"Experience_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317258}},{\"id\":\"customfield_12317379\",\"name\":\"Resolved
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317379]\",\"Resolved
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317379}},{\"id\":\"customfield_12317259\",\"name\":\"Pool
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317259]\",\"Pool
-        Team\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317259}},{\"id\":\"watches\",\"name\":\"Watchers\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"watchers\"],\"schema\":{\"type\":\"watches\",\"system\":\"watches\"}},{\"id\":\"customfield_12317380\",\"name\":\"Triage
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317380]\",\"Triage
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317380}},{\"id\":\"customfield_12317381\",\"name\":\"BZ
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Status\",\"cf[12317381]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317381}},{\"id\":\"customfield_12317260\",\"name\":\"Dev
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317260]\",\"Dev
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317260}},{\"id\":\"customfield_12317261\",\"name\":\"Docs
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317261]\",\"Docs
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317261}},{\"id\":\"customfield_12317140\",\"name\":\"Hierarchy
-        Progress\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317140]\",\"Hierarchy
-        Progress\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317140}},{\"id\":\"customfield_12317382\",\"name\":\"Impact-old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317382]\",\"Impact-old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317382}},{\"id\":\"customfield_12321640\",\"name\":\"Start
-        date-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321640]\",\"Start
-        date-delete\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12321640}},{\"id\":\"customfield_12317262\",\"name\":\"CEE
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CEE
-        Approval\",\"cf[12317262]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317262}},{\"id\":\"customfield_12317141\",\"name\":\"Hierarchy
-        Progress Bar\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317141]\",\"Hierarchy
-        Progress Bar\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317141}},{\"id\":\"customfield_12320551\",\"name\":\"Test
-        Failure Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320551]\",\"Test
-        Failure Category\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320551}},{\"id\":\"customfield_12317263\",\"name\":\"PM
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317263]\",\"PM
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317263}},{\"id\":\"customfield_12319440\",\"name\":\"Planning
-        Target\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319440]\",\"Planning
-        Target\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319440}},{\"id\":\"customfield_12317142\",\"name\":\"RHV
-        Progress\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317142]\",\"RHV
-        Progress\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317142}},{\"id\":\"customfield_12317384\",\"name\":\"Requires_doc_text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317384]\",\"Requires_doc_text\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317384}},{\"id\":\"customfield_12317264\",\"name\":\"QE
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317264]\",\"QE
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317264}},{\"id\":\"customfield_12317143\",\"name\":\"RHV
-        Progress Bar\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317143]\",\"RHV
-        Progress Bar\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317143}},{\"id\":\"customfield_12317386\",\"name\":\"Goal\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317386]\",\"Goal\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317386}},{\"id\":\"customfield_12317265\",\"name\":\"Start
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317265]\",\"Start
-        Date\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12317265}},{\"id\":\"customfield_12320555\",\"name\":\"Operating
-        System\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320555]\",\"Operating
-        System\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320555}},{\"id\":\"customfield_12320554\",\"name\":\"Orchestrator
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320554]\",\"Orchestrator
-        Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12320554}},{\"id\":\"customfield_12320553\",\"name\":\"Orchestrator\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320553]\",\"Orchestrator\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320553}},{\"id\":\"customfield_12320552\",\"name\":\"Cluster
-        Flavor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320552]\",\"Cluster
-        Flavor\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320552}},{\"id\":\"customfield_12321641\",\"name\":\"Closed\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321641]\",\"Closed\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12321641}},{\"id\":\"customfield_12320558\",\"name\":\"Release
-        Delivery\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320558]\",\"Release
-        Delivery\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320558}},{\"id\":\"customfield_12320557\",\"name\":\"Docker
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320557]\",\"Docker
-        Version\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12320557}},{\"id\":\"customfield_12321643\",\"name\":\"External
-        issue ID_Old9\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321643]\",\"External
-        issue ID_Old9\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321643}},{\"id\":\"customfield_12320549\",\"name\":\"Delivery
-        Forecast Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320549]\",\"Delivery
-        Forecast Version\"],\"schema\":{\"type\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:version\",\"customId\":12320549}},{\"id\":\"customfield_12317266\",\"name\":\"Status
-        Summary Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317266]\",\"Status
-        Summary Old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317266}},{\"id\":\"customfield_12317267\",\"name\":\"BZ
-        QE Conditional NAK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        QE Conditional NAK\",\"cf[12317267]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317267}},{\"id\":\"customfield_12317146\",\"name\":\"Internal
-        Target Milestone_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317146]\",\"Internal
-        Target Milestone_old\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317146}},{\"id\":\"customfield_12317268\",\"name\":\"BZ
-        Devel Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Devel Whiteboard\",\"cf[12317268]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317268}},{\"id\":\"customfield_12317389\",\"name\":\"BZ
-        Docs Contact_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Docs Contact_Old\",\"cf[12317389]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317389}},{\"id\":\"updated\",\"name\":\"Updated\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"updated\",\"updatedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"updated\"}},{\"id\":\"customfield_12311840\",\"name\":\"Need
-        Info From\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311840]\",\"Need
-        Info From\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12311840}},{\"id\":\"customfield_12316140\",\"name\":\"Organization
-        Sponsor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316140]\",\"Organization
-        Sponsor\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316140}},{\"id\":\"customfield_12317350\",\"name\":\"Sponsor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317350]\",\"Sponsor\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317350}},{\"id\":\"customfield_12317351\",\"name\":\"Next
-        Review\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317351]\",\"Next
-        Review\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317351}},{\"id\":\"customfield_12316141\",\"name\":\"Product
-        Sponsor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316141]\",\"Product
-        Sponsor\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316141}},{\"id\":\"customfield_12316142\",\"name\":\"Severity\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316142]\",\"Severity\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316142}},{\"id\":\"customfield_12317352\",\"name\":\"Strategy
-        Approved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317352]\",\"Strategy
-        Approved\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317352}},{\"id\":\"timeoriginalestimate\",\"name\":\"Original
-        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"originalEstimate\",\"timeoriginalestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeoriginalestimate\"}},{\"id\":\"customfield_12317353\",\"name\":\"Intelligence
-        Requested_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317353]\",\"Intelligence
-        Requested_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317353}},{\"id\":\"description\",\"name\":\"Description\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"description\"],\"schema\":{\"type\":\"string\",\"system\":\"description\"}},{\"id\":\"customfield_12320640\",\"name\":\"Bugzilla
-        Bug_Old1\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old1\",\"cf[12320640]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320640}},{\"id\":\"customfield_12322940\",\"name\":\"Preliminary
-        Testing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322940]\",\"Preliminary
-        Testing\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12322940}},{\"id\":\"customfield_12322941\",\"name\":\"Dev
-        Target end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322941]\",\"Dev
-        Target end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322941}},{\"id\":\"customfield_12318444\",\"name\":\"DEV
-        Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318444]\",\"DEV
-        Story Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12318444}},{\"id\":\"customfield_12317354\",\"name\":\"Pervasiveness_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317354]\",\"Pervasiveness_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317354}},{\"id\":\"customfield_12318443\",\"name\":\"QE
-        Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318443]\",\"QE
-        Story Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12318443}},{\"id\":\"customfield_12317355\",\"name\":\"Willingness
-        to Pay_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317355]\",\"Willingness
-        to Pay_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317355}},{\"id\":\"customfield_12317356\",\"name\":\"Market_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317356]\",\"Market_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317356}},{\"id\":\"customfield_12318446\",\"name\":\"Regression\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318446]\",\"Regression\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318446}},{\"id\":\"customfield_12318445\",\"name\":\"DOC
-        Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318445]\",\"DOC
-        Story Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12318445}},{\"id\":\"customfield_12317357\",\"name\":\"Market
-        Intelligence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317357]\",\"Market
-        Intelligence\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317357}},{\"id\":\"customfield_12317358\",\"name\":\"Function
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317358]\",\"Function
-        Impact\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317358}},{\"id\":\"customfield_12310840\",\"name\":\"Rank
-        (Obsolete)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310840]\",\"Rank
-        (Obsolete)\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-global-rank\",\"customId\":12310840}},{\"id\":\"customfield_12318448\",\"name\":\"Test
-        Blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318448]\",\"Test
-        Blocker\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318448}},{\"id\":\"customfield_12318447\",\"name\":\"Automated\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Automated\",\"cf[12318447]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318447}},{\"id\":\"customfield_12317359\",\"name\":\"oVirt
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317359]\",\"oVirt
-        Team\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317359}},{\"id\":\"customfield_12318449\",\"name\":\"CDW
-        support_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        support_ack\",\"cf[12318449]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagdocs\",\"customId\":12318449}},{\"id\":\"summary\",\"name\":\"Summary\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"summary\"],\"schema\":{\"type\":\"string\",\"system\":\"summary\"}},{\"id\":\"customfield_12317360\",\"name\":\"Doc
-        Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317360]\",\"Doc
-        Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317360}},{\"id\":\"customfield_12319540\",\"name\":\"Deployment
-        Environment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319540]\",\"Deployment
-        Environment\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319540}},{\"id\":\"customfield_12317361\",\"name\":\"Involved
-        teams\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317361]\",\"Involved
-        teams\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317361}},{\"id\":\"customfield_12317240\",\"name\":\"QE
-        Contacts\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317240]\",\"QE
-        Contacts\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317240}},{\"id\":\"customfield_12317362\",\"name\":\"Additional
-        watchers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Additional
-        watchers\",\"cf[12317362]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12317362}},{\"id\":\"customfield_12318450\",\"name\":\"Fixed
-        in Build\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318450]\",\"Fixed
-        in Build\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318450}},{\"id\":\"customfield_12317241\",\"name\":\"Release
-        Notes text-Delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317241]\",\"Release
-        Notes text-Delete\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317241}},{\"id\":\"customfield_12317242\",\"name\":\"External
-        issue URL\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317242]\",\"External
-        issue URL\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317242}},{\"id\":\"customfield_12317363\",\"name\":\"Fixed
-        In Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317363]\",\"Fixed
-        In Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317363}},{\"id\":\"customfield_12317243\",\"name\":\"ServiceNow
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317243]\",\"ServiceNow
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317243}},{\"id\":\"customfield_12321740\",\"name\":\"Testable
-        Builds\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321740]\",\"Testable
-        Builds\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12321740}},{\"id\":\"customfield_10002\",\"name\":\"SourceForge
-        Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10002]\",\"SourceForge
-        Reference\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":10002}},{\"id\":\"customfield_12317244\",\"name\":\"Gerrit
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317244]\",\"Gerrit
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317244}},{\"id\":\"customfield_12317365\",\"name\":\"Test
-        Plan Link-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317365]\",\"Test
-        Plan Link-delete\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317365}},{\"id\":\"customfield_12317366\",\"name\":\"ACKs
-        Check\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"ACKs
-        Check\",\"cf[12317366]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317366}},{\"id\":\"customfield_12317245\",\"name\":\"Mojo
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317245]\",\"Mojo
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317245}},{\"id\":\"comment\",\"name\":\"Comment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"comment\"],\"schema\":{\"type\":\"comments-page\",\"system\":\"comment\"}},{\"id\":\"customfield_12317246\",\"name\":\"Needs
-        Info\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317246]\",\"Needs
-        Info\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317246}},{\"id\":\"customfield_12317367\",\"name\":\"[QE]
-        How to address?\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[QE]
-        How to address?\",\"cf[12317367]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317367}},{\"id\":\"customfield_12317247\",\"name\":\"Discussion
-        Needed\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317247]\",\"Discussion
-        Needed\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317247}},{\"id\":\"customfield_12317368\",\"name\":\"[QE]
-        Why QE missed?\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[QE]
-        Why QE missed?\",\"cf[12317368]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317368}},{\"id\":\"customfield_12311941\",\"name\":\"CDW
-        docs_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        docs_ack\",\"cf[12311941]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagdocs\",\"customId\":12311941}},{\"id\":\"customfield_12317248\",\"name\":\"Discussion
-        Occurred\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317248]\",\"Discussion
-        Occurred\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317248}},{\"id\":\"customfield_12317369\",\"name\":\"RCA
-        Description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317369]\",\"RCA
-        Description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317369}},{\"id\":\"customfield_12317249\",\"name\":\"Contributing
-        Teams\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317249]\",\"Contributing
-        Teams\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317249}},{\"id\":\"customfield_12311940\",\"name\":\"Rank\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311940]\",\"Rank\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-lexo-rank\",\"customId\":12311940}},{\"id\":\"customfield_12317291\",\"name\":\"Action\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Action\",\"cf[12317291]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317291}},{\"id\":\"customfield_12318141\",\"name\":\"Dev
-        Target Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318141]\",\"Dev
-        Target Milestone\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318141}},{\"id\":\"customfield_12317293\",\"name\":\"External
-        issue ID_Old10\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317293]\",\"External
-        issue ID_Old10\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317293}},{\"id\":\"customfield_12322640\",\"name\":\"Prodsec
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322640]\",\"Prodsec
-        Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12322640}},{\"id\":\"customfield_12317294\",\"name\":\"External
-        issue ID_Old11\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317294]\",\"External
-        issue ID_Old11\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317294}},{\"id\":\"customfield_12322641\",\"name\":\"Reset
-        contact to default\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322641]\",\"Reset
-        contact to default\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12322641}},{\"id\":\"customfield_12318140\",\"name\":\"prev_assignee\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318140]\",\"prev_assignee\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318140}},{\"id\":\"customfield_12317295\",\"name\":\"External
-        issue ID_Old13\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317295]\",\"External
-        issue ID_Old13\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317295}},{\"id\":\"customfield_12318143\",\"name\":\"PLM
-        Business Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318143]\",\"PLM
-        Business Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318143}},{\"id\":\"customfield_12318142\",\"name\":\"PLM
-        \ Technical Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318142]\",\"PLM
-        \ Technical Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318142}},{\"id\":\"customfield_12320341\",\"name\":\"PX
-        Scheduling Request\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320341]\",\"PX
-        Scheduling Request\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiversion\",\"customId\":12320341}},{\"id\":\"customfield_12317296\",\"name\":\"Planned
-        Start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317296]\",\"Planned
-        Start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317296}},{\"id\":\"customfield_12320340\",\"name\":\"Bugzilla
-        Bug_Old2\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old2\",\"cf[12320340]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320340}},{\"id\":\"customfield_12318145\",\"name\":\"Product
-        Page link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318145]\",\"Product
-        Page link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12318145}},{\"id\":\"customfield_12318144\",\"name\":\"PLM
-        Program Manager\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318144]\",\"PLM
-        Program Manager\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318144}},{\"id\":\"customfield_12317298\",\"name\":\"Solution\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317298]\",\"Solution\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317298}},{\"id\":\"fixVersions\",\"name\":\"Fix
-        Version/s\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"fixVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"fixVersions\"}},{\"id\":\"customfield_12317290\",\"name\":\"Reminder
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317290]\",\"Reminder
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317290}},{\"id\":\"customfield_12312840\",\"name\":\"Test
-        Work Items\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312840]\",\"Test
-        Work Items\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiurl\",\"customId\":12312840}},{\"id\":\"customfield_12318147\",\"name\":\"Internal
-        Product/Project names\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318147]\",\"Internal
-        Product/Project names\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12318147}},{\"id\":\"customfield_12317299\",\"name\":\"Latest
-        Status Summary\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317299]\",\"Latest
-        Status Summary\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317299}},{\"id\":\"customfield_12318146\",\"name\":\"Portal
-        Product Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318146]\",\"Portal
-        Product Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318146}},{\"id\":\"customfield_12312848\",\"name\":\"QE
-        Test Coverage\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312848]\",\"QE
-        Test Coverage\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312848}},{\"id\":\"customfield_12318148\",\"name\":\"Stale
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318148]\",\"Stale
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12318148}},{\"id\":\"customfield_12318150\",\"name\":\"Approver\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approver\",\"cf[12318150]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318150}},{\"id\":\"customfield_12321440\",\"name\":\"Internal
-        Target Milestone numeric\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321440]\",\"Internal
-        Target Milestone numeric\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12321440}},{\"id\":\"customfield_12319241\",\"name\":\"DevOps
-        Discussion Occurred\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319241]\",\"DevOps
-        Discussion Occurred\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319241}},{\"id\":\"customfield_12321441\",\"name\":\"EAP
-        PT Cross Product Agreement (CPA)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321441]\",\"EAP
-        PT Cross Product Agreement (CPA)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321441}},{\"id\":\"customfield_12318152\",\"name\":\"MVP
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318152]\",\"MVP
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318152}},{\"id\":\"customfield_12319242\",\"name\":\"Design
-        Review Sign-off\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319242]\",\"Design
-        Review Sign-off\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12319242}},{\"id\":\"customfield_12318156\",\"name\":\"Risk
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318156]\",\"Risk
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318156}},{\"id\":\"customfield_12318155\",\"name\":\"Risk
-        Likelihood\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318155]\",\"Risk
-        Likelihood\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318155}},{\"id\":\"priority\",\"name\":\"Priority\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"priority\"],\"schema\":{\"type\":\"priority\",\"system\":\"priority\"}},{\"id\":\"customfield_12313940\",\"name\":\"Impacts\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313940]\",\"Impacts\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12313940}},{\"id\":\"customfield_12311640\",\"name\":\"Security
-        Sensitive Issue\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311640]\",\"Security
-        Sensitive Issue\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:securitysensitiveissue\",\"customId\":12311640}},{\"id\":\"customfield_12311641\",\"name\":\"Involved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311641]\",\"Involved\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12311641}},{\"id\":\"versions\",\"name\":\"Affects
-        Version/s\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectedVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"versions\"}},{\"id\":\"customfield_12319247\",\"name\":\"Next
-        Planned Release Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319247]\",\"Next
-        Planned Release Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12319247}},{\"id\":\"customfield_12318158\",\"name\":\"Risk
-        Mitigation Strategy\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318158]\",\"Risk
-        Mitigation Strategy\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12318158}},{\"id\":\"customfield_12319246\",\"name\":\"Project
-        Name-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319246]\",\"Project
-        Name-delete\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319246}},{\"id\":\"customfield_12318157\",\"name\":\"Risk
-        Score Assessment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318157]\",\"Risk
-        Score Assessment\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12318157}},{\"id\":\"customfield_12319249\",\"name\":\"Avoidable\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Avoidable\",\"cf[12319249]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319249}},{\"id\":\"customfield_12313942\",\"name\":\"Target
-        end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313942]\",\"Target
-        end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-end\",\"customId\":12313942}},{\"id\":\"customfield_12313941\",\"name\":\"Target
-        start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313941]\",\"Target
-        start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-start\",\"customId\":12313941}},{\"id\":\"customfield_12317270\",\"name\":\"BZ
-        Devel Conditional NAK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Devel Conditional NAK\",\"cf[12317270]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317270}},{\"id\":\"customfield_12317392\",\"name\":\"CDW
-        Resolution\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        Resolution\",\"cf[12317392]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317392}},{\"id\":\"customfield_12317271\",\"name\":\"mvp\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317271]\",\"mvp\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317271}},{\"id\":\"issuekey\",\"name\":\"Key\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"id\",\"issue\",\"issuekey\",\"key\"]},{\"id\":\"customfield_12317272\",\"name\":\"rpl\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317272]\",\"rpl\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317272}},{\"id\":\"customfield_12317273\",\"name\":\"Verified\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317273]\",\"Verified\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317273}},{\"id\":\"customfield_12320440\",\"name\":\"Bugzilla
-        Bug_Old3\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old3\",\"cf[12320440]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320440}},{\"id\":\"customfield_12318241\",\"name\":\"Documenter\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318241]\",\"Documenter\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318241}},{\"id\":\"customfield_12317396\",\"name\":\"ITR-ITM\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317396]\",\"ITR-ITM\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317396}},{\"id\":\"customfield_12318244\",\"name\":\"Internal
-        Target Release and Milestone_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318244]\",\"Internal
-        Target Release and Milestone_Old\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12318244}},{\"id\":\"customfield_12317275\",\"name\":\"Test
-        Link_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317275]\",\"Test
-        Link_Old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317275}},{\"id\":\"customfield_12318243\",\"name\":\"Analyst\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Analyst\",\"cf[12318243]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318243}},{\"id\":\"customfield_12317276\",\"name\":\"Test
-        Coverage_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317276]\",\"Test
-        Coverage_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317276}},{\"id\":\"customfield_12322741\",\"name\":\"Test
-        Single Line text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322741]\",\"Test
-        Single Line text\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlytext\",\"customId\":12322741}},{\"id\":\"customfield_12317277\",\"name\":\"Internal
-        Target Release and Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317277]\",\"Internal
-        Target Release and Milestone\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12317277}},{\"id\":\"customfield_12317278\",\"name\":\"Current
-        Deadline\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317278]\",\"Current
-        Deadline\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317278}},{\"id\":\"customfield_12318245\",\"name\":\"Global
-        Practices Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318245]\",\"Global
-        Practices Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318245}},{\"id\":\"customfield_12317279\",\"name\":\"Current
-        Deadline Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317279]\",\"Current
-        Deadline Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317279}},{\"id\":\"customfield_12312940\",\"name\":\"Eng.
-        priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312940]\",\"Eng.
-        priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312940}},{\"id\":\"customfield_12312941\",\"name\":\"QE
-        priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312941]\",\"QE
-        priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312941}},{\"id\":\"customfield_12317281\",\"name\":\"Embargo
-        Override\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317281]\",\"Embargo
-        Override\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12317281}},{\"id\":\"customfield_12317282\",\"name\":\"Baseline
-        Start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Baseline
-        Start\",\"cf[12317282]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12317282}},{\"id\":\"customfield_12321540\",\"name\":\"Testing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321540]\",\"Testing\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321540}},{\"id\":\"customfield_12319340\",\"name\":\"UXD
-        Design[Test]\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319340]\",\"UXD
-        Design[Test]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319340}},{\"id\":\"customfield_12317040\",\"name\":\"Urgency-old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317040]\",\"Urgency-old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317040}},{\"id\":\"customfield_12317283\",\"name\":\"Baseline
-        End\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Baseline
-        End\",\"cf[12317283]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12317283}},{\"id\":\"customfield_12317041\",\"name\":\"EAP
-        PT Feature Implementation (FI)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317041]\",\"EAP
-        PT Feature Implementation (FI)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317041}},{\"id\":\"customfield_12321541\",\"name\":\"Errata
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321541]\",\"Errata
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321541}},{\"id\":\"customfield_12317042\",\"name\":\"Docs
-        Analysis\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317042]\",\"Docs
-        Analysis\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12317042}},{\"id\":\"customfield_12317284\",\"name\":\"Subproject\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317284]\",\"Subproject\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317284}},{\"id\":\"customfield_12317285\",\"name\":\"Root
-        Cause\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317285]\",\"Root
-        Cause\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317285}},{\"id\":\"customfield_12317043\",\"name\":\"Stage
-        Links\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317043]\",\"Stage
-        Links\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12317043}},{\"id\":\"customfield_12317044\",\"name\":\"Docs
-        Pull Request\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317044]\",\"Docs
-        Pull Request\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12317044}},{\"id\":\"customfield_12317286\",\"name\":\"Project/s\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317286]\",\"Project/s\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317286}},{\"id\":\"aggregateprogress\",\"name\":\"\u03A3
-        Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"progress\",\"system\":\"aggregateprogress\"}},{\"id\":\"customfield_12321542\",\"name\":\"Authorized
-        Party\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Authorized
-        Party\",\"cf[12321542]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12321542}},{\"id\":\"customfield_12311740\",\"name\":\"User
-        Story\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311740]\",\"User
-        Story\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12311740}},{\"id\":\"customfield_12317288\",\"name\":\"Reminder
-        Frequency\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317288]\",\"Reminder
-        Frequency\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317288}},{\"id\":\"customfield_12311741\",\"name\":\"QE
-        Acceptance Test Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311741]\",\"QE
-        Acceptance Test Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12311741}},{\"id\":\"customfield_12320140\",\"name\":\"External
-        issue ID_Old8\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320140]\",\"External
-        issue ID_Old8\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12320140}},{\"id\":\"customfield_12322440\",\"name\":\"Persona\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322440]\",\"Persona\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.easyagile.personas:persona-field\",\"customId\":12322440}},{\"id\":\"customfield_12319272\",\"name\":\"Scoping
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319272]\",\"Scoping
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319272}},{\"id\":\"customfield_12322441\",\"name\":\"Importance
-        to Persona\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322441]\",\"Importance
-        to Persona\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.easyagile.personas:persona-importance-field\",\"customId\":12322441}},{\"id\":\"customfield_12319271\",\"name\":\"QE_AUTO_Coverage\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319271]\",\"QE_AUTO_Coverage\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319271}},{\"id\":\"customfield_12319274\",\"name\":\"Function\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319274]\",\"Function\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319274}},{\"id\":\"customfield_12319273\",\"name\":\"Stakeholders\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319273]\",\"Stakeholders\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319273}},{\"id\":\"customfield_12319276\",\"name\":\"BZ
-        Flags_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Flags_Old\",\"cf[12319276]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319276}},{\"id\":\"customfield_12319275\",\"name\":\"Workstream\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319275]\",\"Workstream\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319275}},{\"id\":\"customfield_12319278\",\"name\":\"Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319278]\",\"Version\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319278}},{\"id\":\"customfield_12319277\",\"name\":\"Product-old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319277]\",\"Product-old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319277}},{\"id\":\"customfield_12319270\",\"name\":\"Security
-        Documentation Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319270]\",\"Security
-        Documentation Type\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319270}},{\"id\":\"customfield_12310220\",\"name\":\"Git
-        Pull Request\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310220]\",\"Git
-        Pull Request\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12310220}},{\"id\":\"customfield_12319279\",\"name\":\"Job
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319279]\",\"Job
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319279}},{\"id\":\"customfield_12319040\",\"name\":\"Products\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319040]\",\"Products\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319040}},{\"id\":\"customfield_12319282\",\"name\":\"Project
-        Name-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319282]\",\"Project
-        Name-delete\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319282}},{\"id\":\"thumbnail\",\"name\":\"Images\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[]},{\"id\":\"customfield_12319285\",\"name\":\"PX
-        Technical Impact Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319285]\",\"PX
-        Technical Impact Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319285}},{\"id\":\"customfield_12319287\",\"name\":\"Docs
-        Impact Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319287]\",\"Docs
-        Impact Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319287}},{\"id\":\"customfield_12319045\",\"name\":\"User
-        Domain\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319045]\",\"User
-        Domain\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319045}},{\"id\":\"customfield_12319286\",\"name\":\"Docs
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319286]\",\"Docs
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319286}},{\"id\":\"customfield_12319044\",\"name\":\"User\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319044]\",\"User\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319044}},{\"id\":\"created\",\"name\":\"Created\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"created\",\"createdDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"created\"}},{\"id\":\"customfield_12319289\",\"name\":\"Marketing
-        Impact Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319289]\",\"Marketing
-        Impact Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319289}},{\"id\":\"customfield_12321240\",\"name\":\"GtmhubTaskParentType\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321240]\",\"GtmhubTaskParentType\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321240}},{\"id\":\"customfield_12319288\",\"name\":\"Marketing
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319288]\",\"Marketing
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319288}},{\"id\":\"customfield_12310110\",\"name\":\"Approvals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approvals\",\"cf[12310110]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310110}},{\"id\":\"customfield_12310230\",\"name\":\"Docs
-        QE Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310230]\",\"Docs
-        QE Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12310230}},{\"id\":\"customfield_12311440\",\"name\":\"External
-        Issue URL_OLD\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311440]\",\"External
-        Issue URL_OLD\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12311440}},{\"id\":\"customfield_12313740\",\"name\":\"Migration
-        Text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313740]\",\"Migration
-        Text\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12313740}},{\"id\":\"customfield_12319250\",\"name\":\"Communication
-        Breakdown\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319250]\",\"Communication
-        Breakdown\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319250}},{\"id\":\"customfield_12318040\",\"name\":\"affectsRHMIVersion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectsRHMIVersion\",\"cf[12318040]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318040}},{\"id\":\"customfield_12322540\",\"name\":\"RHEL
-        component\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322540]\",\"RHEL
-        component\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322540}},{\"id\":\"customfield_12319252\",\"name\":\"Release
-        Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319252]\",\"Release
-        Milestone\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319252}},{\"id\":\"customfield_12319251\",\"name\":\"QE
-        Properly Involved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319251]\",\"QE
-        Properly Involved\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319251}},{\"id\":\"customfield_12318041\",\"name\":\"affectsRHOAMVersion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectsRHOAMVersion\",\"cf[12318041]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318041}},{\"id\":\"customfield_12320240\",\"name\":\"Bugzilla
-        Bug_Old4\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old4\",\"cf[12320240]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320240}},{\"id\":\"customfield_12310440\",\"name\":\"Bugzilla
-        References\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        References\",\"cf[12310440]\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12310440}},{\"id\":\"security\",\"name\":\"Security
-        Level\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"level\"],\"schema\":{\"type\":\"securitylevel\",\"system\":\"security\"}},{\"id\":\"attachment\",\"name\":\"Attachment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"attachments\"],\"schema\":{\"type\":\"array\",\"items\":\"attachment\",\"system\":\"attachment\"}},{\"id\":\"customfield_12319263\",\"name\":\"Proposed
-        Initiative\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319263]\",\"Proposed
-        Initiative\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319263}},{\"id\":\"customfield_12319262\",\"name\":\"Keyword\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319262]\",\"Keyword\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319262}},{\"id\":\"customfield_12319265\",\"name\":\"Contributor_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319265]\",\"Contributor_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12319265}},{\"id\":\"customfield_12319264\",\"name\":\"Immutable
-        Due Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319264]\",\"Immutable
-        Due Date\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319264}},{\"id\":\"customfield_12319267\",\"name\":\"Failure
-        Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319267]\",\"Failure
-        Category\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319267}},{\"id\":\"customfield_12313841\",\"name\":\"Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313841]\",\"Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12313841}},{\"id\":\"customfield_12313840\",\"name\":\"UXD
-        Engagement Level\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313840]\",\"UXD
-        Engagement Level\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313840}},{\"id\":\"customfield_12310211\",\"name\":\"Release
-        Notes - old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310211]\",\"Release
-        Notes - old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310211}},{\"id\":\"customfield_12319269\",\"name\":\"sprint_count\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319269]\",\"sprint_count\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319269}},{\"id\":\"customfield_12319268\",\"name\":\"QE
-        portion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319268]\",\"QE
-        portion\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12319268}},{\"id\":\"customfield_12310213\",\"name\":\"Release
-        Note Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310213]\",\"Release
-        Note Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12310213}},{\"id\":\"customfield_12310214\",\"name\":\"Writer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310214]\",\"Writer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12310214}}]"
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 12 Apr 2023 12:13:40 GMT
-      Expires:
-      - Wed, 12 Apr 2023 12:13:40 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '162204'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-1
-      x-arequestid:
-      - 733x256652x1
-      x-asessionid:
-      - kicclg
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.644e4e68.1681301620.60ced300
-      x-rh-edge-request-id:
-      - 60ced300
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
     uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A98c0c5fd-b2fc-46cb-adf4-5de2bdce2737%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
   response:
     body:
@@ -962,9 +31,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:40 GMT
+      - Tue, 18 Apr 2023 20:58:22 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:40 GMT
+      - Tue, 18 Apr 2023 20:58:22 GMT
       Pragma:
       - no-cache
       Vary:
@@ -977,11 +46,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256653x1
+      - 1258x44556x1
       x-asessionid:
-      - bk9sau
+      - ylwds5
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -989,9 +58,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301620.60ced3b0
+      - 0.357f0660.1681851502.5305522b
       x-rh-edge-request-id:
-      - 60ced3b0
+      - 5305522b
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1141,9 +210,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:40 GMT
+      - Tue, 18 Apr 2023 20:58:22 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:40 GMT
+      - Tue, 18 Apr 2023 20:58:22 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1156,11 +225,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256654x1
+      - 1258x44557x1
       x-asessionid:
-      - vxe6p2
+      - cc1tu1
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1168,9 +237,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301620.60ced467
+      - 0.357f0660.1681851502.53055270
       x-rh-edge-request-id:
-      - 60ced467
+      - '53055270'
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1232,6 +301,7 @@ interactions:
         "Administrators": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10002",
         "Approver": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10840",
         "Viewers": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10440",
+        "Red Hat Partner": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/11140",
         "Users": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10000"},
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
         "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
@@ -1248,26 +318,26 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:22 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:22 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '3812'
+      - '3903'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256656x1
+      - 1258x44558x1
       x-asessionid:
-      - 1uwfy3a
+      - 1udn4hu
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1275,9 +345,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301621.60ced54f
+      - 0.357f0660.1681851502.5305532b
       x-rh-edge-request-id:
-      - 60ced54f
+      - 5305532b
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1287,7 +357,7 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12336420"}, "summary":
-      "CVE-2020-0000 kernel: some description", "description": "Description for CVE-2020-0000",
+      "CVE-2020-0001 kernel: some description", "description": "Description for CVE-2020-0001",
       "labels": ["flawuuid:98c0c5fd-b2fc-46cb-adf4-5de2bdce2737"]}}'
     headers:
       Accept:
@@ -1310,20 +380,20 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: '{"id": "14942936", "key": "OSIM-231", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14942936"}'
+      string: '{"id": "14943814", "key": "OSIM-249", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943814"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - keep-alive
+      - close
       Content-Security-Policy:
       - sandbox
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:23 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:23 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1336,11 +406,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256657x1
+      - 1258x44559x1
       x-asessionid:
-      - 197vxpl
+      - 1pfx0w7
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1348,9 +418,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301621.60ced5f7
+      - 0.357f0660.1681851503.530553f4
       x-rh-edge-request-id:
-      - 60ced5f7
+      - 530553f4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1376,12 +446,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-231
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-249
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14942936", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14942936",
-        "key": "OSIM-231", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943814", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943814",
+        "key": "OSIM-249", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -1395,19 +465,19 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4a38a616[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d993a96[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3e393173[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1ba2b54a[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10cd5dea[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@44d488ef[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@e43281[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4de320c6[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@373b069d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@57c87365[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@76992327[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2228c822[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4d483d14[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@598f2c83[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4256da75[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4cd02f90[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@169e26dd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3d1ea0ac[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49ef4008[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@48e5a0a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@63c13c88[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2b92fb9c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@18ce01e6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6ee656ff[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-231/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:41.071+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-249/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:23.000+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
         "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:98c0c5fd-b2fc-46cb-adf4-5de2bdce2737"],
@@ -1416,13 +486,13 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:41.071+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T20:58:23.000+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
         "customfield_12314040": null, "customfield_12320844": null, "timetracking":
         {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
         null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
@@ -1431,7 +501,7 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1451,10 +521,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-231/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-249/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0ybo:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za105o:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1465,26 +535,26 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:26 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:26 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8633'
+      - '8634'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256658x1
+      - 1258x44563x1
       x-asessionid:
-      - snk2bq
+      - 1alx700
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1492,9 +562,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301621.60ceda63
+      - 0.357f0660.1681851506.53057124
       x-rh-edge-request-id:
-      - 60ceda63
+      - '53057124'
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1522,11 +592,11 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-231/comment
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-249/comment
   response:
     body:
-      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14942936/comment/21279948",
-        "id": "21279948", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14943814/comment/21281355",
+        "id": "21281355", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1540,22 +610,22 @@ interactions:
         "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
         "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
         "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "created":
-        "2023-04-12T12:13:41.656+0000", "updated": "2023-04-12T12:13:41.656+0000"}'
+        "2023-04-18T20:58:26.791+0000", "updated": "2023-04-18T20:58:26.791+0000"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - keep-alive
+      - close
       Content-Security-Policy:
       - sandbox
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:27 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:41 GMT
+      - Tue, 18 Apr 2023 20:58:27 GMT
       Location:
-      - https://issues.stage.redhat.com/rest/api/2/issue/14942936/comment/21279948
+      - https://issues.stage.redhat.com/rest/api/2/issue/14943814/comment/21281355
       Pragma:
       - no-cache
       Vary:
@@ -1568,11 +638,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256659x1
+      - 1258x44565x1
       x-asessionid:
-      - yshs5f
+      - 1wfq5mn
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1580,9 +650,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301621.60cedbcc
+      - 0.357f0660.1681851507.53057235
       x-rh-edge-request-id:
-      - 60cedbcc
+      - '53057235'
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1608,11 +678,11 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-231/comment/21279948
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-249/comment/21281355
   response:
     body:
-      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14942936/comment/21279948",
-        "id": "21279948", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14943814/comment/21281355",
+        "id": "21281355", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1626,7 +696,7 @@ interactions:
         "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
         "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
         "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "created":
-        "2023-04-12T12:13:41.656+0000", "updated": "2023-04-12T12:13:41.656+0000"}'
+        "2023-04-18T20:58:26.791+0000", "updated": "2023-04-18T20:58:26.791+0000"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1637,9 +707,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:42 GMT
+      - Tue, 18 Apr 2023 20:58:38 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:42 GMT
+      - Tue, 18 Apr 2023 20:58:38 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1652,11 +722,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256660x1
+      - 1258x44575x1
       x-asessionid:
-      - 1p31gfq
+      - 167qan8
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1664,9 +734,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301622.60cedf6b
+      - 0.357f0660.1681851518.5305ce58
       x-rh-edge-request-id:
-      - 60cedf6b
+      - 5305ce58
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1694,11 +764,11 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14942936/comment/21279948
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943814/comment/21281355
   response:
     body:
-      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14942936/comment/21279948",
-        "id": "21279948", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14943814/comment/21281355",
+        "id": "21281355", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1712,7 +782,7 @@ interactions:
         "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
         "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
         "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "created":
-        "2023-04-12T12:13:41.656+0000", "updated": "2023-04-12T12:13:42.164+0000"}'
+        "2023-04-18T20:58:26.791+0000", "updated": "2023-04-18T20:58:38.223+0000"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1723,11 +793,11 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:42 GMT
+      - Tue, 18 Apr 2023 20:58:38 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:42 GMT
+      - Tue, 18 Apr 2023 20:58:38 GMT
       Location:
-      - https://issues.stage.redhat.com/rest/api/2/issue/14942936/comment/21279948
+      - https://issues.stage.redhat.com/rest/api/2/issue/14943814/comment/21281355
       Pragma:
       - no-cache
       Vary:
@@ -1740,11 +810,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256661x1
+      - 1258x44576x1
       x-asessionid:
-      - 1unu4ji
+      - mz24v
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1752,9 +822,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301622.60cee0d8
+      - 0.357f0660.1681851518.5305cebd
       x-rh-edge-request-id:
-      - 60cee0d8
+      - 5305cebd
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1780,11 +850,11 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14942936/comment/21279948
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943814/comment/21281355
   response:
     body:
-      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14942936/comment/21279948",
-        "id": "21279948", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+      string: '{"self": "https://issues.stage.redhat.com/rest/api/2/issue/14943814/comment/21281355",
+        "id": "21281355", "author": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1798,7 +868,7 @@ interactions:
         "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
         "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
         "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "created":
-        "2023-04-12T12:13:41.656+0000", "updated": "2023-04-12T12:13:42.164+0000"}'
+        "2023-04-18T20:58:26.791+0000", "updated": "2023-04-18T20:58:38.223+0000"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1809,9 +879,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:42 GMT
+      - Tue, 18 Apr 2023 20:58:38 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:42 GMT
+      - Tue, 18 Apr 2023 20:58:38 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1824,11 +894,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-1
+      - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x256662x1
+      - 1258x44577x1
       x-asessionid:
-      - kp94l4
+      - 1u6jaun
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1836,9 +906,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301622.60cee470
+      - 0.357f0660.1681851518.5305d39b
       x-rh-edge-request-id:
-      - 60cee470
+      - 5305d39b
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/apps/taskman/tests/cassettes/test_integration/TestIntegration.test_group.yaml
+++ b/apps/taskman/tests/cassettes/test_integration/TestIntegration.test_group.yaml
@@ -141,9 +141,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:51 GMT
+      - Tue, 18 Apr 2023 20:58:39 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:51 GMT
+      - Tue, 18 Apr 2023 20:58:39 GMT
       Pragma:
       - no-cache
       Vary:
@@ -158,9 +158,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252269x1
+      - 1258x44578x1
       x-asessionid:
-      - 1o7wjca
+      - 16uzzpy
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -168,9 +168,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301631.60cf3b70
+      - 0.357f0660.1681851519.5305d6e1
       x-rh-edge-request-id:
-      - 60cf3b70
+      - 5305d6e1
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -232,6 +232,7 @@ interactions:
         "Administrators": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10002",
         "Approver": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10840",
         "Viewers": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10440",
+        "Red Hat Partner": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/11140",
         "Users": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10000"},
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
         "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
@@ -248,16 +249,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:51 GMT
+      - Tue, 18 Apr 2023 20:58:39 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:51 GMT
+      - Tue, 18 Apr 2023 20:58:39 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '3812'
+      - '3903'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -265,9 +266,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252270x1
+      - 1258x44579x1
       x-asessionid:
-      - m1kg8x
+      - 67uv5r
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -275,9 +276,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301631.60cf4086
+      - 0.357f0660.1681851519.5305d7e4
       x-rh-edge-request-id:
-      - 60cf4086
+      - 5305d7e4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -310,7 +311,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: '{"id": "14943020", "key": "OSIM-232", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943020"}'
+      string: '{"id": "14943815", "key": "OSIM-250", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943815"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -321,9 +322,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Pragma:
       - no-cache
       Vary:
@@ -338,9 +339,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252271x1
+      - 1258x44580x1
       x-asessionid:
-      - quz2da
+      - 1li0b35
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -348,9 +349,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301632.60cf41f3
+      - 0.357f0660.1681851520.5305d880
       x-rh-edge-request-id:
-      - 60cf41f3
+      - 5305d880
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -358,937 +359,6 @@ interactions:
     status:
       code: 201
       message: Created
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/field
-  response:
-    body:
-      string: "[{\"id\":\"customfield_12322243\",\"name\":\"Release Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322243]\",\"Release
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322243}},{\"id\":\"customfield_12322244\",\"name\":\"PX
-        Impact Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322244]\",\"PX
-        Impact Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlynumber\",\"customId\":12322244}},{\"id\":\"customfield_12322240\",\"name\":\"Staffing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322240]\",\"Staffing\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12322240}},{\"id\":\"customfield_12322241\",\"name\":\"Gating
-        Tests\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322241]\",\"Gating
-        Tests\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12322241}},{\"id\":\"resolution\",\"name\":\"Resolution\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolution\"],\"schema\":{\"type\":\"resolution\",\"system\":\"resolution\"}},{\"id\":\"customfield_12310022\",\"name\":\"SVN
-        / CVS Isolated Branch\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310022]\",\"SVN
-        / CVS Isolated Branch\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12310022}},{\"id\":\"customfield_12314742\",\"name\":\"Percent
-        confident\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314742]\",\"Percent
-        confident\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12314742}},{\"id\":\"customfield_12310021\",\"name\":\"Support
-        Case Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310021]\",\"Support
-        Case Reference\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12310021}},{\"id\":\"customfield_12312441\",\"name\":\"Affects
-        Build\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affects
-        Build\",\"cf[12312441]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312441}},{\"id\":\"customfield_12314741\",\"name\":\"Percent
-        complete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314741]\",\"Percent
-        complete\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12314741}},{\"id\":\"customfield_12314740\",\"name\":\"Development\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314740]\",\"Development\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jira.plugins.jira-development-integration-plugin:devsummary\",\"customId\":12314740}},{\"id\":\"customfield_12312442\",\"name\":\"Fix
-        Build\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312442]\",\"Fix
-        Build\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312442}},{\"id\":\"customfield_12312440\",\"name\":\"Deployment
-        Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312440]\",\"Deployment
-        Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12312440}},{\"id\":\"customfield_12315950\",\"name\":\"Contributors\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315950]\",\"Contributors\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12315950}},{\"id\":\"lastViewed\",\"name\":\"Last
-        Viewed\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"lastViewed\"],\"schema\":{\"type\":\"datetime\",\"system\":\"lastViewed\"}},{\"id\":\"customfield_12321040\",\"name\":\"Internal
-        Target Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321040]\",\"Internal
-        Target Milestone\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321040}},{\"id\":\"customfield_12311244\",\"name\":\"CDW
-        qa_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        qa_ack\",\"cf[12311244]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagqa\",\"customId\":12311244}},{\"id\":\"customfield_12311245\",\"name\":\"CDW
-        blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        blocker\",\"cf[12311245]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagprogman\",\"customId\":12311245}},{\"id\":\"customfield_12315842\",\"name\":\"PX
-        Priority Data_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315842]\",\"PX
-        Priority Data_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12315842}},{\"id\":\"customfield_12311242\",\"name\":\"CDW
-        pm_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        pm_ack\",\"cf[12311242]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagpm\",\"customId\":12311242}},{\"id\":\"customfield_12315841\",\"name\":\"PX
-        Scheduling Request - OLD\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315841]\",\"PX
-        Scheduling Request - OLD\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12315841}},{\"id\":\"customfield_12311243\",\"name\":\"CDW
-        devel_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        devel_ack\",\"cf[12311243]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagdevel\",\"customId\":12311243}},{\"id\":\"customfield_12313541\",\"name\":\"Epic
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313541]\",\"Epic
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313541}},{\"id\":\"customfield_12315840\",\"name\":\"PX
-        Impact Score_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315840]\",\"PX
-        Impact Score_Old\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12315840}},{\"id\":\"aggregatetimeoriginalestimate\",\"name\":\"\u03A3
-        Original Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeoriginalestimate\"}},{\"id\":\"customfield_12310150\",\"name\":\"Defect
-        Tracker URL\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310150]\",\"Defect
-        Tracker URL\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12310150}},{\"id\":\"customfield_12311240\",\"name\":\"Target
-        Release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311240]\",\"Target
-        Release\"],\"schema\":{\"type\":\"version\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwtargetreleasebyversion\",\"customId\":12311240}},{\"id\":\"customfield_12311241\",\"name\":\"CDW
-        release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        release\",\"cf[12311241]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagrelease\",\"customId\":12311241}},{\"id\":\"customfield_12310031\",\"name\":\"Affects\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affects\",\"cf[12310031]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310031}},{\"id\":\"issuelinks\",\"name\":\"Linked
-        Issues\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"issuelinks\"}},{\"id\":\"assignee\",\"name\":\"Assignee\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"assignee\"],\"schema\":{\"type\":\"user\",\"system\":\"assignee\"}},{\"id\":\"customfield_12311246\",\"name\":\"CDW
-        exception\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        exception\",\"cf[12311246]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagprogman\",\"customId\":12311246}},{\"id\":\"customfield_12320041\",\"name\":\"Escape
-        Reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320041]\",\"Escape
-        Reason\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320041}},{\"id\":\"customfield_12319294\",\"name\":\"QE
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319294]\",\"QE
-        Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319294}},{\"id\":\"customfield_12319293\",\"name\":\"Affected
-        Groups\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affected
-        Groups\",\"cf[12319293]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319293}},{\"id\":\"customfield_12320040\",\"name\":\"Work
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320040]\",\"Work
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320040}},{\"id\":\"customfield_12319297\",\"name\":\"BZ
-        Partner_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Partner_Old\",\"cf[12319297]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319297}},{\"id\":\"customfield_12320043\",\"name\":\"Corrective
-        Measures\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320043]\",\"Corrective
-        Measures\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320043}},{\"id\":\"customfield_12320042\",\"name\":\"Escape
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320042]\",\"Escape
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320042}},{\"id\":\"customfield_12319299\",\"name\":\"SME\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319299]\",\"SME\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12319299}},{\"id\":\"customfield_12319290\",\"name\":\"Training
-        Opportunity\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319290]\",\"Training
-        Opportunity\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319290}},{\"id\":\"customfield_12319292\",\"name\":\"Testing
-        Instructions\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319292]\",\"Testing
-        Instructions\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319292}},{\"id\":\"customfield_12319291\",\"name\":\"Training
-        Opportunity Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319291]\",\"Training
-        Opportunity Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319291}},{\"id\":\"customfield_12310120\",\"name\":\"Help
-        Desk Ticket Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310120]\",\"Help
-        Desk Ticket Reference\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiurl\",\"customId\":12310120}},{\"id\":\"customfield_12314840\",\"name\":\"Doc
-        Version/s\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314840]\",\"Doc
-        Version/s\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiversion\",\"customId\":12314840}},{\"id\":\"customfield_12310243\",\"name\":\"Story
-        Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310243]\",\"Story
-        Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12310243}},{\"id\":\"subtasks\",\"name\":\"Sub-Tasks\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"subtasks\"],\"schema\":{\"type\":\"array\",\"items\":\"issuelinks\",\"system\":\"subtasks\"}},{\"id\":\"customfield_12321140\",\"name\":\"GtmhubObjectID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321140]\",\"GtmhubObjectID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321140}},{\"id\":\"customfield_12322356\",\"name\":\"Begin
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Begin
-        Date\",\"cf[12322356]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12322356}},{\"id\":\"customfield_12322357\",\"name\":\"End
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322357]\",\"End
-        Date\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12322357}},{\"id\":\"customfield_12322358\",\"name\":\"Revision\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322358]\",\"Revision\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322358}},{\"id\":\"customfield_12315943\",\"name\":\"Ready-Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315943]\",\"Ready-Ready\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12315943}},{\"id\":\"customfield_12310010\",\"name\":\"Forum
-        Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310010]\",\"Forum
-        Reference\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12310010}},{\"id\":\"customfield_12315944\",\"name\":\"Planned
-        End\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315944]\",\"Planned
-        End\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12315944}},{\"id\":\"customfield_12315948\",\"name\":\"QA
-        Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315948]\",\"QA
-        Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12315948}},{\"id\":\"customfield_12315949\",\"name\":\"Product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315949]\",\"Product\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315949}},{\"id\":\"votes\",\"name\":\"Votes\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"votes\"],\"schema\":{\"type\":\"votes\",\"system\":\"votes\"}},{\"id\":\"worklog\",\"name\":\"Log
-        Work\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"array\",\"items\":\"worklog\",\"system\":\"worklog\"}},{\"id\":\"customfield_12315940\",\"name\":\"Acceptance
-        Criteria\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Acceptance
-        Criteria\",\"cf[12315940]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12315940}},{\"id\":\"customfield_12315941\",\"name\":\"Backlogs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Backlogs\",\"cf[12315941]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12315941}},{\"id\":\"issuetype\",\"name\":\"Issue
-        Type\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"issuetype\",\"type\"],\"schema\":{\"type\":\"issuetype\",\"system\":\"issuetype\"}},{\"id\":\"customfield_12322040\",\"name\":\"Internal
-        Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322040]\",\"Internal
-        Whiteboard\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlytext\",\"customId\":12322040}},{\"id\":\"customfield_12310181\",\"name\":\"Engineering
-        Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310181]\",\"Engineering
-        Response\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310181}},{\"id\":\"customfield_12310060\",\"name\":\"Patch
-        Visibility\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310060]\",\"Patch
-        Visibility\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310060}},{\"id\":\"customfield_12310180\",\"name\":\"Background
-        and Context\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Background
-        and Context\",\"cf[12310180]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310180}},{\"id\":\"customfield_12316845\",\"name\":\"5-Acks
-        Check\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"5-Acks
-        Check\",\"cf[12316845]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316845}},{\"id\":\"customfield_12316846\",\"name\":\"GitHub
-        Issue\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316846]\",\"GitHub
-        Issue\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316846}},{\"id\":\"customfield_12316847\",\"name\":\"Developer
-        Comment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316847]\",\"Developer
-        Comment\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316847}},{\"id\":\"customfield_12316848\",\"name\":\"ODC
-        Planning\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316848]\",\"ODC
-        Planning\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316848}},{\"id\":\"customfield_12312241\",\"name\":\"Code
-        Sample\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312241]\",\"Code
-        Sample\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12312241}},{\"id\":\"customfield_12316849\",\"name\":\"ODC
-        Planning Ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316849]\",\"ODC
-        Planning Ack\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316849}},{\"id\":\"customfield_12310183\",\"name\":\"Steps
-        to Reproduce\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310183]\",\"Steps
-        to Reproduce\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310183}},{\"id\":\"customfield_12310182\",\"name\":\"Product
-        Management Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310182]\",\"Product
-        Management Response\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310182}},{\"id\":\"customfield_12312240\",\"name\":\"QE
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312240]\",\"QE
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312240}},{\"id\":\"customfield_12316840\",\"name\":\"Bugzilla
-        Bug\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug\",\"cf[12316840]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12316840}},{\"id\":\"customfield_12316841\",\"name\":\"Sync
-        Failure Flag\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316841]\",\"Sync
-        Failure Flag\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12316841}},{\"id\":\"customfield_12316842\",\"name\":\"Sync
-        Failure Message\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316842]\",\"Sync
-        Failure Message\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316842}},{\"id\":\"customfield_12316843\",\"name\":\"Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316843]\",\"Whiteboard\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316843}},{\"id\":\"customfield_12316844\",\"name\":\"Subcomponent\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316844]\",\"Subcomponent\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316844}},{\"id\":\"customfield_12310071\",\"name\":\"Patch
-        Repository Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310071]\",\"Patch
-        Repository Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12310071}},{\"id\":\"customfield_12310070\",\"name\":\"Patch
-        Instructions\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310070]\",\"Patch
-        Instructions\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310070}},{\"id\":\"customfield_12315640\",\"name\":\"Doc
-        Required\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315640]\",\"Doc
-        Required\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315640}},{\"id\":\"customfield_12313340\",\"name\":\"Stackoverflow
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313340]\",\"Stackoverflow
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12313340}},{\"id\":\"customfield_12316850\",\"name\":\"Service
-        Delivery Planning ACK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316850]\",\"Service
-        Delivery Planning ACK\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316850}},{\"id\":\"customfield_12317940\",\"name\":\"Funding
-        State\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317940]\",\"Funding
-        State\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317940}},{\"id\":\"customfield_12317941\",\"name\":\"Funding
-        Strategy\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317941]\",\"Funding
-        Strategy\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317941}},{\"id\":\"customfield_12322143\",\"name\":\"PX
-        Impact Range\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322143]\",\"PX
-        Impact Range\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12322143}},{\"id\":\"customfield_12322144\",\"name\":\"Risk
-        Identified Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322144]\",\"Risk
-        Identified Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322144}},{\"id\":\"customfield_12322145\",\"name\":\"Additional
-        Approvers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Additional
-        Approvers\",\"cf[12322145]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12322145}},{\"id\":\"customfield_12322146\",\"name\":\"Security
-        Approvals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322146]\",\"Security
-        Approvals\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12322146}},{\"id\":\"customfield_12322140\",\"name\":\"PX
-        Review Complete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322140]\",\"PX
-        Review Complete\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12322140}},{\"id\":\"customfield_12322141\",\"name\":\"PX
-        Technical Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322141]\",\"PX
-        Technical Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12322141}},{\"id\":\"customfield_12322142\",\"name\":\"PX
-        Priority Data\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322142]\",\"PX
-        Priority Data\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12322142}},{\"id\":\"customfield_12322147\",\"name\":\"External
-        QA Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322147]\",\"External
-        QA Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12322147}},{\"id\":\"customfield_12322148\",\"name\":\"Development
-        Complete Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322148]\",\"Development
-        Complete Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322148}},{\"id\":\"customfield_12322149\",\"name\":\"Project
-        Target Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322149]\",\"Project
-        Target Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322149}},{\"id\":\"timetracking\",\"name\":\"Time
-        Tracking\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"timetracking\",\"system\":\"timetracking\"}},{\"id\":\"customfield_12312340\",\"name\":\"GSS
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312340]\",\"GSS
-        Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12312340}},{\"id\":\"customfield_12314640\",\"name\":\"Upstream
-        Jira\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314640]\",\"Upstream
-        Jira\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12314640}},{\"id\":\"customfield_12310160\",\"name\":\"Customer
-        Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310160]\",\"Customer
-        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12310160}},{\"id\":\"customfield_12316940\",\"name\":\"Team
-        Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316940]\",\"Team
-        Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316940}},{\"id\":\"customfield_12316941\",\"name\":\"QE
-        Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316941]\",\"QE
-        Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316941}},{\"id\":\"customfield_12316942\",\"name\":\"Doc
-        Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316942]\",\"Doc
-        Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316942}},{\"id\":\"customfield_12316943\",\"name\":\"Business
-        Value\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Business
-        Value\",\"cf[12316943]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12316943}},{\"id\":\"customfield_12322150\",\"name\":\"Exception
-        Count\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322150]\",\"Exception
-        Count\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12322150}},{\"id\":\"customfield_12322151\",\"name\":\"Security
-        Controls\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322151]\",\"Security
-        Controls\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12322151}},{\"id\":\"customfield_12322152\",\"name\":\"Blocked
-        by Bugzilla Bug\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Blocked
-        by Bugzilla Bug\",\"cf[12322152]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12322152}},{\"id\":\"customfield_12310170\",\"name\":\"Affects
-        Testing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affects
-        Testing\",\"cf[12310170]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310170}},{\"id\":\"environment\",\"name\":\"Environment\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"environment\"],\"schema\":{\"type\":\"string\",\"system\":\"environment\"}},{\"id\":\"customfield_12313443\",\"name\":\"Affected
-        Jars\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Affected
-        Jars\",\"cf[12313443]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12313443}},{\"id\":\"customfield_12311143\",\"name\":\"Epic
-        Colour\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311143]\",\"Epic
-        Colour\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-color\",\"customId\":12311143}},{\"id\":\"customfield_12313442\",\"name\":\"PDD
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313442]\",\"PDD
-        Priority\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12313442}},{\"id\":\"customfield_12311141\",\"name\":\"Epic
-        Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311141]\",\"Epic
-        Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-label\",\"customId\":12311141}},{\"id\":\"customfield_12313441\",\"name\":\"SFDC
-        Cases Links\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313441]\",\"SFDC
-        Cases Links\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.redhat.engineering.step.step-sfdc-plugin:sfdc_cases\",\"customId\":12313441}},{\"id\":\"customfield_12315740\",\"name\":\"issueFunction\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315740]\",\"issueFunction\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:jqlFunctionsCustomFieldType\",\"customId\":12315740}},{\"id\":\"customfield_12311142\",\"name\":\"Epic
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311142]\",\"Epic
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-status\",\"customId\":12311142}},{\"id\":\"customfield_12313440\",\"name\":\"SFDC
-        Cases Counter\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313440]\",\"SFDC
-        Cases Counter\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.redhat.engineering.step.step-sfdc-plugin:sfdc_cases_counter\",\"customId\":12313440}},{\"id\":\"duedate\",\"name\":\"Due
-        Date\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"due\",\"duedate\"],\"schema\":{\"type\":\"date\",\"system\":\"duedate\"}},{\"id\":\"customfield_12310173\",\"name\":\"Component
-        Fix Version(s)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310173]\",\"Component
-        Fix Version(s)\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12310173}},{\"id\":\"customfield_12311140\",\"name\":\"Epic
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311140]\",\"Epic
-        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-epic-link\",\"customId\":12311140}},{\"id\":\"customfield_12314340\",\"name\":\"cee_cir\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cee_cir\",\"cf[12314340]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cirflag\",\"customId\":12314340}},{\"id\":\"customfield_12318940\",\"name\":\"Workstream
-        (OLD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318940]\",\"Workstream
-        (OLD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318940}},{\"id\":\"customfield_12313140\",\"name\":\"Parent
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313140]\",\"Parent
-        Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-parent\",\"customId\":12313140}},{\"id\":\"customfield_12313145\",\"name\":\"QE
-        Estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313145]\",\"QE
-        Estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12313145}},{\"id\":\"timeestimate\",\"name\":\"Remaining
-        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"remainingEstimate\",\"timeestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeestimate\"}},{\"id\":\"customfield_12313143\",\"name\":\"EAP
-        PT Community Docs (CD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313143]\",\"EAP
-        PT Community Docs (CD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313143}},{\"id\":\"customfield_12313144\",\"name\":\"EAP
-        PT Test Dev (TD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313144]\",\"EAP
-        PT Test Dev (TD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313144}},{\"id\":\"customfield_12315440\",\"name\":\"Verified-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315440]\",\"Verified-delete\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12315440}},{\"id\":\"customfield_12317740\",\"name\":\"Planning
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317740]\",\"Planning
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317740}},{\"id\":\"status\",\"name\":\"Status\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"status\"],\"schema\":{\"type\":\"status\",\"system\":\"status\"}},{\"id\":\"customfield_12310080\",\"name\":\"Tester\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310080]\",\"Tester\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12310080}},{\"id\":\"archiveddate\",\"name\":\"Archived\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"datetime\",\"system\":\"archiveddate\"}},{\"id\":\"customfield_12316747\",\"name\":\"Support
-        Exception Account Number\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316747]\",\"Support
-        Exception Account Number\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316747}},{\"id\":\"customfield_12316749\",\"name\":\"Architect\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Architect\",\"cf[12316749]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316749}},{\"id\":\"aggregatetimeestimate\",\"name\":\"\u03A3
-        Remaining Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimeestimate\"}},{\"id\":\"customfield_12312142\",\"name\":\"Class
-        of work\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312142]\",\"Class
-        of work\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312142}},{\"id\":\"customfield_12314440\",\"name\":\"cee_docs_prio-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cee_docs_prio-delete\",\"cf[12314440]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:ccsprioflag\",\"customId\":12314440}},{\"id\":\"customfield_12316740\",\"name\":\"Prod
-        build version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316740]\",\"Prod
-        build version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316740}},{\"id\":\"customfield_12316745\",\"name\":\"QE
-        ACK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316745]\",\"QE
-        ACK\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12316745}},{\"id\":\"creator\",\"name\":\"Creator\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"creator\"],\"schema\":{\"type\":\"user\",\"system\":\"creator\"}},{\"id\":\"customfield_12323041\",\"name\":\"Domain
-        Pool\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12323041]\",\"Domain
-        Pool\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:multiple-ldap-picker-cf\",\"customId\":12323041}},{\"id\":\"customfield_12310091\",\"name\":\"Workaround
-        Description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310091]\",\"Workaround
-        Description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310091}},{\"id\":\"customfield_12310090\",\"name\":\"Workaround\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310090]\",\"Workaround\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310090}},{\"id\":\"customfield_12310092\",\"name\":\"Estimated
-        Difficulty\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310092]\",\"Estimated
-        Difficulty\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12310092}},{\"id\":\"customfield_12315542\",\"name\":\"Flagged\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315542]\",\"Flagged\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12315542}},{\"id\":\"customfield_12315541\",\"name\":\"Regression
-        Test\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315541]\",\"Regression
-        Test\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315541}},{\"id\":\"customfield_12315540\",\"name\":\"EAP
-        Docs SME\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315540]\",\"EAP
-        Docs SME\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315540}},{\"id\":\"customfield_12313240\",\"name\":\"Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313240]\",\"Team\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.atlassian.teams:rm-teams-custom-field-team\",\"customId\":12313240}},{\"id\":\"customfield_12316750\",\"name\":\"Technical
-        Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316750]\",\"Technical
-        Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316750}},{\"id\":\"customfield_12316751\",\"name\":\"Designer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316751]\",\"Designer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316751}},{\"id\":\"customfield_12317841\",\"name\":\"Fuse
-        Progress Bar\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317841]\",\"Fuse
-        Progress Bar\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317841}},{\"id\":\"customfield_12316752\",\"name\":\"Product
-        Manager\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316752]\",\"Product
-        Manager\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316752}},{\"id\":\"customfield_12317842\",\"name\":\"Fuse
-        Progress\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317842]\",\"Fuse
-        Progress\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317842}},{\"id\":\"customfield_12316753\",\"name\":\"Manager\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316753]\",\"Manager\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316753}},{\"id\":\"customfield_12317843\",\"name\":\"BZ
-        Partner\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Partner\",\"cf[12317843]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317843}},{\"id\":\"timespent\",\"name\":\"Time
-        Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"timespent\"],\"schema\":{\"type\":\"number\",\"system\":\"timespent\"}},{\"id\":\"customfield_12320940\",\"name\":\"Test
-        Coverage\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320940]\",\"Test
-        Coverage\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320940}},{\"id\":\"aggregatetimespent\",\"name\":\"\u03A3
-        Time Spent\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"number\",\"system\":\"aggregatetimespent\"}},{\"id\":\"customfield_12320944\",\"name\":\"Test
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320944]\",\"Test
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12320944}},{\"id\":\"customfield_12320943\",\"name\":\"Pervasiveness\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320943]\",\"Pervasiveness\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320943}},{\"id\":\"customfield_12320941\",\"name\":\"Willingness
-        to Pay\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320941]\",\"Willingness
-        to Pay\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320941}},{\"id\":\"customfield_12316441\",\"name\":\"Work
-        Source\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316441]\",\"Work
-        Source\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316441}},{\"id\":\"workratio\",\"name\":\"Work
-        Ratio\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"workratio\"],\"schema\":{\"type\":\"number\",\"system\":\"workratio\"}},{\"id\":\"customfield_12316442\",\"name\":\"Customer
-        Cloud Subscription (CCS)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316442]\",\"Customer
-        Cloud Subscription (CCS)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316442}},{\"id\":\"customfield_12318740\",\"name\":\"Portfolio
-        Solutions\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318740]\",\"Portfolio
-        Solutions\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12318740}},{\"id\":\"customfield_12316443\",\"name\":\"Cluster
-        Admin Enabled\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316443]\",\"Cluster
-        Admin Enabled\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316443}},{\"id\":\"customfield_12316444\",\"name\":\"Cloud
-        Platform\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316444]\",\"Cloud
-        Platform\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316444}},{\"id\":\"customfield_12317540\",\"name\":\"Support
-        Scope\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317540]\",\"Support
-        Scope\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317540}},{\"id\":\"customfield_12315240\",\"name\":\"EAP
-        Testing By\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315240]\",\"EAP
-        Testing By\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315240}},{\"id\":\"customfield_12320948\",\"name\":\"Experience\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320948]\",\"Experience\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320948}},{\"id\":\"customfield_12317307\",\"name\":\"Original
-        Estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317307]\",\"Original
-        Estimate\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317307}},{\"id\":\"customfield_12320947\",\"name\":\"Market\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320947]\",\"Market\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiselect\",\"customId\":12320947}},{\"id\":\"customfield_12317308\",\"name\":\"QA
-        Contacts\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317308]\",\"QA
-        Contacts\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317308}},{\"id\":\"customfield_12317309\",\"name\":\"BZ
-        URL\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        URL\",\"cf[12317309]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317309}},{\"id\":\"customfield_12320946\",\"name\":\"Intelligence
-        Requested\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320946]\",\"Intelligence
-        Requested\"],\"schema\":{\"type\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlyselect\",\"customId\":12320946}},{\"id\":\"customfield_12320945\",\"name\":\"Risk
-        Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320945]\",\"Risk
-        Category\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320945}},{\"id\":\"customfield_12319840\",\"name\":\"External
-        issue ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319840]\",\"External
-        issue ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319840}},{\"id\":\"customfield_12317300\",\"name\":\"Risk
-        Category - Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317300]\",\"Risk
-        Category - Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317300}},{\"id\":\"customfield_12317301\",\"name\":\"Risk
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317301]\",\"Risk
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317301}},{\"id\":\"customfield_12317302\",\"name\":\"Risk
-        Probability\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317302]\",\"Risk
-        Probability\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317302}},{\"id\":\"customfield_12317303\",\"name\":\"Risk
-        Proximity\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317303]\",\"Risk
-        Proximity\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317303}},{\"id\":\"customfield_12317304\",\"name\":\"Risk
-        Impact Level\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317304]\",\"Risk
-        Impact Level\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317304}},{\"id\":\"customfield_12317305\",\"name\":\"Risk
-        impact description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317305]\",\"Risk
-        impact description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317305}},{\"id\":\"customfield_12317306\",\"name\":\"Risk
-        mitigation/contingency\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317306]\",\"Risk
-        mitigation/contingency\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317306}},{\"id\":\"customfield_12316548\",\"name\":\"Actual
-        Effort\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Actual
-        Effort\",\"cf[12316548]\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12316548}},{\"id\":\"customfield_12316549\",\"name\":\"CRT
-        Milestone Estimate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316549]\",\"CRT
-        Milestone Estimate\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12316549}},{\"id\":\"customfield_12314245\",\"name\":\"EAP
-        PT Pre-Checked (PC)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314245]\",\"EAP
-        PT Pre-Checked (PC)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314245}},{\"id\":\"customfield_12314244\",\"name\":\"EAP
-        PT Product Docs (PD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314244]\",\"EAP
-        PT Product Docs (PD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314244}},{\"id\":\"customfield_12314243\",\"name\":\"EAP
-        PT Docs Analysis (DA)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314243]\",\"EAP
-        PT Docs Analysis (DA)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314243}},{\"id\":\"customfield_12314242\",\"name\":\"EAP
-        PT Test Plan (TP)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314242]\",\"EAP
-        PT Test Plan (TP)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314242}},{\"id\":\"customfield_12314241\",\"name\":\"EAP
-        PT Analysis Document (AD)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314241]\",\"EAP
-        PT Analysis Document (AD)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12314241}},{\"id\":\"customfield_12318840\",\"name\":\"Marketing
-        Info\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318840]\",\"Marketing
-        Info\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12318840}},{\"id\":\"customfield_12316540\",\"name\":\"Reviewer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316540]\",\"Reviewer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316540}},{\"id\":\"customfield_12316541\",\"name\":\"T-Shirt
-        Size\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316541]\",\"T-Shirt
-        Size\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316541}},{\"id\":\"customfield_12316542\",\"name\":\"Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316542]\",\"Ready\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316542}},{\"id\":\"customfield_12316543\",\"name\":\"Blocked\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Blocked\",\"cf[12316543]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316543}},{\"id\":\"customfield_12318841\",\"name\":\"Marketing
-        Info Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318841]\",\"Marketing
-        Info Ready\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318841}},{\"id\":\"customfield_12316544\",\"name\":\"Blocked
-        Reason\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Blocked
-        Reason\",\"cf[12316544]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316544}},{\"id\":\"customfield_12316545\",\"name\":\"Owner\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316545]\",\"Owner\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316545}},{\"id\":\"customfield_12316546\",\"name\":\"Evidence
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316546]\",\"Evidence
-        Score\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316546}},{\"id\":\"customfield_12316547\",\"name\":\"Discussed
-        with Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316547]\",\"Discussed
-        with Team\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12316547}},{\"id\":\"customfield_12313040\",\"name\":\"Test
-        Plan\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313040]\",\"Test
-        Plan\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12313040}},{\"id\":\"customfield_12313041\",\"name\":\"Analysis
-        Document\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Analysis
-        Document\",\"cf[12313041]\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12313041}},{\"id\":\"customfield_12313042\",\"name\":\"Microrelease
-        version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313042]\",\"Microrelease
-        version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12313042}},{\"id\":\"customfield_12317640\",\"name\":\"DevTestDoc\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317640]\",\"DevTestDoc\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317640}},{\"id\":\"customfield_12319940\",\"name\":\"Target
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319940]\",\"Target
-        Version\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiversion\",\"customId\":12319940}},{\"id\":\"customfield_12317401\",\"name\":\"EXD-Service\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317401]\",\"EXD-Service\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12317401}},{\"id\":\"customfield_12317403\",\"name\":\"EXD-WorkType\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317403]\",\"EXD-WorkType\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317403}},{\"id\":\"customfield_12317404\",\"name\":\"Commitment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317404]\",\"Commitment\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12317404}},{\"id\":\"customfield_12317405\",\"name\":\"Requesting
-        Teams\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317405]\",\"Requesting
-        Teams\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317405}},{\"id\":\"customfield_12316240\",\"name\":\"Planning\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316240]\",\"Planning\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316240}},{\"id\":\"customfield_12317330\",\"name\":\"BZ
-        needinfo\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        needinfo\",\"cf[12317330]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317330}},{\"id\":\"customfield_12316241\",\"name\":\"Design
-        Doc\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316241]\",\"Design
-        Doc\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316241}},{\"id\":\"customfield_12319751\",\"name\":\"Risk
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319751]\",\"Risk
-        Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319751}},{\"id\":\"customfield_12317331\",\"name\":\"BZ
-        rhel-8.0.z\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        rhel-8.0.z\",\"cf[12317331]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317331}},{\"id\":\"customfield_12318540\",\"name\":\"Message
-        For OHSS Project\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318540]\",\"Message
-        For OHSS Project\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:messagecustomfield\",\"customId\":12318540}},{\"id\":\"customfield_12316242\",\"name\":\"QEStatus\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316242]\",\"QEStatus\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316242}},{\"id\":\"customfield_12319750\",\"name\":\"WSJF\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319750]\",\"WSJF\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319750}},{\"id\":\"customfield_12320741\",\"name\":\"Urgency\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320741]\",\"Urgency\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320741}},{\"id\":\"customfield_12320740\",\"name\":\"Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320740]\",\"Impact\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320740}},{\"id\":\"customfield_12316243\",\"name\":\"QE
-        Assignee\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316243]\",\"QE
-        Assignee\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12316243}},{\"id\":\"customfield_12317332\",\"name\":\"ZStream
-        Target Release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317332]\",\"ZStream
-        Target Release\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317332}},{\"id\":\"customfield_12317333\",\"name\":\"BZ
-        blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        blocker\",\"cf[12317333]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317333}},{\"id\":\"customfield_12316245\",\"name\":\"Needs
-        Product Docs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316245]\",\"Needs
-        Product Docs\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316245}},{\"id\":\"customfield_12319755\",\"name\":\"PX
-        Review Complete_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319755]\",\"PX
-        Review Complete_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319755}},{\"id\":\"customfield_12317334\",\"name\":\"zstream\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317334]\",\"zstream\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317334}},{\"id\":\"customfield_12317335\",\"name\":\"BZ
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Version\",\"cf[12317335]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317335}},{\"id\":\"customfield_12317336\",\"name\":\"BZ
-        Docs Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Docs Contact\",\"cf[12317336]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317336}},{\"id\":\"customfield_12317337\",\"name\":\"BZ
-        requires_doc_text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        requires_doc_text\",\"cf[12317337]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317337}},{\"id\":\"customfield_12319756\",\"name\":\"PX
-        Scheduling Request - SV-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319756]\",\"PX
-        Scheduling Request - SV-delete\"],\"schema\":{\"type\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:version\",\"customId\":12319756}},{\"id\":\"customfield_12317338\",\"name\":\"Doc
-        Commitment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317338]\",\"Doc
-        Commitment\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317338}},{\"id\":\"customfield_12317339\",\"name\":\"Hardware_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317339]\",\"Hardware_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317339}},{\"id\":\"customfield_12310940\",\"name\":\"Sprint\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310940]\",\"Sprint\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.pyxis.greenhopper.jira:gh-sprint\",\"customId\":12310940}},{\"id\":\"customfield_12316250\",\"name\":\"Link
-        to documentation\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316250]\",\"Link
-        to documentation\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316250}},{\"id\":\"customfield_12317340\",\"name\":\"OS\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317340]\",\"OS\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317340}},{\"id\":\"customfield_12317341\",\"name\":\"Public
-        Target Launch Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317341]\",\"Public
-        Target Launch Date\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317341}},{\"id\":\"customfield_12319640\",\"name\":\"Contributing
-        Groups\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319640]\",\"Contributing
-        Groups\"],\"schema\":{\"type\":\"array\",\"items\":\"group\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multigrouppicker\",\"customId\":12319640}},{\"id\":\"customfield_12317342\",\"name\":\"Onsite
-        Hardware Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317342]\",\"Onsite
-        Hardware Date\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317342}},{\"id\":\"customfield_12315043\",\"name\":\"3scale
-        PT Verified Product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Verified Product\",\"cf[12315043]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315043}},{\"id\":\"customfield_12315042\",\"name\":\"3scale
-        PT Released In Saas\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Released In Saas\",\"cf[12315042]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315042}},{\"id\":\"customfield_12315041\",\"name\":\"3scale
-        PT Docs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Docs\",\"cf[12315041]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315041}},{\"id\":\"customfield_12315040\",\"name\":\"3scale
-        PT Product Specs\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Product Specs\",\"cf[12315040]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315040}},{\"id\":\"customfield_12321840\",\"name\":\"Supply
-        Chain STI\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321840]\",\"Supply
-        Chain STI\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12321840}},{\"id\":\"customfield_12321841\",\"name\":\"Offerings\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321841]\",\"Offerings\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12321841}},{\"id\":\"labels\",\"name\":\"Labels\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"labels\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"system\":\"labels\"}},{\"id\":\"customfield_12321842\",\"name\":\"External
-        issue ID_Old12\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321842]\",\"External
-        issue ID_Old12\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321842}},{\"id\":\"customfield_12315044\",\"name\":\"3scale
-        PT Product Update Ready\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3scale
-        PT Product Update Ready\",\"cf[12315044]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315044}},{\"id\":\"customfield_12317343\",\"name\":\"Target
-        Upstream Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317343]\",\"Target
-        Upstream Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317343}},{\"id\":\"customfield_12317344\",\"name\":\"Close
-        Duplicate Candidate\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317344]\",\"Close
-        Duplicate Candidate\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317344}},{\"id\":\"customfield_12317345\",\"name\":\"Partner
-        Requirement State\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317345]\",\"Partner
-        Requirement State\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317345}},{\"id\":\"customfield_12317346\",\"name\":\"BZ
-        Target Release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Target Release\",\"cf[12317346]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317346}},{\"id\":\"customfield_12317347\",\"name\":\"Upstream
-        Kernel Target\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317347]\",\"Upstream
-        Kernel Target\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317347}},{\"id\":\"customfield_12317348\",\"name\":\"EPM
-        priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317348]\",\"EPM
-        priority\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317348}},{\"id\":\"customfield_12317349\",\"name\":\"Case
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Case
-        Link\",\"cf[12317349]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317349}},{\"id\":\"components\",\"name\":\"Component/s\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"component\"],\"schema\":{\"type\":\"array\",\"items\":\"component\",\"system\":\"components\"}},{\"id\":\"customfield_12318640\",\"name\":\"BZ
-        Flags\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Flags\",\"cf[12318640]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12318640}},{\"id\":\"customfield_12316340\",\"name\":\"Service
-        / (sub)product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316340]\",\"Service
-        / (sub)product\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316340}},{\"id\":\"customfield_12316341\",\"name\":\"Department\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316341]\",\"Department\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316341}},{\"id\":\"customfield_12320841\",\"name\":\"Status
-        Summary\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320841]\",\"Status
-        Summary\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12320841}},{\"id\":\"customfield_12320840\",\"name\":\"Release
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320840]\",\"Release
-        Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320840}},{\"id\":\"customfield_12314040\",\"name\":\"Original
-        story points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12314040]\",\"Original
-        story points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-original-story-points\",\"customId\":12314040}},{\"id\":\"customfield_12320845\",\"name\":\"Color
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320845]\",\"Color
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320845}},{\"id\":\"customfield_12320844\",\"name\":\"Customer
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320844]\",\"Customer
-        Impact\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12320844}},{\"id\":\"customfield_12320843\",\"name\":\"UX
-        Designer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320843]\",\"UX
-        Designer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12320843}},{\"id\":\"customfield_12320842\",\"name\":\"Documentation
-        Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320842]\",\"Documentation
-        Type\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320842}},{\"id\":\"customfield_12317318\",\"name\":\"BZ
-        Keywords\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Keywords\",\"cf[12317318]\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317318}},{\"id\":\"customfield_12317319\",\"name\":\"BZ
-        exception\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        exception\",\"cf[12317319]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317319}},{\"id\":\"customfield_12316342\",\"name\":\"Additional
-        Assignees\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Additional
-        Assignees\",\"cf[12316342]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12316342}},{\"id\":\"customfield_12317310\",\"name\":\"BZ
-        Doc Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Doc Type\",\"cf[12317310]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317310}},{\"id\":\"customfield_12317311\",\"name\":\"BZ
-        QA Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        QA Whiteboard\",\"cf[12317311]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317311}},{\"id\":\"customfield_12316343\",\"name\":\"OpenShift
-        Planning Ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316343]\",\"OpenShift
-        Planning Ack\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12316343}},{\"id\":\"customfield_12317312\",\"name\":\"BZ
-        Internal Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Internal Whiteboard\",\"cf[12317312]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317312}},{\"id\":\"customfield_12316344\",\"name\":\"External
-        issue ID_Old14\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316344]\",\"External
-        issue ID_Old14\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316344}},{\"id\":\"customfield_12317313\",\"name\":\"Release
-        Note Text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317313]\",\"Release
-        Note Text\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317313}},{\"id\":\"customfield_12317314\",\"name\":\"Quarter\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317314]\",\"Quarter\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317314}},{\"id\":\"customfield_12317315\",\"name\":\"release\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317315]\",\"release\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317315}},{\"id\":\"customfield_12316348\",\"name\":\"Architecture\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Architecture\",\"cf[12316348]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12316348}},{\"id\":\"customfield_12317317\",\"name\":\"BZ
-        Target Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Target Milestone\",\"cf[12317317]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317317}},{\"id\":\"customfield_12316349\",\"name\":\"Cluster
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316349]\",\"Cluster
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12316349}},{\"id\":\"customfield_12316350\",\"name\":\"CRT
-        Acceptance Critera\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316350]\",\"CRT
-        Acceptance Critera\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316350}},{\"id\":\"customfield_12319740\",\"name\":\"Approved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approved\",\"cf[12319740]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319740}},{\"id\":\"customfield_12316351\",\"name\":\"CRT
-        Completion Steps\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316351]\",\"CRT
-        Completion Steps\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12316351}},{\"id\":\"customfield_12317320\",\"name\":\"Current
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317320]\",\"Current
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317320}},{\"id\":\"customfield_12317441\",\"name\":\"Satellite
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317441]\",\"Satellite
-        Team\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317441}},{\"id\":\"customfield_12320852\",\"name\":\"Size\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320852]\",\"Size\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320852}},{\"id\":\"customfield_12315141\",\"name\":\"Developer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12315141]\",\"Developer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12315141}},{\"id\":\"customfield_12320851\",\"name\":\"Sub-System
-        Group\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320851]\",\"Sub-System
-        Group\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320851}},{\"id\":\"reporter\",\"name\":\"Reporter\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"reporter\"],\"schema\":{\"type\":\"user\",\"system\":\"reporter\"}},{\"id\":\"customfield_12315140\",\"name\":\"3Scale
-        PT Tested upstream\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"3Scale
-        PT Tested upstream\",\"cf[12315140]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12315140}},{\"id\":\"customfield_12320850\",\"name\":\"Release
-        Note Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320850]\",\"Release
-        Note Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320850}},{\"id\":\"customfield_12321940\",\"name\":\"Supply
-        Chain Program\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321940]\",\"Supply
-        Chain Program\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321940}},{\"id\":\"customfield_12317329\",\"name\":\"PM
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317329]\",\"PM
-        Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12317329}},{\"id\":\"customfield_12320849\",\"name\":\"RICE
-        Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320849]\",\"RICE
-        Score\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12320849}},{\"id\":\"customfield_12319749\",\"name\":\"Cost
-        of Delay\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319749]\",\"Cost
-        of Delay\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319749}},{\"id\":\"customfield_12320848\",\"name\":\"Effort\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320848]\",\"Effort\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320848}},{\"id\":\"customfield_12320847\",\"name\":\"Confidence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320847]\",\"Confidence\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320847}},{\"id\":\"customfield_12320846\",\"name\":\"Reach\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320846]\",\"Reach\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12320846}},{\"id\":\"customfield_12317321\",\"name\":\"BZ
-        Assignee\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Assignee\",\"cf[12317321]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317321}},{\"id\":\"customfield_12319742\",\"name\":\"Release
-        Commit Exception\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319742]\",\"Release
-        Commit Exception\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319742}},{\"id\":\"customfield_12317442\",\"name\":\"Upstream
-        Discussion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317442]\",\"Upstream
-        Discussion\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317442}},{\"id\":\"progress\",\"name\":\"Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"progress\"],\"schema\":{\"type\":\"progress\",\"system\":\"progress\"}},{\"id\":\"customfield_12317322\",\"name\":\"BZ
-        Doc Text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Doc Text\",\"cf[12317322]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317322}},{\"id\":\"customfield_12319741\",\"name\":\"Market
-        Intelligence Score\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319741]\",\"Market
-        Intelligence Score\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12319741}},{\"id\":\"customfield_12319744\",\"name\":\"Responsible\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319744]\",\"Responsible\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319744}},{\"id\":\"customfield_12317324\",\"name\":\"BZ
-        Product\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Product\",\"cf[12317324]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317324}},{\"id\":\"customfield_12319743\",\"name\":\"Release
-        Blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319743]\",\"Release
-        Blocker\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319743}},{\"id\":\"customfield_12317325\",\"name\":\"BZ
-        URL_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        URL_Old\",\"cf[12317325]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317325}},{\"id\":\"customfield_12319746\",\"name\":\"Risk
-        Response\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319746]\",\"Risk
-        Response\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319746}},{\"id\":\"archivedby\",\"name\":\"Archiver\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[],\"schema\":{\"type\":\"user\",\"system\":\"archivedby\"}},{\"id\":\"customfield_12317326\",\"name\":\"Hold\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317326]\",\"Hold\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12317326}},{\"id\":\"customfield_12319745\",\"name\":\"Watch
-        List\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319745]\",\"Watch
-        List\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12319745}},{\"id\":\"customfield_12317327\",\"name\":\"RHEL
-        Sub Components\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317327]\",\"RHEL
-        Sub Components\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317327}},{\"id\":\"customfield_12317328\",\"name\":\"BZ
-        Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Whiteboard\",\"cf[12317328]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317328}},{\"id\":\"customfield_12317370\",\"name\":\"Need
-        Info Requestees\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317370]\",\"Need
-        Info Requestees\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317370}},{\"id\":\"customfield_12316040\",\"name\":\"PX
-        Technical Impact_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316040]\",\"PX
-        Technical Impact_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316040}},{\"id\":\"customfield_12317250\",\"name\":\"Product
-        Affects Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317250]\",\"Product
-        Affects Version\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317250}},{\"id\":\"customfield_12318341\",\"name\":\"Feature
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318341]\",\"Feature
-        Link\"],\"schema\":{\"type\":\"issuelinks\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12318341}},{\"id\":\"customfield_12317372\",\"name\":\"Git
-        Commit\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317372]\",\"Git
-        Commit\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317372}},{\"id\":\"customfield_12320540\",\"name\":\"Major
-        Project\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320540]\",\"Major
-        Project\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320540}},{\"id\":\"customfield_12316041\",\"name\":\"PX
-        Impact Range_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316041]\",\"PX
-        Impact Range_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12316041}},{\"id\":\"customfield_12317251\",\"name\":\"Target
-        Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317251]\",\"Target
-        Milestone\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317251}},{\"id\":\"customfield_12318340\",\"name\":\"Cross
-        Team Epic\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318340]\",\"Cross
-        Team Epic\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12318340}},{\"id\":\"customfield_12317252\",\"name\":\"In
-        Portfolio\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317252]\",\"In
-        Portfolio\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317252}},{\"id\":\"customfield_12316042\",\"name\":\"MoSCoW\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316042]\",\"MoSCoW\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:radiobuttons\",\"customId\":12316042}},{\"id\":\"customfield_12317374\",\"name\":\"Ack'd
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Ack'd
-        Status\",\"cf[12317374]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317374}},{\"id\":\"customfield_12316043\",\"name\":\"Brief\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Brief\",\"cf[12316043]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12316043}},{\"id\":\"customfield_12317253\",\"name\":\"EXD-Watchlist\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317253]\",\"EXD-Watchlist\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317253}},{\"id\":\"customfield_12317375\",\"name\":\"Block/Fail
-        - Additional Details\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Block/Fail
-        - Additional Details\",\"cf[12317375]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317375}},{\"id\":\"customfield_12317254\",\"name\":\"Watchlist
-        Proposed Solution\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317254]\",\"Watchlist
-        Proposed Solution\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317254}},{\"id\":\"customfield_12322844\",\"name\":\"Product
-        Experience Engineering Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322844]\",\"Product
-        Experience Engineering Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12322844}},{\"id\":\"customfield_12320544\",\"name\":\"Shepherd\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320544]\",\"Shepherd\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12320544}},{\"id\":\"project\",\"name\":\"Project\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"project\"],\"schema\":{\"type\":\"project\",\"system\":\"project\"}},{\"id\":\"customfield_12320543\",\"name\":\"Automated
-        Test\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Automated
-        Test\",\"cf[12320543]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320543}},{\"id\":\"customfield_12320542\",\"name\":\"Test
-        Plan Created\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320542]\",\"Test
-        Plan Created\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320542}},{\"id\":\"customfield_12320541\",\"name\":\"Design
-        Doc Created\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320541]\",\"Design
-        Doc Created\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320541}},{\"id\":\"customfield_12320548\",\"name\":\"Committed
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320548]\",\"Committed
-        Version\"],\"schema\":{\"type\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:version\",\"customId\":12320548}},{\"id\":\"customfield_12322840\",\"name\":\"Partner
-        Fixed Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322840]\",\"Partner
-        Fixed Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322840}},{\"id\":\"customfield_12322841\",\"name\":\"Partner
-        Affects Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322841]\",\"Partner
-        Affects Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322841}},{\"id\":\"customfield_12320547\",\"name\":\"Product
-        Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320547]\",\"Product
-        Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12320547}},{\"id\":\"customfield_12320546\",\"name\":\"Level
-        of Effort\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320546]\",\"Level
-        of Effort\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320546}},{\"id\":\"customfield_12322843\",\"name\":\"Customer
-        Affects Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322843]\",\"Customer
-        Affects Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322843}},{\"id\":\"customfield_12320545\",\"name\":\"Eng
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320545]\",\"Eng
-        Team\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320545}},{\"id\":\"resolutiondate\",\"name\":\"Resolved\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"resolutiondate\",\"resolved\"],\"schema\":{\"type\":\"datetime\",\"system\":\"resolutiondate\"}},{\"id\":\"customfield_12317376\",\"name\":\"Interop
-        Bug ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317376]\",\"Interop
-        Bug ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317376}},{\"id\":\"customfield_12317255\",\"name\":\"Watchlist
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317255]\",\"Watchlist
-        Impact\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317255}},{\"id\":\"customfield_12317256\",\"name\":\"PM
-        Business Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317256]\",\"PM
-        Business Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317256}},{\"id\":\"customfield_12317377\",\"name\":\"Request
-        Description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317377]\",\"Request
-        Description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317377}},{\"id\":\"customfield_12317257\",\"name\":\"Customers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317257]\",\"Customers\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317257}},{\"id\":\"customfield_12317258\",\"name\":\"Experience_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317258]\",\"Experience_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317258}},{\"id\":\"customfield_12317379\",\"name\":\"Resolved
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317379]\",\"Resolved
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317379}},{\"id\":\"customfield_12317259\",\"name\":\"Pool
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317259]\",\"Pool
-        Team\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317259}},{\"id\":\"watches\",\"name\":\"Watchers\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"watchers\"],\"schema\":{\"type\":\"watches\",\"system\":\"watches\"}},{\"id\":\"customfield_12317380\",\"name\":\"Triage
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317380]\",\"Triage
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317380}},{\"id\":\"customfield_12317381\",\"name\":\"BZ
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Status\",\"cf[12317381]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317381}},{\"id\":\"customfield_12317260\",\"name\":\"Dev
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317260]\",\"Dev
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317260}},{\"id\":\"customfield_12317261\",\"name\":\"Docs
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317261]\",\"Docs
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317261}},{\"id\":\"customfield_12317140\",\"name\":\"Hierarchy
-        Progress\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317140]\",\"Hierarchy
-        Progress\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317140}},{\"id\":\"customfield_12317382\",\"name\":\"Impact-old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317382]\",\"Impact-old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317382}},{\"id\":\"customfield_12321640\",\"name\":\"Start
-        date-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321640]\",\"Start
-        date-delete\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12321640}},{\"id\":\"customfield_12317262\",\"name\":\"CEE
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CEE
-        Approval\",\"cf[12317262]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317262}},{\"id\":\"customfield_12317141\",\"name\":\"Hierarchy
-        Progress Bar\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317141]\",\"Hierarchy
-        Progress Bar\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317141}},{\"id\":\"customfield_12320551\",\"name\":\"Test
-        Failure Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320551]\",\"Test
-        Failure Category\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320551}},{\"id\":\"customfield_12317263\",\"name\":\"PM
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317263]\",\"PM
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317263}},{\"id\":\"customfield_12319440\",\"name\":\"Planning
-        Target\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319440]\",\"Planning
-        Target\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319440}},{\"id\":\"customfield_12317142\",\"name\":\"RHV
-        Progress\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317142]\",\"RHV
-        Progress\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317142}},{\"id\":\"customfield_12317384\",\"name\":\"Requires_doc_text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317384]\",\"Requires_doc_text\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317384}},{\"id\":\"customfield_12317264\",\"name\":\"QE
-        Approval\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317264]\",\"QE
-        Approval\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317264}},{\"id\":\"customfield_12317143\",\"name\":\"RHV
-        Progress Bar\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317143]\",\"RHV
-        Progress Bar\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317143}},{\"id\":\"customfield_12317386\",\"name\":\"Goal\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317386]\",\"Goal\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317386}},{\"id\":\"customfield_12317265\",\"name\":\"Start
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317265]\",\"Start
-        Date\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12317265}},{\"id\":\"customfield_12320555\",\"name\":\"Operating
-        System\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320555]\",\"Operating
-        System\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320555}},{\"id\":\"customfield_12320554\",\"name\":\"Orchestrator
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320554]\",\"Orchestrator
-        Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12320554}},{\"id\":\"customfield_12320553\",\"name\":\"Orchestrator\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320553]\",\"Orchestrator\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320553}},{\"id\":\"customfield_12320552\",\"name\":\"Cluster
-        Flavor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320552]\",\"Cluster
-        Flavor\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12320552}},{\"id\":\"customfield_12321641\",\"name\":\"Closed\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321641]\",\"Closed\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12321641}},{\"id\":\"customfield_12320558\",\"name\":\"Release
-        Delivery\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320558]\",\"Release
-        Delivery\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12320558}},{\"id\":\"customfield_12320557\",\"name\":\"Docker
-        Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320557]\",\"Docker
-        Version\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12320557}},{\"id\":\"customfield_12321643\",\"name\":\"External
-        issue ID_Old9\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321643]\",\"External
-        issue ID_Old9\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321643}},{\"id\":\"customfield_12320549\",\"name\":\"Delivery
-        Forecast Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320549]\",\"Delivery
-        Forecast Version\"],\"schema\":{\"type\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:version\",\"customId\":12320549}},{\"id\":\"customfield_12317266\",\"name\":\"Status
-        Summary Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317266]\",\"Status
-        Summary Old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317266}},{\"id\":\"customfield_12317267\",\"name\":\"BZ
-        QE Conditional NAK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        QE Conditional NAK\",\"cf[12317267]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317267}},{\"id\":\"customfield_12317146\",\"name\":\"Internal
-        Target Milestone_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317146]\",\"Internal
-        Target Milestone_old\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12317146}},{\"id\":\"customfield_12317268\",\"name\":\"BZ
-        Devel Whiteboard\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Devel Whiteboard\",\"cf[12317268]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317268}},{\"id\":\"customfield_12317389\",\"name\":\"BZ
-        Docs Contact_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Docs Contact_Old\",\"cf[12317389]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317389}},{\"id\":\"updated\",\"name\":\"Updated\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"updated\",\"updatedDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"updated\"}},{\"id\":\"customfield_12311840\",\"name\":\"Need
-        Info From\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311840]\",\"Need
-        Info From\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12311840}},{\"id\":\"customfield_12316140\",\"name\":\"Organization
-        Sponsor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316140]\",\"Organization
-        Sponsor\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316140}},{\"id\":\"customfield_12317350\",\"name\":\"Sponsor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317350]\",\"Sponsor\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317350}},{\"id\":\"customfield_12317351\",\"name\":\"Next
-        Review\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317351]\",\"Next
-        Review\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317351}},{\"id\":\"customfield_12316141\",\"name\":\"Product
-        Sponsor\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316141]\",\"Product
-        Sponsor\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316141}},{\"id\":\"customfield_12316142\",\"name\":\"Severity\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12316142]\",\"Severity\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12316142}},{\"id\":\"customfield_12317352\",\"name\":\"Strategy
-        Approved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317352]\",\"Strategy
-        Approved\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317352}},{\"id\":\"timeoriginalestimate\",\"name\":\"Original
-        Estimate\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"originalEstimate\",\"timeoriginalestimate\"],\"schema\":{\"type\":\"number\",\"system\":\"timeoriginalestimate\"}},{\"id\":\"customfield_12317353\",\"name\":\"Intelligence
-        Requested_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317353]\",\"Intelligence
-        Requested_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317353}},{\"id\":\"description\",\"name\":\"Description\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"description\"],\"schema\":{\"type\":\"string\",\"system\":\"description\"}},{\"id\":\"customfield_12320640\",\"name\":\"Bugzilla
-        Bug_Old1\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old1\",\"cf[12320640]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320640}},{\"id\":\"customfield_12322940\",\"name\":\"Preliminary
-        Testing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322940]\",\"Preliminary
-        Testing\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12322940}},{\"id\":\"customfield_12322941\",\"name\":\"Dev
-        Target end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322941]\",\"Dev
-        Target end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12322941}},{\"id\":\"customfield_12318444\",\"name\":\"DEV
-        Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318444]\",\"DEV
-        Story Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12318444}},{\"id\":\"customfield_12317354\",\"name\":\"Pervasiveness_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317354]\",\"Pervasiveness_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317354}},{\"id\":\"customfield_12318443\",\"name\":\"QE
-        Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318443]\",\"QE
-        Story Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12318443}},{\"id\":\"customfield_12317355\",\"name\":\"Willingness
-        to Pay_old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317355]\",\"Willingness
-        to Pay_old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317355}},{\"id\":\"customfield_12317356\",\"name\":\"Market_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317356]\",\"Market_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317356}},{\"id\":\"customfield_12318446\",\"name\":\"Regression\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318446]\",\"Regression\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318446}},{\"id\":\"customfield_12318445\",\"name\":\"DOC
-        Story Points\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318445]\",\"DOC
-        Story Points\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12318445}},{\"id\":\"customfield_12317357\",\"name\":\"Market
-        Intelligence\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317357]\",\"Market
-        Intelligence\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317357}},{\"id\":\"customfield_12317358\",\"name\":\"Function
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317358]\",\"Function
-        Impact\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317358}},{\"id\":\"customfield_12310840\",\"name\":\"Rank
-        (Obsolete)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310840]\",\"Rank
-        (Obsolete)\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-global-rank\",\"customId\":12310840}},{\"id\":\"customfield_12318448\",\"name\":\"Test
-        Blocker\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318448]\",\"Test
-        Blocker\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318448}},{\"id\":\"customfield_12318447\",\"name\":\"Automated\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Automated\",\"cf[12318447]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318447}},{\"id\":\"customfield_12317359\",\"name\":\"oVirt
-        Team\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317359]\",\"oVirt
-        Team\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317359}},{\"id\":\"customfield_12318449\",\"name\":\"CDW
-        support_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        support_ack\",\"cf[12318449]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagdocs\",\"customId\":12318449}},{\"id\":\"summary\",\"name\":\"Summary\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"summary\"],\"schema\":{\"type\":\"string\",\"system\":\"summary\"}},{\"id\":\"customfield_12317360\",\"name\":\"Doc
-        Contact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317360]\",\"Doc
-        Contact\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317360}},{\"id\":\"customfield_12319540\",\"name\":\"Deployment
-        Environment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319540]\",\"Deployment
-        Environment\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319540}},{\"id\":\"customfield_12317361\",\"name\":\"Involved
-        teams\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317361]\",\"Involved
-        teams\"],\"schema\":{\"type\":\"array\",\"items\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:labels\",\"customId\":12317361}},{\"id\":\"customfield_12317240\",\"name\":\"QE
-        Contacts\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317240]\",\"QE
-        Contacts\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317240}},{\"id\":\"customfield_12317362\",\"name\":\"Additional
-        watchers\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Additional
-        watchers\",\"cf[12317362]\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12317362}},{\"id\":\"customfield_12318450\",\"name\":\"Fixed
-        in Build\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318450]\",\"Fixed
-        in Build\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318450}},{\"id\":\"customfield_12317241\",\"name\":\"Release
-        Notes text-Delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317241]\",\"Release
-        Notes text-Delete\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317241}},{\"id\":\"customfield_12317242\",\"name\":\"External
-        issue URL\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317242]\",\"External
-        issue URL\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317242}},{\"id\":\"customfield_12317363\",\"name\":\"Fixed
-        In Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317363]\",\"Fixed
-        In Version\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317363}},{\"id\":\"customfield_12317243\",\"name\":\"ServiceNow
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317243]\",\"ServiceNow
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317243}},{\"id\":\"customfield_12321740\",\"name\":\"Testable
-        Builds\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321740]\",\"Testable
-        Builds\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12321740}},{\"id\":\"customfield_10002\",\"name\":\"SourceForge
-        Reference\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[10002]\",\"SourceForge
-        Reference\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":10002}},{\"id\":\"customfield_12317244\",\"name\":\"Gerrit
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317244]\",\"Gerrit
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317244}},{\"id\":\"customfield_12317365\",\"name\":\"Test
-        Plan Link-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317365]\",\"Test
-        Plan Link-delete\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317365}},{\"id\":\"customfield_12317366\",\"name\":\"ACKs
-        Check\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"ACKs
-        Check\",\"cf[12317366]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317366}},{\"id\":\"customfield_12317245\",\"name\":\"Mojo
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317245]\",\"Mojo
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12317245}},{\"id\":\"comment\",\"name\":\"Comment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"comment\"],\"schema\":{\"type\":\"comments-page\",\"system\":\"comment\"}},{\"id\":\"customfield_12317246\",\"name\":\"Needs
-        Info\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317246]\",\"Needs
-        Info\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12317246}},{\"id\":\"customfield_12317367\",\"name\":\"[QE]
-        How to address?\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[QE]
-        How to address?\",\"cf[12317367]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317367}},{\"id\":\"customfield_12317247\",\"name\":\"Discussion
-        Needed\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317247]\",\"Discussion
-        Needed\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317247}},{\"id\":\"customfield_12317368\",\"name\":\"[QE]
-        Why QE missed?\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"[QE]
-        Why QE missed?\",\"cf[12317368]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317368}},{\"id\":\"customfield_12311941\",\"name\":\"CDW
-        docs_ack\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        docs_ack\",\"cf[12311941]\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.cdw-plugin:cdwflagdocs\",\"customId\":12311941}},{\"id\":\"customfield_12317248\",\"name\":\"Discussion
-        Occurred\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317248]\",\"Discussion
-        Occurred\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317248}},{\"id\":\"customfield_12317369\",\"name\":\"RCA
-        Description\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317369]\",\"RCA
-        Description\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317369}},{\"id\":\"customfield_12317249\",\"name\":\"Contributing
-        Teams\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317249]\",\"Contributing
-        Teams\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12317249}},{\"id\":\"customfield_12311940\",\"name\":\"Rank\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311940]\",\"Rank\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.pyxis.greenhopper.jira:gh-lexo-rank\",\"customId\":12311940}},{\"id\":\"customfield_12317291\",\"name\":\"Action\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Action\",\"cf[12317291]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317291}},{\"id\":\"customfield_12318141\",\"name\":\"Dev
-        Target Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318141]\",\"Dev
-        Target Milestone\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318141}},{\"id\":\"customfield_12317293\",\"name\":\"External
-        issue ID_Old10\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317293]\",\"External
-        issue ID_Old10\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317293}},{\"id\":\"customfield_12322640\",\"name\":\"Prodsec
-        Priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322640]\",\"Prodsec
-        Priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12322640}},{\"id\":\"customfield_12317294\",\"name\":\"External
-        issue ID_Old11\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317294]\",\"External
-        issue ID_Old11\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317294}},{\"id\":\"customfield_12322641\",\"name\":\"Reset
-        contact to default\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322641]\",\"Reset
-        contact to default\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12322641}},{\"id\":\"customfield_12318140\",\"name\":\"prev_assignee\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318140]\",\"prev_assignee\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318140}},{\"id\":\"customfield_12317295\",\"name\":\"External
-        issue ID_Old13\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317295]\",\"External
-        issue ID_Old13\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317295}},{\"id\":\"customfield_12318143\",\"name\":\"PLM
-        Business Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318143]\",\"PLM
-        Business Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318143}},{\"id\":\"customfield_12318142\",\"name\":\"PLM
-        \ Technical Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318142]\",\"PLM
-        \ Technical Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318142}},{\"id\":\"customfield_12320341\",\"name\":\"PX
-        Scheduling Request\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320341]\",\"PX
-        Scheduling Request\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiversion\",\"customId\":12320341}},{\"id\":\"customfield_12317296\",\"name\":\"Planned
-        Start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317296]\",\"Planned
-        Start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317296}},{\"id\":\"customfield_12320340\",\"name\":\"Bugzilla
-        Bug_Old2\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old2\",\"cf[12320340]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320340}},{\"id\":\"customfield_12318145\",\"name\":\"Product
-        Page link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318145]\",\"Product
-        Page link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12318145}},{\"id\":\"customfield_12318144\",\"name\":\"PLM
-        Program Manager\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318144]\",\"PLM
-        Program Manager\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318144}},{\"id\":\"customfield_12317298\",\"name\":\"Solution\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317298]\",\"Solution\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317298}},{\"id\":\"fixVersions\",\"name\":\"Fix
-        Version/s\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"fixVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"fixVersions\"}},{\"id\":\"customfield_12317290\",\"name\":\"Reminder
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317290]\",\"Reminder
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317290}},{\"id\":\"customfield_12312840\",\"name\":\"Test
-        Work Items\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312840]\",\"Test
-        Work Items\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlymultiurl\",\"customId\":12312840}},{\"id\":\"customfield_12318147\",\"name\":\"Internal
-        Product/Project names\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318147]\",\"Internal
-        Product/Project names\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12318147}},{\"id\":\"customfield_12317299\",\"name\":\"Latest
-        Status Summary\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317299]\",\"Latest
-        Status Summary\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12317299}},{\"id\":\"customfield_12318146\",\"name\":\"Portal
-        Product Name\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318146]\",\"Portal
-        Product Name\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318146}},{\"id\":\"customfield_12312848\",\"name\":\"QE
-        Test Coverage\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312848]\",\"QE
-        Test Coverage\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312848}},{\"id\":\"customfield_12318148\",\"name\":\"Stale
-        Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318148]\",\"Stale
-        Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12318148}},{\"id\":\"customfield_12318150\",\"name\":\"Approver\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approver\",\"cf[12318150]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318150}},{\"id\":\"customfield_12321440\",\"name\":\"Internal
-        Target Milestone numeric\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321440]\",\"Internal
-        Target Milestone numeric\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12321440}},{\"id\":\"customfield_12319241\",\"name\":\"DevOps
-        Discussion Occurred\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319241]\",\"DevOps
-        Discussion Occurred\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319241}},{\"id\":\"customfield_12321441\",\"name\":\"EAP
-        PT Cross Product Agreement (CPA)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321441]\",\"EAP
-        PT Cross Product Agreement (CPA)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321441}},{\"id\":\"customfield_12318152\",\"name\":\"MVP
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318152]\",\"MVP
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318152}},{\"id\":\"customfield_12319242\",\"name\":\"Design
-        Review Sign-off\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319242]\",\"Design
-        Review Sign-off\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12319242}},{\"id\":\"customfield_12318156\",\"name\":\"Risk
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318156]\",\"Risk
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318156}},{\"id\":\"customfield_12318155\",\"name\":\"Risk
-        Likelihood\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318155]\",\"Risk
-        Likelihood\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12318155}},{\"id\":\"priority\",\"name\":\"Priority\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"priority\"],\"schema\":{\"type\":\"priority\",\"system\":\"priority\"}},{\"id\":\"customfield_12313940\",\"name\":\"Impacts\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313940]\",\"Impacts\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12313940}},{\"id\":\"customfield_12311640\",\"name\":\"Security
-        Sensitive Issue\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311640]\",\"Security
-        Sensitive Issue\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:securitysensitiveissue\",\"customId\":12311640}},{\"id\":\"customfield_12311641\",\"name\":\"Involved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311641]\",\"Involved\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12311641}},{\"id\":\"versions\",\"name\":\"Affects
-        Version/s\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectedVersion\"],\"schema\":{\"type\":\"array\",\"items\":\"version\",\"system\":\"versions\"}},{\"id\":\"customfield_12319247\",\"name\":\"Next
-        Planned Release Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319247]\",\"Next
-        Planned Release Date\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12319247}},{\"id\":\"customfield_12318158\",\"name\":\"Risk
-        Mitigation Strategy\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318158]\",\"Risk
-        Mitigation Strategy\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12318158}},{\"id\":\"customfield_12319246\",\"name\":\"Project
-        Name-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319246]\",\"Project
-        Name-delete\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319246}},{\"id\":\"customfield_12318157\",\"name\":\"Risk
-        Score Assessment\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318157]\",\"Risk
-        Score Assessment\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12318157}},{\"id\":\"customfield_12319249\",\"name\":\"Avoidable\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Avoidable\",\"cf[12319249]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319249}},{\"id\":\"customfield_12313942\",\"name\":\"Target
-        end\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313942]\",\"Target
-        end\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-end\",\"customId\":12313942}},{\"id\":\"customfield_12313941\",\"name\":\"Target
-        start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313941]\",\"Target
-        start\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jpo:jpo-custom-field-baseline-start\",\"customId\":12313941}},{\"id\":\"customfield_12317270\",\"name\":\"BZ
-        Devel Conditional NAK\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Devel Conditional NAK\",\"cf[12317270]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12317270}},{\"id\":\"customfield_12317392\",\"name\":\"CDW
-        Resolution\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"CDW
-        Resolution\",\"cf[12317392]\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317392}},{\"id\":\"customfield_12317271\",\"name\":\"mvp\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317271]\",\"mvp\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317271}},{\"id\":\"issuekey\",\"name\":\"Key\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[\"id\",\"issue\",\"issuekey\",\"key\"]},{\"id\":\"customfield_12317272\",\"name\":\"rpl\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317272]\",\"rpl\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317272}},{\"id\":\"customfield_12317273\",\"name\":\"Verified\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317273]\",\"Verified\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317273}},{\"id\":\"customfield_12320440\",\"name\":\"Bugzilla
-        Bug_Old3\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old3\",\"cf[12320440]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320440}},{\"id\":\"customfield_12318241\",\"name\":\"Documenter\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318241]\",\"Documenter\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318241}},{\"id\":\"customfield_12317396\",\"name\":\"ITR-ITM\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317396]\",\"ITR-ITM\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317396}},{\"id\":\"customfield_12318244\",\"name\":\"Internal
-        Target Release and Milestone_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318244]\",\"Internal
-        Target Release and Milestone_Old\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12318244}},{\"id\":\"customfield_12317275\",\"name\":\"Test
-        Link_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317275]\",\"Test
-        Link_Old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317275}},{\"id\":\"customfield_12318243\",\"name\":\"Analyst\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Analyst\",\"cf[12318243]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318243}},{\"id\":\"customfield_12317276\",\"name\":\"Test
-        Coverage_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317276]\",\"Test
-        Coverage_Old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317276}},{\"id\":\"customfield_12322741\",\"name\":\"Test
-        Single Line text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322741]\",\"Test
-        Single Line text\"],\"schema\":{\"type\":\"string\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:jbonlytext\",\"customId\":12322741}},{\"id\":\"customfield_12317277\",\"name\":\"Internal
-        Target Release and Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317277]\",\"Internal
-        Target Release and Milestone\"],\"schema\":{\"type\":\"option-with-child\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:cascadingselect\",\"customId\":12317277}},{\"id\":\"customfield_12317278\",\"name\":\"Current
-        Deadline\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317278]\",\"Current
-        Deadline\"],\"schema\":{\"type\":\"date\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datepicker\",\"customId\":12317278}},{\"id\":\"customfield_12318245\",\"name\":\"Global
-        Practices Lead\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12318245]\",\"Global
-        Practices Lead\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12318245}},{\"id\":\"customfield_12317279\",\"name\":\"Current
-        Deadline Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317279]\",\"Current
-        Deadline Type\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317279}},{\"id\":\"customfield_12312940\",\"name\":\"Eng.
-        priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312940]\",\"Eng.
-        priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312940}},{\"id\":\"customfield_12312941\",\"name\":\"QE
-        priority\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12312941]\",\"QE
-        priority\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12312941}},{\"id\":\"customfield_12317281\",\"name\":\"Embargo
-        Override\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317281]\",\"Embargo
-        Override\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12317281}},{\"id\":\"customfield_12317282\",\"name\":\"Baseline
-        Start\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Baseline
-        Start\",\"cf[12317282]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12317282}},{\"id\":\"customfield_12321540\",\"name\":\"Testing\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321540]\",\"Testing\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12321540}},{\"id\":\"customfield_12319340\",\"name\":\"UXD
-        Design[Test]\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319340]\",\"UXD
-        Design[Test]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319340}},{\"id\":\"customfield_12317040\",\"name\":\"Urgency-old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317040]\",\"Urgency-old\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317040}},{\"id\":\"customfield_12317283\",\"name\":\"Baseline
-        End\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Baseline
-        End\",\"cf[12317283]\"],\"schema\":{\"type\":\"datetime\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:datetime\",\"customId\":12317283}},{\"id\":\"customfield_12317041\",\"name\":\"EAP
-        PT Feature Implementation (FI)\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317041]\",\"EAP
-        PT Feature Implementation (FI)\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317041}},{\"id\":\"customfield_12321541\",\"name\":\"Errata
-        Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321541]\",\"Errata
-        Link\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321541}},{\"id\":\"customfield_12317042\",\"name\":\"Docs
-        Analysis\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317042]\",\"Docs
-        Analysis\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12317042}},{\"id\":\"customfield_12317284\",\"name\":\"Subproject\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317284]\",\"Subproject\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12317284}},{\"id\":\"customfield_12317285\",\"name\":\"Root
-        Cause\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317285]\",\"Root
-        Cause\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317285}},{\"id\":\"customfield_12317043\",\"name\":\"Stage
-        Links\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317043]\",\"Stage
-        Links\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12317043}},{\"id\":\"customfield_12317044\",\"name\":\"Docs
-        Pull Request\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317044]\",\"Docs
-        Pull Request\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12317044}},{\"id\":\"customfield_12317286\",\"name\":\"Project/s\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317286]\",\"Project/s\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317286}},{\"id\":\"aggregateprogress\",\"name\":\"\u03A3
-        Progress\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[],\"schema\":{\"type\":\"progress\",\"system\":\"aggregateprogress\"}},{\"id\":\"customfield_12321542\",\"name\":\"Authorized
-        Party\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Authorized
-        Party\",\"cf[12321542]\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12321542}},{\"id\":\"customfield_12311740\",\"name\":\"User
-        Story\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311740]\",\"User
-        Story\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12311740}},{\"id\":\"customfield_12317288\",\"name\":\"Reminder
-        Frequency\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12317288]\",\"Reminder
-        Frequency\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12317288}},{\"id\":\"customfield_12311741\",\"name\":\"QE
-        Acceptance Test Link\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311741]\",\"QE
-        Acceptance Test Link\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12311741}},{\"id\":\"customfield_12320140\",\"name\":\"External
-        issue ID_Old8\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12320140]\",\"External
-        issue ID_Old8\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12320140}},{\"id\":\"customfield_12322440\",\"name\":\"Persona\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322440]\",\"Persona\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.easyagile.personas:persona-field\",\"customId\":12322440}},{\"id\":\"customfield_12319272\",\"name\":\"Scoping
-        Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319272]\",\"Scoping
-        Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319272}},{\"id\":\"customfield_12322441\",\"name\":\"Importance
-        to Persona\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322441]\",\"Importance
-        to Persona\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.easyagile.personas:persona-importance-field\",\"customId\":12322441}},{\"id\":\"customfield_12319271\",\"name\":\"QE_AUTO_Coverage\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319271]\",\"QE_AUTO_Coverage\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319271}},{\"id\":\"customfield_12319274\",\"name\":\"Function\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319274]\",\"Function\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319274}},{\"id\":\"customfield_12319273\",\"name\":\"Stakeholders\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319273]\",\"Stakeholders\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319273}},{\"id\":\"customfield_12319276\",\"name\":\"BZ
-        Flags_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"BZ
-        Flags_Old\",\"cf[12319276]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12319276}},{\"id\":\"customfield_12319275\",\"name\":\"Workstream\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319275]\",\"Workstream\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319275}},{\"id\":\"customfield_12319278\",\"name\":\"Version\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319278]\",\"Version\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319278}},{\"id\":\"customfield_12319277\",\"name\":\"Product-old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319277]\",\"Product-old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319277}},{\"id\":\"customfield_12319270\",\"name\":\"Security
-        Documentation Type\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319270]\",\"Security
-        Documentation Type\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319270}},{\"id\":\"customfield_12310220\",\"name\":\"Git
-        Pull Request\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310220]\",\"Git
-        Pull Request\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12310220}},{\"id\":\"customfield_12319279\",\"name\":\"Job
-        ID\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319279]\",\"Job
-        ID\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319279}},{\"id\":\"customfield_12319040\",\"name\":\"Products\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319040]\",\"Products\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiselect\",\"customId\":12319040}},{\"id\":\"customfield_12319282\",\"name\":\"Project
-        Name-delete\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319282]\",\"Project
-        Name-delete\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319282}},{\"id\":\"thumbnail\",\"name\":\"Images\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":false,\"clauseNames\":[]},{\"id\":\"customfield_12319285\",\"name\":\"PX
-        Technical Impact Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319285]\",\"PX
-        Technical Impact Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319285}},{\"id\":\"customfield_12319287\",\"name\":\"Docs
-        Impact Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319287]\",\"Docs
-        Impact Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319287}},{\"id\":\"customfield_12319045\",\"name\":\"User
-        Domain\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319045]\",\"User
-        Domain\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319045}},{\"id\":\"customfield_12319286\",\"name\":\"Docs
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319286]\",\"Docs
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319286}},{\"id\":\"customfield_12319044\",\"name\":\"User\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319044]\",\"User\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319044}},{\"id\":\"created\",\"name\":\"Created\",\"custom\":false,\"orderable\":false,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"created\",\"createdDate\"],\"schema\":{\"type\":\"datetime\",\"system\":\"created\"}},{\"id\":\"customfield_12319289\",\"name\":\"Marketing
-        Impact Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319289]\",\"Marketing
-        Impact Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12319289}},{\"id\":\"customfield_12321240\",\"name\":\"GtmhubTaskParentType\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12321240]\",\"GtmhubTaskParentType\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12321240}},{\"id\":\"customfield_12319288\",\"name\":\"Marketing
-        Impact\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319288]\",\"Marketing
-        Impact\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319288}},{\"id\":\"customfield_12310110\",\"name\":\"Approvals\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Approvals\",\"cf[12310110]\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12310110}},{\"id\":\"customfield_12310230\",\"name\":\"Docs
-        QE Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310230]\",\"Docs
-        QE Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12310230}},{\"id\":\"customfield_12311440\",\"name\":\"External
-        Issue URL_OLD\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12311440]\",\"External
-        Issue URL_OLD\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12311440}},{\"id\":\"customfield_12313740\",\"name\":\"Migration
-        Text\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313740]\",\"Migration
-        Text\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12313740}},{\"id\":\"customfield_12319250\",\"name\":\"Communication
-        Breakdown\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319250]\",\"Communication
-        Breakdown\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319250}},{\"id\":\"customfield_12318040\",\"name\":\"affectsRHMIVersion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectsRHMIVersion\",\"cf[12318040]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318040}},{\"id\":\"customfield_12322540\",\"name\":\"RHEL
-        component\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12322540]\",\"RHEL
-        component\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12322540}},{\"id\":\"customfield_12319252\",\"name\":\"Release
-        Milestone\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319252]\",\"Release
-        Milestone\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319252}},{\"id\":\"customfield_12319251\",\"name\":\"QE
-        Properly Involved\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319251]\",\"QE
-        Properly Involved\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319251}},{\"id\":\"customfield_12318041\",\"name\":\"affectsRHOAMVersion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"affectsRHOAMVersion\",\"cf[12318041]\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textfield\",\"customId\":12318041}},{\"id\":\"customfield_12320240\",\"name\":\"Bugzilla
-        Bug_Old4\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        Bug_Old4\",\"cf[12320240]\"],\"schema\":{\"type\":\"any\",\"custom\":\"com.redhat.engineering.step.step-bugzilla-plugin:cfRhbzBug\",\"customId\":12320240}},{\"id\":\"customfield_12310440\",\"name\":\"Bugzilla
-        References\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"Bugzilla
-        References\",\"cf[12310440]\"],\"schema\":{\"type\":\"any\",\"custom\":\"org.jboss.labs.jira.plugin.jboss-custom-field-types-plugin:multiurl\",\"customId\":12310440}},{\"id\":\"security\",\"name\":\"Security
-        Level\",\"custom\":false,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"level\"],\"schema\":{\"type\":\"securitylevel\",\"system\":\"security\"}},{\"id\":\"attachment\",\"name\":\"Attachment\",\"custom\":false,\"orderable\":true,\"navigable\":false,\"searchable\":true,\"clauseNames\":[\"attachments\"],\"schema\":{\"type\":\"array\",\"items\":\"attachment\",\"system\":\"attachment\"}},{\"id\":\"customfield_12319263\",\"name\":\"Proposed
-        Initiative\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319263]\",\"Proposed
-        Initiative\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319263}},{\"id\":\"customfield_12319262\",\"name\":\"Keyword\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319262]\",\"Keyword\"],\"schema\":{\"type\":\"array\",\"items\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multicheckboxes\",\"customId\":12319262}},{\"id\":\"customfield_12319265\",\"name\":\"Contributor_Old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319265]\",\"Contributor_Old\"],\"schema\":{\"type\":\"array\",\"items\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:multiuserpicker\",\"customId\":12319265}},{\"id\":\"customfield_12319264\",\"name\":\"Immutable
-        Due Date\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319264]\",\"Immutable
-        Due Date\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319264}},{\"id\":\"customfield_12319267\",\"name\":\"Failure
-        Category\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319267]\",\"Failure
-        Category\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12319267}},{\"id\":\"customfield_12313841\",\"name\":\"Notes\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313841]\",\"Notes\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:url\",\"customId\":12313841}},{\"id\":\"customfield_12313840\",\"name\":\"UXD
-        Engagement Level\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12313840]\",\"UXD
-        Engagement Level\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12313840}},{\"id\":\"customfield_12310211\",\"name\":\"Release
-        Notes - old\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310211]\",\"Release
-        Notes - old\"],\"schema\":{\"type\":\"string\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:textarea\",\"customId\":12310211}},{\"id\":\"customfield_12319269\",\"name\":\"sprint_count\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319269]\",\"sprint_count\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.onresolve.jira.groovy.groovyrunner:scripted-field\",\"customId\":12319269}},{\"id\":\"customfield_12319268\",\"name\":\"QE
-        portion\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12319268]\",\"QE
-        portion\"],\"schema\":{\"type\":\"number\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:float\",\"customId\":12319268}},{\"id\":\"customfield_12310213\",\"name\":\"Release
-        Note Status\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310213]\",\"Release
-        Note Status\"],\"schema\":{\"type\":\"option\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:select\",\"customId\":12310213}},{\"id\":\"customfield_12310214\",\"name\":\"Writer\",\"custom\":true,\"orderable\":true,\"navigable\":true,\"searchable\":true,\"clauseNames\":[\"cf[12310214]\",\"Writer\"],\"schema\":{\"type\":\"user\",\"custom\":\"com.atlassian.jira.plugin.system.customfieldtypes:userpicker\",\"customId\":12310214}}]"
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 12 Apr 2023 12:13:52 GMT
-      Expires:
-      - Wed, 12 Apr 2023 12:13:52 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '162204'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 733x252272x1
-      x-asessionid:
-      - x2sv0l
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.644e4e68.1681301632.60cf4b69
-      x-rh-edge-request-id:
-      - 60cf4b69
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
 - request:
     body: null
     headers:
@@ -1321,9 +391,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1338,9 +408,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252273x1
+      - 1258x44581x1
       x-asessionid:
-      - 1felztn
+      - uhhan0
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1348,9 +418,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301632.60cf4dc9
+      - 0.357f0660.1681851520.5305de72
       x-rh-edge-request-id:
-      - 60cf4dc9
+      - 5305de72
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1500,9 +570,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1517,9 +587,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252274x1
+      - 1258x44582x1
       x-asessionid:
-      - 7m02at
+      - yiokzg
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1527,9 +597,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301632.60cf4eb3
+      - 0.357f0660.1681851520.5305dfad
       x-rh-edge-request-id:
-      - 60cf4eb3
+      - 5305dfad
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1591,6 +661,7 @@ interactions:
         "Administrators": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10002",
         "Approver": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10840",
         "Viewers": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10440",
+        "Red Hat Partner": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/11140",
         "Users": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10000"},
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
         "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
@@ -1607,16 +678,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:52 GMT
+      - Tue, 18 Apr 2023 20:58:40 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '3812'
+      - '3903'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1624,9 +695,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252275x1
+      - 1258x44583x1
       x-asessionid:
-      - h8z2rl
+      - 1i6ulzl
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1634,9 +705,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301632.60cf4f92
+      - 0.357f0660.1681851520.5305e080
       x-rh-edge-request-id:
-      - 60cf4f92
+      - 5305e080
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1646,7 +717,7 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12336420"}, "summary":
-      "CVE-2020-0000 kernel: some description", "description": "Description for CVE-2020-0000",
+      "CVE-2020-0002 kernel: some description", "description": "Description for CVE-2020-0002",
       "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"]}}'
     headers:
       Accept:
@@ -1669,7 +740,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: '{"id": "14943021", "key": "OSIM-233", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943021"}'
+      string: '{"id": "14943816", "key": "OSIM-251", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943816"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1680,9 +751,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1697,9 +768,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252276x1
+      - 1258x44584x1
       x-asessionid:
-      - z07oi1
+      - nresrp
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1707,9 +778,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301633.60cf5036
+      - 0.357f0660.1681851521.5305e134
       x-rh-edge-request-id:
-      - 60cf5036
+      - 5305e134
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1735,12 +806,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-233
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-251
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943021", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943021",
-        "key": "OSIM-233", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943816", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943816",
+        "key": "OSIM-251", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -1754,19 +825,19 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@e494d84[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@71f0c7fb[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1fd0b9e5[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@59e9b7f3[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3bb5f30[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@74038fa3[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@285ec0bd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3feaf99b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66716389[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@e679673[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5062f42a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@382ce99c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@552cb83b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@674a78e3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@14daf664[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@188d23[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@524b40f0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@27af7a53[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6405d114[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@20303922[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2874b114[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@74d52bab[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3e12c954[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1f4a0e9d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:52.837+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:40.498+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
         "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"],
@@ -1775,13 +846,13 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:52.837+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T20:58:40.498+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0002",
         "customfield_12314040": null, "customfield_12320844": null, "timetracking":
         {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
         null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
@@ -1790,7 +861,7 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0002 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -1810,10 +881,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0yc4:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za1064:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1824,16 +895,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8632'
+      - '8633'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1841,9 +912,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252277x1
+      - 1258x44585x1
       x-asessionid:
-      - 1iojn82
+      - 1a187p6
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1851,9 +922,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301633.60cf58c3
+      - 0.357f0660.1681851521.5305e6b8
       x-rh-edge-request-id:
-      - 60cf58c3
+      - 5305e6b8
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1893,9 +964,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1910,9 +981,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252278x1
+      - 1258x44586x1
       x-asessionid:
-      - 45tcno
+      - 1oqcxva
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1920,9 +991,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301633.60cf5adf
+      - 0.357f0660.1681851521.5305e7d5
       x-rh-edge-request-id:
-      - 60cf5adf
+      - 5305e7d5
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2072,9 +1143,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Pragma:
       - no-cache
       Vary:
@@ -2089,9 +1160,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252279x1
+      - 1258x44588x1
       x-asessionid:
-      - 1fgpdlz
+      - 1d4ht6h
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2099,9 +1170,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301633.60cf5bd8
+      - 0.357f0660.1681851521.5305ea39
       x-rh-edge-request-id:
-      - 60cf5bd8
+      - 5305ea39
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2163,6 +1234,7 @@ interactions:
         "Administrators": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10002",
         "Approver": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10840",
         "Viewers": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10440",
+        "Red Hat Partner": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/11140",
         "Users": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10000"},
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
         "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
@@ -2179,16 +1251,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:53 GMT
+      - Tue, 18 Apr 2023 20:58:41 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '3812'
+      - '3903'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2196,9 +1268,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252280x1
+      - 1258x44589x1
       x-asessionid:
-      - 1x84y65
+      - 1329rf7
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2206,9 +1278,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301633.60cf5cc3
+      - 0.357f0660.1681851521.5305eb05
       x-rh-edge-request-id:
-      - 60cf5cc3
+      - 5305eb05
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2218,7 +1290,7 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12336420"}, "summary":
-      "CVE-2020-0001 kernel: some description", "description": "Description for CVE-2020-0001",
+      "CVE-2020-0003 kernel: some description", "description": "Description for CVE-2020-0003",
       "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"]}}'
     headers:
       Accept:
@@ -2241,7 +1313,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: '{"id": "14943022", "key": "OSIM-234", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943022"}'
+      string: '{"id": "14943817", "key": "OSIM-252", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943817"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2252,9 +1324,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:54 GMT
+      - Tue, 18 Apr 2023 20:58:42 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:54 GMT
+      - Tue, 18 Apr 2023 20:58:42 GMT
       Pragma:
       - no-cache
       Vary:
@@ -2269,9 +1341,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252281x1
+      - 1258x44590x1
       x-asessionid:
-      - s39j58
+      - 1wtx226
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2279,9 +1351,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301634.60cf5d65
+      - 0.357f0660.1681851522.5305ebac
       x-rh-edge-request-id:
-      - 60cf5d65
+      - 5305ebac
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2307,12 +1379,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-234
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-252
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943022", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943022",
-        "key": "OSIM-234", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943817", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943817",
+        "key": "OSIM-252", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -2326,19 +1398,19 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@c4274a9[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61762dfa[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@700b2315[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@30365584[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@36c3fa33[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@668a08ec[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@901bc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@70663280[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@59dd5cdd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6fa6f262[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@27ea0acb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@66d9de84[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@55515d36[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@dbc901c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66a81153[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6430e277[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d8f7519[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@46478d7f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@60c32e6d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3834b58[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6542c18c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1f14942e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@665d61e7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7f1d2fff[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:54.065+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:41.853+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
         "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"],
@@ -2347,13 +1419,13 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:54.065+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T20:58:41.853+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0003",
         "customfield_12314040": null, "customfield_12320844": null, "timetracking":
         {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
         null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
@@ -2362,7 +1434,7 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0003 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -2382,10 +1454,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0ycc:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za106c:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2396,16 +1468,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:54 GMT
+      - Tue, 18 Apr 2023 20:58:42 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:54 GMT
+      - Tue, 18 Apr 2023 20:58:42 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8630'
+      - '8634'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2413,9 +1485,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252283x1
+      - 1258x44591x1
       x-asessionid:
-      - t4nb1y
+      - k2hgwc
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2423,9 +1495,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301634.60cf646d
+      - 0.357f0660.1681851522.5305f153
       x-rh-edge-request-id:
-      - 60cf646d
+      - 5305f153
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2451,12 +1523,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-233
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-251
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943021", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943021",
-        "key": "OSIM-233", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943816", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943816",
+        "key": "OSIM-251", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -2470,19 +1542,19 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7d152614[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13810ba4[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@517fccd1[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e610c67[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70c8ac3d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6b8f55ab[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@43dddf21[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2fd1fca9[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1a4d042a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@bfe38c5[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2677ca4c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6635e9f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@74fd762d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@e3f5067[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@32d47d6d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@24c04d64[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@40953947[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4c61ca12[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5dcfe9e6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7b423456[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12f47578[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@50871c6e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@72a54f41[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@18af35c7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:52.837+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:40.498+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
         "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"],
@@ -2491,13 +1563,13 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:52.837+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T20:58:40.498+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0002",
         "customfield_12314040": null, "customfield_12320844": null, "timetracking":
         {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
         null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
@@ -2506,7 +1578,7 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0002 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -2526,10 +1598,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0yc4:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za1064:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2540,363 +1612,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:55 GMT
+      - Tue, 18 Apr 2023 20:58:42 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:55 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '8632'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 733x252284x1
-      x-asessionid:
-      - 1nanfrl
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.644e4e68.1681301635.60cf66a2
-      x-rh-edge-request-id:
-      - 60cf66a2
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"customfield_12311140": "OSIM-232"}, "update": {}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '62'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943021
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 12 Apr 2023 12:13:55 GMT
-      Expires:
-      - Wed, 12 Apr 2023 12:13:55 GMT
-      Pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 733x252285x1
-      x-asessionid:
-      - cqs9eu
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.644e4e68.1681301635.60cf68e9
-      x-rh-edge-request-id:
-      - 60cf68e9
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943021
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943021", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943021",
-        "key": "OSIM-233", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6bbe33ff[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2b4021c4[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@591705d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2ff52f2a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@65818fec[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2e2c9c29[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@20311229[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@26bbe57a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f2cf0ae[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5abe0b6[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2da31a70[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@54caaa8b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:52.837+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:55.412+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
-        "customfield_12314040": null, "customfield_12320844": null, "timetracking":
-        {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        "OSIM-232", "customfield_12319742": null, "progress": {"progress": 0, "total":
-        0}, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/votes",
-        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
-        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0yc4:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 12 Apr 2023 12:13:56 GMT
-      Expires:
-      - Wed, 12 Apr 2023 12:13:56 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '8639'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 733x252286x1
-      x-asessionid:
-      - gtwv19
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.644e4e68.1681301636.60cf70dd
-      x-rh-edge-request-id:
-      - 60cf70dd
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-234
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943022", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943022",
-        "key": "OSIM-234", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2be53b06[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@454384b6[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13c72881[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4af8687b[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3db056ba[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6cfcd8ab[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@46d57695[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4f676584[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@705dff54[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7aee5874[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@17e2e862[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@635de45f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:54.065+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:54.065+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
-        "customfield_12314040": null, "customfield_12320844": null, "timetracking":
-        {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/votes",
-        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
-        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0ycc:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 12 Apr 2023 12:13:56 GMT
-      Expires:
-      - Wed, 12 Apr 2023 12:13:56 GMT
+      - Tue, 18 Apr 2023 20:58:42 GMT
       Pragma:
       - no-cache
       Vary:
@@ -2911,9 +1629,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252287x1
+      - 1258x44592x1
       x-asessionid:
-      - 1mwd02r
+      - 1qqylgk
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2921,9 +1639,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301636.60cf728c
+      - 0.357f0660.1681851522.5305f26c
       x-rh-edge-request-id:
-      - 60cf728c
+      - 5305f26c
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2932,7 +1650,7 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fields": {"customfield_12311140": "OSIM-232"}, "update": {}}'
+    body: '{"fields": {"customfield_12311140": "OSIM-250"}, "update": {}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -2951,7 +1669,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943022
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943816
   response:
     body:
       string: ''
@@ -2965,9 +1683,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:56 GMT
+      - Tue, 18 Apr 2023 20:58:43 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:56 GMT
+      - Tue, 18 Apr 2023 20:58:43 GMT
       Pragma:
       - no-cache
       referrer-policy:
@@ -2977,9 +1695,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252288x1
+      - 1258x44593x1
       x-asessionid:
-      - 1aeu69s
+      - 18dx5ic
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2987,9 +1705,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301636.60cf7437
+      - 0.357f0660.1681851523.5305f435
       x-rh-edge-request-id:
-      - 60cf7437
+      - 5305f435
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3015,12 +1733,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943022
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943816
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943022", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943022",
-        "key": "OSIM-234", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943816", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943816",
+        "key": "OSIM-251", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -3034,34 +1752,34 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@49dc4ac0[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4310565f[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5bbce8ac[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@42c5e544[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7644ef70[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3727fd49[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4d7a6182[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@39c93b6f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@68276c49[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@60e209b1[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7e8a125e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@ee85ca3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d7e2c13[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2d21098c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4a28c67b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@272af5bf[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@326f3ea0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@295530d6[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@25c23099[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5535ae93[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e6410ab[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1e374031[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2ac5ed96[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@52fc9f6b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:54.065+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:40.498+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"],
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"],
         "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:56.451+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T20:58:43.101+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0002",
         "customfield_12314040": null, "customfield_12320844": null, "timetracking":
         {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
         null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
@@ -3070,7 +1788,7 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0002 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -3088,12 +1806,12 @@ interactions:
         {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
         "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        "OSIM-232", "customfield_12319742": null, "progress": {"progress": 0, "total":
+        "OSIM-250", "customfield_12319742": null, "progress": {"progress": 0, "total":
         0}, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/votes",
+        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za0ycc:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za1064:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -3104,16 +1822,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:57 GMT
+      - Tue, 18 Apr 2023 20:58:43 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:57 GMT
+      - Tue, 18 Apr 2023 20:58:43 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8640'
+      - '8641'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -3121,9 +1839,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252289x1
+      - 1258x44594x1
       x-asessionid:
-      - 1n8bgdb
+      - cmz253
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3131,9 +1849,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301637.60cf7c40
+      - 0.357f0660.1681851523.5305fa96
       x-rh-edge-request-id:
-      - 60cf7c40
+      - 5305fa96
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3159,13 +1877,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+cf%5B12311140%5D%3D%22OSIM-232%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-252
   response:
     body:
-      string: '{"expand": "schema,names", "startAt": 0, "maxResults": 50, "total":
-        2, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943022", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943022",
-        "key": "OSIM-234", "fields": {"customfield_12322440": null, "issuetype": {"self":
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "14943817", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943817",
+        "key": "OSIM-252", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -3179,19 +1896,19 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3cbdc7bd[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@522f4d67[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6b01acd[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a9e093d[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@79c498da[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@5128b6f0[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21251a63[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3b387b1f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66e726ea[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@726c83f0[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7b1379dc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@38b0522[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5c04b3cf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@4a61d8bc[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2116d066[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@bebe298[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@14ca83c2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5ac1e94[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12ae6ba7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4605a448[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@691fbd9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@63ac0d21[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2beb1a0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6972725b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:54.000+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:41.853+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
         "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"],
@@ -3200,21 +1917,22 @@ interactions:
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:56.000+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T20:58:41.853+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
-        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0003",
+        "customfield_12314040": null, "customfield_12320844": null, "timetracking":
+        {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
+        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0003 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -3232,82 +1950,12 @@ interactions:
         {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
         "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        "OSIM-232", "customfield_12319742": null, "progress": {"progress": 0, "total":
-        0}, "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-234/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za0ycc:"}}, {"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943021", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943021",
-        "key": "OSIM-233", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7589fe28[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@214e1c1f[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66d9e93a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3726af1a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13a94725[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1616b333[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f2f18f2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3d732e72[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64bac696[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@47967e19[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b91691[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@249db84a[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-12T12:13:52.000+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-12T12:13:55.000+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
-        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        "OSIM-232", "customfield_12319742": null, "progress": {"progress": 0, "total":
-        0}, "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-233/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za0yc4:"}}]}'
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/votes",
+        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
+        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
+        null, "archivedby": null, "customfield_12311940": "1|za106c:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -3318,16 +1966,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 12 Apr 2023 12:13:57 GMT
+      - Tue, 18 Apr 2023 20:58:43 GMT
       Expires:
-      - Wed, 12 Apr 2023 12:13:57 GMT
+      - Tue, 18 Apr 2023 20:58:43 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '16931'
+      - '8630'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -3335,9 +1983,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 733x252290x1
+      - 1258x44595x1
       x-asessionid:
-      - b21la6
+      - 9eumwh
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3345,9 +1993,433 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.644e4e68.1681301637.60cf7e98
+      - 0.357f0660.1681851523.5305fc93
       x-rh-edge-request-id:
-      - 60cf7e98
+      - 5305fc93
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"customfield_12311140": "OSIM-250"}, "update": {}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '62'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943817
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 20:58:44 GMT
+      Expires:
+      - Tue, 18 Apr 2023 20:58:44 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1258x44596x1
+      x-asessionid:
+      - d59ykh
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.357f0660.1681851524.5305fe6b
+      x-rh-edge-request-id:
+      - 5305fe6b
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/14943817
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "14943817", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943817",
+        "key": "OSIM-252", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
+        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
+        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
+        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
+        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
+        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
+        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
+        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@8333a89[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4669202[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@151525ef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@25d343cd[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4aeab0d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1d502c70[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21565868[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1ea4aaa4[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6fa38cbe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@738c1e96[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@600a9d97[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5b40eab8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
+        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
+        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
+        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:41.853+0000", "customfield_12321240":
+        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
+        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"],
+        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        null, "updated": "2023-04-18T20:58:44.317+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0003",
+        "customfield_12314040": null, "customfield_12320844": null, "timetracking":
+        {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
+        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "CVE-2020-0003 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
+        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
+        "OSIM-250", "customfield_12319742": null, "progress": {"progress": 0, "total":
+        0}, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0},
+        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/votes",
+        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
+        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
+        null, "archivedby": null, "customfield_12311940": "1|za106c:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 20:58:44 GMT
+      Expires:
+      - Tue, 18 Apr 2023 20:58:44 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '8638'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1258x44598x1
+      x-asessionid:
+      - 18zfmt0
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.357f0660.1681851524.53060519
+      x-rh-edge-request-id:
+      - '53060519'
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+cf%5B12311140%5D%3D%22OSIM-250%22&maxResults=50&startAt=0&validateQuery=True
+  response:
+    body:
+      string: '{"expand": "schema,names", "startAt": 0, "maxResults": 50, "total":
+        2, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+        "id": "14943817", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943817",
+        "key": "OSIM-252", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
+        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
+        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
+        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
+        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
+        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
+        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
+        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@36e4d88f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2e2f9a5d[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7877c6c9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2ad856e8[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49708a26[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1b3a30cd[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d3deced[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@353a8eb4[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@78d6038f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3220e800[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48302d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@616651be[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
+        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
+        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
+        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:41.000+0000", "customfield_12321240":
+        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
+        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:faaeaab0-e470-4a45-94ab-28dc06044161"],
+        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        null, "updated": "2023-04-18T20:58:44.000+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0003",
+        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "CVE-2020-0003 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
+        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
+        "OSIM-250", "customfield_12319742": null, "progress": {"progress": 0, "total":
+        0}, "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-252/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
+        null, "customfield_12311940": "1|za106c:"}}, {"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+        "id": "14943816", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943816",
+        "key": "OSIM-251", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
+        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
+        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
+        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
+        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
+        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
+        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
+        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4355b022[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6d7821e8[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49ce0803[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@659517b3[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49b830a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@28a476[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@399f3a60[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@747a9a6f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c21d439[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@696fcedf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@29e3b5a8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@96aeb19[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
+        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
+        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
+        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T20:58:40.000+0000", "customfield_12321240":
+        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
+        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:08b02ba4-d80e-4b3c-9a08-b86229f5f83c"],
+        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        null, "updated": "2023-04-18T20:58:43.000+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0002",
+        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "CVE-2020-0002 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
+        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
+        "OSIM-250", "customfield_12319742": null, "progress": {"progress": 0, "total":
+        0}, "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-251/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
+        null, "customfield_12311940": "1|za1064:"}}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 20:58:45 GMT
+      Expires:
+      - Tue, 18 Apr 2023 20:58:45 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16928'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1258x44599x1
+      x-asessionid:
+      - 195kvtf
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.357f0660.1681851525.53060669
+      x-rh-edge-request-id:
+      - '53060669'
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/apps/taskman/tests/cassettes/test_service/TestTaskmanService.test_task_ownership.yaml
+++ b/apps/taskman/tests/cassettes/test_service/TestTaskmanService.test_task_ownership.yaml
@@ -893,9 +893,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:17 GMT
+      - Tue, 18 Apr 2023 22:11:36 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:17 GMT
+      - Tue, 18 Apr 2023 22:11:36 GMT
       Pragma:
       - no-cache
       Vary:
@@ -910,9 +910,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44543x1
+      - 1331x45422x1
       x-asessionid:
-      - 1h6xm8a
+      - 6491kg
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -920,9 +920,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851497.5305286b
+      - 0.e4912f17.1681855896.2584106e
       x-rh-edge-request-id:
-      - 5305286b
+      - 2584106e
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -948,7 +948,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3Aef810d00-8415-453a-89f6-96a1c72fd2f7%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
   response:
     body:
       string: '{"startAt": 0, "maxResults": 50, "total": 0, "issues": []}'
@@ -962,9 +962,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:11:36 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:11:36 GMT
       Pragma:
       - no-cache
       Vary:
@@ -979,9 +979,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44544x1
+      - 1331x45423x1
       x-asessionid:
-      - 11ddnnb
+      - 1b75p3h
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -989,9 +989,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851498.53052957
+      - 0.e4912f17.1681855896.2584113e
       x-rh-edge-request-id:
-      - '53052957'
+      - 2584113e
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1141,9 +1141,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1158,9 +1158,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44545x1
+      - 1331x45424x1
       x-asessionid:
-      - nmyxpx
+      - 13pd3bi
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1168,9 +1168,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851498.53052a51
+      - 0.e4912f17.1681855897.2584124a
       x-rh-edge-request-id:
-      - 53052a51
+      - 2584124a
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1249,9 +1249,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:18 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1266,9 +1266,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44546x1
+      - 1331x45425x1
       x-asessionid:
-      - b7q6rj
+      - 1vmnfic
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1276,9 +1276,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851498.53052df3
+      - 0.e4912f17.1681855897.25841307
       x-rh-edge-request-id:
-      - 53052df3
+      - '25841307'
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1289,7 +1289,7 @@ interactions:
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12336420"}, "summary":
       "CVE-2020-0000 kernel: some description", "description": "Description for CVE-2020-0000",
-      "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"]}}'
+      "labels": ["flawuuid:ef810d00-8415-453a-89f6-96a1c72fd2f7"]}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1311,7 +1311,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: '{"id": "14943813", "key": "OSIM-248", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813"}'
+      string: '{"id": "14943823", "key": "OSIM-260", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943823"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1322,9 +1322,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Pragma:
       - no-cache
       Vary:
@@ -1339,9 +1339,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44547x1
+      - 1331x45426x1
       x-asessionid:
-      - 1rwj4wq
+      - 1qrds42
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1349,9 +1349,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851499.53052fce
+      - 0.e4912f17.1681855897.258413de
       x-rh-edge-request-id:
-      - 53052fce
+      - 258413de
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1377,12 +1377,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-260
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943823", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943823",
+        "key": "OSIM-260", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -1396,28 +1396,28 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5c48499c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f6172ca[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5acd88f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7d8c031c[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@514f8a6c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@658c55ad[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6a2619a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@ce092e4[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21d165fe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@26f77d54[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7cc6a31e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@74b979d0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5eed0c2c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@436dc778[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48528174[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@55dbef81[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28444e4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@63dda0d8[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3fd8d4f6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3575936b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@15765245[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1b23fb53[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@62a5e3a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7bd2da51[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.002+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-260/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:11:37.205+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:ef810d00-8415-453a-89f6-96a1c72fd2f7"],
         "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:19.002+0000", "customfield_12313942": null,
+        null, "updated": "2023-04-18T22:11:37.205+0000", "customfield_12313942": null,
         "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
@@ -1452,10 +1452,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-260/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za105g:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za1084:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1466,16 +1466,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:19 GMT
+      - Tue, 18 Apr 2023 22:11:37 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8634'
+      - '8633'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1483,9 +1483,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44548x1
+      - 1331x45427x1
       x-asessionid:
-      - 1q1kgxj
+      - qfbf83
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1493,9 +1493,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851499.530537ff
+      - 0.e4912f17.1681855897.25841941
       x-rh-edge-request-id:
-      - 530537ff
+      - '25841941'
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1521,83 +1521,10 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A60e979cf-7d85-4687-b04f-9252d31e4778%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
   response:
     body:
-      string: '{"expand": "names,schema", "startAt": 0, "maxResults": 50, "total":
-        1, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6d03f9d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4ad52b2[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6be75e7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@68e89f40[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4a5b0b74[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@67979546[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12f3d51e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3e4d4a9f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2cdfe689[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@77b96bf1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7bee0b3d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2fa3bf6d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.000+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:19.000+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
-        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za105g:"}}]}'
+      string: '{"startAt": 0, "maxResults": 50, "total": 0, "issues": []}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1608,16 +1535,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:20 GMT
+      - Tue, 18 Apr 2023 22:11:38 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:20 GMT
+      - Tue, 18 Apr 2023 22:11:38 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8495'
+      - '51'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1625,9 +1552,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44549x1
+      - 1331x45428x1
       x-asessionid:
-      - dtp8t9
+      - r8w2c4
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1635,9 +1562,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851500.53053aa0
+      - 0.e4912f17.1681855898.25841a69
       x-rh-edge-request-id:
-      - 53053aa0
+      - 25841a69
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1663,83 +1590,120 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issuetype
   response:
     body:
-      string: '{"expand": "names,schema", "startAt": 0, "maxResults": 50, "total":
-        1, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@64a87aef[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e624046[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7b34c386[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3718ccd6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@ab5bf5d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@33cfe8f8[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6eba25f4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1fb53a89[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38dd3175[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@749986be[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4b33985c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7d6482c1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.000+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:19.000+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
-        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za105g:"}}]}'
+      string: '[{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/3","id":"3","description":"A
+        task that needs to be done.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/5","id":"5","description":"The
+        sub-task of the issue","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/17","id":"17","description":"Created
+        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/1","id":"1","description":"A
+        problem which impairs or prevents the functions of the product.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/16","id":"16","description":"Created
+        by Jira Software - do not edit or delete. Issue type for a big user story
+        that needs to be broken down.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11406","id":"11406","description":"Project
+        Risk","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/2","id":"2","description":"Feature
+        requests from customers and/or users","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
+        Request","subtask":false,"avatarId":13271},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/13","id":"13","description":"An
+        enhancement or refactoring of existing functionality","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/18","id":"18","description":"A
+        technical task.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
+        task","subtask":true,"avatarId":17260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11403","id":"11403","description":"As
+        RCA type of Issue with specific custom fields","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
+        Loop","subtask":false,"avatarId":13269},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/8","id":"8","description":"A
+        one-off patch related to a customer support case","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
+        Patch","subtask":false,"avatarId":13270},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/4","id":"4","description":"An
+        improvement or enhancement to an existing feature or task. Includes patches
+        submitted by community commiters.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
+        a possible testsuite challenge","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
+        Challenge","subtask":false,"avatarId":17262},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/9","id":"9","description":"A
+        container task to coordinate the tasks for a given release.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10","id":"10","description":"A
+        potential bug.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
+        Risk","subtask":false,"avatarId":13268},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11","id":"11","description":"A
+        subtask tracking an update to a bundled component","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
+        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12","id":"12","description":"A
+        task tracking an update to a bundled component","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
+        Upgrade","subtask":false,"avatarId":13270},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10100","id":"10100","description":"Portfolio
+        Level Initiative","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11418","id":"11418","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Imperative","subtask":false,"avatarId":13280},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11500","id":"11500","description":"Large
+        focus areas that can span the organization","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Theme","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10800","id":"10800","description":"Research
+        activity","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10703","id":"10703","description":"Strategic
+        direction aligned with operating strategy.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Market
+        Problem","subtask":false,"avatarId":13280},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
+        or a well-defined set of functionality that delivers business value. Features
+        can include additions or changes to existing functionality. Features can easily
+        span multiple teams, and potentially multiple releases.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
+        of a library dependency","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
+        Upgrade","subtask":false,"avatarId":17260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/15","id":"15","description":"A
+        clarification needed to a specification based on community feedback","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/19","id":"19","description":"Issue
+        tracking a bug fix or improvement in another component","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/20","id":"20","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/21","id":"21","description":"Same
+        as Requirement type but for subtasks","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
+        ","subtask":true,"avatarId":13276},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/24","id":"24","description":"Support
+        Request","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
+        Request","subtask":false,"avatarId":13264},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
+        Change","subtask":false,"avatarId":13266},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
+        Requirement","subtask":false,"avatarId":13278},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
+        Requirement","subtask":false,"avatarId":13274},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
+        task","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
+        Task","subtask":false,"avatarId":17260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
+        Task","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
+        Task","subtask":false,"avatarId":13278},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
+        Task","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
+        Task","subtask":false,"avatarId":13266},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
+        and Key Results","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
+        are the way we interact with our work and with each other.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
+        issue requiring coordinated response","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10900","id":"10900","description":"This
+        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
+        Request","subtask":false,"avatarId":13275},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10901","id":"10901","description":"This
+        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
+        Task issuetype for OCSPLAT","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11000","id":"11000","description":"A
+        request for change","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
+        Request","subtask":false,"avatarId":17261},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
+        Exception","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
+        Task","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11201","id":"11201","description":"The
+        sub-task of the issue used to track related QE work","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
+        Sub-task","subtask":true,"avatarId":13273},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11202","id":"11202","description":"The
+        sub-task of the issue used to track related development work","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
+        Sub-task","subtask":true,"avatarId":17260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11203","id":"11203","description":"The
+        sub-task of the issue used to track related documentation work","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
+        Sub-task","subtask":true,"avatarId":13266},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
+        Sub-task","subtask":true,"avatarId":13271},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
+        Action","subtask":false,"avatarId":13270},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11400","id":"11400","description":"This
+        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
+        Initiative","subtask":false,"avatarId":17261},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11402","id":"11402","description":"General
+        issue to be triaged","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
+        PA tracking issue for Milestones","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
+        Task","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11409","id":"11409","description":"For
+        Documentation Issues","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
+        type for Feature as Story","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
+        Feature","subtask":false,"avatarId":13275},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11411","id":"11411","description":"Grouping
+        release operations","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
+        Milestone","subtask":false,"avatarId":13273},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
+        major releases","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
+        tracker","subtask":false,"avatarId":13275},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
+        Service issue or request (non-code change)","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
+        level than an epic","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
+        Cause Analysis","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
+        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
+        Task","subtask":false,"avatarId":13278},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
+        Request","subtask":false,"avatarId":17261},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11600","id":"11600","description":"A
+        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
+        Bug","subtask":true,"avatarId":13263},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
+        Improvement","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
+        Security Supply Chain Security Exception","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
+        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
+        Offering Exception","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Offering
+        Exception","subtask":false,"avatarId":40577},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12000","id":"12000","description":"","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=41420&avatarType=issuetype","name":"BU
+        Priority","subtask":false,"avatarId":41420},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12100","id":"12100","description":"Represents
+        a Test","iconUrl":"https://issues.stage.redhat.com/download/resources/com.xpandit.plugins.xray/images/test.png","name":"Test","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12101","id":"12101","description":"Represents
+        a Test Set","iconUrl":"https://issues.stage.redhat.com/download/resources/com.xpandit.plugins.xray/images/test-set.png","name":"Test
+        Set","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12102","id":"12102","description":"Represents
+        a Test Execution","iconUrl":"https://issues.stage.redhat.com/download/resources/com.xpandit.plugins.xray/images/test-execution.png","name":"Test
+        Execution","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12103","id":"12103","description":"Represents
+        a Pre-Condition","iconUrl":"https://issues.stage.redhat.com/download/resources/com.xpandit.plugins.xray/images/pre-condition.png","name":"Pre-Condition","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12104","id":"12104","description":"Represents
+        a Test Plan","iconUrl":"https://issues.stage.redhat.com/download/resources/com.xpandit.plugins.xray/images/test-plan.png","name":"Test
+        Plan","subtask":false},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/12105","id":"12105","description":"Represents
+        a Sub Test Execution","iconUrl":"https://issues.stage.redhat.com/download/resources/com.xpandit.plugins.xray/images/sub-test-execution.png","name":"Sub
+        Test Execution","subtask":true},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/23","id":"23","description":"A
+        new feature of the product, which has yet to be developed.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
+        Feature","subtask":false,"avatarId":13271},{"self":"https://issues.stage.redhat.com/rest/api/2/issuetype/10200","id":"10200","description":"An
+        improvement or enhancement to an existing feature or task.","iconUrl":"https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1750,16 +1714,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:20 GMT
+      - Tue, 18 Apr 2023 22:11:38 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:20 GMT
+      - Tue, 18 Apr 2023 22:11:38 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8497'
+      - '25109'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1767,9 +1731,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44550x1
+      - 1331x45429x1
       x-asessionid:
-      - 1vefw7c
+      - 7fv3ld
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1777,9 +1741,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851500.53053df6
+      - 0.e4912f17.1681855898.25841b2d
       x-rh-edge-request-id:
-      - 53053df6
+      - 25841b2d
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1788,8 +1752,117 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: '{"fields": {"summary": "CVE-2020-0000 kernel: some description modified",
-      "description": "Description for CVE-2020-0000"}}'
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/project/OSIM
+  response:
+    body:
+      string: '{"expand": "description,lead,url,projectKeys", "self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
+        "id": "12336420", "key": "OSIM", "description": "This project will serve Incident
+        Response team as a task repository, managing the workflow in PSIR.", "lead":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta@redhat.com",
+        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
+        "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
+        [{"self": "https://issues.stage.redhat.com/rest/api/2/issuetype/3", "id":
+        "3", "description": "A task that needs to be done.", "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
+        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://issues.stage.redhat.com/rest/api/2/issuetype/5",
+        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
+        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://issues.stage.redhat.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://issues.stage.redhat.com/rest/api/2/issuetype/1",
+        "id": "1", "description": "A problem which impairs or prevents the functions
+        of the product.", "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://issues.stage.redhat.com/rest/api/2/issuetype/16",
+        "id": "16", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a big user story that needs to be broken down.", "iconUrl":
+        "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
+        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://issues.stage.redhat.com/rest/api/2/issuetype/11406",
+        "id": "11406", "description": "Project Risk", "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
+        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
+        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
+        "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10540",
+        "Developers": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10001",
+        "Administrators": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10002",
+        "Approver": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10840",
+        "Viewers": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10440",
+        "Red Hat Partner": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/11140",
+        "Users": "https://issues.stage.redhat.com/rest/api/2/project/12336420/role/10000"},
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
+        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
+        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
+        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"},
+        "projectTypeKey": "software", "archived": false}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:11:38 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:11:38 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '3903'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1331x45430x1
+      x-asessionid:
+      - 1ypv363
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.e4912f17.1681855898.25841ca5
+      x-rh-edge-request-id:
+      - 25841ca5
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12336420"}, "summary":
+      "CVE-2020-0001 kernel: some description", "description": "Description for CVE-2020-0001",
+      "labels": ["flawuuid:60e979cf-7d85-4687-b04f-9252d31e4778"]}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1800,305 +1873,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '122'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Pragma:
-      - no-cache
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44551x1
-      x-asessionid:
-      - 1hgxqa5
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851501.53054096
-      x-rh-edge-request-id:
-      - '53054096'
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+labels%3D%22flawuuid%3A0a9d00d7-b846-4840-abe5-becda57f0a14%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
-  response:
-    body:
-      string: '{"expand": "names,schema", "startAt": 0, "maxResults": 50, "total":
-        1, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
-        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
-        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
-        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
-        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
-        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
-        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
-        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
-        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2f7ab70c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@42fd4a4a[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38afd5a8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@102867ed[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2bc8727d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@57e2e1f5[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@11a66c34[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@42e266e2[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a51bf59[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6a7c1eaf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48190818[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@191da28f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
-        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.000+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
-        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
-        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
-        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:20.000+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
-        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description modified", "creator": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
-        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
-        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
-        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
-        null, "customfield_12311940": "1|za105g:"}}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '8507'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44552x1
-      x-asessionid:
-      - siv3rv
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851501.5305455a
-      x-rh-edge-request-id:
-      - 5305455a
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.26.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248/transitions
-  response:
-    body:
-      string: '{"expand": "transitions", "transitions": [{"id": "31", "name": "In
-        Progress", "opsbarSequence": 2147483647, "to": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10018",
-        "description": "Work has started", "iconUrl": "https://issues.stage.redhat.com/images/icons/status_generic.gif",
-        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
-        {"id": "41", "name": "Closed", "opsbarSequence": 2147483647, "to": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/status/6", "description": "The
-        issue is closed. See the resolution for context regarding why (for example
-        Done, Abandoned, Duplicate, etc)", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/closed.png",
-        "name": "Closed", "id": "6", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/3",
-        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}, {"id":
-        "51", "name": "New", "opsbarSequence": 2147483647, "to": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "61", "name": "Refinement", "opsbarSequence": 2147483647, "to": {"self": "https://issues.stage.redhat.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - sandbox
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Expires:
-      - Tue, 18 Apr 2023 20:58:21 GMT
-      Pragma:
-      - no-cache
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      content-length:
-      - '1952'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-0
-      x-arequestid:
-      - 1258x44553x1
-      x-asessionid:
-      - 145gvs1
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.357f0660.1681851501.5305475b
-      x-rh-edge-request-id:
-      - 5305475b
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"transition": {"id": "31"}, "fields": {}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '42'
+      - '232'
       Content-Type:
       - application/json
       User-Agent:
@@ -2106,10 +1881,10 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248/transitions
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
   response:
     body:
-      string: ''
+      string: '{"id": "14943824", "key": "OSIM-261", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943824"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2120,11 +1895,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:22 GMT
+      - Tue, 18 Apr 2023 22:11:39 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:22 GMT
+      - Tue, 18 Apr 2023 22:11:39 GMT
       Pragma:
       - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '101'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2132,9 +1912,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44554x1
+      - 1331x45431x1
       x-asessionid:
-      - ywswpd
+      - cil74p
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2142,16 +1922,16 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851502.53054845
+      - 0.e4912f17.1681855899.25841e87
       x-rh-edge-request-id:
-      - '53054845'
+      - 25841e87
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
     status:
-      code: 204
-      message: No Content
+      code: 201
+      message: Created
 - request:
     body: null
     headers:
@@ -2170,12 +1950,12 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-248
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIM-261
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "14943813", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943813",
-        "key": "OSIM-248", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "id": "14943824", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943824",
+        "key": "OSIM-261", "fields": {"customfield_12322440": null, "issuetype": {"self":
         "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
         "Created by Jira Software - do not edit or delete. Issue type for a user story.",
         "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
@@ -2189,43 +1969,43 @@ interactions:
         "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@77b76e20[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@63eb827c[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@416ec66f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@58f92af[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@44d55720[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7b92c5a4[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a59a97a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@d824c02[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@630076c5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@ed230e4[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@39774a3d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@268af34d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@46dc1f07[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@59964228[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6233176e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1bd0fb6d[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3db6eb96[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@27051bfa[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5df7e013[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@41606353[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4b00dab2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4455d2e3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@26c05502[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@64f8d072[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
         "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
         null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2023-04-18T20:58:19.002+0000", "customfield_12321240":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-261/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:11:38.834+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
         "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:0a9d00d7-b846-4840-abe5-becda57f0a14"],
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:60e979cf-7d85-4687-b04f-9252d31e4778"],
         "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
         "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2023-04-18T20:58:21.658+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10018",
-        "description": "Work has started", "iconUrl": "https://issues.stage.redhat.com/images/icons/status_generic.gif",
-        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}},
-        "components": [], "timeoriginalestimate": null, "description": "Description
-        for CVE-2020-0000", "customfield_12314040": null, "customfield_12320844":
-        null, "timetracking": {}, "customfield_12320842": null, "archiveddate": null,
-        "customfield_12310243": null, "attachment": [], "aggregatetimeestimate": null,
-        "customfield_12316542": {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
+        null, "updated": "2023-04-18T22:11:38.834+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
+        "customfield_12314040": null, "customfield_12320844": null, "timetracking":
+        {}, "customfield_12320842": null, "archiveddate": null, "customfield_12310243":
+        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
         {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
         null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
-        "summary": "CVE-2020-0000 kernel: some description modified", "creator": {"self":
-        "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -2245,10 +2025,10 @@ interactions:
         "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-248/votes",
+        {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-261/votes",
         "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
         "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|za105g:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|za108c:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2259,16 +2039,16 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 18 Apr 2023 20:58:22 GMT
+      - Tue, 18 Apr 2023 22:11:39 GMT
       Expires:
-      - Tue, 18 Apr 2023 20:58:22 GMT
+      - Tue, 18 Apr 2023 22:11:39 GMT
       Pragma:
       - no-cache
       Vary:
       - User-Agent
       - Accept-Encoding
       content-length:
-      - '8576'
+      - '8634'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2276,9 +2056,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-0
       x-arequestid:
-      - 1258x44555x1
+      - 1331x45432x1
       x-asessionid:
-      - 1295qe9
+      - 1r1ybuo
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2286,9 +2066,509 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.357f0660.1681851502.53054e1c
+      - 0.e4912f17.1681855899.2584254f
       x-rh-edge-request-id:
-      - 53054e1c
+      - 2584254f
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/user/search?includeActive=True&includeInactive=False&maxResults=1&username=concosta%40redhat.com
+  response:
+    body:
+      string: '[{"self":"https://issues.stage.redhat.com/rest/api/2/user?username=concosta@redhat.com","key":"JIRAUSER196381","name":"concosta@redhat.com","emailAddress":"concosta+stage@redhat.com","avatarUrls":{"48x48":"https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326","24x24":"https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326","16x16":"https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326","32x32":"https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},"displayName":"Conrado
+        Costa","active":true,"deleted":false,"timeZone":"GMT","locale":"en_US"}]'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:11:39 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:11:39 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '720'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1331x45433x1
+      x-asessionid:
+      - qavj92
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.e4912f17.1681855899.25842798
+      x-rh-edge-request-id:
+      - '25842798'
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "concosta@redhat.com"}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '31'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://squid.corp.redhat.com:3128/rest/api/latest/issue/OSIM-260/assignee
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:11:40 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:11:40 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1331x45434x1
+      x-asessionid:
+      - 180e0g6
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.e4912f17.1681855900.25842859
+      x-rh-edge-request-id:
+      - '25842859'
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/user/search?includeActive=True&includeInactive=False&maxResults=1&username=concosta%40redhat.com
+  response:
+    body:
+      string: '[{"self":"https://issues.stage.redhat.com/rest/api/2/user?username=concosta@redhat.com","key":"JIRAUSER196381","name":"concosta@redhat.com","emailAddress":"concosta+stage@redhat.com","avatarUrls":{"48x48":"https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326","24x24":"https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326","16x16":"https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326","32x32":"https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},"displayName":"Conrado
+        Costa","active":true,"deleted":false,"timeZone":"GMT","locale":"en_US"}]'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:11:40 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:11:40 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '720'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1331x45435x1
+      x-asessionid:
+      - rzjqd2
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.e4912f17.1681855900.25842c20
+      x-rh-edge-request-id:
+      - 25842c20
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "concosta@redhat.com"}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '31'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://squid.corp.redhat.com:3128/rest/api/latest/issue/OSIM-261/assignee
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:11:40 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:11:40 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1331x45436x1
+      x-asessionid:
+      - c1l34b
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.e4912f17.1681855900.25842d18
+      x-rh-edge-request-id:
+      - 25842d18
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.26.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/search?jql=PROJECT%3DOSIM+++++++++++++++++AND+assignee%3D%22concosta%40redhat.com%22+++++++++++++++++AND+type%3D%22Story%22&maxResults=50&startAt=0&validateQuery=True
+  response:
+    body:
+      string: '{"expand": "schema,names", "startAt": 0, "maxResults": 50, "total":
+        2, "issues": [{"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+        "id": "14943824", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943824",
+        "key": "OSIM-261", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
+        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
+        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
+        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
+        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
+        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
+        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
+        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@22b3bc98[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d980ef[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@18b971d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@489ca13b[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28d55200[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@bcc6ebc[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@562233a7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7b1ad521[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@79dddd10[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@118ce519[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@56744384[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7bea37b6[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
+        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
+        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
+        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-261/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:11:38.000+0000", "customfield_12321240":
+        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
+        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:60e979cf-7d85-4687-b04f-9252d31e4778"],
+        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "updated":
+        "2023-04-18T22:11:40.000+0000", "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0001",
+        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "CVE-2020-0001 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
+        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-261/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
+        null, "customfield_12311940": "1|za108c:"}}, {"expand": "operations,versionedRepresentations,editmeta,changelog,renderedFields",
+        "id": "14943823", "self": "https://issues.stage.redhat.com/rest/api/2/issue/14943823",
+        "key": "OSIM-260", "fields": {"customfield_12322440": null, "issuetype": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://issues.stage.redhat.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12322441":
+        null, "customfield_12322244": null, "customfield_12318341": null, "timespent":
+        null, "customfield_12320940": null, "project": {"self": "https://issues.stage.redhat.com/rest/api/2/project/12336420",
+        "id": "12336420", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
+        "software", "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/projectavatar?pid=12336420&avatarId=12560",
+        "24x24": "https://issues.stage.redhat.com/secure/projectavatar?size=small&pid=12336420&avatarId=12560",
+        "16x16": "https://issues.stage.redhat.com/secure/projectavatar?size=xsmall&pid=12336420&avatarId=12560",
+        "32x32": "https://issues.stage.redhat.com/secure/projectavatar?size=medium&pid=12336420&avatarId=12560"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2e6c8ef3[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2efd112a[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@582035b6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1e121bd9[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@53b1637[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1e01e54f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4755febc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4997e95c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1440c4f7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5fa70ad[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6db2deb0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1b990753[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
+        "resolutiondate": null, "workratio": -1, "customfield_12317379": null, "customfield_12316840":
+        null, "customfield_12315950": null, "customfield_12316841": null, "customfield_12310940":
+        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
+        "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-260/watchers", "watchCount":
+        1, "isWatching": true}, "created": "2023-04-18T22:11:37.000+0000", "customfield_12321240":
+        null, "customfield_12313140": null, "priority": {"self": "https://issues.stage.redhat.com/rest/api/2/priority/10300",
+        "iconUrl": "https://issues.stage.redhat.com/images/icons/priorities/trivial.svg",
+        "name": "Undefined", "id": "10300"}, "labels": ["flawuuid:ef810d00-8415-453a-89f6-96a1c72fd2f7"],
+        "customfield_12320947": [{"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "updated":
+        "2023-04-18T22:11:39.000+0000", "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://issues.stage.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.stage.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.stage.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "timeoriginalestimate": null, "description": "Description for CVE-2020-0000",
+        "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12316542":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "CVE-2020-0000 kernel: some description", "creator": {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://issues.stage.redhat.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.stage.redhat.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://issues.stage.redhat.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://issues.stage.redhat.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://issues.stage.redhat.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12310211": null, "customfield_12313441":
+        "", "customfield_12315542": null, "customfield_12315740": null, "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12313240": null, "customfield_12311140":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://issues.stage.redhat.com/rest/api/2/issue/OSIM-260/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "customfield_12310213":
+        null, "customfield_12311940": "1|za1084:"}}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 18 Apr 2023 22:11:41 GMT
+      Expires:
+      - Tue, 18 Apr 2023 22:11:41 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '18283'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-0
+      x-arequestid:
+      - 1331x45437x1
+      x-asessionid:
+      - yktlih
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.e4912f17.1681855901.258430e5
+      x-rh-edge-request-id:
+      - 258430e5
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/apps/taskman/urls.py
+++ b/apps/taskman/urls.py
@@ -9,12 +9,14 @@ from django.urls import path
 from .api import (
     healthy,
     task,
+    task_assignee,
     task_comment,
     task_comment_new,
     task_flaw,
     task_group,
     task_group_new,
     task_status,
+    task_unassigneed,
 )
 from .constants import TASKMAN_API_VERSION
 
@@ -24,6 +26,10 @@ urlpatterns = [
     path("healthy", healthy.as_view()),
     path(f"api/{TASKMAN_API_VERSION}/task/flaw/<str:flaw_uuid>", task_flaw.as_view()),
     path(f"api/{TASKMAN_API_VERSION}/task/<str:task_key>", task.as_view()),
+    path(
+        f"api/{TASKMAN_API_VERSION}/task/assignee/<str:user>", task_assignee.as_view()
+    ),
+    path(f"api/{TASKMAN_API_VERSION}/task/unassigned/", task_unassigneed.as_view()),
     path(
         f"api/{TASKMAN_API_VERSION}/task/<str:task_key>/status", task_status.as_view()
     ),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - More granular filtering for Flaw, Affect and Tracker API endpoints (OSIDB-667)
 - Ordering (ascending/descending) for Flaw, Affect and Tracker API endpoints (OSIDB-668)
 - Implement proper NVD CVSS score collector (OSIDB-632)
+- Introduce flaw ownership through task management system (OSIDB-69)
 
 ### Changed
 - Rework the mapping from Bugzilla sumary to OSIDB title and vice versa (OSIDB-694)

--- a/openapi.yml
+++ b/openapi.yml
@@ -4248,6 +4248,86 @@ paths:
                   version:
                     type: string
           description: ''
+  /taskman/api/v1/task/assignee/{user}:
+    get:
+      operationId: taskman_api_v1_task_assignee_retrieve
+      description: Get a list of tasks from a user
+      parameters:
+      - in: header
+        name: JiraAuthentication
+        schema:
+          type: string
+        description: User generated token for Jira authentication.
+        required: true
+      - in: path
+        name: user
+        schema:
+          type: string
+        required: true
+      tags:
+      - taskman
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JiraIssueQueryResult'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+    put:
+      operationId: taskman_api_v1_task_assignee_update
+      description: Assign a task to a user
+      parameters:
+      - in: header
+        name: JiraAuthentication
+        schema:
+          type: string
+        description: User generated token for Jira authentication.
+        required: true
+      - in: query
+        name: task_key
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: user
+        schema:
+          type: string
+        required: true
+      tags:
+      - taskman
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '204':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+          description: ''
   /taskman/api/v1/task/flaw/{flaw_uuid}:
     get:
       operationId: taskman_api_v1_task_flaw_retrieve
@@ -4358,6 +4438,40 @@ paths:
                     type: string
                   version:
                     type: string
+          description: ''
+  /taskman/api/v1/task/unassigned/:
+    get:
+      operationId: taskman_api_v1_task_unassigned_retrieve
+      description: Get a list of tasks without an user assigned
+      parameters:
+      - in: header
+        name: JiraAuthentication
+        schema:
+          type: string
+        description: User generated token for Jira authentication.
+        required: true
+      tags:
+      - taskman
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/JiraIssueQueryResult'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
           description: ''
   /taskman/healthy:
     get:
@@ -5243,14 +5357,20 @@ components:
           type: string
         assignee:
           $ref: '#/components/schemas/JiraUser'
+        reporter:
+          $ref: '#/components/schemas/JiraUser'
+        creator:
+          $ref: '#/components/schemas/JiraUser'
         customfield_12311140:
           type: string
           description: Task group key
       required:
       - assignee
+      - creator
       - customfield_12311140
       - description
       - issuetype
+      - reporter
       - summary
     JiraIssueQueryResult:
       type: object


### PR DESCRIPTION
This PR introduces task ownership.

Since we have relationship of 1:1 of task and flaw, assigning a user to a task may be enough to fulfill task ownership without storing user data in OSIDB. Please doing the review take an extra time to see if this approach would be adequate in OSIDB-69 scenario.

Closes OSIDB-69.