### PR TITLE
Validate NIST RH CVSS feedback loop

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -251,7 +251,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 224,
+        "line_number": 225,
         "is_secret": false
       }
     ],
@@ -284,5 +284,5 @@
       }
     ]
   },
-  "generated_at": "2023-08-07T07:09:58Z"
+  "generated_at": "2023-08-09T11:24:13Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement daily monitoring email for failed tasks / collectors
 - Implement nist_cvss_validation in Flaw API (OSIDB-1006)
 - Implement additional tracker validations (OSIDB-787)
+- Validate NIST RH CVSS feedback loop (OSIDB-334)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)


### PR DESCRIPTION
This PR adds validation to check if RH should send a request to NIST on flaw CVSS rescore when defined conditions are met.

Closes OSIDB-334