### PR TITLE
Allow writing/modification actions on FlawAcknowledgment API.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,7 +261,7 @@
         "filename": "osidb/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1152,
+        "line_number": 1153,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-26T10:48:18Z"
+  "generated_at": "2023-07-31T12:48:05Z"
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -2839,6 +2839,50 @@ paths:
                     version:
                       type: string
           description: ''
+    post:
+      operationId: osidb_api_v1_flaws_acknowledgments_create
+      parameters:
+      - in: path
+        name: flaw_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      tags:
+      - osidb
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlawAcknowledgmentPost'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FlawAcknowledgmentPost'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FlawAcknowledgmentPost'
+        required: true
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/FlawAcknowledgment'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
   /osidb/api/v1/flaws/{flaw_id}/acknowledgments/{id}:
     get:
       operationId: osidb_api_v1_flaws_acknowledgments_retrieve
@@ -2907,6 +2951,90 @@ paths:
                       type: string
                     version:
                       type: string
+          description: ''
+    put:
+      operationId: osidb_api_v1_flaws_acknowledgments_update
+      parameters:
+      - in: path
+        name: flaw_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - osidb
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlawAcknowledgmentPut'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FlawAcknowledgmentPut'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FlawAcknowledgmentPut'
+        required: true
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/FlawAcknowledgment'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+    delete:
+      operationId: osidb_api_v1_flaws_acknowledgments_destroy
+      parameters:
+      - in: path
+        name: flaw_id
+        schema:
+          type: string
+          format: uuid
+        required: true
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - osidb
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '204':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
           description: ''
   /osidb/api/v1/flaws/{flaw_id}/comments:
     get:
@@ -6027,6 +6155,76 @@ components:
       - created_dt
       - embargoed
       - flaw
+      - from_upstream
+      - name
+      - updated_dt
+      - uuid
+    FlawAcknowledgmentPost:
+      type: object
+      description: FlawAcknowledgment serializer
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        affiliation:
+          type: string
+          maxLength: 255
+        from_upstream:
+          type: boolean
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        embargoed:
+          type: boolean
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+        created_dt:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - affiliation
+      - created_dt
+      - embargoed
+      - from_upstream
+      - name
+      - uuid
+    FlawAcknowledgmentPut:
+      type: object
+      description: FlawAcknowledgment serializer
+      properties:
+        name:
+          type: string
+          maxLength: 255
+        affiliation:
+          type: string
+          maxLength: 255
+        from_upstream:
+          type: boolean
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        embargoed:
+          type: boolean
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+        created_dt:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_dt:
+          type: string
+          format: date-time
+          description: The updated_dt timestamp attribute is mandatory on update as
+            it is used to detect mit-air collisions.
+      required:
+      - affiliation
+      - created_dt
+      - embargoed
       - from_upstream
       - name
       - updated_dt

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -380,12 +380,7 @@ class FlawView(ModelViewSet):
 )
 class FlawAcknowledgmentView(ModelViewSet):
     serializer_class = FlawAcknowledgmentSerializer
