### PR TITLE
Add check for breaking changes in OpenAPI schema

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -2,9 +2,22 @@ name: Meta checks
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches:
-      - master
 jobs:
+  openapi:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          path: head
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+      - uses: actions/setup-go@v4
+      - name: Install oasdiff go package
+        run: go install github.com/tufin/oasdiff@v1.5.0
+      - name: Compare existing schema to new schema
+        run: oasdiff -fail-on-diff -check-breaking -base base/openapi.yml -revision head/openapi.yml
   changelog:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This commit adds a GitHub workflow action that will run Atlassian's openapi-diff on the base branch's openapi.yml and the head branch's openapi.yml on every pull request, and if the tool detects any backwards-incompatible changes the check will fail.

This commit also makes these checks no longer bound to PRs with a base branch of `master`, as it can happen with `release-x.y.z` branches too.