### PR TITLE
Move test_ps_module fixture into relevant tests

### DIFF
--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -27,13 +27,6 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
-@pytest.fixture(autouse=True)
-def test_ps_module():
-    from osidb.tests.factories import PsModuleFactory
-
-    PsModuleFactory(name="rhel-6")
-
-
 @pytest.fixture
 def root_url():
     return "http://osdib-service:8000"

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -831,6 +831,7 @@ class TestFlawValidators:
         ],
     )
     def test_validate_affect_ps_module_alerts(self, bz_id, ps_module, should_alert):
+        PsModuleFactory(name="rhel-6")
         flaw = FlawFactory(meta_attr={"bz_id": bz_id})
         affect = AffectFactory(flaw=flaw, ps_module=ps_module)
         if should_alert:
@@ -850,6 +851,7 @@ class TestFlawValidators:
         ],
     )
     def test_validate_affect_ps_module_errors(self, bz_id, ps_module, should_raise):
+        PsModuleFactory(name="rhel-6")
         flaw = FlawFactory(meta_attr={"bz_id": bz_id})
         if should_raise:
             with pytest.raises(ValidationError) as e:


### PR DESCRIPTION
The `test_ps_module()` fixture with `autouse=True` is used only in `test_validate_affect_ps_module_alerts()` and `test_validate_affect_ps_module_errors()`. This PR moves the fixture's code directly into the tests and deletes the fixture.