### PR TITLE
Include raw summary from BZ in Flaw.meta_attr

### DIFF
--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -613,6 +613,7 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
         meta_attr["alias"] = self.alias
         meta_attr["depends_on"] = self.depends_on
         meta_attr["related_cves"] = [c for c in self.cve_ids if c != cve_id]
+        meta_attr["bz_summary"] = self.flaw_bug["summary"]
         meta_attr["last_change_time"] = self.flaw_bug["last_change_time"]
         meta_attr["last_imported_dt"] = timezone.now()
         meta_attr["acl_labels"] = self.groups

--- a/collectors/bzimport/tests/test_convertors.py
+++ b/collectors/bzimport/tests/test_convertors.py
@@ -536,7 +536,7 @@ class TestFlawConvertor:
             "last_change_time": "2001-01-01T12:12:12Z",
             "status": "CLOSED",
             "resolution": "",
-            "summary": "kernel: text",
+            "summary": "EMBARGOED TRIAGE CVE-2000-1234 foo: ACL bypass with Authorization: 0000 HTTP header",
             "cf_srtnotes": cls.get_flaw_srtnotes(),
         }
 
@@ -1112,6 +1112,31 @@ class TestFlawConvertor:
         assert affect.cvss2_score is None
         assert affect.cvss3 == ""
         assert affect.cvss3_score is None
+
+    def test_summary_meta_attr(self):
+        """
+        Test that the title (summary in BZ) is saved as-is in Flaw.meta_attr
+
+        Since the actual Flaw title goes through some parsing / transformations,
+        we need to at least provide the summary as-is from BZ in case the
+        parsing was subpar, this way clients can have the full context.
+        """
+        # TODO: make self.get_flaw_bug() into a fixture
+        flaw_bug = self.get_flaw_bug()
+        fbc = FlawConvertor(
+            flaw_bug,
+            [],
+            None,
+            None,
+            [],
+            [],
+        )
+        [flaw] = fbc.bug2flaws()
+        flaw.save()
+        flaw = Flaw.objects.first()
+
+        assert "bz_summary" in flaw.meta_attr
+        assert flaw.meta_attr["bz_summary"] == flaw_bug["summary"]
 
 
 class TestFlawConvertorFixedIn:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement adding new flaw comments (OSIDB-81)
 - Erratum advisory name to flaw filter (OSIDB-922)
 - CORS allow-list functionality (OSIDB-967, OSIDB-965)
+- Raw bugzilla summary to Flaw.meta_attr (OSIDB-1016)
 
 ### Changed
 - Set Jira trackers as public instead of embargoed when private (OSIDB-1013)


### PR DESCRIPTION
The Flaw.title attribute is based off of the `summary` attribute from Bugzilla, however before setting Flaw.title the summary goes through various transformations which might not be perfect and the resulting title might be incorrect.

With this commit we include the raw BZ version of the title (summary in BZ) so that clients have the full context should they need it.

Closes OSIDB-1016