-    # As long as SRTNotesBuilder.generate_acknowledgments() builds from FlawMeta,
-    # POST, DELETE and PUT don't work.
-    # TODO: Resolve in a follow-up to PR 265.
-    http_method_names = get_valid_http_methods(
-        ModelViewSet, excluded=["post", "delete", "put"]
-    )
+    http_method_names = get_valid_http_methods(ModelViewSet)
     permission_classes = [IsAuthenticatedOrReadOnly]
     filterset_class = FlawAcknowledgmentFilter
 

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -146,7 +146,7 @@ class ComparableTextChoices(models.TextChoices):
         to ensure that that we are comparing the instances of the same type as
         comparing different types (even two ComparableTextChoices) is undefined
         """
-        return type(self) != type(other)
+        return type(self) is not type(other)
 
     def __hash__(self):
         return super().__hash__()

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -20,6 +20,7 @@ from ..helpers import ensure_list
 from ..models import (
     Affect,
     Flaw,
+    FlawAcknowledgment,
     FlawComment,
     FlawMeta,
     FlawReference,
@@ -1646,27 +1647,22 @@ class TestEndpoints(object):
             format="json",
             HTTP_BUGZILLA_API_KEY="SECRET",
         )
+        assert response.status_code == status.HTTP_201_CREATED
+        acknowledgment_uuid = response.data["uuid"]
 
-        # TODO: Resolve in a follow-up to PR 265.
-        # As long as SRTNotesBuilder.generate_acknowledgments() builds from FlawMeta,
-        # POST, DELETE and PUT don't work.
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-        # TODO: assert response.status_code == status.HTTP_201_CREATED
-        # TODO: acknowledgment_uuid = response.data["uuid"]
+        # Tests "GET" on flaws/{uuid}/acknowledgments
+        response = auth_client.get(
+            f"{test_api_uri}/flaws/{str(flaw.uuid)}/acknowledgments"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json()["count"] == 1
 
-        # TODO: # Tests "GET" on flaws/{uuid}/acknowledgments
-        # TODO: response = auth_client.get(
-        # TODO:     f"{test_api_uri}/flaws/{str(flaw.uuid)}/acknowledgments"
-        # TODO: )
-        # TODO: assert response.status_code == status.HTTP_200_OK
-        # TODO: assert response.json()["count"] == 1
-
-        # TODO: # Tests "GET" on flaws/{uuid}/acknowledgments/{uuid}
-        # TODO: response = auth_client.get(
-        # TODO:     f"{test_api_uri}/flaws/{str(flaw.uuid)}/acknowledgments/{acknowledgment_uuid}"
-        # TODO: )
-        # TODO: assert response.status_code == status.HTTP_200_OK
-        # TODO: assert response.data["uuid"] == acknowledgment_uuid
+        # Tests "GET" on flaws/{uuid}/acknowledgments/{uuid}
+        response = auth_client.get(
+            f"{test_api_uri}/flaws/{str(flaw.uuid)}/acknowledgments/{acknowledgment_uuid}"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["uuid"] == acknowledgment_uuid
 
     def test_flawacknowledgment_update(self, auth_client, embargo_access, test_api_uri):
         """
@@ -1692,13 +1688,8 @@ class TestEndpoints(object):
             format="json",
             HTTP_BUGZILLA_API_KEY="SECRET",
         )
-
-        # TODO: Resolve in a follow-up to PR 265.
-        # As long as SRTNotesBuilder.generate_acknowledgments() builds from FlawMeta,
-        # POST, DELETE and PUT don't work.
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-        # TODO: assert response.status_code == status.HTTP_200_OK
-        # TODO: assert response.data["name"] == "Jon A"
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["name"] == "Jon A"
 
     def test_flawacknowledgment_delete(self, auth_client, embargo_access, test_api_uri):
         """
@@ -1717,13 +1708,8 @@ class TestEndpoints(object):
 
         # Tests "DELETE" on flaws/{uuid}/acknowledgments/{uuid}
         response = auth_client.delete(url, HTTP_BUGZILLA_API_KEY="SECRET")
-
-        # TODO: Resolve in a follow-up to PR 265.
-        # As long as SRTNotesBuilder.generate_acknowledgments() builds from FlawMeta,
-        # POST, DELETE and PUT don't work.
-        assert response.status_code == status.HTTP_405_METHOD_NOT_ALLOWED
-        # TODO: assert response.status_code == status.HTTP_200_OK
-        # TODO: assert FlawAcknowledgment.objects.count() == 0
+        assert response.status_code == status.HTTP_200_OK
+        assert FlawAcknowledgment.objects.count() == 0
 
     def test_flawreference_create(self, auth_client, embargo_access, test_api_uri):
         """


### PR DESCRIPTION
Follow-up to https://github.com/RedHatProductSecurity/osidb/pull/278 and https://github.com/RedHatProductSecurity/osidb/pull/273.

Allow POST, PUT, DELETE methods on FlawAcknowledgment API.

Closes OSIDB-1004.