### PR TITLE
make flaw Bugzilla children entities respect flaw visibility

### DIFF
--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -184,7 +184,14 @@ class TestBZImportCollector:
             uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])
         ]
         new_acls = doctext_meta.acl_read + doctext_meta.acl_write
-        doctext_meta.save()
+
+        # in Bugzilla world it is not possible to have different Flaw and FlawMeta visibility
+        # but here we want to be in OSIDB world only so let us turn off this Bugzilla validation
+        with monkeypatch.context() as m:
+            m.setattr(
+                FlawMeta, "_validate_acl_identical_to_parent_flaw", lambda s: None
+            )
+            doctext_meta.save()
 
         assert old_acls != new_acls
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make Bugzilla collector aware of migration of old style acks to SRT notes (OSIDB-904)
 - Fix BBSync flaw summary composition (OSIDB-902, OSIDB-909)
 - Fix Bugzilla import not reflecting some attribute removals (OSIDB-910)
+- Make flaw Bugzilla children entities respect flaw visibility (OSIDB-914)
 
 ### Removed
 

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -442,5 +442,20 @@ class ACLMixin(models.Model):
         ):
             raise ValidationError("ACLs must not contain duplicit ACL groups")
 
+    # additionally in Bugzilla all the flaw related entities are at the end
+    # stored as part of the flaw metadata so for the time being it does
+    # not make any sense to have a different visibility of them
+
+    def _validate_acl_identical_to_parent_flaw(self):
+        """
+        validate that the eventual parent flaw has the identical ACLs
+        """
+        if hasattr(self, "flaw"):
+            if not self.is_embargoed == self.flaw.is_embargoed:
+                raise ValidationError(
+                    "ACLs must correspond to the parrent flaw: "
+                    + ("embargoed" if self.flaw.is_embargoed else "public")
+                )
+
     class Meta:
         abstract = True

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -221,8 +221,10 @@ class AffectFactory(factory.django.DjangoModelFactory):
 
     flaw = factory.SubFactory(FlawFactory)
 
-    acl_read = [DATA_PRODSEC_ACL_READ]
-    acl_write = [DATA_PRODSEC_ACL_WRITE]
+    # let us inherit the parent flaw ACLs if not specified
+    acl_read = factory.LazyAttribute(lambda o: o.flaw.acl_read)
+    acl_write = factory.LazyAttribute(lambda o: o.flaw.acl_write)
+
     meta_attr = factory.Dict({"test": "1"})
 
     @classmethod
@@ -332,8 +334,10 @@ class FlawCommentFactory(factory.django.DjangoModelFactory):
     created_dt = factory.Faker("date_time", tzinfo=UTC)
     updated_dt = factory.Faker("date_time", tzinfo=UTC)
     external_system_id = factory.sequence(lambda n: f"fake-external-id{n}")
-    acl_read = [DATA_PRODSEC_ACL_READ]
-    acl_write = [DATA_PRODSEC_ACL_WRITE]
+
+    # let us inherit the parent flaw ACLs if not specified
+    acl_read = factory.LazyAttribute(lambda o: o.flaw.acl_read)
+    acl_write = factory.LazyAttribute(lambda o: o.flaw.acl_write)
 
     flaw = factory.SubFactory(FlawFactory)
 
@@ -358,8 +362,11 @@ class FlawMetaFactory(factory.django.DjangoModelFactory):
     type = "REFERENCE"
     created_dt = factory.Faker("date_time", tzinfo=UTC)
     updated_dt = factory.Faker("date_time", tzinfo=UTC)
