### PR TITLE
account for TRIAGE in the title/summary

### DIFF
--- a/collectors/bzimport/fixups.py
+++ b/collectors/bzimport/fixups.py
@@ -213,6 +213,8 @@ class FlawFixer:
 
         # try to strip EMBARGOED
         title = re.sub(r"^EMBARGOED\s*", "", title)
+        # try to strip TRIAGE
+        title = re.sub(r"^TRIAGE(-|\s*)", "", title)
         # try to strip CVE IDs possibly followed by three dots
         title = re.sub(r"^(CVE-[0-9]{4}-[0-9]+\s*)+\.*\s*", "", title)
 

--- a/collectors/bzimport/tests/test_fixups.py
+++ b/collectors/bzimport/tests/test_fixups.py
@@ -101,6 +101,21 @@ class TestFlawFixer:
                 "cheesecake",
                 "carbon",
             ),
+            (
+                "TRIAGE carbon: cheesecake",
+                "cheesecake",
+                "carbon",
+            ),
+            (
+                "TRIAGE-CVE-2000-12345 carbon: cheesecake",
+                "cheesecake",
+                "carbon",
+            ),
+            (
+                "EMBARGOED TRIAGE carbon: cheesecake",
+                "cheesecake",
+                "carbon",
+            ),
         ],
     )
     def test_fix_title(self, summary, title, component):

--- a/collectors/tests/test_utils.py
+++ b/collectors/tests/test_utils.py
@@ -46,6 +46,26 @@ class TestParseUpdateStreamComponent:
                 "stream",
                 "component",
             ),
+            (
+                "TRIAGE component: text [stream]",
+                "stream",
+                "component",
+            ),
+            (
+                "TRIAGE-CVE-2222-1111 component: text [stream]",
+                "stream",
+                "component",
+            ),
+            (
+                "EMBARGOED TRIAGE component: text [stream]",
+                "stream",
+                "component",
+            ),
+            (
+                "[CISA Major Incident] TRIAGECVE-2222-1111 component: another: text [stream]",
+                "stream",
+                "component",
+            ),
         ],
     )
     def test_correct(self, title, stream, component):

--- a/collectors/utils.py
+++ b/collectors/utils.py
@@ -6,6 +6,7 @@ from osidb.models import PsUpdateStream
 TRACKER_COMPONENT_UPDATE_STREAM_RE = re.compile(
     r"^(?:\s*EMBARGOED\s+)?"  # Embargoed keyword
     r"(?:\[(?:CISA\s)?Major\sIncident\]\s+)?"  # Major Incident
+    r"(?:\s*TRIAGE)?(?:-|\s*)?"  # TRIAGE keyword or prefix
     r"(?:CVE-[0-9]+-[0-9]+,?\s*)*"  # list of CVEs
     r"(?:\.+\s+)?"  # dots, when too many CVEs are present
     r"(?P<component>.+?):\s"  # PSComponent (might contain spaces or rhel module)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement a new FlawReference API (OSIDB-71)
 
+### Changed
+
+- Account for TRIAGE in the title/summary (OSIDB-999)
+
 ## [3.2.0] - 2023-06-05
 ### Added
 - Introduce flaw ownership through task management system (OSIDB-69)


### PR DESCRIPTION
the latest workflow change introduced an unexpected TRIAGE keyword into the tracker summaries/titles
which makes them unable to link to the affects

therefore this fix

Closes OSIDB-999