### PR TITLE
FlawReference BBSync and API fixes

### DIFF
--- a/apps/bbsync/srtnotes.py
+++ b/apps/bbsync/srtnotes.py
@@ -176,12 +176,17 @@ class SRTNotesBuilder:
     def generate_references(self):
         """
         generate array of references to SRT notes
+
+        OSIDB uses "ARTICLE" and "EXTERNAL",
+        but Bugzilla uses "vuln_response" and "external".
         """
+        references_mapping = {"ARTICLE": "vuln_response", "EXTERNAL": "external"}
+
         self.add_conditionally(
             "references",
             [
                 {
-                    "type": reference.type,
+                    "type": references_mapping[reference.type],
                     "url": reference.url,
                     "description": reference.description or None,
                 }

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -386,7 +386,7 @@ class TestGenerateSRTNotes:
 
         assert len(references) == 1
         reference = references[0]
-        assert reference["type"] == "EXTERNAL"
+        assert reference["type"] == "external"
         assert reference["url"] == "https://httpd.apache.org/link123"
         assert reference["description"] == "link description"
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -5951,9 +5951,6 @@ components:
       properties:
         description:
           type: string
-        flaw:
-          type: string
-          format: uuid
         type:
           $ref: '#/components/schemas/FlawReferenceType'
         url:
@@ -5976,7 +5973,6 @@ components:
       required:
       - created_dt
       - embargoed
-      - flaw
       - url
       - uuid
     FlawReferenceType:

--- a/openapi.yml
+++ b/openapi.yml
@@ -2770,7 +2770,6 @@ paths:
         name: flaw_id
         schema:
           type: string
-          format: uuid
         required: true
       - in: query
         name: include_fields
@@ -2836,7 +2835,6 @@ paths:
         name: flaw_id
         schema:
           type: string
-          format: uuid
         required: true
       tags:
       - osidb
@@ -2873,7 +2871,7 @@ paths:
                     version:
                       type: string
           description: ''
-  /osidb/api/v1/flaws/{flaw_id}/references/{uuid}:
+  /osidb/api/v1/flaws/{flaw_id}/references/{id}:
     get:
       operationId: osidb_api_v1_flaws_references_retrieve
       parameters:
@@ -2890,7 +2888,11 @@ paths:
         name: flaw_id
         schema:
           type: string
-          format: uuid
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
         required: true
       - in: query
         name: include_fields
@@ -2913,13 +2915,6 @@ paths:
           wildcards eg. `include_meta_attr=*,related_model.*` for retrieving all the
           keys from meta_attr. Omit this parameter to not include meta_attr fields
           at all. '
-      - in: path
-        name: uuid
-        schema:
-          type: string
-          format: uuid
-        description: A UUID string identifying this flaw reference.
-        required: true
       tags:
       - osidb
       security:
@@ -2951,14 +2946,11 @@ paths:
         name: flaw_id
         schema:
           type: string
-          format: uuid
         required: true
       - in: path
-        name: uuid
+        name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this flaw reference.
         required: true
       tags:
       - osidb
@@ -3002,14 +2994,11 @@ paths:
         name: flaw_id
         schema:
           type: string
-          format: uuid
         required: true
       - in: path
-        name: uuid
+        name: id
         schema:
           type: string
-          format: uuid
-        description: A UUID string identifying this flaw reference.
         required: true
       tags:
       - osidb

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -353,7 +353,6 @@ class FlawView(ModelViewSet):
     ),
 )
 class FlawReferenceView(ModelViewSet):
-    queryset = FlawReference.objects.all()
     serializer_class = FlawReferenceSerializer
     http_method_names = get_valid_http_methods(ModelViewSet)
     permission_classes = [IsAuthenticatedOrReadOnly]
@@ -373,6 +372,24 @@ class FlawReferenceView(ModelViewSet):
         flaw = instance.flaw
         instance.delete()
         flaw.save(bz_api_key=bz_api_key)
