### PR TITLE
Add extra flaw metadata for tasks

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement mitigation validation for Major Incident flaw (OSIDB-656)
 - Implement statement validation for Major Incident flaw (OSIDB-657)
 - Introduce new module for creating trackers in Jira (OSIDB-93)
+- Introduce aditional metadata in tasks generated from Taskman (OSIDB-861)
 
 ### Changed
 - Integrate Jira tracker collector with collector framework (OSIDB-576)


### PR DESCRIPTION
This PR introduce new metadata in Tasks needed for more meaningful Jira dashboards.
 
Closes OSIDB-940.