### PR TITLE
Store task args & kwargs into the DB

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -171,6 +171,14 @@ CELERY_RESULT_BACKEND_MAX_RETRIES = 2
 # osidb.tasks.expire_task_results) with a longer time period and extra logging.
 CELERY_RESULT_EXPIRES = None
 
+# Store task args and kwargs into the DB, in newer django-celery-results versions:
+# https://github.com/celery/django-celery-results/issues/326
+CELERY_RESULT_EXTENDED = True
+
+# Track the start time of each task by creating its TaskResult as soon as it enters the STARTED
+# state. This allows us to measure task execution time of each task by `date_done - date_created`.
+CELERY_TASK_TRACK_STARTED = True
+
 CELERY_TASK_SOFT_TIME_LIMIT = 3600
 CELERY_TASK_IGNORE_RESULT = False
 CELERY_TASK_ROUTES = (

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement a new FlawAcknowledgment API (OSIDB-1002)
 - Implement requires_summary in Flaw API (OSIDB-1005)
 - Implement ps_update_stream in Tracker API (OSIDB-1064)
-- Implement daily monitoring email for failed tasks
+- Implement daily monitoring email for failed tasks / collectors
 - Implement nist_cvss_validation in Flaw API (OSIDB-1006)
 - Implement additional tracker validations (OSIDB-787)
 


### PR DESCRIPTION
Quick fix for `None: args=None, kwargs=None` in the monitoring email. That should say something like `task_name: args=(1, "a"), kwargs={2: 2, "b": "b"}` instead.