+
+    def get_flaw(self):
+        """
+        Gets a flaw associated with a given flaw reference.
+        """
+        _id = self.kwargs["flaw_id"]
+        if CVE_RE_STR.match(_id):
+            flaw = get_object_or_404(Flaw, cve_id=_id)
+        else:
+            flaw = get_object_or_404(Flaw, uuid=_id)
+        self.check_object_permissions(self.request, flaw)
+        return flaw
+
+    def get_queryset(self):
+        """
+        Returns flaw references only for a specified flaw.
+        """
+        return FlawReference.objects.filter(flaw=self.get_flaw())
 
 
 @extend_schema(

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -391,6 +391,16 @@ class FlawReferenceView(ModelViewSet):
         """
         return FlawReference.objects.filter(flaw=self.get_flaw())
 
+    def get_serializer(self, *args, **kwargs):
+        """
+        Updates a serializer to contain also a flaw uuid.
+        """
+        if "data" in kwargs:
+            data = kwargs["data"].copy()
+            data["flaw"] = str(self.get_flaw().uuid)
+            kwargs["data"] = data
+        return super().get_serializer(*args, **kwargs)
+
 
 @extend_schema(
     responses={

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -627,6 +627,7 @@ class FlawReferenceSerializer(
     ACLMixinSerializer,
     BugzillaSyncMixinSerializer,
     IncludeExcludeFieldsMixin,
+    IncludeMetaAttrMixin,
     TrackingMixinSerializer,
 ):
     """FlawReference serializer"""

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -642,7 +642,7 @@ class FlawReferenceSerializer(
         )
 
 
-@extend_schema_serializer(exclude_fields=["updated_dt"])
+@extend_schema_serializer(exclude_fields=["updated_dt", "flaw"])
 class FlawReferencePostSerializer(FlawReferenceSerializer):
     # extra serializer for POST request as there is no last update
     # timestamp but we need to make the field mandatory otherwise

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1656,6 +1656,7 @@ class TestEndpoints(object):
         """
         flaw = FlawFactory()
         flawreference = FlawReferenceFactory(flaw=flaw)
+        AffectFactory(flaw=flaw)
 
         url = f"{test_api_uri}/flaws/{str(flaw.uuid)}/references/{flawreference.uuid}"
         response = auth_client.get(url)
@@ -1663,7 +1664,7 @@ class TestEndpoints(object):
 
         # Tests "DELETE" on flaws/{uuid}/references/{uuid}
         response = auth_client.delete(url, HTTP_BUGZILLA_API_KEY="SECRET")
-        assert response.status_code == status.HTTP_204_NO_CONTENT
+        assert response.status_code == status.HTTP_200_OK
         assert FlawReference.objects.count() == 0
 
     def test_tracker_create(self, auth_client, test_api_uri):

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -23,7 +23,11 @@ router.register(r"flaws", FlawView)
 router.register(
     r"flaws/(?P<flaw_id>[^/.]+)/comments", FlawCommentView, basename="flawcomments"
 )
-router.register(r"flaws/(?P<flaw_id>[^/.]+)/references", FlawReferenceView)
+router.register(
+    r"flaws/(?P<flaw_id>[^/.]+)/references",
+    FlawReferenceView,
+    basename="flawreferences",
+)
 router.register(r"affects", AffectView)
 router.register(r"trackers", TrackerView)
 


### PR DESCRIPTION
This PR fixes a few `FlawReference` issues:
- References from OSIDB are saved into Bugzzilla in incorrect format. This causes references to be missing in SFM2.
- `FlawReferenceView` does not propagate the deletion to Bugzilla. This causes references to be deleted in OSIDB but not in Bugzilla.
- `FlawReferenceView` does not return references for a specified flaw only. This causes all references to be returned.
- `FlawReferenceView` does not contain a flaw uuid in a serializer only.
- `FlawReferenceSerializer` does not inherit from `IncludeMetaAttrMixin.`

Fixes OSIDB-1035