### PR TITLE
Include flaw references when saving data via bbsync

### DIFF
--- a/apps/bbsync/srtnotes.py
+++ b/apps/bbsync/srtnotes.py
@@ -69,9 +69,7 @@ class SRTNotesBuilder:
         self.generate_date("reported_dt", "reported")
         self.generate_impact()
         self.generate_jira_trackers()
-        # TODO the references are not yet fully implemented in OSIDB
-        # this requirement is trackerd in OSIDB-71 and when fulfilled
-        # we need to implement generate_references accordingly
+        self.generate_references()
         self.generate_source()
         self.generate_string("cvss2", "cvss2")
         self.generate_string("cvss3", "cvss3")
@@ -172,6 +170,22 @@ class SRTNotesBuilder:
                 {"bts_name": "jboss", "key": tracker.external_system_id}
                 for affect in self.flaw.affects.all()
                 for tracker in affect.trackers.filter(type=Tracker.TrackerType.JIRA)
+            ],
+        )
+
+    def generate_references(self):
+        """
+        generate array of references to SRT notes
+        """
+        self.add_conditionally(
+            "references",
+            [
+                {
+                    "type": reference.type,
+                    "url": reference.url,
+                    "description": reference.description or None,
+                }
+                for reference in self.flaw.references.all()
             ],
         )
 

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -13,6 +13,7 @@ from osidb.tests.factories import (
     FlawCommentFactory,
     FlawFactory,
     FlawMetaFactory,
+    FlawReferenceFactory,
     PsModuleFactory,
     TrackerFactory,
 )
@@ -357,6 +358,29 @@ class TestGenerateSRTNotes:
         assert rhel8affect["impact"] is None
         assert rhel8affect["cvss2"] is None
         assert rhel8affect["cvss3"] is None
+
+    def test_generate_references(self):
+        """
+        test generating of SRT references attribute array
+        """
+        flaw = FlawFactory()
+        FlawReferenceFactory(
+            flaw=flaw,
+            type="EXTERNAL",
+            url="https://httpd.apache.org/link123",
+            description="link description",
+        )
+
+        bqb = BugzillaQueryBuilder(flaw)
+        cf_srtnotes = bqb.query.get("cf_srtnotes")
+        cf_srtnotes_json = json.loads(cf_srtnotes)
+        references = cf_srtnotes_json.get("references", [])
+
+        assert len(references) == 1
+        reference = references[0]
+        assert reference["type"] == "EXTERNAL"
+        assert reference["url"] == "https://httpd.apache.org/link123"
+        assert reference["description"] == "link description"
 
     @pytest.mark.parametrize(
         "osidb_cvss2,osidb_cvss3,srtnotes,bz_cvss2_present,bz_cvss3_present,bz_cvss2,bz_cvss3",

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2002,6 +2002,14 @@ class FlawReference(ACLMixin, BugzillaSyncMixin, TrackingMixin):
                 f"but only 1 is allowed."
             )
 
+    def bzsync(self, *args, bz_api_key, **kwargs):
+        """
+        Bugzilla sync of the FlawReference instance
+        """
+        self.save()
+        # FlawReference needs to be synced through flaw
+        self.flaw.save(*args, bz_api_key=bz_api_key, **kwargs)
+
 
 class VersionStatus(models.TextChoices):
     AFFECTED = "AFFECTED"


### PR DESCRIPTION
Follow-up to https://github.com/RedHatProductSecurity/osidb/pull/199.

Related to "implement adding of external links to flaws" (OSIDB-71).