### PR TITLE
account for SRT email disabling Bugzilla data migration in bzimport

### DIFF
--- a/collectors/bzimport/collectors.py
+++ b/collectors/bzimport/collectors.py
@@ -304,6 +304,15 @@ class FlawCollector(Collector, BugzillaQuerier, JiraQuerier):
             "end": timezone.datetime(2023, 5, 13, 2, 3, tzinfo=TIMEZONE),
             "step": relativedelta(hours=5),
         },
+        # migration reassigning flaws to nobody@redhat.com
+        # after security-response-team@redhat.com disabling
+        # 2023-07-07 08:25 UTC – 2023-07-07 08:40 UTC
+        # so we prevent large batches going by 3 minutes
+        {
+            "start": timezone.datetime(2023, 7, 7, 8, 25, tzinfo=TIMEZONE),
+            "end": timezone.datetime(2023, 7, 7, 8, 40, tzinfo=TIMEZONE),
+            "step": relativedelta(minutes=3),
+        },
     ]
 
     def end_period_heuristic(self, period_start):


### PR DESCRIPTION
https://bugzilla.redhat.com/buglist.cgi?columnlist=product%2Ccomponent%2Cassigned_to%2Cstatus%2Csummary%2Clast_change_time%2Cseverity%2Cpriority&component=vulnerability&f1=delta_ts&f2=delta_ts&list_id=13258299&o1=greaterthaneq&o2=lessthaneq&order=status%2C%20priority%2C%20assigned_to%2C%20id%2C%20&product=Security%20Response&query_format=advanced&v1=2023-07-07T08%3A25%3A00&v2=2023-07-07T08%3A40%3A00