### PR TITLE
Fix monitoring emails for failed tasks in OSIDB

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -12,3 +12,14 @@ app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 @signals.setup_logging.connect
 def on_celery_setup_logging(**kwargs):
     pass
+
+
+@signals.worker_process_init.connect
+def configure_worker_greenthreads(*args, **kwargs):
+    from gevent import monkey
+
+    monkey.patch_all()
+
+    from psycogreen import gevent
+
+    gevent.patch_psycopg()

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -92,7 +92,7 @@ STATIC_URL = "/static/"
 # Celery settings
 
 REDIS_PASSWORD = get_env("OSIDB_REDIS_PASSWORD")
-CELERY_BROKER_URL = CELERY_RESULT_BACKEND = f"rediss://:{REDIS_PASSWORD}@redis:6379/"
+CELERY_BROKER_URL = f"rediss://:{REDIS_PASSWORD}@redis:6379/"
 CELERY_BROKER_USE_SSL = {
     "ssl_keyfile": "/opt/app-root/etc/redis/certs/osidb-redis.key",
     "ssl_certfile": "/opt/app-root/etc/redis/certs/osidb-redis.crt",

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -95,7 +95,7 @@ STATIC_URL = "/static/"
 # Celery settings
 
 REDIS_PASSWORD = get_env("OSIDB_REDIS_PASSWORD")
-CELERY_BROKER_URL = CELERY_RESULT_BACKEND = f"rediss://:{REDIS_PASSWORD}@redis:6379/"
+CELERY_BROKER_URL = f"rediss://:{REDIS_PASSWORD}@redis:6379/"
 CELERY_BROKER_USE_SSL = {
     "ssl_keyfile": "/opt/app-root/etc/redis/certs/osidb-redis.key",
     "ssl_certfile": "/opt/app-root/etc/redis/certs/osidb-redis.crt",


### PR DESCRIPTION
This PR introduces two commits which will:

* Actually save the task results in the database in stage & production
* Ensure the pool workers are gevent and psycogreen patched