### PR TITLE
make CVSSv3 score mandatory no more

### DIFF
--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -274,7 +274,7 @@ class TestBBSyncIntegration:
             HTTP_BUGZILLA_API_KEY="SECRET",
         )
         assert response.status_code == 400
-        assert "CVSSv3 score is missing" in str(response.content)
+        assert "Component value is required" in str(response.content)
 
     @pytest.mark.vcr
     def test_flaw_update_multi_cve(self, auth_client, test_api_uri):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Integrate Jira tracker collector with collector framework (OSIDB-576)
+- Make CVSSv3 score mandatory no more (OSIDB-901)
 
 ### Removed
 

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -687,7 +687,10 @@ class Flaw(
         Check that a CVSSv3 string is present.
         """
         if not self.cvss3:
-            raise ValidationError("CVSSv3 score is missing")
+            self.alert(
+                "cvss3_missing",
+                "CVSSv3 score is missing",
+            )
 
     def _validate_summary_major_incident(self):
         """

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -846,22 +846,17 @@ class TestFlawValidators:
             # no exception should be raised now
 
     @pytest.mark.parametrize(
-        "cvss3,should_raise",
+        "cvss3,should_alert",
         [
             ("3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N", False),
             (None, True),
         ],
     )
-    def test_validate_cvss3_model(self, cvss3, should_raise):
+    def test_validate_cvss3_model(self, cvss3, should_alert):
         """
-        Test that the ValidationError is not raised when the flaw has a CVSS3 string
+        Test that an alert is not raised when the flaw has a CVSS3 string
         """
-        if should_raise:
-            with pytest.raises(ValidationError) as e:
-                FlawFactory(cvss3=cvss3)
-            assert "CVSSv3 score is missing" in str(e)
-        else:
-            assert FlawFactory(cvss3=cvss3)
+        assert should_alert == ("cvss3_missing" in FlawFactory(cvss3=cvss3)._alerts)
 
     @pytest.mark.parametrize(
         "summary,is_major_incident,req,should_raise",


### PR DESCRIPTION
It should be possible to create a flaw without CVSS3 provided.
This was identified as a discrepancy in the required OSIDB functionality during the IR acceptance testing

https://docs.google.com/spreadsheets/d/1JXjtwpCbpQesXWOQCkuh8rzkR3MbweM2zuEcBlX-bpk/edit?usp=sharing

Closing OSIDB-901