-    acl_read = [DATA_PRODSEC_ACL_READ]
-    acl_write = [DATA_PRODSEC_ACL_WRITE]
+
+    # let us inherit the parent flaw ACLs if not specified
+    acl_read = factory.LazyAttribute(lambda o: o.flaw.acl_read)
+    acl_write = factory.LazyAttribute(lambda o: o.flaw.acl_write)
+
     meta_attr = {
         "url": "http://nonexistenturl.example.com/1285930",
         "type": "external",
@@ -379,8 +386,9 @@ class FlawReferenceFactory(factory.django.DjangoModelFactory):
     created_dt = factory.Faker("date_time", tzinfo=UTC)
     updated_dt = factory.Faker("date_time", tzinfo=UTC)
 
-    acl_read = [DATA_PRODSEC_ACL_READ]
-    acl_write = [DATA_PRODSEC_ACL_WRITE]
+    # let us inherit the parent flaw ACLs if not specified
+    acl_read = factory.LazyAttribute(lambda o: o.flaw.acl_read)
+    acl_write = factory.LazyAttribute(lambda o: o.flaw.acl_write)
 
     flaw = factory.SubFactory(FlawFactory)
 

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1420,18 +1420,36 @@ class TestEndpoints(object):
         assert "data-prodsec" in res["groups"]
         assert res["profile"] is None
 
-    def test_affect_create(self, auth_client, test_api_uri):
+    @pytest.mark.parametrize(
+        "flaw_embargo,affect_embargo,fails",
+        [
+            (False, False, False),
+            (True, True, False),
+            (False, True, True),
+            (True, False, True),
+        ],
+    )
+    def test_affect_create(
+        self,
+        auth_client,
+        embargo_access,
+        test_api_uri,
+        flaw_embargo,
+        affect_embargo,
+        fails,
+    ):
         """
-        Test the creation of Affect records via a REST API POST request.
+        test the creation of Affect records via a REST API POST request
+        also with respect to the flaw and affect visibility (which should be equal in Buzilla world)
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(embargoed=flaw_embargo)
         affect_data = {
             "flaw": str(flaw.uuid),
             "affectedness": Affect.AffectAffectedness.NEW,
             "resolution": Affect.AffectResolution.NOVALUE,
             "ps_module": "rhacm-2",
             "ps_component": "curl",
-            "embargoed": False,
+            "embargoed": affect_embargo,
         }
         response = auth_client.post(
             f"{test_api_uri}/affects",
@@ -1439,14 +1457,19 @@ class TestEndpoints(object):
             format="json",
             HTTP_BUGZILLA_API_KEY="SECRET",
         )
-        assert response.status_code == 201
-        body = response.json()
-        created_uuid = body["uuid"]
+        if fails:
+            assert response.status_code == 400
+            assert "ACLs must correspond to the parrent flaw:" in str(response.content)
 
-        response = auth_client.get(f"{test_api_uri}/affects/{created_uuid}")
-        assert response.status_code == 200
-        body = response.json()
-        assert body["ps_module"] == "rhacm-2"
+        else:
+            assert response.status_code == 201
+            body = response.json()
+            created_uuid = body["uuid"]
+
+            response = auth_client.get(f"{test_api_uri}/affects/{created_uuid}")
+            assert response.status_code == 200
+            body = response.json()
+            assert body["ps_module"] == "rhacm-2"
 
     def test_affect_update(self, auth_client, test_api_uri):
         """

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -314,8 +314,8 @@ class TestFlaw:
             flaw=flaw,
             _type=FlawMeta.FlawMetaType.MAJOR_INCIDENT,
             meta={},
-            acl_read=self.acl_read,
-            acl_write=self.acl_write,
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
         )
         meta.save()
         old_updated_dt = meta.updated_dt
@@ -551,7 +551,7 @@ class TestFlawValidators:
         )
         assert FlawMeta.objects.count() == 2
         # test that it works with RelatedManager methods such as add()
-        flaw = FlawFactory()
+        flaw = FlawFactory(embargoed=flaw.embargoed)
         # see previous test for explanation on bulk=False
         flaw.meta.set([meta1, meta2], bulk=False)
         assert flaw.meta.count() == 2


### PR DESCRIPTION
...as until we leave Bugzilla we simply cannot make the entities which are essential parts of the flaw there to have a different visibility. This also closes the following test finding as the current behavior was that creating a flaw children entity with a different visibility would simply result in silent change of the children visibility to the parent flaw one without any information to the user.

Closes OSIDB-914