### PR TITLE
Implement ps_update_stream in Tracker API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,7 +261,7 @@
         "filename": "osidb/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1148,
+        "line_number": 1152,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-07-21T14:17:24Z"
+  "generated_at": "2023-07-26T10:48:18Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement major_incident_state in Flaw API (OSIDB-266)
 - Implement a new FlawAcknowledgment API (OSIDB-1002)
 - Implement requires_summary in Flaw API (OSIDB-1005)
+- Implement ps_update_stream in Tracker API (OSIDB-1064)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)

--- a/openapi.yml
+++ b/openapi.yml
@@ -7015,6 +7015,9 @@ components:
             status:
               type: string
           readOnly: true
+        ps_update_stream:
+          type: string
+          maxLength: 100
         created_dt:
           type: string
           format: date-time

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -318,6 +318,7 @@ class TrackerSerializer(
             "resolution",
             "errata",
             "meta_attr",
+            "ps_update_stream",
         ] + TrackingMixinSerializer.Meta.fields
 
 

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1058,7 +1058,10 @@ class TestEndpoints(object):
             resolution=Affect.AffectResolution.DELEGATED,
         )
         TrackerFactory(
-            affects=(delegated_affect,), status="won't fix", embargoed=flaw.is_embargoed
+            affects=(delegated_affect,),
+            status="won't fix",
+            embargoed=flaw.is_embargoed,
+            ps_update_stream="rhel-7.0",
         )
 
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw.cve_id}")
@@ -1068,6 +1071,7 @@ class TestEndpoints(object):
         affect = body["affects"][0]
         assert "trackers" in affect
         assert affect["delegated_resolution"] == Affect.AffectFix.WONTFIX
+        assert affect["trackers"][0]["ps_update_stream"] == "rhel-7.0"
 
         # assert delegated_affect.delegated_resolution == Affect.AffectFix.WONTFIX
 


### PR DESCRIPTION
This PR extends the `Tracker` API to contain the `ps_update_stream` field. This field has already been in the `Tracker` model but has not been included in the API.

Closes OSIDB-1064