### PR TITLE
Remove wrong __str__ in PsProduct

### DIFF
--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2595,9 +2595,6 @@ class PsProduct(models.Model):
     # the business unit to which the product belongs
     business_unit = models.CharField(max_length=50)
 
-    def __str__(self):
-        return self.package
-
 
 class PsModule(NullStrFieldsMixin, ValidateMixin):
 


### PR DESCRIPTION
The `PsProduct` model contains `__str__` with `self.package`. However, this field does not exist in the model. This PR removes it with its `__str__`.