### PR TITLE
tracker BTSs join

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,6 +159,16 @@
         "is_secret": false
       }
     ],
+    "apps/trackers/tests/test_save.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/trackers/tests/test_save.py",
+        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
+        "is_verified": false,
+        "line_number": 63,
+        "is_secret": false
+      }
+    ],
     "config/settings_ci.py": [
       {
         "type": "Secret Keyword",

--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -1,27 +1,19 @@
 import logging
-from functools import cached_property
 
 from apps.bbsync.cc import AffectCCBuilder, RHSCLAffectCCBuilder
 from apps.bbsync.exceptions import ProductDataError
 from apps.bbsync.models import BugzillaComponent
 from apps.bbsync.query import BugzillaQueryBuilder
-from osidb.models import PsModule, PsUpdateStream
+from apps.trackers.common import TrackerQueryBuilder
 
 logger = logging.getLogger(__name__)
 
 
-class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder):
+class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
     """
     Bugzilla tracker bug query builder
     to generate general tracker save query
     """
-
-    @property
-    def tracker(self):
-        """
-        concrete name shortcut
-        """
-        return self.instance
 
     @property
     def old_tracker(self):
@@ -29,29 +21,6 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder):
         concrete name shortcut
         """
         return self.old_instance
-
-    @cached_property
-    def ps_module(self):
-        """
-        cached PS module getter
-        """
-        # even when multiple affects they must all have the same PS module
-        return PsModule.objects.get(name=self.tracker.affects.first().ps_module)
-
-    @cached_property
-    def ps_component(self):
-        """
-        cached PS component getter
-        """
-        # even when multiple affects they must all have the same PS component
-        return self.tracker.affects.first().ps_component
-
-    @cached_property
-    def ps_update_stream(self):
-        """
-        cached PS update stream getter
-        """
-        return PsUpdateStream.objects.get(name=self.tracker.ps_update_stream)
 
     def generate(self):
         """

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -2,50 +2,8 @@
 common tracker functionality shared between BTSs
 """
 from functools import cached_property
-from typing import Any, Dict
 
-from apps.trackers.exceptions import UnsupportedTrackerError
-from osidb.models import Affect, Flaw, PsModule, PsUpdateStream
-
-
-class BTSTracker:
-    """
-    In-memory BTS tracker instance that should hold enough data to
-    create tracker in all BTS supported (currently Bugzilla and Jira)
-    """
-
-    def __init__(self, flaw: Flaw, affect: Affect, stream: PsUpdateStream) -> None:
-        """
-        performs feasibility checks and initializes context
-        """
-        assert (
-            flaw and affect and stream
-        ), "parameters are mandatory and must be non-empty"
-
-        # we do not support tracker filing for the old multi-CVE flaws
-        if Flaw.objects.filter(meta_attr__bz_id=flaw.bz_id).count() > 1:
-            raise UnsupportedTrackerError(
-                "Creating trackers for flaws with multiple CVEs is not supported"
-            )
-
-        self._flaw = flaw
-        self._affect = affect
-        self._ps_module = PsModule.objects.filter(name=affect.ps_module).first()
-        self._stream = stream
-
-    def generate_bts_object(self) -> Dict[str, Any]:
-        """
-        Generates an object that contains all needed fields
-        to create or update a new tracker in the corresponding BTS
-        """
-
-    def _generate_summary(self) -> str:
-        """
-        Generates the summary of a tracker
-        """
-        # CVE ID might be not yet assigned
-        cve_id = self._flaw.cve_id + " " if self._flaw.cve_id else ""
-        return f"{cve_id}{self._affect.ps_component}: {self._flaw.title} [{self._stream.name}]"
+from osidb.models import PsModule, PsUpdateStream
 
 
 class TrackerQueryBuilder:

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -1,6 +1,7 @@
 """
 common tracker functionality shared between BTSs
 """
+from functools import cached_property
 from typing import Any, Dict
 
 from apps.trackers.exceptions import UnsupportedTrackerError
@@ -45,3 +46,39 @@ class BTSTracker:
         # CVE ID might be not yet assigned
         cve_id = self._flaw.cve_id + " " if self._flaw.cve_id else ""
         return f"{cve_id}{self._affect.ps_component}: {self._flaw.title} [{self._stream.name}]"
+
+
+class TrackerQueryBuilder:
+    """
+    common base for the shared query building functionality
+    """
+
+    @property
+    def tracker(self):
+        """
+        concrete name shortcut
+        """
+        return self.instance
+
+    @cached_property
+    def ps_module(self):
+        """
+        cached PS module getter
+        """
+        # even when multiple affects they must all have the same PS module
+        return PsModule.objects.get(name=self.tracker.affects.first().ps_module)
+
+    @cached_property
+    def ps_component(self):
+        """
+        cached PS component getter
+        """
+        # even when multiple affects they must all have the same PS component
+        return self.tracker.affects.first().ps_component
+
+    @cached_property
+    def ps_update_stream(self):
+        """
+        cached PS update stream getter
+        """
+        return PsUpdateStream.objects.get(name=self.tracker.ps_update_stream)

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -4,9 +4,10 @@ Jira tracker query generation module
 import logging
 from functools import cached_property
 
+from apps.trackers.common import TrackerQueryBuilder
 from apps.trackers.exceptions import NoPriorityAvailableError
 from apps.trackers.models import JiraProjectFields
-from osidb.models import Impact, PsModule, PsUpdateStream
+from osidb.models import Impact
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +39,7 @@ IMPACT_TO_JIRA_PRIORITY = {
 }
 
 
-class TrackerJiraQueryBuilder:
+class TrackerJiraQueryBuilder(TrackerQueryBuilder):
     """
     Jira tracker bug query builder
     to generate general tracker save query
