### PR TITLE
document no trailing slash in Bugzilla URL

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -211,7 +211,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 61,
+        "line_number": 62,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-06-30T12:42:25Z"
+  "generated_at": "2023-07-04T07:51:00Z"
 }

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -15,6 +15,7 @@ Create a file named `.env`:
 BZIMPORT_BZ_API_KEY=####################
 
 # Bugzilla URL (optional, defaults to RedHat production Bugzilla)
+# Never add the trailing slash to the URL as the python-bugzilla handles it wrong
 BZIMPORT_BZ_URL="https://foo.bar"
 
 # Jira REST API authentication token


### PR DESCRIPTION
The `python-bugzilla` lib logic will result in calling the endpoints without `/rest` and those do not exist.

FYI @jobselko 