### PR TITLE
tracker validations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -261,7 +261,7 @@
         "filename": "osidb/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1155,
+        "line_number": 1221,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-04T19:53:57Z"
+  "generated_at": "2023-08-07T07:09:58Z"
 }

--- a/apps/bbsync/tests/cassettes/test_integration/TestBBSyncIntegration.test_flaw_update_add_cve.yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestBBSyncIntegration.test_flaw_update_add_cve.yaml
@@ -397,7 +397,7 @@ interactions:
         0, "severity": "medium", "creator_detail": {"email": "osoukup@redhat.com",
         "partner": false, "real_name": "Ondrej Soukup", "name": "osoukup@redhat.com",
         "active": true, "id": 412888, "insider": true}, "cf_qe_conditional_nak": [],
-        "assigned_to": "nobody@redhat.com", "depends_on": [1995563], "creator": "osoukup@redhat.com",
+        "assigned_to": "nobody@redhat.com", "depends_on": [], "creator": "osoukup@redhat.com",
         "status": "NEW", "cf_internal_whiteboard": "", "sub_components": {}, "cf_qa_whiteboard":
         "", "summary": "CVE-2000-3000 ssh: I cannot ssh into Matrix", "target_milestone":
         "---", "priority": "medium"}], "offset": 0, "limit": "20", "total_matches":

--- a/apps/bbsync/tests/cassettes/test_integration/TestBBSyncIntegration.test_flaw_update_remove_cve.yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestBBSyncIntegration.test_flaw_update_remove_cve.yaml
@@ -372,7 +372,7 @@ interactions:
         "", "cf_qe_conditional_nak": [], "cf_environment": "", "assigned_to_detail":
         {"email": "nobody@redhat.com", "real_name": "Nobody", "name": "nobody@redhat.com",
         "insider": false, "id": 29451, "partner": false, "active": true}, "depends_on":
-        [1995563], "cf_last_closed": null, "deadline": null, "target_release": ["---"],
+        [], "cf_last_closed": null, "deadline": null, "target_release": ["---"],
         "version": ["unspecified"], "cf_internal_whiteboard": "", "creator_detail":
         {"insider": true, "name": "osoukup@redhat.com", "real_name": "Ondrej Soukup",
         "email": "osoukup@redhat.com", "active": true, "partner": false, "id": 412888},

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -606,6 +606,10 @@ class TestGenerateSRTNotes:
         flaw = FlawFactory()
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
+        PsModuleFactory(
+            bts_name="jboss",
+            name=affect.ps_module,
+        )
         TrackerFactory(
             affects=[affect],
             external_system_id="PROJECT-1",
@@ -907,6 +911,10 @@ class TestGenerateSRTNotes:
             cvss2="5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
             cvss3="3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N",
         )
