### PR TITLE
create a foundation of Bugzilla tracker filing functionality based on BBSync

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -155,7 +155,7 @@
         "filename": "apps/bbsync/tests/test_saver.py",
         "hashed_secret": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
         "is_verified": false,
-        "line_number": 25,
+        "line_number": 31,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-22T18:41:52Z"
+  "generated_at": "2023-06-23T16:45:52Z"
 }

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -6,7 +6,7 @@ from django.utils.timezone import make_aware
 from freezegun import freeze_time
 
 from apps.bbsync.exceptions import SRTNotesValidationError
-from apps.bbsync.query import BugzillaQueryBuilder, SRTNotesBuilder
+from apps.bbsync.query import FlawBugzillaQueryBuilder, SRTNotesBuilder
 from osidb.models import (
     Affect,
     Flaw,
@@ -74,7 +74,7 @@ class TestGenerateBasics:
             title=title,
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         assert bbq.query["summary"] == summary
 
     @pytest.mark.parametrize(
@@ -137,7 +137,7 @@ class TestGenerateBasics:
             title=title,
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         assert bbq.query["summary"] == summary
 
     def test_generate_summary_added_cve(self):
@@ -154,7 +154,7 @@ class TestGenerateBasics:
         old_flaw = Flaw.objects.first()
         flaw.cve_id = "CVE-2000-1000"
 
-        bbq = BugzillaQueryBuilder(flaw, old_flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw, old_flaw)
         assert bbq.query["summary"] == "CVE-2000-1000 hammer: is too heavy"
 
     def test_generate_summary_removed_cve(self):
@@ -171,7 +171,7 @@ class TestGenerateBasics:
         old_flaw = Flaw.objects.first()
         flaw.cve_id = ""
 
-        bbq = BugzillaQueryBuilder(flaw, old_flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw, old_flaw)
         assert bbq.query["summary"] == "hammer: is too heavy"
 
 
@@ -233,7 +233,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=old_flaw)
         AffectFactory(flaw=old_flaw)
 
-        bbq = BugzillaQueryBuilder(flaw, old_flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw, old_flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -268,7 +268,7 @@ class TestGenerateSRTNotes:
             },
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -324,7 +324,7 @@ class TestGenerateSRTNotes:
             cvss3="",
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -379,7 +379,7 @@ class TestGenerateSRTNotes:
             description="link description",
         )
 
-        bqb = BugzillaQueryBuilder(flaw)
+        bqb = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bqb.query.get("cf_srtnotes")
         cf_srtnotes_json = json.loads(cf_srtnotes)
         references = cf_srtnotes_json.get("references", [])
@@ -453,7 +453,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=flaw)
         AffectFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -511,7 +511,7 @@ class TestGenerateSRTNotes:
         flaw = FlawFactory(cwe_id=osidb_cwe, meta_attr={"original_srtnotes": srtnotes})
         FlawCommentFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -574,7 +574,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=flaw)
         AffectFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -593,7 +593,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=flaw)
         AffectFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -609,7 +609,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=flaw)
         AffectFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -630,7 +630,7 @@ class TestGenerateSRTNotes:
             embargoed=flaw.is_embargoed,
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -688,7 +688,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=old_flaw)
         AffectFactory(flaw=old_flaw)
 
-        bbq = BugzillaQueryBuilder(flaw, old_flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw, old_flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -738,7 +738,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=old_flaw)
         AffectFactory(flaw=old_flaw)
 
-        bbq = BugzillaQueryBuilder(flaw, old_flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw, old_flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -799,7 +799,7 @@ class TestGenerateSRTNotes:
         FlawCommentFactory(flaw=flaw)
         AffectFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -848,7 +848,7 @@ class TestGenerateSRTNotes:
         )
         FlawCommentFactory(flaw=flaw)
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
@@ -933,7 +933,7 @@ class TestGenerateSRTNotes:
             type=Tracker.TrackerType.JIRA,
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         # SRTNotesValidationError exception should not be raised here
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes and json.loads(cf_srtnotes)
@@ -971,7 +971,7 @@ class TestGenerateGroups:
             },
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         query = bbq.query
 
         assert not query.get("groups", [])
