### PR TITLE
BugzillaSaver generalization and two tracker validations

### DIFF
--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -134,12 +134,19 @@ class TestJiraTrackerCollector:
         test collecting a known Jira issue specified by the given ID
         linked to an affect which should preserve the linking
         """
-        flaw = FlawFactory(embargoed=False)
+        flaw1 = FlawFactory(embargoed=False)
+        flaw2 = FlawFactory(embargoed=False)
         affect1 = AffectFactory(
-            affectedness=Affect.AffectAffectedness.AFFECTED, flaw=flaw
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            flaw=flaw1,
+            ps_module="module",
+            ps_component="component",
         )
         affect2 = AffectFactory(
-            affectedness=Affect.AffectAffectedness.AFFECTED, flaw=flaw
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            flaw=flaw2,
+            ps_module="module",
+            ps_component="component",
         )
         tracker_id = "ENTMQ-755"
         TrackerFactory(

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -942,7 +942,17 @@ class Flaw(
 
     @property
     def bz_id(self):
+        """
+        shortcut to get underlying Bugzilla bug ID
+        """
         return self.meta_attr.get("bz_id", None)
+
+    @bz_id.setter
+    def bz_id(self, value):
+        """
+        shortcut to set underlying Bugzilla bug ID
+        """
+        self.meta_attr["bz_id"] = value
 
     @property
     def api_url(self):
@@ -993,11 +1003,11 @@ class Flaw(
         Bugzilla sync of the Flaw instance
         """
         # imports here to prevent cycles
-        from apps.bbsync.save import BugzillaSaver
+        from apps.bbsync.save import FlawBugzillaSaver
         from collectors.bzimport.collectors import FlawCollector
 
         # sync to Bugzilla
-        bs = BugzillaSaver(self, bz_api_key)
+        bs = FlawBugzillaSaver(self, bz_api_key)
         self = bs.save()
         # save in case a new Bugzilla ID was obtained
         # so the flaw is later matched in BZ import
@@ -1582,6 +1592,24 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
                 f"Affect ({affect.uuid}) for {affect.ps_module}/{affect.ps_component} is marked as "
                 "WONTFIX but has open tracker(s).",
             )
+
+    @property
+    def bz_id(self):
+        """
+        shortcut to enable unified Bugzilla Flaw and Tracker handling when meaningful
+        """
+        # this should be always asserted or we failed
+        assert (
+            self.type == self.TrackerType.BUGZILLA
+        ), "Only Bugzilla trackers have Bugzilla IDs"
+        return self.external_system_id
+
+    @bz_id.setter
+    def bz_id(self, value):
+        """
+        shortcut to enable unified Bugzilla Flaw and Tracker handling when meaningful
+        """
+        self.external_system_id = value
 
     @property
     def fix_state(self):

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1593,6 +1593,25 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
                 "WONTFIX but has open tracker(s).",
             )
 
+    def _validate_multi_flaw_tracker(self):
+        """
+        validate multi-flaw tracker
+        """
+        if self.affects.count() < 2:
+            return
+
+        first_affect = self.affects.first()
+        for affect in self.affects.exclude(uuid=first_affect.uuid):
+            if first_affect.ps_module != affect.ps_module:
+                raise ValidationError(
+                    "Tracker must be associated only with affects with the same PS module"
+                )
+
+            if first_affect.ps_component != affect.ps_component:
+                raise ValidationError(
+                    "Tracker must be associated only with affects with the same PS component"
+                )
+
     @property
     def bz_id(self):
         """

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1047,7 +1047,13 @@ class TestFlawValidators:
 
         affects = []
         for embargoed_flaw in flaws_embargoed_status:
-            affects.append(AffectFactory(flaw__embargoed=embargoed_flaw))
+            affects.append(
+                AffectFactory(
+                    flaw__embargoed=embargoed_flaw,
+                    ps_module="module",
+                    ps_component="component",
+                )
+            )
 
         if should_raise:
             with pytest.raises(

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -1,0 +1,69 @@
+"""
+Tracker model related tests
+"""
+import pytest
+from django.core.exceptions import ValidationError
+
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    TrackerFactory,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestTrackerValidators:
+    def test_validate_good(self):
+        """
+        test that no validator complains about valid tracker
+        """
+        # do not raise here
+        # validation is run on save
+        TrackerFactory()
+
+    def test_validate_multi_flaw_tracker_ps_module(self):
+        """
+        test that a multi-flaw tracker is always associated
+        with affects with the same PS module only
+        """
+        flaw1 = FlawFactory()
+        flaw2 = FlawFactory()
+        affect1 = AffectFactory(
+            flaw=flaw1,
+            ps_module="first",
+            ps_component="component",
+        )
+        affect2 = AffectFactory(
+            flaw=flaw2,
+            ps_module="second",
+            ps_component="component",
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Tracker must be associated only with affects with the same PS module",
+        ):
+            TrackerFactory(affects=[affect1, affect2])
+
+    def test_validate_multi_flaw_tracker_ps_component(self):
+        """
+        test that a multi-flaw tracker is always associated
+        with affects with the same PS component only
+        """
+        flaw1 = FlawFactory()
+        flaw2 = FlawFactory()
+        affect1 = AffectFactory(
+            flaw=flaw1,
+            ps_module="module",
+            ps_component="firts",
+        )
+        affect2 = AffectFactory(
+            flaw=flaw2,
+            ps_module="module",
+            ps_component="second",
+        )
+        with pytest.raises(
+            ValidationError,
+            match="Tracker must be associated only with affects with the same PS component",
+        ):
+            TrackerFactory(affects=[affect1, affect2])


### PR DESCRIPTION
This PR closes my day and it brings two pieces on the way to the Bugzilla trackers. The validations are actually applicable to the Jira trackers too. 