+        PsModuleFactory(
+            bts_name="jboss",
+            name="fedora-all",
+        )
         TrackerFactory(
             affects=[affect],
             external_system_id="PROJECT-1",
@@ -946,14 +954,18 @@ class TestGenerateGroups:
         flaw = FlawFactory(embargoed=False)
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
-        TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
-        PsModuleFactory(
+        ps_module = PsModuleFactory(
             name=affect.ps_module,
             bts_groups={
                 "embargoed": [
                     "private",
                 ]
             },
+        )
+        TrackerFactory(
+            affects=[affect],
+            embargoed=flaw.is_embargoed,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
         bbq = FlawBugzillaQueryBuilder(flaw)
@@ -969,14 +981,18 @@ class TestGenerateGroups:
         flaw = FlawFactory(embargoed=True)
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
-        TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
-        PsModuleFactory(
+        ps_module = PsModuleFactory(
             name=affect.ps_module,
             bts_groups={
                 "embargoed": [
                     "private",
                 ]
             },
+        )
+        TrackerFactory(
+            affects=[affect],
+            embargoed=flaw.is_embargoed,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
         bbq = FlawBugzillaQueryBuilder(flaw)
@@ -996,14 +1012,18 @@ class TestGenerateGroups:
         flaw = FlawFactory(embargoed=True)
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
-        TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
-        PsModuleFactory(
+        ps_module = PsModuleFactory(
             name=affect.ps_module,
             bts_groups={
                 "embargoed": [
                     "redhat",
                 ]
             },
+        )
+        TrackerFactory(
+            affects=[affect],
+            embargoed=flaw.is_embargoed,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
         bbq = FlawBugzillaQueryBuilder(flaw)
@@ -1022,14 +1042,18 @@ class TestGenerateGroups:
         )
         FlawCommentFactory(flaw=flaw)
         affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
-        TrackerFactory(affects=[affect], embargoed=flaw.is_embargoed)
-        PsModuleFactory(
+        ps_module = PsModuleFactory(
             name=affect.ps_module,
             bts_groups={
                 "embargoed": [
                     "private",
                 ]
             },
+        )
+        TrackerFactory(
+            affects=[affect],
+            embargoed=flaw.is_embargoed,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
         new_flaw = Flaw.objects.first()
@@ -1056,14 +1080,18 @@ class TestGenerateGroups:
         )
         FlawCommentFactory(flaw=flaw)
         affect1 = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
-        TrackerFactory(affects=[affect1], embargoed=flaw.is_embargoed)
-        PsModuleFactory(
+        ps_module1 = PsModuleFactory(
             name=affect1.ps_module,
             bts_groups={
                 "embargoed": [
                     "private",
                 ]
             },
+        )
+        TrackerFactory(
+            affects=[affect1],
+            embargoed=flaw.is_embargoed,
+            type=Tracker.BTS2TYPE[ps_module1.bts_name],
         )
 
         new_flaw = Flaw.objects.first()
@@ -1073,14 +1101,18 @@ class TestGenerateGroups:
         affect2 = AffectFactory(
             flaw=new_flaw, affectedness=Affect.AffectAffectedness.NEW
         )
-        TrackerFactory(affects=[affect2], embargoed=new_flaw.is_embargoed)
-        PsModuleFactory(
+        ps_module2 = PsModuleFactory(
             name=affect2.ps_module,
             bts_groups={
                 "embargoed": [
                     "secalert",
                 ]
             },
+        )
+        TrackerFactory(
+            affects=[affect2],
+            embargoed=new_flaw.is_embargoed,
+            type=Tracker.BTS2TYPE[ps_module2.bts_name],
         )
 
         bbq = FlawBugzillaQueryBuilder(new_flaw, flaw)

--- a/apps/exploits/tests/test_api.py
+++ b/apps/exploits/tests/test_api.py
@@ -77,12 +77,15 @@ def load_data():
     )
 
     # Affect with tracker
-    t1 = TrackerFactory(
+    t1 = TrackerFactory.build(
         type=Tracker.TrackerType.BUGZILLA,
         external_system_id="12345678",
         status="CLOSED",
         resolution="ERRATA",
     )
+    # creating tracker without an affect causes
+    # validation error but we ignore it here
+    t1.save(raise_validation_error=False)
 
     a1.trackers.add(t1)
 
@@ -242,7 +245,7 @@ class TestAPI(object):
         response = auth_client.get("/exploits/api/v1/supported-products")
         body = response.json()
         assert response.status_code == 200
-        assert body["results"] == [{"name": "ps-module"}]
+        assert {"name": "ps-module"} in body["results"]
 
     def test_unsupported_products(self, auth_client):
         # Unsupported products have no active_to_ps_module
@@ -251,7 +254,7 @@ class TestAPI(object):
         response = auth_client.get("/exploits/api/v1/supported-products")
         body = response.json()
         assert response.status_code == 200
-        assert body["results"] == []
+        assert {"name": "ps-module"} not in body["results"]
 
     def test_exploits_report_data(self, auth_client):
         response = auth_client.get("/exploits/api/v1/report_data")

--- a/apps/trackers/bugzilla/save.py
+++ b/apps/trackers/bugzilla/save.py
@@ -32,30 +32,3 @@ class TrackerBugzillaSaver(BugzillaSaver):
         query builder class getter
         """
         return TrackerBugzillaQueryBuilder
-
-    def create(self):
-        """
-        create tracker in Bugzilla
-        """
-        self.assert_context()
-        return super().create()
-
-    def update(self):
-        """
-        update tracker in Bugzilla
-        """
-        self.assert_context()
-        return super().update()
-
-    def assert_context(self):
-        """
-        the vital tracker related pieces of information need to exist
-        or otherwise we would not be able to construct the tracker query
-        """
-        # TODO these assertions are applicable to the Jira
-        # trackers too but let me keep it here until we merge
-        from osidb.models import PsModule, PsUpdateStream
-
-        assert self.tracker.affects.first()
-        assert PsModule.objects.filter(name=self.tracker.affects.first().ps_module)
-        assert PsUpdateStream.objects.filter(name=self.tracker.ps_update_stream)

--- a/apps/trackers/save.py
+++ b/apps/trackers/save.py
@@ -1,7 +1,7 @@
 """
 common tracker save funtionality
 """
-from osidb.models import PsModule, PsUpdateStream, Tracker
+from osidb.models import Tracker
 
 from .bugzilla.save import TrackerBugzillaSaver
 from .exceptions import BTSException
@@ -19,8 +19,6 @@ class TrackerSaver:
         detect and return the correct saver
         assuming that all prerequisites are met
         """
-        cls.assert_context(tracker)
-
         if tracker.type == Tracker.TrackerType.BUGZILLA:
             assert bz_api_key, "Bugzilla API key not provided"
             return TrackerBugzillaSaver(tracker, bz_api_key)
@@ -30,13 +28,3 @@ class TrackerSaver:
 
         # we should never get here
         raise BTSException("Unknown BTS")
-
-    @staticmethod
-    def assert_context(tracker):
-        """
-        the vital tracker related pieces of information need to exist
-        or otherwise we would not be able to construct the tracker query
-        """
-        assert tracker.affects.first()
-        assert PsModule.objects.filter(name=tracker.affects.first().ps_module)
-        assert PsUpdateStream.objects.filter(name=tracker.ps_update_stream)

--- a/apps/trackers/tests/test_bts_tracker.py
+++ b/apps/trackers/tests/test_bts_tracker.py
@@ -12,7 +12,7 @@ import pytest
 
 from apps.trackers.jira.core import JiraPriority, JiraTracker
 from apps.trackers.models import JiraProjectFields
-from osidb.models import Impact, Tracker
+from osidb.models import Affect, Impact, Tracker
 from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
@@ -99,7 +99,11 @@ class TestJiraTracker(object):
             impact=Impact.CRITICAL,
         )
         embargoed_affect = AffectFactory(
-            flaw=embargoed_flaw, ps_module="foo-module", ps_component="foo-component"
+            flaw=embargoed_flaw,
+            ps_module="foo-module",
+            ps_component="foo-component",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
         )
         expected3 = {
             "fields": {
@@ -141,12 +145,13 @@ class TestJiraTracker(object):
             flaw=embargoed_flaw, ps_module="foo-module", ps_component="foo-component"
         )
         assert not embargoed_affect2.trackers.exists()
-        osidb_tracker = TrackerFactory(
+        TrackerFactory(
+            affects=[embargoed_affect],
+            embargoed=True,
             type=Tracker.TrackerType.JIRA,
             ps_update_stream=stream.name,
             external_system_id="FOOPROJECT-140",
         )
-        osidb_tracker.affects.add(embargoed_affect)
         tracker4 = JiraTracker(
             embargoed_flaw, embargoed_affect2, stream
         ).generate_bts_object()

--- a/collectors/bzimport/tests/cassettes/test_collectors/TestBZImportCollector.test_flawmeta_acl_change.yaml
+++ b/collectors/bzimport/tests/cassettes/test_collectors/TestBZImportCollector.test_flawmeta_acl_change.yaml
@@ -220,10 +220,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -342,11 +339,7 @@ interactions:
         kernel address information leak, arbitrary execution, etc.", "blocks": [2086700],
         "severity": "high", "status": "NEW", "estimated_time": 0, "creator": "mrehak@redhat.com",
         "cf_conditional_nak": [], "is_cc_accessible": true, "dupe_of": null, "id":
-        2086753, "keywords": ["Security"], "depends_on": [2087945, 2087946, 2087947,
-        2087948, 2087949, 2087950, 2087952, 2087953, 2087954, 2087955, 2087956, 2087959,
-        2087960, 2087961, 2087962, 2087963, 2087964, 2087965, 2087966, 2087951, 2087957,
-        2087973, 2087974, 2087975, 2087976, 2087977, 2087978, 2087979, 2087980, 2088501,
-        2088502, 2089288, 2089289], "cf_fixed_in": "kernel 5.18 rc9", "summary": "CVE-2022-1729
+        2086753, "keywords": ["Security"], "depends_on": [], "cf_fixed_in": "kernel 5.18 rc9", "summary": "CVE-2022-1729
         kernel: race condition in perf_event_open leads to privilege escalation",
         "cf_last_closed": null, "assigned_to": "security-response-team@redhat.com",
         "external_bugs": [{"ext_priority": "3 (Normal)", "ext_bz_bug_id": "03231420",
@@ -451,11 +444,7 @@ interactions:
         the leading PERF_TYPE_TRACEPOINT and sub PERF_EVENT_HARDWARE plus the PERF_EVENT_SOFTWARE
         using the perf_event_open() function with these three types. This flaw allows
         a local user to crash the system.", "docs_contact": "", "cf_pgm_internal":
-        "", "resolution": "", "see_also": [], "cf_build_id": "", "depends_on": [2087945,
-        2087946, 2087947, 2087948, 2087949, 2087950, 2087952, 2087953, 2087954, 2087955,
-        2087956, 2087959, 2087960, 2087961, 2087962, 2087963, 2087964, 2087965, 2087966,
-        2087951, 2087957, 2087973, 2087974, 2087975, 2087976, 2087977, 2087978, 2087979,
-        2087980, 2088501, 2088502, 2089288, 2089289], "product": "Security Response",
+        "", "resolution": "", "see_also": [], "cf_build_id": "", "depends_on": [], "product": "Security Response",
         "tags": [], "actual_time": 0, "cc_detail": [{"name": "acaringi@redhat.com",
         "real_name": "Augusto Caringi", "email": "acaringi@redhat.com", "id": 408364},
         {"id": 448206, "email": "adscvr@gmail.com", "real_name": "Facundo", "name":
@@ -690,10 +679,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -1057,10 +1043,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -1087,11 +1070,7 @@ interactions:
         "security-response-team@redhat.com", "steved@redhat.com", "swood@redhat.com",
         "vkumar@redhat.com", "walters@redhat.com", "williams@redhat.com", "ycote@redhat.com",
         "yozone@redhat.com"], "keywords": ["Security"], "creator": "mrehak@redhat.com",
-        "depends_on": [2087945, 2087946, 2087947, 2087948, 2087949, 2087950, 2087952,
-        2087953, 2087954, 2087955, 2087956, 2087959, 2087960, 2087961, 2087962, 2087963,
-        2087964, 2087965, 2087966, 2087951, 2087957, 2087973, 2087974, 2087975, 2087976,
-        2087977, 2087978, 2087979, 2087980, 2088501, 2088502, 2089288, 2089289], "classification":
-        "Other", "resolution": "", "see_also": []}]}'
+        "depends_on": [], "classification": "Other", "resolution": "", "see_also": []}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1984,9 +1963,7 @@ interactions:
         \"2022-05-20\", \"reported\": \"2022-05-16\", \"source\": \"distros\"}"}],
         "when": "2022-05-18T14:36:56Z", "who": "allarkin@redhat.com"}, {"who": "allarkin@redhat.com",
         "when": "2022-05-18T15:07:47Z", "changes": [{"removed": "", "field_name":
-        "depends_on", "added": "2087961, 2087949, 2087963, 2087946, 2087954, 2087945,
-        2087950, 2087959, 2087960, 2087956, 2087966, 2087955, 2087952, 2087948, 2087953,
-        2087965, 2087947, 2087962, 2087964, 2087957, 2087951"}]}, {"when": "2022-05-18T15:13:22Z",
+        "depends_on", "added": ""}]}, {"when": "2022-05-18T15:13:22Z",
         "changes": [{"removed": "{\"affects\": [{\"affectedness\": \"affected\", \"cvss2\":
         null, \"cvss3\": null, \"impact\": \"important\", \"ps_component\": \"kernel\",
         \"ps_module\": \"rhel-8\", \"resolution\": \"fix\"}, {\"affectedness\": \"affected\",
@@ -3091,7 +3068,7 @@ interactions:
         {"removed": "", "added": "michal.skrivanek@redhat.com, mperina@redhat.com,
         sbonazzo@redhat.com", "field_name": "cc"}], "when": "2022-05-19T15:01:48Z",
         "who": "allarkin@redhat.com"}, {"when": "2022-05-19T15:03:32Z", "changes":
-        [{"removed": "", "field_name": "depends_on", "added": "2088501, 2088502"},
+        [{"removed": "", "field_name": "depends_on", "added": ""},
         {"field_name": "cf_srtnotes", "added": "{\"affects\": [{\"affectedness\":
         \"affected\", \"cvss2\": null, \"cvss3\": null, \"impact\": \"important\",
         \"ps_component\": \"kernel\", \"ps_module\": \"rhel-8\", \"resolution\": \"fix\"},
@@ -11987,10 +11964,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -12186,10 +12160,7 @@ interactions:
         reported in secalert/postmortem\", \"not_applicable\": false}], \"name\":
         \"Base flaw\", \"signature\": \"4350164\", \"template\": \"base_flaw\"}],
         \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cwe\":
-        \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -12704,10 +12675,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -14879,10 +14847,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11626\"},
-        {\"bts_name\": \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11627\"}], \"mitigation\": \"By default,  for Red Hat Enterprise
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [], \"mitigation\": \"By default,  for Red Hat Enterprise
         Linux, an unprivileged user can trigger an attack. To prevent the possibility
         of an unprivileged users'' attack, set kernel.perf_event_paranoid to the value
         3.\\nIt is possible with the command:\\n\\nsudo /sbin/sysctl -w \\\"kernel.perf_event_paranoid=3\\\"\\n\\n\\nOr
@@ -14963,10 +14928,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11626\"},
-        {\"bts_name\": \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11627\"}], \"mitigation\": \"By default,  for Red Hat Enterprise
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [], \"mitigation\": \"By default,  for Red Hat Enterprise
         Linux, an unprivileged user can trigger an attack. To prevent the possibility
         of an unprivileged users'' attack, set kernel.perf_event_paranoid to the value
         3.\\nIt is possible with the command:\\n\\nsudo /sbin/sysctl -w \\\"kernel.perf_event_paranoid=3\\\"\\n\\n\\nOr
@@ -15044,10 +15006,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11627\"}], \"mitigation\": \"By default,  for Red Hat Enterprise
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [], \"mitigation\": \"By default,  for Red Hat Enterprise
         Linux, an unprivileged user can trigger an attack. To prevent the possibility
         of an unprivileged users'' attack, set kernel.perf_event_paranoid to the value
         3.\\nIt is possible with the command:\\n\\nsudo /sbin/sysctl -w \\\"kernel.perf_event_paranoid=3\\\"\\n\\n\\nOr
@@ -15140,10 +15099,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11627\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"By default,  for Red Hat Enterprise Linux, an unprivileged
         user can trigger an attack. To prevent the possibility of an unprivileged
         users'' attack, set kernel.perf_event_paranoid to the value 3.\\nIt is possible
@@ -15223,10 +15179,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11627\"}], \"mitigation\": \"By default,  for Red Hat Enterprise
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [], \"mitigation\": \"By default,  for Red Hat Enterprise
         Linux, an unprivileged user can trigger an attack. To prevent the possibility
         of an unprivileged users'' attack, set kernel.perf_event_paranoid to the value
         3.\\nIt is possible with the command:\\n\\nsudo /sbin/sysctl -w \\\"kernel.perf_event_paranoid=3\\\"\\n\\n\\nOr
@@ -15306,10 +15259,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11627\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"By default,  for Red Hat Enterprise Linux, an unprivileged
         user can trigger an attack. To prevent the possibility of an unprivileged
         users'' attack, set kernel.perf_event_paranoid to the value 3.\\nIt is possible
@@ -15388,10 +15338,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"By default,  for Red Hat Enterprise Linux, an unprivileged
         user can trigger an attack. To prevent the possibility of an unprivileged
         users'' attack, set kernel.perf_event_paranoid to the value 3.\\nIt is possible
@@ -15475,10 +15422,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"7/CVSS:3.1/AV:L/AC:H/PR:L/UI:N/S:U/C:H/I:H/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"By default,  for Red Hat Enterprise Linux, an unprivileged
         user can trigger an attack. To prevent the possibility of an unprivileged
         users'' attack, set kernel.perf_event_paranoid to the value 3.\\nIt is possible
@@ -15557,10 +15501,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"By default,  for Red Hat Enterprise Linux, an unprivileged
         user can trigger an attack. To prevent the possibility of an unprivileged
         users'' attack, set kernel.perf_event_paranoid to the value 3.\\nIt is possible
@@ -15665,10 +15606,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"By default,  for Red Hat Enterprise Linux, an unprivileged
         user can trigger an attack. To prevent the possibility of an unprivileged
         users'' attack, set kernel.perf_event_paranoid to the value 3.\\nIt is possible
@@ -15747,10 +15685,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -15842,10 +15777,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"moderate\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -15921,10 +15853,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -16032,10 +15961,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -16111,10 +16037,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -16202,10 +16125,7 @@ interactions:
         reported in secalert/postmortem\", \"not_applicable\": false}], \"name\":
         \"Base flaw\", \"signature\": \"4350164\", \"template\": \"base_flaw\"}],
         \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\", \"cwe\":
-        \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation
@@ -16283,10 +16203,7 @@ interactions:
         null, \"item\": \"14. Task problems reported in secalert/postmortem\", \"not_applicable\":
         false}], \"name\": \"Base flaw\", \"signature\": \"4350164\", \"template\":
         \"base_flaw\"}], \"cvss3\": \"6.2/CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H\",
-        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [{\"bts_name\":
-        \"jboss\", \"key\": \"ARO-1092\"}, {\"bts_name\": \"jboss\", \"key\": \"ARO-1102\"},
-        {\"bts_name\": \"jboss\", \"key\": \"OSD-11625\"}, {\"bts_name\": \"jboss\",
-        \"key\": \"OSD-11626\"}, {\"bts_name\": \"jboss\", \"key\": \"OSD-11627\"}],
+        \"cwe\": \"CWE-362\", \"impact\": \"important\", \"jira_trackers\": [],
         \"mitigation\": \"Mitigation for this issue is either not available or the
         currently available options don''t meet the Red Hat Product Security criteria
         comprising ease of use and deployment, applicability to widespread installation

--- a/collectors/bzimport/tests/cassettes/test_collectors/TestBugzillaTrackerCollector.test_sync_tracker.yaml
+++ b/collectors/bzimport/tests/cassettes/test_collectors/TestBugzillaTrackerCollector.test_sync_tracker.yaml
@@ -134,7 +134,7 @@ interactions:
         "name": "bressers@redhat.com"}, {"id": 8542, "email": "paul@city-fan.org",
         "name": "paul@city-fan.org", "real_name": "Paul Howarth"}], "severity": "medium",
         "target_milestone": "---", "whiteboard": "", "assigned_to": "paul@city-fan.org",
-        "summary": "CVE-2010-1132 spamass-milter: remote command execution", "creator_detail":
+        "summary": "CVE-2010-1132 spamass-milter: remote command execution [update-stream]", "creator_detail":
         {"email": "vdanen@redhat.com", "id": 275188, "real_name": "Vincent Danen",
         "name": "vdanen@redhat.com"}, "is_cc_accessible": true, "cf_cust_facing":
         "---", "alias": [], "qa_contact": "extras-qa@fedoraproject.org", "platform":

--- a/collectors/bzimport/tests/cassettes/test_collectors/TestBugzillaTrackerCollector.test_sync_with_affect.yaml
+++ b/collectors/bzimport/tests/cassettes/test_collectors/TestBugzillaTrackerCollector.test_sync_with_affect.yaml
@@ -162,7 +162,7 @@ interactions:
         "tags": [], "bug_id": 577404, "creation_time": "2010-03-26T21:10:29Z", "creator_id":
         275188, "time": "2010-03-26T21:10:29Z", "id": 2742308}], "cf_build_id": "",
         "cf_doc_type": "Release Note", "product": "Fedora", "summary": "CVE-2010-1132
-        spamass-milter: remote command execution", "blocks": [577401], "qa_contact":
+        spamass-milter: remote command execution [update-stream]", "blocks": [577401], "qa_contact":
         "extras-qa@fedoraproject.org", "assigned_to": "paul@city-fan.org", "cf_conditional_nak":
         [], "sub_components": {}, "flags": [], "component": ["spamass-milter"], "cf_release_notes":
         "", "cf_fixed_in": "", "see_also": []}]}'

--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -215,6 +215,8 @@ class TestBugzillaTrackerCollector:
 
     @pytest.mark.vcr
     def test_sync_tracker(self, bz_tracker_collector):
+        PsUpdateStreamFactory(name="update-stream")
+
         assert Tracker.objects.count() == 0
         bz_tracker_collector.sync_tracker("577404")
 
@@ -228,14 +230,19 @@ class TestBugzillaTrackerCollector:
         assert tracker.resolution == "NOTABUG"
         # no affect, thus this should be empty
         assert list(tracker.affects.all()) == []
-        assert tracker.ps_update_stream == ""
+        assert tracker.ps_update_stream == "update-stream"
 
     @pytest.mark.vcr
     def test_sync_with_affect(self, bz_tracker_collector):
+        PsModuleFactory(bts_name="bugzilla", name="module")
+        PsUpdateStreamFactory(name="update-stream")
+
         creation_dt = datetime(2011, 1, 1, tzinfo=timezone.utc)
         with freeze_time(creation_dt):
             affect = AffectFactory.create(
-                flaw__embargoed=False, affectedness=Affect.AffectAffectedness.NEW
+                flaw__embargoed=False,
+                affectedness=Affect.AffectAffectedness.NEW,
+                ps_module="module",
             )
             TrackerFactory.create(
                 affects=(affect,),

--- a/collectors/errata/tests/test_core.py
+++ b/collectors/errata/tests/test_core.py
@@ -1,8 +1,8 @@
 import pytest
 from django.utils import timezone
 
-from osidb.models import Erratum, Tracker
-from osidb.tests.factories import TrackerFactory
+from osidb.models import Affect, Erratum, Tracker
+from osidb.tests.factories import AffectFactory, PsModuleFactory, TrackerFactory
 
 from ..core import (
     get_all_errata,
@@ -69,11 +69,24 @@ class TestErrataToolCollection:
         self, sample_erratum_with_bz_bugs, sample_erratum_name
     ):
         """Test that a given (et_id, advisory_name) pair can have its data fetched, saved to the DB, and linked"""
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect = AffectFactory(
+            ps_module=ps_module.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+
         TrackerFactory.create(
-            external_system_id="2021161", type=Tracker.TrackerType.BUGZILLA
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            external_system_id="2021161",
+            type=Tracker.TrackerType.BUGZILLA,
         )
         TrackerFactory.create(
-            external_system_id="2021168", type=Tracker.TrackerType.BUGZILLA
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            external_system_id="2021168",
+            type=Tracker.TrackerType.BUGZILLA,
         )
         link_bugs_to_errata(
             [
@@ -103,9 +116,19 @@ class TestErrataToolCollection:
         self, sample_erratum_with_jira_issues, sample_erratum_name
     ):
         """Test that a given (et_id, advisory_name) pair can have its data fetched, saved to the DB, and linked"""
+        ps_module = PsModuleFactory(bts_name="jboss")
+        affect = AffectFactory(
+            ps_module=ps_module.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+
         # The test uses the same code as above, but no errata I've checked have both Bugzilla and Jira trackers
         TrackerFactory.create(
-            external_system_id="LOG-2064", type=Tracker.TrackerType.JIRA
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            external_system_id="LOG-2064",
+            type=Tracker.TrackerType.JIRA,
         )
         link_bugs_to_errata(
             [
@@ -184,11 +207,24 @@ class TestErrataToolCollection:
         self, sample_erratum_with_bz_bugs, sample_erratum_name
     ):
         """Test that when advisory_name changes the Erratum is updated during linking"""
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect = AffectFactory(
+            ps_module=ps_module.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+
         TrackerFactory.create(
-            external_system_id="2021161", type=Tracker.TrackerType.BUGZILLA
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            external_system_id="2021161",
+            type=Tracker.TrackerType.BUGZILLA,
         )
         TrackerFactory.create(
-            external_system_id="2021168", type=Tracker.TrackerType.BUGZILLA
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            external_system_id="2021168",
+            type=Tracker.TrackerType.BUGZILLA,
         )
 
         link_bugs_to_errata(

--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -72,6 +72,7 @@ class TrackerConvertor:
             meta_attr=self.tracker_data,
             acl_read=self.acl_read,
             acl_write=self.acl_write,
+            raise_validation_error=False,  # do not raise exceptions here
         )
         # eventual save inside create_tracker would
         # override the timestamps so we have to set them here

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -111,9 +111,17 @@ class TestJiraTrackerCollector:
         test collecting a known Jira issue specified by the given ID
         which should result in updating the known one and no duplicates
         """
+        ps_module = PsModuleFactory(bts_name="jboss")
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+        )
         tracker_id = "ENTMQ-755"
         TrackerFactory(
+            affects=[affect],
             type=Tracker.TrackerType.JIRA,
+            embargoed=affect.flaw.embargoed,
             external_system_id=tracker_id,
             status="New",
             resolution=None,
@@ -136,6 +144,7 @@ class TestJiraTrackerCollector:
         """
         flaw1 = FlawFactory(embargoed=False)
         flaw2 = FlawFactory(embargoed=False)
+        PsModuleFactory(bts_name="jboss", name="module")
         affect1 = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
             flaw=flaw1,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement ps_update_stream in Tracker API (OSIDB-1064)
 - Implement daily monitoring email for failed tasks
 - Implement nist_cvss_validation in Flaw API (OSIDB-1006)
+- Implement additional tracker validations (OSIDB-787)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1912,7 +1912,9 @@ class TrackerManager(ACLMixinManager, TrackingMixinManager):
     """tracker manager"""
 
     @staticmethod
-    def create_tracker(affect, external_system_id, _type, **extra_fields):
+    def create_tracker(
+        affect, external_system_id, _type, raise_validation_error=True, **extra_fields
+    ):
         """return a new tracker or update an existing tracker"""
         try:
             tracker = Tracker.objects.get(
@@ -1929,7 +1931,7 @@ class TrackerManager(ACLMixinManager, TrackingMixinManager):
             # must save, otherwise assigning affects won't work (no pk)
             # this is probably why before the affects were not being added
             # to newly created trackers
-            tracker.save()
+            tracker.save(raise_validation_error=raise_validation_error)
         if affect is not None:
             tracker.affects.add(affect)
         return tracker

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1575,7 +1575,9 @@ class Affect(
         """
         if (
             self.affectedness == Affect.AffectAffectedness.NOTAFFECTED
-            and self.trackers.exclude(status__iexact="CLOSED").exists()
+            and self.trackers.exclude(
+                status__iexact="CLOSED"
+            ).exists()  # see tracker.is_closed
         ):
             raise ValidationError(
                 f"Affect ({self.uuid}) for {self.ps_module}/{self.ps_component} is marked as "
@@ -1588,7 +1590,9 @@ class Affect(
         """
         if (
             self.resolution == Affect.AffectResolution.OOSS
-            and self.trackers.exclude(status__iexact="CLOSED").exists()
+            and self.trackers.exclude(
+                status__iexact="CLOSED"
+            ).exists()  # see tracker.is_closed
         ):
             raise ValidationError(
                 f"Affect ({self.uuid}) for {self.ps_module}/{self.ps_component} is marked as "
@@ -1601,7 +1605,9 @@ class Affect(
         """
         if (
             self.resolution == Affect.AffectResolution.WONTFIX
-            and self.trackers.exclude(status__iexact="CLOSED").exists()
+            and self.trackers.exclude(
+                status__iexact="CLOSED"
+            ).exists()  # see tracker.is_closed
         ):
             raise ValidationError(
                 f"Affect ({self.uuid}) for {self.ps_module}/{self.ps_component} is marked as "
@@ -2178,6 +2184,13 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
 
     @property
     def is_closed(self):
+        """
+        this property unifies the notion of the tracker closure between
+        Bugzilla where CLOSED is used and Jira with Closed instead
+
+        note that this reliably covers only the after-OJA world
+        while before it is pretty much impossible to unify anything
+        """
         return self.status.upper() == "CLOSED"
 
     @property

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1582,6 +1582,19 @@ class Affect(
                 "NOTAFFECTED but has open tracker(s).",
             )
 
+    def _validate_ooss_open_tracker(self):
+        """
+        Check whether out of support scope products have open trackers.
+        """
+        if (
+            self.resolution == Affect.AffectResolution.OOSS
+            and self.trackers.exclude(status__iexact="CLOSED").exists()
+        ):
+            raise ValidationError(
+                f"Affect ({self.uuid}) for {self.ps_module}/{self.ps_component} is marked as "
+                "OOSS but has open tracker(s).",
+            )
+
     def _validate_wontfix_open_tracker(self):
         """
         Check whether wontfix affects have open trackers.
@@ -2048,6 +2061,16 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             raise ValidationError(
                 f"Affect ({affect.uuid}) for {affect.ps_module}/{affect.ps_component} is marked as "
                 "NOTAFFECTED but has open tracker(s).",
+            )
+
+    def _validate_ooss_open_tracker(self):
+        """
+        Check whether out of support scope products have open trackers.
+        """
+        affect = self.affects.filter(resolution=Affect.AffectResolution.OOSS).first()
+        if not self.is_closed and affect:
+            raise ValidationError(
+                f"The tracker is associated with an OOSS affect: {affect.uuid}",
             )
 
     def _validate_wontfix_open_tracker(self):

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1992,6 +1992,36 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
     def __str__(self):
         return str(self.uuid)
 
+    def _validate_tracker_affect(self):
+        """
+        check that the tracker is associated with an affect
+        """
+        # there are no references before the first save to DB
+        if self._state.adding:
+            return
+
+        if not self.affects.exists():
+            raise ValidationError("Tracker must be associated with an affect")
+
+    def _validate_tracker_ps_module(self):
+        """
+        check that the tracker is associated with a valid PS module
+        """
+        if not self.affects.exists():
+            return
+
+        if not PsModule.objects.filter(name=self.affects.first().ps_module):
+            raise ValidationError("Tracker must be associated with a valid PS module")
+
+    def _validate_tracker_ps_update_stream(self):
+        """
+        check that the tracker is associated with a valid PS update stream
+        """
+        if not PsUpdateStream.objects.filter(name=self.ps_update_stream):
+            raise ValidationError(
+                "Tracker must be associated with a valid PS update stream"
+            )
+
     def _validate_tracker_flaw_accesses(self):
         """
         Check whether an public tracker is associated with an embargoed flaw.

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1952,6 +1952,8 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         TrackerType.BUGZILLA: "bugzilla",
         TrackerType.JIRA: "jboss",
     }
+    # plus opposite direction mapping
+    BTS2TYPE = {b: t for t, b in TYPE2BTS.items()}
 
     # internal primary key
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2059,8 +2059,7 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
 
         if not self.is_closed and affect:
             raise ValidationError(
-                f"Affect ({affect.uuid}) for {affect.ps_module}/{affect.ps_component} is marked as "
-                "NOTAFFECTED but has open tracker(s).",
+                f"The tracker is associated with a NOTAFFECTED affect: {affect.uuid}",
             )
 
     def _validate_ooss_open_tracker(self):
@@ -2080,8 +2079,7 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         affect = self.affects.filter(resolution=Affect.AffectResolution.WONTFIX).first()
         if not self.is_closed and affect:
             raise ValidationError(
-                f"Affect ({affect.uuid}) for {affect.ps_module}/{affect.ps_component} is marked as "
-                "WONTFIX but has open tracker(s).",
+                f"The tracker is associated with a WONTFIX affect: {affect.uuid}",
             )
 
     def _validate_multi_flaw_tracker(self):

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1953,6 +1953,7 @@ class TrackerManager(ACLMixinManager, TrackingMixinManager):
             tracker.save(raise_validation_error=raise_validation_error)
         if affect is not None:
             tracker.affects.add(affect)
+            tracker.save(raise_validation_error=raise_validation_error)  # revalidate
         return tracker
 
 

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -36,6 +36,8 @@ from .factories import (
     FlawFactory,
     FlawMetaFactory,
     FlawReferenceFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -281,11 +283,17 @@ class TestEndpoints(object):
 
     @freeze_time(datetime(2021, 11, 23))
     def test_changed_after_from_tracker(self, auth_client, test_api_uri):
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
         )
-        tracker = TrackerFactory(affects=(affect,), embargoed=affect.flaw.embargoed)
+        tracker = TrackerFactory(
+            affects=(affect,),
+            embargoed=affect.flaw.embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         future_dt = datetime(2021, 11, 27)
 
         # first check that we cannot get anything by querying any flaws changed after future_dt
@@ -361,9 +369,11 @@ class TestEndpoints(object):
 
     @freeze_time(datetime(2021, 11, 23))
     def test_changed_before_from_tracker(self, auth_client, test_api_uri):
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory(updated_dt=datetime(2021, 11, 23))
         affect = AffectFactory(
             flaw=flaw,
+            ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.FIX,
             updated_dt=datetime(2021, 11, 23),
@@ -372,6 +382,7 @@ class TestEndpoints(object):
             affects=(affect,),
             embargoed=affect.flaw.embargoed,
             updated_dt=datetime(2021, 11, 23),
+            type=Tracker.TrackerType.BUGZILLA,
         )
         past_dt = datetime(2019, 11, 27)
 
@@ -419,15 +430,18 @@ class TestEndpoints(object):
 
     @freeze_time(datetime(2021, 11, 23))
     def test_changed_before_from_multi_tracker(self, auth_client, test_api_uri):
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory(updated_dt=datetime(2021, 11, 23))
         affect1 = AffectFactory(
             flaw=flaw,
+            ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.FIX,
             updated_dt=datetime(2021, 11, 23),
         )
         affect2 = AffectFactory(
             flaw=flaw,
+            ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.FIX,
             updated_dt=datetime(2021, 11, 23),
@@ -436,11 +450,13 @@ class TestEndpoints(object):
             affects=(affect1,),
             embargoed=flaw.embargoed,
             updated_dt=datetime(2021, 11, 23),
+            type=Tracker.TrackerType.BUGZILLA,
         )
         tracker2 = TrackerFactory(
             affects=(affect2,),
             embargoed=flaw.embargoed,
             updated_dt=datetime(2021, 11, 23),
+            type=Tracker.TrackerType.BUGZILLA,
         )
         past_dt = datetime(2019, 11, 27)
 
@@ -543,10 +559,20 @@ class TestEndpoints(object):
         body = response.json()
         assert body["count"] == 0
 
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory()
         for _ in range(5):
-            affect = AffectFactory(flaw=flaw)
-            affect.trackers.set([TrackerFactory(embargoed=flaw.is_embargoed)])
+            affect = AffectFactory(
+                flaw=flaw,
+                ps_module=ps_module.name,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+            )
+            TrackerFactory(
+                affects=[affect],
+                embargoed=flaw.is_embargoed,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
 
         flaw_exclude_fields = ["resolution", "state", "uuid", "impact"]
         affect_exclude_fields = ["ps_module", "ps_component", "type", "affectedness"]
@@ -583,10 +609,20 @@ class TestEndpoints(object):
         body = response.json()
         assert body["count"] == 0
 
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory()
         for _ in range(5):
-            affect = AffectFactory(flaw=flaw)
-            affect.trackers.set([TrackerFactory(embargoed=flaw.is_embargoed)])
+            affect = AffectFactory(
+                flaw=flaw,
+                ps_module=ps_module.name,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+            )
+            TrackerFactory(
+                affects=[affect],
+                embargoed=flaw.is_embargoed,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
 
         flaw_include_fields = ["resolution", "state", "uuid", "impact"]
         affect_include_fields = ["ps_module", "ps_component", "type", "affectedness"]
@@ -633,10 +669,20 @@ class TestEndpoints(object):
         body = response.json()
         assert body["count"] == 0
 
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory()
         for _ in range(5):
-            affect = AffectFactory(flaw=flaw)
-            affect.trackers.set([TrackerFactory(embargoed=flaw.is_embargoed)])
+            affect = AffectFactory(
+                flaw=flaw,
+                ps_module=ps_module.name,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+            )
+            TrackerFactory(
+                affects=[affect],
+                embargoed=flaw.is_embargoed,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
 
         affect_include_fields = ["ps_module", "ps_component", "type", "affectedness"]
 
@@ -670,10 +716,20 @@ class TestEndpoints(object):
         body = response.json()
         assert body["count"] == 0
 
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory()
         for _ in range(5):
-            affect = AffectFactory(flaw=flaw)
-            affect.trackers.set([TrackerFactory(embargoed=flaw.is_embargoed)])
+            affect = AffectFactory(
+                flaw=flaw,
+                ps_module=ps_module.name,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+            )
+            TrackerFactory(
+                affects=[affect],
+                embargoed=flaw.is_embargoed,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
 
         flaw_include_fields = ["resolution", "state", "uuid", "impact"]
         affect_include_fields = ["ps_module", "ps_component", "type", "affectedness"]
@@ -821,18 +877,21 @@ class TestEndpoints(object):
         """retrieve list of flaws with various meta_attr keys in nested serializers"""
 
         for _ in range(2):
+            ps_module = PsModuleFactory(bts_name="bugzilla")
             flaw = FlawFactory(meta_attr={f"test_key_{i}": "test" for i in range(5)})
             for _ in range(3):
                 affect = AffectFactory(
-                    flaw=flaw, meta_attr={f"test_key_{i}": "test" for i in range(5)}
+                    flaw=flaw,
+                    ps_module=ps_module.name,
+                    meta_attr={f"test_key_{i}": "test" for i in range(5)},
+                    affectedness=Affect.AffectAffectedness.AFFECTED,
+                    resolution=Affect.AffectResolution.DELEGATED,
                 )
-                affect.trackers.set(
-                    [
-                        TrackerFactory(
-                            embargoed=flaw.is_embargoed,
-                            meta_attr={f"test_key_{i}": "test" for i in range(5)},
-                        )
-                    ]
+                TrackerFactory(
+                    affects=[affect],
+                    embargoed=flaw.is_embargoed,
+                    meta_attr={f"test_key_{i}": "test" for i in range(5)},
+                    type=Tracker.TrackerType.BUGZILLA,
                 )
 
         response = auth_client.get(f"{test_api_uri}/flaws?{query_params}")
@@ -925,18 +984,21 @@ class TestEndpoints(object):
     ):
         """retrieve specific flaw with various meta_attr keys in nested serializers"""
 
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         flaw = FlawFactory(meta_attr={f"test_key_{i}": "test" for i in range(5)})
         for _ in range(3):
             affect = AffectFactory(
-                flaw=flaw, meta_attr={f"test_key_{i}": "test" for i in range(5)}
+                flaw=flaw,
+                ps_module=ps_module.name,
+                meta_attr={f"test_key_{i}": "test" for i in range(5)},
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
             )
-            affect.trackers.set(
-                [
-                    TrackerFactory(
-                        embargoed=flaw.is_embargoed,
-                        meta_attr={f"test_key_{i}": "test" for i in range(5)},
-                    )
-                ]
+            TrackerFactory(
+                affects=[affect],
+                embargoed=flaw.is_embargoed,
+                meta_attr={f"test_key_{i}": "test" for i in range(5)},
+                type=Tracker.TrackerType.BUGZILLA,
             )
 
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw.cve_id}?{query_params}")
@@ -1054,9 +1116,12 @@ class TestEndpoints(object):
         assert body["classification"]["state"] is not None
 
     def test_flaw_including_delegated_resolution(self, auth_client, test_api_uri):
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        PsUpdateStreamFactory(name="rhel-7.0", active_to_ps_module=ps_module)
         flaw = FlawFactory()
         delegated_affect = AffectFactory(
             flaw=flaw,
+            ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
         )
@@ -1065,6 +1130,7 @@ class TestEndpoints(object):
             status="won't fix",
             embargoed=flaw.is_embargoed,
             ps_update_stream="rhel-7.0",
+            type=Tracker.TrackerType.BUGZILLA,
         )
 
         response = auth_client.get(f"{test_api_uri}/flaws/{flaw.cve_id}")
@@ -1489,19 +1555,40 @@ class TestEndpoints(object):
         flaw = FlawFactory()
         FlawFactory()
 
-        affects_with_trackers_to_fetch = [AffectFactory(flaw=flaw) for _ in range(5)]
-        other_affects = [AffectFactory(flaw=flaw) for _ in range(5)]
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affects_with_trackers_to_fetch = [
+            AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+                ps_module=ps_module.name,
+            )
+            for _ in range(5)
+        ]
+        other_affects = [
+            AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+                ps_module=ps_module.name,
+            )
+            for _ in range(5)
+        ]
 
         trackers_to_fetch = [
-            TrackerFactory(embargoed=flaw.is_embargoed) for _ in range(5)
+            TrackerFactory(
+                affects=[affects_with_trackers_to_fetch[idx]],
+                embargoed=flaw.is_embargoed,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
+            for idx in range(5)
         ]
-        other_trackers = [TrackerFactory(embargoed=flaw.is_embargoed) for _ in range(5)]
-
-        for affect, tracker in zip(affects_with_trackers_to_fetch, trackers_to_fetch):
-            affect.trackers.set([tracker])
-
-        for affect, tracker in zip(other_affects, other_trackers):
-            affect.trackers.set([tracker])
+        for idx in range(5):
+            TrackerFactory(
+                affects=[other_affects[idx]],
+                embargoed=flaw.is_embargoed,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
 
         affect_ids = {str(affect.uuid) for affect in affects_with_trackers_to_fetch}
         tracker_ids = {str(tracker.external_system_id) for tracker in trackers_to_fetch}
@@ -1813,7 +1900,17 @@ class TestEndpoints(object):
         """
         Test the update of Tracker records via a REST API PUT request.
         """
-        tracker = TrackerFactory()
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         response = auth_client.get(f"{test_api_uri}/trackers/{tracker.uuid}")
         assert response.status_code == 200
         original_body = response.json()
@@ -1834,7 +1931,17 @@ class TestEndpoints(object):
         """
         Test the deletion of Tracker records via a REST API DELETE request.
         """
-        tracker = TrackerFactory()
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         tracker_url = f"{test_api_uri}/trackers/{tracker.uuid}"
         response = auth_client.get(tracker_url)
         assert response.status_code == 200

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1749,11 +1749,16 @@ class TestFlawValidators:
         tracker.save(raise_validation_error=False)
         tracker.affects.add(affect)
 
+        match = (
+            f"The tracker is associated with a NOTAFFECTED affect: {affect.uuid}"
+            if entity == "tracker"
+            else f"{affect.uuid}.*is marked as.*but has open tracker"
+        )
         entity = tracker if entity == "tracker" else affect
         if should_raise:
             with pytest.raises(
                 ValidationError,
-                match=f"{affect.uuid}.*is marked as.*but has open tracker",
+                match=match,
             ):
                 entity.save()
         else:
@@ -1862,11 +1867,16 @@ class TestFlawValidators:
         tracker.save(raise_validation_error=False)
         tracker.affects.add(affect)
 
+        match = (
+            f"The tracker is associated with a WONTFIX affect: {affect.uuid}"
+            if entity == "tracker"
+            else f"{affect.uuid}.*is marked as.*but has open tracker"
+        )
         entity = tracker if entity == "tracker" else affect
         if should_raise:
             with pytest.raises(
                 ValidationError,
-                match=f"{affect.uuid}.*is marked as.*but has open tracker",
+                match=match,
             ):
                 entity.save()
         else:

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -117,10 +117,13 @@ class TestFlaw:
             acl_write=self.acl_write,
         )
         affect2.save()
+        PsModuleFactory(bts_name="bugzilla", name="fakemodule")
         tracker1 = TrackerFactory(
             affects=(affect2,),
+            embargoed=affect2.flaw.embargoed,
             status="random_status",
             resolution="random_resolution",
+            type=Tracker.TrackerType.BUGZILLA,
         )
         tracker1.save()
         all_affects = vuln_1.affects.all()
@@ -263,13 +266,23 @@ class TestFlaw:
         assert Flaw.objects.first().title == "second"
 
     def test_multi_affect_tracker(self):
-        affect1 = AffectFactory(affectedness=Affect.AffectAffectedness.NEW)
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect1 = AffectFactory(
+            affectedness=Affect.AffectAffectedness.NEW,
+            ps_module=ps_module.name,
+            ps_component="component",
+        )
         tracker = TrackerFactory.create(
-            affects=(affect1,), embargoed=affect1.flaw.is_embargoed
+            affects=(affect1,),
+            embargoed=affect1.flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
         )
         assert len(tracker.affects.all()) == 1
         affect2 = AffectFactory(
-            flaw__embargoed=False, affectedness=Affect.AffectAffectedness.NEW
+            flaw__embargoed=False,
+            affectedness=Affect.AffectAffectedness.NEW,
+            ps_module=ps_module.name,
+            ps_component="component",
         )
         Tracker.objects.create_tracker(
             affect2, tracker.external_system_id, tracker.type
@@ -278,13 +291,19 @@ class TestFlaw:
 
     def test_trackers_filed(self):
         flaw = FlawFactory()
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         fix_affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
             flaw=flaw,
         )
         assert not flaw.trackers_filed
-        TrackerFactory(affects=(fix_affect,), embargoed=flaw.is_embargoed)
+        TrackerFactory(
+            affects=(fix_affect,),
+            embargoed=flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         assert flaw.trackers_filed
         AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
@@ -294,15 +313,18 @@ class TestFlaw:
         assert not flaw.trackers_filed
 
     def test_delegated_affects(self):
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         delegated_affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
             flaw__embargoed=False,
         )
         TrackerFactory(
             affects=(delegated_affect,),
             status="won't fix",
             embargoed=delegated_affect.flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
         )
         assert delegated_affect.delegated_resolution == Affect.AffectFix.WONTFIX
         # NOTAFFECTED is ranked higher than WONTFIX
@@ -311,6 +333,7 @@ class TestFlaw:
             status="done",
             resolution="notabug",
             embargoed=delegated_affect.flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
         )
         assert delegated_affect.delegated_resolution == Affect.AffectFix.NOTAFFECTED
         # DEFER is ranged lower than NOTAFFECTED
@@ -319,6 +342,7 @@ class TestFlaw:
             status="closed",
             resolution="deferred",
             embargoed=delegated_affect.flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
         )
         assert delegated_affect.delegated_resolution == Affect.AffectFix.NOTAFFECTED
 
@@ -331,11 +355,32 @@ class TestFlaw:
         assert undelegated_affect.delegated_resolution is None
 
     def test_tracker_fix_state(self):
-        wontfix_tracker = TrackerFactory(status="won't fix")
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+            flaw__embargoed=False,
+        )
+        wontfix_tracker = TrackerFactory(
+            affects=[affect],
+            status="won't fix",
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         assert wontfix_tracker.fix_state == Affect.AffectFix.WONTFIX
-        random_tracker = TrackerFactory(status="foo", resolution="bar")
+        random_tracker = TrackerFactory(
+            status="foo",
+            resolution="bar",
+            affects=[affect],
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         assert random_tracker.fix_state == Affect.AffectFix.AFFECTED
-        empty_tracker = TrackerFactory(status="foo", resolution="")
+        empty_tracker = TrackerFactory(
+            status="foo",
+            resolution="",
+            affects=[affect],
+            type=Tracker.TrackerType.BUGZILLA,
+        )
         assert empty_tracker.fix_state == Affect.AffectFix.AFFECTED
 
     def test_flawmeta_create_or_update(self):
@@ -1261,6 +1306,7 @@ class TestFlawValidators:
         """test Tracker model validator making sure flaws can't have a public tracker"""
 
         affects = []
+        PsModuleFactory(bts_name="bugzilla", name="module")
         for embargoed_flaw in flaws_embargoed_status:
             affects.append(
                 AffectFactory(
@@ -1276,11 +1322,17 @@ class TestFlawValidators:
                 match="Tracker is public but is associated with an embargoed flaw",
             ):
                 TrackerFactory(
-                    affects=affects, embargoed=embargoed_tracker, status="CLOSED"
+                    affects=affects,
+                    embargoed=embargoed_tracker,
+                    type=Tracker.TrackerType.BUGZILLA,
+                    status="CLOSED",
                 )
         else:
             assert TrackerFactory(
-                affects=affects, embargoed=embargoed_tracker, status="CLOSED"
+                affects=affects,
+                embargoed=embargoed_tracker,
+                type=Tracker.TrackerType.BUGZILLA,
+                status="CLOSED",
             )
 
     def test_validate_no_placeholder(self):
@@ -1347,12 +1399,19 @@ class TestFlawValidators:
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
             impact=start_impact,
         )
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         affect = AffectFactory(
             flaw=flaw,
+            ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.NEW,
         )
         for status in tracker_statuses:
-            TrackerFactory(embargoed=False, status=status, affects=(affect,))
+            TrackerFactory(
+                embargoed=False,
+                status=status,
+                type=Tracker.TrackerType.BUGZILLA,
+                affects=(affect,),
+            )
         flaw.impact = new_impact
         flaw.save()
 
@@ -1421,9 +1480,19 @@ class TestFlawValidators:
             type=FlawReference.FlawReferenceType.ARTICLE,
             url="https://access.redhat.com/link123",
         )
-        affect = AffectFactory(flaw=flaw, affectedness=Affect.AffectAffectedness.NEW)
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            affectedness=Affect.AffectAffectedness.NEW,
+        )
         for status in tracker_statuses:
-            TrackerFactory(embargoed=False, status=status, affects=(affect,))
+            TrackerFactory(
+                affects=(affect,),
+                embargoed=False,
+                status=status,
+                type=Tracker.TrackerType.BUGZILLA,
+            )
         flaw.major_incident_state = is_major
         flaw.save()
 
@@ -1665,12 +1734,19 @@ class TestFlawValidators:
         """
         status = "OPEN" if is_tracker_open else "CLOSED"
         flaw = FlawFactory(embargoed=False)
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         affect = AffectFactory(
             flaw=flaw,
+            ps_module=ps_module.name,
             affectedness=affectedness,
             resolution=Affect.AffectResolution.NOVALUE,
         )
-        tracker = TrackerFactory(embargoed=False, status=status)
+        tracker = TrackerFactory.build(
+            embargoed=False,
+            status=status,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+        tracker.save(raise_validation_error=False)
         tracker.affects.add(affect)
 
         entity = tracker if entity == "tracker" else affect
@@ -1712,12 +1788,19 @@ class TestFlawValidators:
         """
         status = "OPEN" if is_tracker_open else "CLOSED"
         flaw = FlawFactory(embargoed=False)
+        ps_module = PsModuleFactory(bts_name="bugzilla")
         affect = AffectFactory(
             flaw=flaw,
-            resolution=resolution,
+            ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=resolution,
         )
-        tracker = TrackerFactory(embargoed=False, status=status)
+        tracker = TrackerFactory.build(
+            embargoed=False,
+            status=status,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+        tracker.save(raise_validation_error=False)
         tracker.affects.add(affect)
 
         entity = tracker if entity == "tracker" else affect

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -54,7 +54,13 @@ class TestTracker:
             resolution=Affect.AffectResolution.FIX,
         )
 
-        tracker = TrackerFactory(affects=[affect1, affect2], embargoed=flaw1.embargoed)
+        ps_module = PsModuleFactory(name=affect1.ps_module)
+
+        tracker = TrackerFactory(
+            affects=[affect1, affect2],
+            embargoed=flaw1.embargoed,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
         assert tracker.aggregated_impact == expected_impact
 
     def test_is_unacked(self):
@@ -71,8 +77,24 @@ class TestTracker:
             unacked_to_ps_module=ps_module,
         )
 
-        acked_tracker = TrackerFactory(ps_update_stream=acked_ps_update_stream.name)
-        unacked_tracker = TrackerFactory(ps_update_stream=unacked_ps_update_stream.name)
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+        )
+
+        acked_tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=acked_ps_update_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+        unacked_tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=unacked_ps_update_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
 
         assert acked_tracker.is_acked and not acked_tracker.is_unacked
         assert not unacked_tracker.is_acked and unacked_tracker.is_unacked

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -105,23 +105,26 @@ class TestTrackerValidators:
         """
         test that no validator complains about valid tracker
         """
-        flaw = FlawFactory()
-        ps_module = PsModuleFactory()
-        affect = AffectFactory(
-            flaw=flaw,
-            affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
-            ps_module=ps_module.name,
-        )
-        ps_update_stream = PsUpdateStreamFactory()
-        # do not raise here
-        # validation is run on save
-        TrackerFactory(
-            affects=[affect],
-            embargoed=flaw.embargoed,
-            type=Tracker.BTS2TYPE[ps_module.bts_name],
-            ps_update_stream=ps_update_stream.name,
-        )
+        try:
+            flaw = FlawFactory()
+            ps_module = PsModuleFactory()
+            affect = AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.FIX,
+                ps_module=ps_module.name,
+            )
+            ps_update_stream = PsUpdateStreamFactory()
+            # do not raise here
+            # validation is run on save
+            TrackerFactory(
+                affects=[affect],
+                embargoed=flaw.embargoed,
+                type=Tracker.BTS2TYPE[ps_module.bts_name],
+                ps_update_stream=ps_update_stream.name,
+            )
+        except ValidationError:
+            pytest.fail("Tracker creation should not fail here")
 
     def test_validate_no_affect(self):
         """


### PR DESCRIPTION
I went through the `Tracker` model and introduced data migrations which I could think about for now. It resulted in a refactoring of a huge number of tests as they used trackers without all the necessary context set and not all was easy to be done through the factories.

Closes OSIDB-787