@@ -994,7 +994,7 @@ class TestGenerateGroups:
             },
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         query = bbq.query
 
         groups = query.get("groups", [])
@@ -1021,7 +1021,7 @@ class TestGenerateGroups:
             },
         )
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         query = bbq.query
 
         groups = query.get("groups", [])
@@ -1050,7 +1050,7 @@ class TestGenerateGroups:
         new_flaw = Flaw.objects.first()
         new_flaw.acl_read = []  # make it whatever but embargoed
 
-        bbq = BugzillaQueryBuilder(new_flaw, old_flaw=flaw)
+        bbq = FlawBugzillaQueryBuilder(new_flaw, flaw)
         query = bbq.query
 
         groups = query.get("groups", [])
@@ -1098,7 +1098,7 @@ class TestGenerateGroups:
             },
         )
 
-        bbq = BugzillaQueryBuilder(new_flaw, old_flaw=flaw)
+        bbq = FlawBugzillaQueryBuilder(new_flaw, flaw)
         query = bbq.query
 
         groups = query.get("groups", [])
@@ -1122,7 +1122,7 @@ class TestGenerateComment:
         )
         assert FlawComment.objects.pending().count() == 1
 
-        bbq = BugzillaQueryBuilder(flaw)
+        bbq = FlawBugzillaQueryBuilder(flaw)
         assert bbq.query["comment"] == {
             "body": "Hello World",
             "is_private": False,

--- a/apps/bbsync/tests/test_saver.py
+++ b/apps/bbsync/tests/test_saver.py
@@ -2,6 +2,7 @@ import bugzilla
 import pytest
 import requests
 
+from apps.bbsync.query import FlawBugzillaQueryBuilder
 from apps.bbsync.save import BugzillaSaver
 from collectors.bzimport.constants import BZ_URL
 from osidb.exceptions import DataInconsistencyException
@@ -17,6 +18,11 @@ class TestBugzillaSaver:
 
         with monkeypatch.context() as m:
             m.setattr(BugzillaSaver, "model", property(lambda _: Flaw))
+            m.setattr(
+                BugzillaSaver,
+                "query_builder",
+                property(lambda _: FlawBugzillaQueryBuilder),
+            )
 
             bs = BugzillaSaver(test_flaw, "foo")
             m.setattr(

--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -1,0 +1,176 @@
+from functools import cached_property
+
+from apps.bbsync.exceptions import ProductDataError
+from apps.bbsync.query import BugzillaQueryBuilder
+from osidb.models import PsModule, PsUpdateStream
+
+
+class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder):
+    """
+    Bugzilla tracker bug query builder
+    to generate general tracker save query
+    """
+
+    @property
+    def tracker(self):
+        """
+        concrete name shortcut
+        """
+        return self.instance
+
+    @property
+    def old_tracker(self):
+        """
+        concrete name shortcut
+        """
+        return self.old_instance
+
+    @cached_property
+    def ps_module(self):
+        """
+        cached PS module getter
+        """
+        # even when multiple affects they must all have the same PS module
+        return PsModule.objects.get(name=self.tracker.affects.first().ps_module)
+
+    @cached_property
+    def ps_component(self):
+        """
+        cached PS component getter
+        """
+        # even when multiple affects they must all have the same PS component
+        return self.tracker.affects.first().ps_component
+
+    @cached_property
+    def ps_update_stream(self):
+        """
+        cached PS update stream getter
+        """
+        return PsUpdateStream.objects.get(name=self.tracker.ps_update_stream)
+
+    def generate(self):
+        """
+        generate query
+        """
+        self.generate_base()
+        self.generate_cc()
+        self.generate_component()  # TODO sub_components
+        self.generate_deadline()
+        self.generate_description()
+        self.generate_flags()
+        self.generate_groups()
+        self.generate_keywords()
+        self.generate_summary()
+        self.generate_version()
+
+    def generate_base(self):
+        """
+        generate static base of the query
+        """
+        self._query = {
+            "product": self.ps_module.bts_key,
+        }
+        # priority and severity is mirrored
+        self._query["priority"] = self._query[
+            "severity"
+        ] = self.IMPACT_TO_SEVERITY_PRIORITY[self.tracker.aggregated_impact]
+
+    def generate_cc(self):
+        """
+        generate query for CC list
+        """
+        # TODO CC list module
+
+    def generate_component(self):
+        """
+        generate Bugzilla component
+        """
+        # TODO not so simple for RHSCL or RHEL
+        self._query["component"] = self.ps_component
+
+    def generate_deadline(self):
+        """
+        generate query for Bugzilla deadline
+        """
+        # TODO SLA module
+        pass
+
+    def generate_description(self):
+        """
+        generate query for flaw description on create
+        """
+        if self.creation:
+            self._query["description"] = "TODO"
+            # auto-created description should be always public
+            self._query["comment_is_private"] = False
+
+        # TODO update comments
+
+    def generate_flags(self):
+        """
+        generate query for Bugzilla flags
+        """
+        # we add flags on creation only
+        if not self.creation:
+            return
+
+        self._query["flags"] = []
+        # TODO set_pm_ack
+        # TODO set_prodces_priority
+        # TODO sfm2.sla.py:330
+
+    def generate_groups(self):
+        """
+        generate query for Bugzilla groups which control the access to the tracker
+        they are based on the product definitions for both public and embargoed
+        """
+        groups = []
+
+        if self.tracker.embargoed:
+            groups = self.ps_module.bts_groups["embargoed"]
+            if not groups:
+                # safety check for the theoretical case of misconfigured PS module
+                # without groups the embargoed tracker would be public and so leaking
+                raise ProductDataError(
+                    "Cannot create EMBARGOED trackers without group restrictions!"
+                    " (empty bts_groups.embargoed for PSModule {})".format(
+                        self.ps_module.name
+                    )
+                )
+        else:
+            groups = self.ps_module.bts_groups["public"]
+
+        # on creation we provide a list of groups
+        if self.creation:
+            self._query["groups"] = groups
+
+        # otherwise we provide the differences
+        else:
+            # TODO we change the tracker groups on unembargo only
+            pass
+
+    def generate_keywords(self):
+        """
+        generate keywords query based on creation|update
+        """
+        self._query["keywords"] = (
+            ["Security", "SecurityTracking"]
+            if self.old_tracker is None
+            else {"add": ["Security", "SecurityTracking"]}
+        )
+
+    def generate_summary(self):
+        """
+        generate query for tracker summary
+        """
+        # TODO
+        self._query[
+            "summary"
+        ] = f"{self.ps_component}: TODO [{self.ps_update_stream.name}]"
+
+    def generate_version(self):
+        """
+        generate Bugzilla component
+        """
+        # TODO RHSCL can override this
+        self._query["version"] = self.ps_update_stream.version

--- a/apps/trackers/bugzilla/save.py
+++ b/apps/trackers/bugzilla/save.py
@@ -1,0 +1,61 @@
+"""
+Bugzilla tracker funtionality module
+"""
+from apps.bbsync.save import BugzillaSaver
+from osidb.models import Tracker
+
+from .query import TrackerBugzillaQueryBuilder
+
+
+class TrackerBugzillaSaver(BugzillaSaver):
+    """
+    Bugzilla tracker bug save handler
+    """
+
+    @property
+    def tracker(self):
+        """
+        concrete name shortcut
+        """
+        return self.instance
+
+    @property
+    def model(self):
+        """
+        Tracker model class getter
+        """
+        return Tracker
+
+    @property
+    def query_builder(self):
+        """
+        query builder class getter
+        """
+        return TrackerBugzillaQueryBuilder
+
+    def create(self):
+        """
+        create tracker in Bugzilla
+        """
+        self.assert_context()
+        return super().create()
+
+    def update(self):
+        """
+        update tracker in Bugzilla
+        """
+        self.assert_context()
+        return super().update()
+
+    def assert_context(self):
+        """
+        the vital tracker related pieces of information need to exist
+        or otherwise we would not be able to construct the tracker query
+        """
+        # TODO these assertions are applicable to the Jira
+        # trackers too but let me keep it here until we merge
+        from osidb.models import PsModule, PsUpdateStream
+
+        assert self.tracker.affects.first()
+        assert PsModule.objects.filter(name=self.tracker.affects.first().ps_module)
+        assert PsUpdateStream.objects.filter(name=self.tracker.ps_update_stream)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1794,6 +1794,27 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
     def is_closed(self):
         return self.status.upper() == "CLOSED"
 
+    @property
+    def is_acked(self):
+        """
+        tracker acked by ProdSec - filed against an acked stream
+        the default approach important and critical aggregated impact
+        """
+        return not self.is_unacked
+
+    @property
+    def is_unacked(self):
+        """
+        tracker not acked by ProdSec - filed against an unacked stream
+        the default approach low and moderate aggregated impact
+        """
+        return (
+            PsUpdateStream.objects.filter(
+                name=self.ps_update_stream, unacked_to_ps_module__isnull=False
+            ).first()
+            is not None
+        )
+
 
 class ErratumManager(TrackingMixinManager):
     """

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1733,6 +1733,17 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             )
 
     @property
+    def aggregated_impact(self):
+        """
+        this property simply gives the maximum impact of the related entities
+        """
+        return max(
+            Impact(impact)
+            for impact in [affect.impact for affect in self.affects.all()]
+            + [affect.flaw.impact for affect in self.affects.all()]
+        )
+
+    @property
     def bz_id(self):
         """
         shortcut to enable unified Bugzilla Flaw and Tracker handling when meaningful

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -9,6 +9,7 @@ from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -55,6 +56,26 @@ class TestTracker:
 
         tracker = TrackerFactory(affects=[affect1, affect2], embargoed=flaw1.embargoed)
         assert tracker.aggregated_impact == expected_impact
+
+    def test_is_unacked(self):
+        """
+        test that (un)acked property works correctly
+        """
+        ps_module = PsModuleFactory()
+        acked_ps_update_stream = PsUpdateStreamFactory(
+            ps_module=ps_module,
+            unacked_to_ps_module=None,
+        )
+        unacked_ps_update_stream = PsUpdateStreamFactory(
+            ps_module=ps_module,
+            unacked_to_ps_module=ps_module,
+        )
+
+        acked_tracker = TrackerFactory(ps_update_stream=acked_ps_update_stream.name)
+        unacked_tracker = TrackerFactory(ps_update_stream=unacked_ps_update_stream.name)
+
+        assert acked_tracker.is_acked and not acked_tracker.is_unacked
+        assert not unacked_tracker.is_acked and unacked_tracker.is_unacked
 
 
 class TestTrackerValidators:


### PR DESCRIPTION
This is a very foundation of Bugzilla tracker filing functionality. A lot of BBSync stuff is reused. There is a number of TODOs and the code itself is not integrated into OSIDB yet (not being called anywhere). The goal was to be able to create a Bugzilla tracker using OSIDB shell which was successful

https://bugzilla.stage.redhat.com/show_bug.cgi?id=2014466

and also checked in SFM2 that the tracker is valid enough (according to the current level of the implementation). There is still a lot of work but that is tracked in the followup Jiras.

Closes OSIDB-92