### PR TITLE
Add requires_summary to Flaw API and update BZImport and BBSync

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,7 +261,7 @@
         "filename": "osidb/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1140,
+        "line_number": 1148,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-18T12:08:32Z"
+  "generated_at": "2023-07-21T14:17:24Z"
 }

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -220,11 +220,15 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
     def generate_flags(self):
         """
         generate query for Bugzilla flags
+        TODO: needinfo, nist_cvss_validation, requires_doc_text and other flags
         """
         self._query["flags"] = []
-        # TODO needinfo and other flags
-        # nist_cvss_validation | requires_doc_text
+        self.generate_hightouch_flags()
 
+    def generate_hightouch_flags(self):
+        """
+        Generate hightouch and hightouch-lite flags from major_incident_state.
+        """
         flags_to_write = {
             Flaw.FlawMajorIncident.REQUESTED: ("?", "?"),
             Flaw.FlawMajorIncident.REJECTED: ("-", "-"),

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -220,10 +220,11 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
     def generate_flags(self):
         """
         generate query for Bugzilla flags
-        TODO: needinfo, nist_cvss_validation, requires_doc_text and other flags
+        TODO: needinfo, nist_cvss_validation and other flags
         """
         self._query["flags"] = []
         self.generate_hightouch_flags()
+        self.generate_requires_doc_text_flag()
 
     def generate_hightouch_flags(self):
         """
@@ -243,6 +244,22 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
             self._query["flags"].append({"name": "hightouch", "status": hightouch})
             self._query["flags"].append(
                 {"name": "hightouch-lite", "status": hightouch_lite}
+            )
+
+    def generate_requires_doc_text_flag(self):
+        """
+        Generate requires_doc_text flag from requires_summary.
+        """
+        flags_to_write = {
+            Flaw.FlawRequiresSummary.REQUESTED: "?",
+            Flaw.FlawRequiresSummary.APPROVED: "+",
+            Flaw.FlawRequiresSummary.REJECTED: "-",
+            # flag NOVALUE is ignored
+        }
+
+        if bz_value := flags_to_write.get(self.flaw.requires_summary):
+            self._query["flags"].append(
+                {"name": "requires_doc_text", "status": bz_value}
             )
 
     # Bugzilla groups allowed to be set for Bugzilla Security Response product

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement major_incident_state in Flaw API (OSIDB-266)
 - Implement a new FlawAcknowledgment API (OSIDB-1002)
+- Implement requires_summary in Flaw API (OSIDB-1005)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2326,6 +2326,7 @@ paths:
             - -nvd_cvss2
             - -nvd_cvss3
             - -reported_dt
+            - -requires_summary
             - -source
             - -type
             - -unembargo_dt
@@ -2372,6 +2373,7 @@ paths:
             - nvd_cvss2
             - nvd_cvss3
             - reported_dt
+            - requires_summary
             - source
             - type
             - unembargo_dt
@@ -2420,6 +2422,15 @@ paths:
         schema:
           type: string
           format: date-time
+      - in: query
+        name: requires_summary
+        schema:
+          type: string
+          enum:
+          - ''
+          - APPROVED
+          - REJECTED
+          - REQUESTED
       - in: query
         name: search
         schema:
@@ -5787,6 +5798,10 @@ components:
           type: string
         summary:
           type: string
+        requires_summary:
+          oneOf:
+          - $ref: '#/components/schemas/RequiresSummaryEnum'
+          - $ref: '#/components/schemas/BlankEnum'
         statement:
           type: string
         cwe_id:
@@ -6149,6 +6164,10 @@ components:
           type: string
         summary:
           type: string
+        requires_summary:
+          oneOf:
+          - $ref: '#/components/schemas/RequiresSummaryEnum'
+          - $ref: '#/components/schemas/BlankEnum'
         statement:
           type: string
         cwe_id:
@@ -6789,6 +6808,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tracker'
+    RequiresSummaryEnum:
+      enum:
+      - REQUESTED
+      - APPROVED
+      - REJECTED
+      type: string
     ResolutionEnum:
       enum:
       - FIX

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -180,6 +180,7 @@ class FlawFilter(DistinctFilterSet):
             "nvd_cvss3": ["exact"],
             "component": ["exact"],
             "major_incident_state": ["exact"],
+            "requires_summary": ["exact"],
             # Affect fields
             "affects__uuid": ["exact"],
             "affects__type": ["exact"],

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -824,6 +824,7 @@ class FlawSerializer(
                 "trackers",
                 "description",
                 "summary",
+                "requires_summary",
                 "statement",
                 "cwe_id",
                 "unembargo_dt",

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -136,7 +136,10 @@ class TestEndpoints(object):
     def test_get_flaw(self, auth_client, test_api_uri):
         """retrieve specific flaw from endpoint"""
 
-        flaw1 = FlawFactory.build(major_incident_state=Flaw.FlawMajorIncident.APPROVED)
+        flaw1 = FlawFactory.build(
+            major_incident_state=Flaw.FlawMajorIncident.APPROVED,
+            requires_summary=Flaw.FlawRequiresSummary.APPROVED,
+        )
         flaw1.save(raise_validation_error=False)
         FlawMetaFactory(
             flaw=flaw1,
@@ -150,6 +153,7 @@ class TestEndpoints(object):
         )
         AffectFactory(flaw=flaw1)
         assert flaw1.save() is None
+        assert flaw1.requires_summary == Flaw.FlawRequiresSummary.APPROVED
         FlawCommentFactory(flaw=flaw1)
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw1.cve_id}")
         assert response.status_code == 200
@@ -1088,7 +1092,10 @@ class TestEndpoints(object):
         assert "refresh" in body
         token = body["access"]
 
-        flaw1 = FlawFactory.build(major_incident_state=Flaw.FlawMajorIncident.APPROVED)
+        flaw1 = FlawFactory.build(
+            major_incident_state=Flaw.FlawMajorIncident.APPROVED,
+            requires_summary=Flaw.FlawRequiresSummary.APPROVED,
+        )
         flaw1.save(raise_validation_error=False)
         FlawMetaFactory(
             flaw=flaw1,
@@ -1103,6 +1110,7 @@ class TestEndpoints(object):
         AffectFactory(flaw=flaw1)
 
         assert flaw1.save() is None
+        assert flaw1.requires_summary == Flaw.FlawRequiresSummary.APPROVED
         FlawCommentFactory(flaw=flaw1)
 
         # attempt to access with unauthenticated client using good token value


### PR DESCRIPTION
Follow-up to #280.

This PR updates the `Flaw` API to propagate the recently added `requires_summary` field in the `Flaw` model. The `requires_summary` value is read from the `requires_doc_text` flag via BZImport and synced backwards via BBSync.

Closes OSIDB-1005