@@ -50,36 +51,6 @@ class TrackerJiraQueryBuilder:
         """
         self.instance = instance
         self._query = {}
-
-    @property
-    def tracker(self):
-        """
-        concrete name shortcut
-        """
-        return self.instance
-
-    @cached_property
-    def ps_module(self):
-        """
-        cached PS module getter
-        """
-        # even when multiple affects they must all have the same PS module
-        return PsModule.objects.get(name=self.tracker.affects.first().ps_module)
-
-    @cached_property
-    def ps_component(self):
-        """
-        cached PS component getter
-        """
-        # even when multiple affects they must all have the same PS component
-        return self.tracker.affects.first().ps_component
-
-    @cached_property
-    def ps_update_stream(self):
-        """
-        cached PS update stream getter
-        """
-        return PsUpdateStream.objects.get(name=self.tracker.ps_update_stream)
 
     @cached_property
     def impact(self):

--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -17,15 +17,28 @@ class TrackerJiraSaver(JiraQuerier):
     Jira tracker bug save handler
     """
 
-    def __init__(self, token) -> None:
+    def __init__(self, tracker, token) -> None:
         """
         Instantiate a new JiraTrackerQuerier object.
 
         Keyword arguments:
         token -- user token used in every request to Jira
         """
+        self.tracker = tracker
         self._jira_server = JIRA_SERVER
         self._jira_token = token
+
+    def save(self):
+        """
+        generic save serving as class entry point
+        which calls create or update handler to continue
+        returns an updated instance (without saving)
+        """
+        return (
+            self.create(self.tracker)
+            if not self.tracker.external_system_id
+            else self.update(self.tracker)
+        )
 
     def create(self, tracker):
         """

--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -6,8 +6,8 @@ import logging
 
 from collectors.jiraffe.core import JiraQuerier
 
-from . import TrackerJiraQueryBuilder
 from .constants import JIRA_SERVER
+from .query import TrackerJiraQueryBuilder
 
 logger = logging.getLogger(__name__)
 

--- a/apps/trackers/save.py
+++ b/apps/trackers/save.py
@@ -5,6 +5,7 @@ from osidb.models import Flaw, Tracker
 
 from .bugzilla.save import TrackerBugzillaSaver
 from .exceptions import BTSException, UnsupportedTrackerError
+from .jira.save import TrackerJiraSaver
 
 
 class TrackerSaver:
@@ -13,8 +14,7 @@ class TrackerSaver:
     provides the specific sub-handler
     """
 
