### PR TITLE
make impact comparable

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -251,7 +251,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 154,
+        "line_number": 219,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-21T08:54:51Z"
+  "generated_at": "2023-06-22T18:41:52Z"
 }

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -3,7 +3,7 @@ import re
 from itertools import chain
 
 from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT
-from osidb.models import Flaw, FlawComment, FlawImpact, PsModule
+from osidb.models import Flaw, FlawComment, Impact, PsModule
 
 from .cc import CCBuilder
 from .constants import DATE_FMT
@@ -78,11 +78,11 @@ class BugzillaQueryBuilder:
         }
 
     IMPACT_TO_SEVERITY_PRIORITY = {
-        FlawImpact.CRITICAL: "urgent",
-        FlawImpact.IMPORTANT: "high",
-        FlawImpact.MODERATE: "medium",
-        FlawImpact.LOW: "low",
-        FlawImpact.NOVALUE: "unspecified",
+        Impact.CRITICAL: "urgent",
+        Impact.IMPORTANT: "high",
+        Impact.MODERATE: "medium",
+        Impact.LOW: "low",
+        Impact.NOVALUE: "unspecified",
     }
 
     def generate_unconditional(self):

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -11,9 +11,9 @@ from osidb.models import (
     Affect,
     Flaw,
     FlawComment,
-    FlawImpact,
     FlawMeta,
     FlawSource,
+    Impact,
     Tracker,
 )
 from osidb.tests.factories import (
@@ -208,7 +208,7 @@ class TestGenerateSRTNotes:
         """
         flaw = FlawFactory(
             embargoed=False,
-            impact=FlawImpact.MODERATE,
+            impact=Impact.MODERATE,
             source=FlawSource.CUSTOMER,
             reported_dt=timezone.datetime(2022, 11, 23, tzinfo=timezone.utc),
             unembargo_dt=timezone.datetime(2022, 11, 23, tzinfo=timezone.utc),
@@ -221,7 +221,7 @@ class TestGenerateSRTNotes:
             resolution=Affect.AffectResolution.FIX,
             ps_component="libssh",
             ps_module="fedora-all",
-            impact=Affect.AffectImpact.NOVALUE,
+            impact=Impact.NOVALUE,
             cvss2="",
             cvss3="",
         )
@@ -299,7 +299,7 @@ class TestGenerateSRTNotes:
             ps_component="ImageMagick",
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.FIX,
-            impact=Affect.AffectImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             cvss2="10.0/AV:N/AC:L/Au:N/C:C/I:C/A:C",
             cvss3="",
         )
@@ -309,7 +309,7 @@ class TestGenerateSRTNotes:
             ps_component="kernel",
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
-            impact=Affect.AffectImpact.MODERATE,
+            impact=Impact.MODERATE,
             cvss2="5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
             cvss3="7.5/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
         )
@@ -319,7 +319,7 @@ class TestGenerateSRTNotes:
             ps_component="bash",
             affectedness=Affect.AffectAffectedness.NOTAFFECTED,
             resolution=Affect.AffectResolution.NOVALUE,
-            impact=Affect.AffectImpact.NOVALUE,
+            impact=Impact.NOVALUE,
             cvss2="",
             cvss3="",
         )
@@ -526,37 +526,37 @@ class TestGenerateSRTNotes:
         "osidb_impact,srtnotes,bz_present,bz_impact",
         [
             (
-                FlawImpact.LOW,
+                Impact.LOW,
                 """{"impact": "low"}""",
                 True,
                 "low",
             ),
             (
-                FlawImpact.MODERATE,
+                Impact.MODERATE,
                 """{"impact": "low"}""",
                 True,
                 "moderate",
             ),
             (
-                FlawImpact.IMPORTANT,
+                Impact.IMPORTANT,
                 "",
                 True,
                 "important",
             ),
             (
-                FlawImpact.CRITICAL,
+                Impact.CRITICAL,
                 "{}",
                 True,
                 "critical",
             ),
             (
-                FlawImpact.NOVALUE,
+                Impact.NOVALUE,
                 """{"impact": "critical"}""",
                 True,
                 "none",
             ),
             (
-                FlawImpact.NOVALUE,
+                Impact.NOVALUE,
                 "",
                 False,
                 None,
@@ -900,7 +900,7 @@ class TestGenerateSRTNotes:
         flaw = FlawFactory(
             cwe_id="CWE-123",
             embargoed=False,
-            impact=FlawImpact.IMPORTANT,
+            impact=Impact.IMPORTANT,
             meta_attr={"original_srtnotes": srtnotes},
             reported_dt=make_aware(timezone.datetime(2022, 9, 21)),
             source=FlawSource.CUSTOMER,
@@ -923,7 +923,7 @@ class TestGenerateSRTNotes:
             resolution=Affect.AffectResolution.FIX,
             ps_component="libssh",
             ps_module="fedora-all",
-            impact=Affect.AffectImpact.MODERATE,
+            impact=Impact.MODERATE,
             cvss2="5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         )

--- a/apps/exploits/mixins.py
+++ b/apps/exploits/mixins.py
@@ -60,7 +60,7 @@ class AffectExploitExtensionMixin(models.Model):
         # TODO: Theoretically "NONE" value should not be used anymore, but for transitional period
         #       it seems that both values are possible (maybe caused by broken migration).
         #       Remove when not needed anymore.
-        if self.impact in [osidb.models.Affect.AffectImpact.NOVALUE, "NONE"]:
+        if self.impact in [osidb.models.Impact.NOVALUE, "NONE"]:
             return self.flaw.impact
         else:
             return self.impact

--- a/apps/osim/tests/test_models.py
+++ b/apps/osim/tests/test_models.py
@@ -5,7 +5,7 @@ from django.utils import timezone
 
 from apps.osim.models import Check, State, Workflow
 from apps.osim.workflow import WorkflowFramework, WorkflowModel
-from osidb.models import Flaw, FlawImpact, FlawMeta, FlawSource, FlawType
+from osidb.models import Flaw, FlawMeta, FlawSource, FlawType, Impact
 from osidb.tests.factories import AffectFactory, FlawFactory, FlawMetaFactory
 
 pytestmark = pytest.mark.unit
@@ -33,7 +33,7 @@ class CheckDescFactory:
         ("has type", "type", FlawType.VULNERABILITY),
         ("has created_dt", "created_dt", timezone.now()),
         ("has updated_dt", "updated_dt", timezone.now()),
-        ("has impact", "impact", FlawImpact.MODERATE),
+        ("has impact", "impact", Impact.MODERATE),
         ("has title", "title", "random title"),
         ("has description", "description", "random description"),
         ("has summary", "summary", "random summary"),

--- a/apps/trackers/exceptions.py
+++ b/apps/trackers/exceptions.py
@@ -8,7 +8,7 @@ class BTSException(Exception):
 
 
 class NoPriorityAvailableError(BTSException):
-    """exception class for missing correct priority corresponding to FlawImpact"""
+    """exception class for missing correct priority corresponding to Impact"""
 
 
 class UnsupportedTrackerError(BTSException):

--- a/apps/trackers/jira.py
+++ b/apps/trackers/jira.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 from apps.trackers.exceptions import NoPriorityAvailableError
 from apps.trackers.models import JiraProjectFields
-from osidb.models import FlawImpact
+from osidb.models import Impact
 
 from .bts_tracker import BTSTracker
 
@@ -24,16 +24,16 @@ class JiraPriority:
 
 
 IMPACT_TO_JIRA_PRIORITY = {
-    FlawImpact.CRITICAL: [JiraPriority.CRITICAL],
-    FlawImpact.IMPORTANT: [JiraPriority.MAJOR],
-    FlawImpact.MODERATE: [
+    Impact.CRITICAL: [JiraPriority.CRITICAL],
+    Impact.IMPORTANT: [JiraPriority.MAJOR],
+    Impact.MODERATE: [
         JiraPriority.NORMAL,
         JiraPriority.MINOR,
     ],  # some projects still miss Normal priority
-    FlawImpact.LOW: [JiraPriority.MINOR],
+    Impact.LOW: [JiraPriority.MINOR],
     # mapping below is just safeguard
     # but we should never file such trackers
-    FlawImpact.NOVALUE: [JiraPriority.UNDEFINED],
+    Impact.NOVALUE: [JiraPriority.UNDEFINED],
 }
 
 

--- a/apps/trackers/tests/test_bts_tracker.py
+++ b/apps/trackers/tests/test_bts_tracker.py
@@ -12,7 +12,7 @@ import pytest
 
 from apps.trackers.jira import JiraPriority, JiraTracker
 from apps.trackers.models import JiraProjectFields
-from osidb.models import FlawImpact, Tracker
+from osidb.models import Impact, Tracker
 from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
@@ -59,7 +59,7 @@ class TestJiraTracker(object):
             }
         }
         regular_flaw = FlawFactory(
-            embargoed=False, bz_id="123", cve_id="CVE-2999-1000", impact=FlawImpact.LOW
+            embargoed=False, bz_id="123", cve_id="CVE-2999-1000", impact=Impact.LOW
         )
         regular_affect = AffectFactory(
             flaw=regular_flaw, ps_module="foo-module", ps_component="foo-component"
@@ -96,7 +96,7 @@ class TestJiraTracker(object):
             embargoed=True,
             bz_id="456",
             cve_id="CVE-2999-1001",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
         )
         embargoed_affect = AffectFactory(
             flaw=embargoed_flaw, ps_module="foo-module", ps_component="foo-component"

--- a/apps/trackers/tests/test_service.py
+++ b/apps/trackers/tests/test_service.py
@@ -12,7 +12,7 @@ from apps.trackers.jira import JiraTracker
 from apps.trackers.models import JiraProjectFields
 from apps.trackers.service import JiraTrackerQuerier
 from apps.trackers.tests.test_bts_tracker import validate_minimum_key_value
-from osidb.models import FlawImpact, Tracker
+from osidb.models import Impact, Tracker
 from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
@@ -57,7 +57,7 @@ class TestJiraService(object):
             cve_id="CVE-2999-2001",
             embargoed=False,
             uuid="0bd02877-e04c-4174-a436-cafb7b79f111",
-            impact=FlawImpact.MODERATE,
+            impact=Impact.MODERATE,
         )
         affect1 = AffectFactory(
             flaw=flaw1, ps_module="foo-module", ps_component="fixed-ps-component-0"
@@ -67,7 +67,7 @@ class TestJiraService(object):
             cve_id="CVE-2999-2002",
             embargoed=True,
             uuid="4c534902-c270-4302-97f5-878bece153f3",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
         )
         affect2 = AffectFactory(
             flaw=flaw2, ps_module="foo-module", ps_component="fixed-ps-component-1"

--- a/collectors/bzimport/fixups.py
+++ b/collectors/bzimport/fixups.py
@@ -6,7 +6,7 @@ from typing import Any, List, Tuple
 
 from django.utils.timezone import make_aware
 
-from osidb.models import Affect, Flaw, FlawImpact, FlawSource
+from osidb.models import Affect, Flaw, FlawSource, Impact
 
 
 class AffectFixer:
@@ -100,10 +100,10 @@ class AffectFixer:
     def fix_impact(self) -> None:
         """impact fixup"""
         impact = self.affect_json.get("impact")
-        if impact and impact.upper() in Affect.AffectImpact:
+        if impact and impact.upper() in Impact:
             self.affect_obj.impact = impact.upper()
         else:
-            self.affect_obj.impact = Affect.AffectImpact.NOVALUE
+            self.affect_obj.impact = Impact.NOVALUE
 
     def fix_cvss2(self) -> None:
         """CVSS2 fixup"""
@@ -269,11 +269,11 @@ class FlawFixer:
     def fix_impact(self) -> None:
         """impact fixup"""
         impact = self.srtnotes.get("impact")
-        if impact and impact.upper() in FlawImpact:
+        if impact and impact.upper() in Impact:
             self.flaw_obj.impact = impact.upper()
         else:
             self.errors.append("impact has NOVALUE")
-            self.flaw_obj.impact = FlawImpact.NOVALUE
+            self.flaw_obj.impact = Impact.NOVALUE
 
     def fix_mitigation(self) -> None:
         """mitigation fixup"""

--- a/collectors/bzimport/tests/test_convertors.py
+++ b/collectors/bzimport/tests/test_convertors.py
@@ -11,9 +11,9 @@ from osidb.models import (
     Flaw,
     FlawComment,
     FlawHistory,
-    FlawImpact,
     FlawMeta,
     FlawReference,
+    Impact,
     Tracker,
     VersionStatus,
 )
@@ -42,7 +42,7 @@ class TestFlawSaver:
             cve_id="CVE-2000-1234",
             title="title",
             description="description",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             created_dt=timezone.now(),
             updated_dt=timezone.now(),
             acl_read=self.get_acls(),
@@ -89,7 +89,7 @@ class TestFlawSaver:
         return [
             FlawHistory(
                 cve_id="CVE-2000-1234",
-                impact=FlawImpact.IMPORTANT,
+                impact=Impact.IMPORTANT,
                 title="historical title",
                 description="historical description",
                 pgh_created_at=timezone.now(),
@@ -201,7 +201,7 @@ class TestFlawSaver:
         assert flaw.cve_id == "CVE-2000-1234"
         assert flaw.title == "title"
         assert flaw.description == "description"
-        assert flaw.impact == FlawImpact.CRITICAL
+        assert flaw.impact == Impact.CRITICAL
         assert flaw.acl_read == acls
         assert flaw.acl_write == acls
         assert flaw.affects.first() == affect
@@ -228,7 +228,7 @@ class TestFlawSaver:
 
         assert history is not None
         assert history.cve_id == "CVE-2000-1234"
-        assert history.impact == FlawImpact.IMPORTANT
+        assert history.impact == Impact.IMPORTANT
         assert history.title == "historical title"
         assert history.description == "historical description"
         assert history.acl_read == acls

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -112,7 +112,72 @@ class FlawType(models.TextChoices):
     WEAKNESS = "WEAKNESS"
 
 
-class FlawImpact(models.TextChoices):
+class ComparableTextChoices(models.TextChoices):
+    """
+    extension of the models.TextChoices classes
+    making them comparable with the standard operators
+
+    the comparison order is defined simply by the
+    top-down order in which the choices are written
+    """
+
+    @classmethod
+    def get_choices(cls):
+        """
+        get processed choices
+        """
+        return [choice[0] for choice in cls.choices]
+
+    @property
+    def weight(self):
+        """
+        weight of the instance for the comparison
+        defined by the order of the definition of the choices
+        """
+        return self.get_choices().index(str(self))
+
+    def incomparable_with(self, other):
+        """
+        to ensure that that we are comparing the instances of the same type as
+        comparing different types (even two ComparableTextChoices) is undefined
+        """
+        return type(self) != type(other)
+
+    def __hash__(self):
+        return super().__hash__()
+
+    def __eq__(self, other):
+        if self.incomparable_with(other):
+            return NotImplemented
+        return self.weight == other.weight
+
+    def __ne__(self, other):
+        if self.incomparable_with(other):
+            return NotImplemented
+        return self.weight != other.weight
+
+    def __lt__(self, other):
+        if self.incomparable_with(other):
+            return NotImplemented
+        return self.weight < other.weight
+
+    def __gt__(self, other):
+        if self.incomparable_with(other):
+            return NotImplemented
+        return self.weight > other.weight
+
+    def __le__(self, other):
+        if self.incomparable_with(other):
+            return NotImplemented
+        return self == other or self.__lt__(other)
+
+    def __ge__(self, other):
+        if self.incomparable_with(other):
+            return NotImplemented
+        return self == other or self.__gt__(other)
+
+
+class Impact(ComparableTextChoices):
     """allowable impact"""
 
     NOVALUE = ""

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -342,7 +342,7 @@ class FlawHistory(NullStrFieldsMixin, ValidateMixin, ACLMixin):
     )
 
     # flaw severity, from srtnotes "impact"
-    impact = models.CharField(choices=FlawImpact.choices, max_length=20, blank=True)
+    impact = models.CharField(choices=Impact.choices, max_length=20, blank=True)
 
     # from BZ summary
     title = models.TextField()
@@ -531,7 +531,7 @@ class Flaw(
     )
 
     # flaw severity, from srtnotes "impact"
-    impact = models.CharField(choices=FlawImpact.choices, max_length=20, blank=True)
+    impact = models.CharField(choices=Impact.choices, max_length=20, blank=True)
 
     # flaw component was originally a part of the Bugzilla sumary
     # so the value may depend on how successfully it was parsed
@@ -871,12 +871,11 @@ class Flaw(
 
         old_flaw = Flaw.objects.get(pk=self.pk)
         was_high_impact = (
-            old_flaw.impact in [FlawImpact.CRITICAL, FlawImpact.IMPORTANT]
+            old_flaw.impact in [Impact.CRITICAL, Impact.IMPORTANT]
             or old_flaw.is_major_incident
         )
         is_high_impact = (
-            self.impact in [FlawImpact.CRITICAL, FlawImpact.IMPORTANT]
-            or self.is_major_incident
+            self.impact in [Impact.CRITICAL, Impact.IMPORTANT] or self.is_major_incident
         )
         if (
             was_high_impact != is_high_impact
@@ -1127,15 +1126,6 @@ class Affect(
         DELEGATED = "DELEGATED"
         WONTREPORT = "WONTREPORT"
 
-    class AffectImpact(models.TextChoices):
-        """allowable impact"""
-
-        NOVALUE = ""
-        LOW = "LOW"
-        MODERATE = "MODERATE"
-        IMPORTANT = "IMPORTANT"
-        CRITICAL = "CRITICAL"
-
     class AffectFix(models.TextChoices):
         AFFECTED = "AFFECTED"
         NOTAFFECTED = "NOTAFFECTED"
@@ -1180,7 +1170,7 @@ class Affect(
     ps_component = models.CharField(max_length=255)
 
     # from srtnotes affects/impact
-    impact = models.CharField(choices=AffectImpact.choices, max_length=20, blank=True)
+    impact = models.CharField(choices=Impact.choices, max_length=20, blank=True)
 
     # from srtnotes affects/cvss2
     cvss2 = models.CharField(max_length=100, blank=True, validators=[validate_cvss2])
@@ -1421,8 +1411,7 @@ class Affect(
         """
         if (
             self.resolution == Affect.AffectResolution.WONTREPORT
-            and self.impact
-            not in [Affect.AffectImpact.LOW, Affect.AffectImpact.MODERATE]
+            and self.impact not in [Impact.LOW, Impact.MODERATE]
         ):
             raise ValidationError(
                 "wontreport can only be associated with low or moderate severity"

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -14,11 +14,11 @@ from osidb.models import (
     Flaw,
     FlawAcknowledgment,
     FlawComment,
-    FlawImpact,
     FlawMeta,
     FlawReference,
     FlawSource,
     FlawType,
+    Impact,
     PsContact,
     PsModule,
     PsProduct,
@@ -48,7 +48,7 @@ class FlawFactory(factory.django.DjangoModelFactory):
     reported_dt = factory.Faker("date_time", tzinfo=UTC)
     updated_dt = factory.Faker("date_time", tzinfo=UTC)
     impact = factory.Faker(
-        "random_element", elements=list(set(FlawImpact) - {FlawImpact.NOVALUE})
+        "random_element", elements=list(set(Impact) - {Impact.NOVALUE})
     )
     # max_nb_chars is the approximate length of generated text
     component = factory.Faker("text", max_nb_chars=50)
@@ -225,7 +225,7 @@ class AffectFactory(factory.django.DjangoModelFactory):
     )
     ps_module = factory.sequence(lambda n: f"ps-module-{n}")
     ps_component = factory.sequence(lambda n: f"ps-component-{n}")
-    impact = factory.Faker("random_element", elements=list(Affect.AffectImpact))
+    impact = factory.Faker("random_element", elements=list(Impact))
 
     created_dt = factory.Faker("date_time", tzinfo=UTC)
     updated_dt = factory.Faker("date_time", tzinfo=UTC)

--- a/osidb/tests/models.py
+++ b/osidb/tests/models.py
@@ -1,4 +1,5 @@
 from osidb.mixins import AlertMixin
+from osidb.models import ComparableTextChoices
 
 
 class TestAlertModelBasic(AlertMixin):
@@ -11,3 +12,11 @@ class TestAlertModel(AlertMixin):
         Creates a new alert when validate() method runs.
         """
         self.alert("new_alert", "This is a new alert.")
+
+
+class TestComparableTextChoices_1(ComparableTextChoices):
+    TEST = "TEST"
+
+
+class TestComparableTextChoices_2(ComparableTextChoices):
+    TEST = "TEST"

--- a/osidb/tests/test_core.py
+++ b/osidb/tests/test_core.py
@@ -14,7 +14,12 @@ from osidb.tests.factories import (
     FlawMetaFactory,
     FlawReferenceFactory,
 )
-from osidb.tests.models import TestAlertModel, TestAlertModelBasic
+from osidb.tests.models import (
+    TestAlertModel,
+    TestAlertModelBasic,
+    TestComparableTextChoices_1,
+    TestComparableTextChoices_2,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -117,3 +122,34 @@ class TestModelDefinitions:
         with pytest.raises(ValueError) as e:
             m.alert("my_error", "This is a weird error", _type="weird")
         assert "Alert type 'weird' is not valid" in str(e)
+
+
+class TestComparableTextChoices:
+    def test_incomparable(self):
+        instance1 = TestComparableTextChoices_1(
+            TestComparableTextChoices_1.get_choices()[0]
+        )
+        instance2 = TestComparableTextChoices_2(
+            TestComparableTextChoices_2.get_choices()[0]
+        )
+
+        # even without equality being defined
+        # Python can decide this on identiy
+        assert not instance1 == instance2
+        assert instance1 != instance2
+
+        with pytest.raises(TypeError) as e:
+            assert instance1 < instance2
+        assert "'<' not supported" in str(e)
+
+        with pytest.raises(TypeError) as e:
+            assert instance1 <= instance2
+        assert "'<=' not supported" in str(e)
+
+        with pytest.raises(TypeError) as e:
+            assert instance1 > instance2
+        assert "'>' not supported" in str(e)
+
+        with pytest.raises(TypeError) as e:
+            assert instance1 >= instance2
+        assert "'>=' not supported" in str(e)

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -434,6 +434,44 @@ class TestFlaw:
         assert Flaw.objects.fts_search("title")
 
 
+class TestImpact:
+    @pytest.mark.parametrize(
+        "first,second",
+        [
+            ("", "LOW"),
+            ("", "MODERATE"),
+            ("", "IMPORTANT"),
+            ("", "CRITICAL"),
+            ("LOW", "MODERATE"),
+            ("LOW", "IMPORTANT"),
+            ("LOW", "CRITICAL"),
+            ("MODERATE", "IMPORTANT"),
+            ("MODERATE", "CRITICAL"),
+            ("IMPORTANT", "CRITICAL"),
+        ],
+    )
+    def test_less(self, first, second):
+        """
+        test that the first is less than the second
+        """
+        assert Impact(first) < Impact(second)
+
+    @pytest.mark.parametrize(
+        "maximum,impacts",
+        [
+            ("LOW", ["", "", "LOW", "LOW"]),
+            ("MODERATE", ["MODERATE"]),
+            ("IMPORTANT", ["LOW", "MODERATE", "IMPORTANT"]),
+            ("CRITICAL", ["IMPORTANT", "CRITICAL", ""]),
+        ],
+    )
+    def test_max(self, maximum, impacts):
+        """
+        test that the maximum is correctly identified
+        """
+        assert Impact(maximum) == max(Impact(impact) for impact in impacts)
+
+
 class TestFlawValidators:
     def test_validate_good(self):
         """test that no validator complains about valid flaw"""

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -16,11 +16,11 @@ from osidb.models import (
     Flaw,
     FlawAcknowledgment,
     FlawComment,
-    FlawImpact,
     FlawMeta,
     FlawReference,
     FlawSource,
     FlawType,
+    Impact,
     Tracker,
 )
 from osidb.tests.factories import (
@@ -74,7 +74,7 @@ class TestFlaw:
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             source=FlawSource.APPLE,
             statement="statement",
             is_major_incident=True,
@@ -108,7 +108,7 @@ class TestFlaw:
             "fake_component",
             affectedness=Affect.AffectAffectedness.NEW,
             resolution=Affect.AffectResolution.NOVALUE,
-            impact=Affect.AffectImpact.NOVALUE,
+            impact=Impact.NOVALUE,
             acl_read=self.acl_read,
             acl_write=self.acl_write,
         )
@@ -209,7 +209,7 @@ class TestFlaw:
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             component="curl",
             source=FlawSource.INTERNET,
             statement="statement",
@@ -230,7 +230,7 @@ class TestFlaw:
             title="first",
             unembargo_dt=tzdatetime(2000, 1, 1),
             description="description",
-            impact=FlawImpact.LOW,
+            impact=Impact.LOW,
             component="curl",
             source=FlawSource.INTERNET,
             acl_read=self.acl_read,
@@ -247,7 +247,7 @@ class TestFlaw:
             bz_id="12345",
             title="second",
             description="description",
-            impact=FlawImpact.LOW,
+            impact=Impact.LOW,
             source=FlawSource.INTERNET,
             acl_read=self.acl_read,
             acl_write=self.acl_write,
@@ -371,7 +371,7 @@ class TestFlaw:
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             component="curl",
             source=FlawSource.INTERNET,
             statement="statement",
@@ -395,7 +395,7 @@ class TestFlaw:
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             component="curl",
             source=FlawSource.INTERNET,
             statement="statement",
@@ -418,7 +418,7 @@ class TestFlaw:
             type=FlawType.VULNERABILITY,
             title="title",
             description="description",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             component="curl",
             source=FlawSource.INTERNET,
             statement="statement",
@@ -1175,12 +1175,12 @@ class TestFlawValidators:
     @pytest.mark.parametrize(
         "start_impact,new_impact,tracker_statuses,should_raise",
         [
-            (FlawImpact.LOW, FlawImpact.MODERATE, ["Closed", "Open"], False),
-            (FlawImpact.CRITICAL, FlawImpact.IMPORTANT, ["Closed", "Open"], False),
-            (FlawImpact.LOW, FlawImpact.CRITICAL, ["Closed", "Open"], True),
-            (FlawImpact.CRITICAL, FlawImpact.LOW, ["Closed", "Open"], True),
-            (FlawImpact.LOW, FlawImpact.CRITICAL, ["Closed", "Closed"], False),
-            (FlawImpact.CRITICAL, FlawImpact.LOW, ["Closed", "Closed"], False),
+            (Impact.LOW, Impact.MODERATE, ["Closed", "Open"], False),
+            (Impact.CRITICAL, Impact.IMPORTANT, ["Closed", "Open"], False),
+            (Impact.LOW, Impact.CRITICAL, ["Closed", "Open"], True),
+            (Impact.CRITICAL, Impact.LOW, ["Closed", "Open"], True),
+            (Impact.LOW, Impact.CRITICAL, ["Closed", "Closed"], False),
+            (Impact.CRITICAL, Impact.LOW, ["Closed", "Closed"], False),
         ],
     )
     def test_validate_unsupported_impact_change(
@@ -1222,7 +1222,7 @@ class TestFlawValidators:
         """test that major incident flaws cannot be changed to non-major while having open trackers"""
 
         flaw = FlawFactory.build(
-            embargoed=False, is_major_incident=was_major, impact=FlawImpact.LOW
+            embargoed=False, is_major_incident=was_major, impact=Impact.LOW
         )
         flaw.save(raise_validation_error=False)
         FlawMetaFactory(
@@ -1316,31 +1316,31 @@ class TestFlawValidators:
         "impact,resolution,product,should_raise",
         [
             (
-                Affect.AffectImpact.LOW,
+                Impact.LOW,
                 Affect.AffectResolution.WONTREPORT,
                 "other-services",
                 False,
             ),
             (
-                Affect.AffectImpact.MODERATE,
+                Impact.MODERATE,
                 Affect.AffectResolution.WONTREPORT,
                 "other-services",
                 False,
             ),
             (
-                Affect.AffectImpact.IMPORTANT,
+                Impact.IMPORTANT,
                 Affect.AffectResolution.WONTREPORT,
                 "other-services",
                 True,
             ),
             (
-                Affect.AffectImpact.LOW,
+                Impact.LOW,
                 Affect.AffectResolution.WONTREPORT,
                 "regular-product",
                 True,
             ),
             (
-                Affect.AffectImpact.LOW,
+                Impact.LOW,
                 Affect.AffectResolution.WONTREPORT,
                 "invalid",
                 True,
@@ -1439,7 +1439,7 @@ class TestFlawValidators:
                 ps_product=PsProductFactory(short_name="other-services"),
             )
             affect.ps_module = "other-services-test-module"
-            affect.impact = Affect.AffectImpact.LOW
+            affect.impact = Impact.LOW
 
         if should_raise:
             with pytest.raises(

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -8,7 +8,7 @@ from freezegun import freeze_time
 from collectors.bzimport.convertors import FlawConvertor
 from osidb.core import generate_acls
 from osidb.exceptions import DataInconsistencyException
-from osidb.models import Flaw, FlawImpact, FlawSource
+from osidb.models import Flaw, FlawSource, Impact
 from osidb.tests.factories import AffectFactory, FlawFactory
 
 from .test_flaw import tzdatetime
@@ -194,7 +194,7 @@ class TestTrackingMixin:
             title="title",
             cwe_id="CWE-1",
             description="description",
-            impact=FlawImpact.LOW,
+            impact=Impact.LOW,
             component="curl",
             source=FlawSource.INTERNET,
             acl_read=acl_read,

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 
-from osidb.models import Flaw, FlawImpact, FlawSource, FlawType
+from osidb.models import Flaw, FlawSource, FlawType, Impact
 
 from .factories import AffectFactory, FlawFactory
 
@@ -81,7 +81,7 @@ class TestSearch:
             type=FlawType.VULNERABILITY,
             title="TITLE",
             description="DESCRIPTION",
-            impact=FlawImpact.CRITICAL,
+            impact=Impact.CRITICAL,
             component="kernel",
             source=FlawSource.INTERNET,
             summary="SUMMARY",


### PR DESCRIPTION
As the tracker priority/severity depends on the highest impacts of all the related affects and flaws so we would like to be easily able to do things like `max` with it.