### PR TITLE
consistent test URLs

### DIFF
--- a/apps/taskman/tests/conftest.py
+++ b/apps/taskman/tests/conftest.py
@@ -1,5 +1,5 @@
 import pytest
-from taskman.constants import HTTPS_TASKMAN_PROXY, TASKMAN_API_VERSION
+from taskman.constants import TASKMAN_API_VERSION
 
 
 @pytest.fixture(autouse=True)
@@ -20,12 +20,6 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
-@pytest.fixture(autouse=True)
-def enable_proxy_for_stage_environment(monkeypatch):
-    if HTTPS_TASKMAN_PROXY:
-        monkeypatch.setenv("HTTPS_PROXY", HTTPS_TASKMAN_PROXY)
-
-
 @pytest.fixture
 def user_token():
     return "USER_JIRA_TOKEN"
@@ -44,3 +38,12 @@ def api_version():
 @pytest.fixture
 def test_api_uri(test_scheme_host, api_version):
     return f"{test_scheme_host}/api/{api_version}"
+
+
+@pytest.fixture(autouse=True)
+def pin_urls(monkeypatch) -> None:
+    """
+    the tests should be immune to what .evn you build the testrunner with
+    """
+    monkeypatch.setenv("HTTPS_PROXY", "http://squid.corp.redhat.com:3128")
+    monkeypatch.setenv("JIRA_TASKMAN_URL", "https://issues.stage.redhat.com")

--- a/collectors/errata/constants.py
+++ b/collectors/errata/constants.py
@@ -7,6 +7,11 @@ from xmlrpc.client import ProtocolError
 
 from requests.exceptions import RequestException
 
+from osidb.helpers import get_env
+
 # Celery task constants
 PAGE_SIZE = 100
 RETRYABLE_ERRORS = (ProtocolError, RequestException, SSLError, TimeoutError)
+
+ERRATA_TOOL_SERVER = get_env("ET_URL")
+ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"

--- a/collectors/errata/core.py
+++ b/collectors/errata/core.py
@@ -13,7 +13,12 @@ from osidb.models import Erratum, Tracker
 
 from ..bzimport.constants import BZ_ENABLE_IMPORT_EMBARGOED
 from ..utils import BACKOFF_KWARGS, fatal_code
-from .constants import PAGE_SIZE, RETRYABLE_ERRORS
+from .constants import (
+    ERRATA_TOOL_SERVER,
+    ERRATA_TOOL_XMLRPC_BASE_URL,
+    PAGE_SIZE,
+    RETRYABLE_ERRORS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +28,7 @@ logger = logging.getLogger(__name__)
 )
 def get(path, return_json=True, session=None, **request_kwargs):
     """Get the response to a REST API call or raise an exception."""
-    url = urljoin(settings.ERRATA_TOOL_SERVER, path)
+    url = urljoin(ERRATA_TOOL_SERVER, path)
     if session:
         response = session.get(url, **request_kwargs)
     else:
@@ -162,7 +167,7 @@ def search(query):
     See ET's documentation /rdoc/ErrataService.html#method-i-get_advisory_list
     """
     query["per_page"] = PAGE_SIZE
-    server = ServerProxy(settings.ERRATA_TOOL_XMLRPC_BASE_URL)
+    server = ServerProxy(ERRATA_TOOL_XMLRPC_BASE_URL)
     i = 1
     while True:
         query["page"] = i

--- a/collectors/errata/tests/conftest.py
+++ b/collectors/errata/tests/conftest.py
@@ -34,3 +34,20 @@ def sample_erratum_name():
 @pytest.fixture()
 def sample_search_time():
     return datetime(2022, 4, 21, 20, 12, 00, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def pin_urls(monkeypatch) -> None:
+    """
+    the tests should be immune to what .evn you build the testrunner with
+    """
+    import collectors.errata.core as core
+
+    monkeypatch.setattr(
+        core, "ERRATA_TOOL_SERVER", "https://errata.stage.engineering.redhat.com"
+    )
+    monkeypatch.setattr(
+        core,
+        "ERRATA_TOOL_XMLRPC_BASE_URL",
+        "https://errata.stage.engineering.redhat.com/errata/errata_service",
+    )

--- a/config/settings.py
+++ b/config/settings.py
@@ -247,9 +247,6 @@ SPECTACULAR_SETTINGS = {
     ],
 }
 
-ERRATA_TOOL_SERVER = get_env("ET_URL")
-ERRATA_TOOL_XMLRPC_BASE_URL = f"{ERRATA_TOOL_SERVER}/errata/errata_service"
-
 # Execute once a day by default
 CISA_COLLECTOR_CRONTAB = crontab(minute=0, hour=1)
 


### PR DESCRIPTION
This PR makes the test URLs independent of the `.env` the developer builds the `testrunner` with.

@Elkasitu @costaconrado this is quite opinionated PR so I would like to hear your opinion two.

The issue I am trying to address is that the current design of the tests takes the constants through the `testrunner` from your local `.env`. That would be OK if we agreed that all the tests will either use the staging or the production URLs (the later is my preference) so the developer can have a meaningful `.env` set as either staging or production. Unfortunately some tests count of production URLs and some on staging so you cannot have a meaningful `.env` and run the tests successfully at the same time - you need to have a mix of production and stage. We have IMO two ways how to address this.

One approach might be this PR and pinning all the test URLs to the expected ones on the module or even test case bases (the later would be quite laborious). The it does not matter what you record in the cassette when writing a test because you make the pinning accordingly.

Another approach would be to agree on either production or stage and create all the tests in context of that one environment. That would require to adjust the cassettes accordingly. Eg. I normally do that I record the cassette from the staging Bugzilla and then I remove all `stage.` strings from the cassette so it succeeds with production Bugzilla URL in the `.env`

The status qua of the wild west is IMO bad and probably leads to various workarounds or mixed `.env` files. Or maybe I am wrong and trying to solve something what is not an issue at all. WDYT?