### PR TITLE
add additional index to Tracker model

### DIFF
--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2007,7 +2007,7 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             "uuid",
         )
         unique_together = ["type", "external_system_id"]
-        indexes = TrackingMixin.Meta.indexes.append("external_system_id")
+        indexes = TrackingMixin.Meta.indexes + models.Index(fields=["external_system_id"])
 
     objects = TrackerManager()
 

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2007,7 +2007,7 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             "uuid",
         )
         unique_together = ["type", "external_system_id"]
-        indexes = TrackingMixin.Meta.indexes
+        indexes = TrackingMixin.Meta.indexes.append("external_system_id")
 
     objects = TrackerManager()
 


### PR DESCRIPTION
Adds an additional index (`external_system_id`) to `Tracker` model to speed up main bottlenecking query for OSIDB-1113 (looking up trackers by bug system id).