### PR TITLE
Allow lint and test workflows to run on PRs from forks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,5 @@
 name: Lint
-on: [push]
+on: [push, pull_request]
 jobs:
   detect-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
   unit-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previously this was not possible as these workflows were set to run only on repository push, which worked for PRs from branches of the repository as those are considered push events, but not on PRs from community forks as those are *not* considered push events.

By adding `pull_request` to the list of events that trigger these workflows PRs from forks should be covered.