### PR TITLE
Ensure that oasdiff returns exit code 1 on warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 jobs:
   detect-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,9 @@
 name: Lint
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   detect-secrets:
     runs-on: ubuntu-latest

--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install oasdiff go package
         run: go install github.com/tufin/oasdiff@v1.5.0
       - name: Compare existing schema to new schema
-        run: oasdiff -fail-on-diff -check-breaking -base base/openapi.yml -revision head/openapi.yml
+        run: oasdiff -fail-on-diff -fail-on-warns -check-breaking -base base/openapi.yml -revision head/openapi.yml
   changelog:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,9 @@
 name: Test
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,7 +109,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 24,
+        "line_number": 25,
         "is_secret": false
       },
       {
@@ -117,7 +117,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 42,
+        "line_number": 43,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-04T09:43:06Z"
+  "generated_at": "2023-07-04T12:42:51Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -109,7 +109,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 20,
+        "line_number": 24,
         "is_secret": false
       },
       {
@@ -117,7 +117,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 42,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-04T07:51:00Z"
+  "generated_at": "2023-07-04T09:43:06Z"
 }


### PR DESCRIPTION
The oasdiff tool used in the CI pipeline does not return exit code 1 on warnings by default, yet the warnings can include backwards-incompatible changes even if these changes do not yield out an error for the client but are simply undefined behavior.

This commit adds the -fail-on-warns flag so that warnings are also considered breaking changes.