### PR TITLE
Update sqlparse to latest security revision

### DIFF
--- a/devel-requirements.txt
+++ b/devel-requirements.txt
@@ -677,9 +677,9 @@ six==1.16.0 \
     #   tox
     #   vcrpy
     #   virtualenv
-sqlparse==0.4.2 \
-    --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
-    --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d
+sqlparse==0.4.4 \
+    --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
+    --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
     # via
     #   -c requirements.txt
     #   django

--- a/requirements.txt
+++ b/requirements.txt
@@ -580,9 +580,9 @@ six==1.16.0 \
     #   djangorestframework-csv
     #   python-dateutil
     #   url-normalize
-sqlparse==0.4.2 \
-    --hash=sha256:0c00730c74263a94e5a9919ade150dfc3b19c574389985446148402998287dae \
-    --hash=sha256:48719e356bb8b42991bdbb1e8b83223757b93789c00910a616a071910ca4a64d
+sqlparse==0.4.4 \
+    --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
+    --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
     # via django
 structlog==21.2.0 \
     --hash=sha256:63a7111a32e5b615671536bb745692ea02cebfea2b39dcb7d2617eed19437cfe \


### PR DESCRIPTION
Version 0.4.2 is affected by a ReDoS vulnerability which is patched in 0.4.4, our usage of the lib is unlikely to be affected but better safe than sorry.