-    # TODO Jira part
-    def __new__(cls, tracker, bz_api_key=None):
+    def __new__(cls, tracker, bz_api_key=None, jira_token=None):
         """
         detect and return the correct saver
         assuming that all prerequisites are met
@@ -31,7 +31,8 @@ class TrackerSaver:
             return TrackerBugzillaSaver(tracker, bz_api_key)
 
         if tracker.type == Tracker.TrackerType.JIRA:
-            raise NotImplementedError
+            assert jira_token, "Jira access token not provided"
+            return TrackerJiraSaver(tracker, jira_token)
 
         # we should never get here
         raise BTSException("Unknown BTS")

--- a/apps/trackers/tests/test_save.py
+++ b/apps/trackers/tests/test_save.py
@@ -1,0 +1,169 @@
+"""
+tracker saver tests
+"""
+
+import pytest
+
+from apps.trackers.bugzilla.save import TrackerBugzillaSaver
+from apps.trackers.exceptions import UnsupportedTrackerError
+from apps.trackers.jira.save import TrackerJiraSaver
+from apps.trackers.save import TrackerSaver
+from osidb.models import Affect, Tracker
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+    TrackerFactory,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class TestTrackerSaver:
+    def test_refuse_multi_cve_flaw(self):
+        """
+        test that a multi-CVE flaw is refused with the expected
+        error message when attemting to file a tracker against it
+        """
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        flaw1 = FlawFactory(bz_id="12345", cve_id="CVE-2020-1111")
+        flaw2 = FlawFactory(
+            bz_id="12345", cve_id="CVE-2020-2222", embargoed=flaw1.embargoed
+        )
+
+        affect1 = AffectFactory(
+            flaw=flaw1,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+            ps_component="component",
+        )
+        affect2 = AffectFactory(
+            flaw=flaw2,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=affect1.ps_module,
+            ps_component=affect1.ps_component,
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect1, affect2],
+            embargoed=flaw1.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+
+        with pytest.raises(
+            UnsupportedTrackerError,
+            match="Creating trackers for flaws with multiple CVEs is not supported",
+        ):
+            TrackerSaver(tracker, bz_api_key="SECRET")
+
+    def test_bugzilla(self):
+        """
+        test that the general TrackerSaver turns into TrackerBugzillaSaver for Bugzilla trackers
+        """
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+            ps_component="component",
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+
+        assert isinstance(
+            TrackerSaver(tracker, bz_api_key="SECRET"), TrackerBugzillaSaver
+        )
+
+    def test_bugzilla_no_secret(self):
+        """
+        test that the tracker filing is refused with the expected error message
+        when attemting to file a Bugzilla tracker without providing the API key
+        """
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+            ps_component="component",
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="Bugzilla API key not provided",
+        ):
+            TrackerSaver(tracker)
+
+    def test_jira(self):
+        """
+        test that the general TrackerSaver turns into TrackerJiraSaver for Jira trackers
+        """
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+            ps_component="component",
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.JIRA,
+        )
+
+        assert isinstance(
+            TrackerSaver(tracker, jira_token="SECRET"), TrackerJiraSaver  # nosec
+        )
+
+    def test_jira_no_secret(self):
+        """
+        test that the tracker filing is refused with the expected error message
+        when attemting to file a Jira tracker without providing the access token
+        """
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            ps_module=ps_module.name,
+            ps_component="component",
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.JIRA,
+        )
+
+        with pytest.raises(
+            AssertionError,
+            match="Jira access token not provided",
+        ):
+            TrackerSaver(tracker)


### PR DESCRIPTION
This PR introduces a shared base for the Bugzilla and Jira query building and integrates the Jira part to the joint saver class so the `Tracker` model does not have to care for the saver type when `tracker.save` (not yet integrated).

Based on https://github.com/RedHatProductSecurity/osidb/pull/294 (review first)

Closes OSIDB-1178