### PR TITLE
Add nist_cvss_validation flag to Flaw API and BBSync, update BZImport

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,7 +261,7 @@
         "filename": "osidb/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1153,
+        "line_number": 1155,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-31T12:48:05Z"
+  "generated_at": "2023-08-04T19:53:57Z"
 }

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -220,11 +220,12 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
     def generate_flags(self):
         """
         generate query for Bugzilla flags
-        TODO: needinfo, nist_cvss_validation and other flags
+        TODO: needinfo and other flags
         """
         self._query["flags"] = []
         self.generate_hightouch_flags()
         self.generate_requires_doc_text_flag()
+        self.generate_nist_cvss_validation_flag()
 
     def generate_hightouch_flags(self):
         """
@@ -260,6 +261,23 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         if bz_value := flags_to_write.get(self.flaw.requires_summary):
             self._query["flags"].append(
                 {"name": "requires_doc_text", "status": bz_value}
+            )
+
+    def generate_nist_cvss_validation_flag(self):
+        """
+        Generate nist_cvss_validation bugzilla flag from Flaw field nist_cvss_validation.
+        """
+
+        flag_to_write = {
+            Flaw.FlawNistCvssValidation.REQUESTED: "?",
+            Flaw.FlawNistCvssValidation.APPROVED: "+",
+            Flaw.FlawNistCvssValidation.REJECTED: "-",
+            # flag NOVALUE is ignored
+        }
+
+        if flag_value := flag_to_write.get(self.flaw.nist_cvss_validation):
+            self._query["flags"].append(
+                {"name": "nist_cvss_validation", "status": flag_value}
             )
 
     # Bugzilla groups allowed to be set for Bugzilla Security Response product

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -624,6 +624,25 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
         return pairs.get(status)
 
     @cached_property
+    def nist_cvss_validation(self):
+        """
+        Set Flaw field nist_cvss_validation from bugzilla flag nist_cvss_validation.
+        """
+        flag_value = ""
+        for flag in self.flags:
+            if flag["name"] == "nist_cvss_validation":
+                flag_value = flag["status"]
+
+        mapping = {
+            "": Flaw.FlawNistCvssValidation.NOVALUE,
+            "?": Flaw.FlawNistCvssValidation.REQUESTED,
+            "+": Flaw.FlawNistCvssValidation.APPROVED,
+            "-": Flaw.FlawNistCvssValidation.REJECTED,
+        }
+
+        return mapping.get(flag_value)
+
+    @cached_property
     def package_versions(self):
         """parse fixed_in to package versions"""
         fixed_in = self.flaw_bug["fixed_in"]
@@ -808,6 +827,7 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
             meta_attr=self.get_meta_attr(cve_id),
             major_incident_state=self.major_incident_state,
             requires_summary=self.requires_summary,
+            nist_cvss_validation=self.nist_cvss_validation,
             created_dt=self.flaw_bug["creation_time"],
             updated_dt=self.flaw_bug["last_change_time"],
             acl_read=self.acl_read,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement requires_summary in Flaw API (OSIDB-1005)
 - Implement ps_update_stream in Tracker API (OSIDB-1064)
 - Implement daily monitoring email for failed tasks
+- Implement nist_cvss_validation in Flaw API (OSIDB-1006)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2265,6 +2265,15 @@ paths:
           - REJECTED
           - REQUESTED
       - in: query
+        name: nist_cvss_validation
+        schema:
+          type: string
+          enum:
+          - ''
+          - APPROVED
+          - REJECTED
+          - REQUESTED
+      - in: query
         name: nvd_cvss2
         schema:
           type: string
@@ -2323,6 +2332,7 @@ paths:
             - -cwe_id
             - -impact
             - -major_incident_state
+            - -nist_cvss_validation
             - -nvd_cvss2
             - -nvd_cvss3
             - -reported_dt
@@ -2370,6 +2380,7 @@ paths:
             - cwe_id
             - impact
             - major_incident_state
+            - nist_cvss_validation
             - nvd_cvss2
             - nvd_cvss3
             - reported_dt
@@ -5976,6 +5987,10 @@ components:
           oneOf:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
+        nist_cvss_validation:
+          oneOf:
+          - $ref: '#/components/schemas/NistCvssValidationEnum'
+          - $ref: '#/components/schemas/BlankEnum'
         affects:
           type: array
           items:
@@ -6412,6 +6427,10 @@ components:
           oneOf:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
+        nist_cvss_validation:
+          oneOf:
+          - $ref: '#/components/schemas/NistCvssValidationEnum'
+          - $ref: '#/components/schemas/BlankEnum'
         affects:
           type: array
           items:
@@ -6806,6 +6825,12 @@ components:
       - type
       - updated_dt
       - uuid
+    NistCvssValidationEnum:
+      enum:
+      - REQUESTED
+      - APPROVED
+      - REJECTED
+      type: string
     PaginatedAffectList:
       type: object
       properties:

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -181,6 +181,7 @@ class FlawFilter(DistinctFilterSet):
             "component": ["exact"],
             "major_incident_state": ["exact"],
             "requires_summary": ["exact"],
+            "nist_cvss_validation": ["exact"],
             # Affect fields
             "affects__uuid": ["exact"],
             "affects__type": ["exact"],

--- a/osidb/migrations/0087_migrate_flaw_flag_nist_cvss_validation.py
+++ b/osidb/migrations/0087_migrate_flaw_flag_nist_cvss_validation.py
@@ -1,0 +1,86 @@
+"""
+Written manually on 2023-07-17
+
+Copy FlawMeta NIST_CVSS_VALIDATION into Flaw field nist_cvss_validation.
+
+To prevent out of memory issues, FlawMeta are iterated using .iterator()
+so that FlawMeta instances are not cached. To prevent further out of
+memory issues and runtime efficiency, the migration uses a generator,
+islice and bulk_update in the way recommended by
+https://docs.djangoproject.com/en/3.2/ref/models/querysets/#bulk-create
+
+"""
+
+from django.db import migrations
+from itertools import islice
+
+BATCH_SIZE = 1000
+
+# maps BZ flags to OSIDB values
+MAPPING = {
+    "": "",
+    "?": "REQUESTED",
+    "+": "APPROVED",
+    "-": "REJECTED",
+}
+
+
+def generate_flag_values(apps):
+    """
+    Generates pairs of (Flaw instance, value of flag nist_cvss_validation for that Flaw).
+    """
+    FlawMeta = apps.get_model("osidb", "FlawMeta")
+    for flawmeta in FlawMeta.objects.filter(type="NIST_CVSS_VALIDATION").iterator():
+        flaw = flawmeta.flaw
+        flag_value = flawmeta.meta_attr["status"]
+        yield flaw, flag_value
+
+
+def forwards_func(apps, schema_editor):
+    """
+    For all Flaws that have the bugzilla flag nist_cvss_validation set, this
+    migration sets the value of the field nist_cvss_validation to be identical
+    to existing FlawMeta NIST_CVSS_VALIDATION.
+    """
+    flag_val_generator = generate_flag_values(apps)
+    Flaw = apps.get_model("osidb", "Flaw")
+
+    while True:
+        batch_flaws_flags = list(islice(flag_val_generator, BATCH_SIZE))
+        if not batch_flaws_flags:
+            break
+
+        flaws = []
+        for flaw, flag in batch_flaws_flags:
+            flaw.nist_cvss_validation = MAPPING[flag]
+            flaws.append(flaw)
+        Flaw.objects.bulk_update(flaws, ["nist_cvss_validation"])
+
+
+def backwards_func(apps, schema_editor):
+    """
+    Reverts value of the field nist_cvss_validation to empty string for all Flaws.
+    """
+    Flaw = apps.get_model("osidb", "Flaw")
+    all_flaws = (
+        Flaw.objects.exclude(nist_cvss_validation="")
+        .only("uuid", "nist_cvss_validation")
+        .iterator()
+    )
+    while True:
+        batch = list(islice(all_flaws, BATCH_SIZE))
+        if not batch:
+            break
+        for flaw in batch:
+            flaw.nist_cvss_validation = ""
+        Flaw.objects.bulk_update(batch, ["nist_cvss_validation"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("osidb", "0086_osidb_flawdraft"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, backwards_func, atomic=True),
+    ]

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -840,6 +840,7 @@ class FlawSerializer(
                 "nvd_cvss3",
                 "is_major_incident",
                 "major_incident_state",
+                "nist_cvss_validation",
                 "affects",
                 "meta",
                 "comments",

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -140,6 +140,7 @@ class TestEndpoints(object):
         flaw1 = FlawFactory.build(
             major_incident_state=Flaw.FlawMajorIncident.APPROVED,
             requires_summary=Flaw.FlawRequiresSummary.APPROVED,
+            nist_cvss_validation=Flaw.FlawNistCvssValidation.REJECTED,
         )
         flaw1.save(raise_validation_error=False)
         FlawMetaFactory(
@@ -160,6 +161,7 @@ class TestEndpoints(object):
         assert response.status_code == 200
         body = response.json()
         assert body["major_incident_state"] == Flaw.FlawMajorIncident.APPROVED
+        assert body["nist_cvss_validation"] == Flaw.FlawNistCvssValidation.REJECTED
         assert len(body["comments"]) == 1
 
     def test_list_flaws(self, auth_client, test_api_uri):


### PR DESCRIPTION
Follow-up to https://github.com/RedHatProductSecurity/osidb/pull/279.

This PR updates the Flaw API to propagate the recently added `nist_cvss_validation` field in the Flaw model, adds `nist_cvss_validation` flag sync to BBSync, and switches BZImport to import the `nist_cvss_validation` flag to the new Flaw field `nist_cvss_validation` instead of `FlawMeta`.

Closes OSIDB-1006