### PR TITLE
tracker summary generation

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -1,8 +1,8 @@
 import json
-import re
 from itertools import chain
 
 from collectors.bzimport.constants import ANALYSIS_TASK_PRODUCT
+from osidb.helpers import cve_id_comparator
 from osidb.models import Flaw, FlawComment, Impact, PsModule
 
 from .cc import CCBuilder
@@ -146,17 +146,6 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
             * then follows the title
 
         """
-
-        def cve_id_comparator(cve_id):
-            """
-            comparator to sort CVE IDs by
-
-                1) the year
-                2) the sequence
-            """
-            digits = re.sub(r"[^0-9]", "", cve_id)
-            # stress the value of the year above the sequence
-            return int(digits[:4]) ** 2 + int(digits[4:])
 
         embargoed = "EMBARGOED " if self.flaw.is_embargoed else ""
 

--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -194,7 +194,4 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         """
         generate query for tracker summary
         """
-        # TODO
-        self._query[
-            "summary"
-        ] = f"{self.ps_component}: TODO [{self.ps_update_stream.name}]"
+        self._query["summary"] = self.summary

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -3,7 +3,13 @@ common tracker functionality shared between BTSs
 """
 from functools import cached_property
 
-from osidb.models import PsModule, PsUpdateStream
+from apps.trackers.constants import (
+    MAX_SUMMARY_LENGTH,
+    MULTIPLE_DESCRIPTIONS_SUBSTITUTION,
+)
+from apps.trackers.exceptions import TrackerCreationError
+from osidb.helpers import cve_id_comparator
+from osidb.models import Flaw, PsModule, PsUpdateStream
 
 
 class TrackerQueryBuilder:
@@ -17,6 +23,13 @@ class TrackerQueryBuilder:
         concrete name shortcut
         """
         return self.instance
+
+    @cached_property
+    def flaws(self):
+        """
+        cached flaws getter
+        """
+        return [affect.flaw for affect in self.tracker.affects.all()]
 
     @cached_property
     def ps_module(self):
@@ -40,3 +53,95 @@ class TrackerQueryBuilder:
         cached PS update stream getter
         """
         return PsUpdateStream.objects.get(name=self.tracker.ps_update_stream)
+
+    @cached_property
+    def summary(self):
+        """
+        tracker summary getter
+        """
+        prefixes = self._summary_prefixes()
+        cves = sorted(
+            [flaw.cve_id for flaw in self.flaws if flaw.cve_id], key=cve_id_comparator
+        )
+        # we can assume that the tracker has a positive number of flaws
+        # associated which are all different because it is validated
+        description = (
+            self.flaws[0].title
+            if len(self.flaws) == 1
+            else MULTIPLE_DESCRIPTIONS_SUBSTITUTION
+        )
+
+        # try to compose the summary
+        # until it is short enough
+        while True:
+
+            cve_string = " ".join(cves) + " " if cves else ""
+            summary = f"{prefixes}{cve_string}{self.ps_component}: {description} [{self.ps_update_stream.name}]"
+
+            if len(summary) <= MAX_SUMMARY_LENGTH:
+                break
+
+            cves, description = self._summary_shorten(cves, description)
+
+        return summary
+
+    def _summary_prefixes(self) -> str:
+        """
+        generate string of sorted tracker summary prefixes
+        """
+        prefixes = []
+
+        if self.tracker.is_embargoed:
+            prefixes.append("EMBARGOED")
+
+        if any(
+            flaw
+            for flaw in self.flaws
+            if flaw.major_incident_state == Flaw.FlawMajorIncident.APPROVED
+        ):
+            prefixes.append("[Major Incident]")
+
+        # we can theoretically have normal and CISA one at once
+        # and then we prioritize the normal one above CISA
+        elif any(
+            flaw
+            for flaw in self.flaws
+            if flaw.major_incident_state == Flaw.FlawMajorIncident.CISA_APPROVED
+        ):
+            prefixes.append("[CISA Major Incident]")
+
+        # TODO TRIAGE prefix is based on the flaw workflow state
+        # be aware that it is still undefined for trackers with multiple flaws
+
+        if not prefixes:
+            return ""
+
+        # join sorted prefixes with space delimiter and
+        # add a trailing space to separate from the rest
+        return " ".join(sorted(prefixes)) + " "
+
+    def _summary_shorten(self, cves, description):
+        """
+        shorten the aligable parts of the tracker summary
+        """
+        # first shorten CVE list
+        if len(cves) > 1:
+
+            # remove the last CVE
+            cves = cves[0:-1]
+            # add the dots to the new last
+            cves[-1] = cves[-1] + " ..."
+
+        # finally shorten the description
+        else:
+            # when we cannot preserve at least a minimal meaningful description
+            # something is fairly wrong and we cannot create such tracker
+            if len(description) <= len(MULTIPLE_DESCRIPTIONS_SUBSTITUTION):
+                raise TrackerCreationError(
+                    f"Summary generated for the tracker is longer than {MAX_SUMMARY_LENGTH}"
+                )
+
+            # simply shorten the desciption by one
+            description = description[0:-5] + " ..."
+
+        return cves, description

--- a/apps/trackers/constants.py
+++ b/apps/trackers/constants.py
@@ -3,3 +3,7 @@ common tracker constants
 """
 
 TRACKER_API_VERSION = "v1"
+
+# tracker summary constants
+MAX_SUMMARY_LENGTH = 255
+MULTIPLE_DESCRIPTIONS_SUBSTITUTION = "various flaws"

--- a/apps/trackers/exceptions.py
+++ b/apps/trackers/exceptions.py
@@ -11,6 +11,12 @@ class NoPriorityAvailableError(BTSException):
     """exception class for missing correct priority corresponding to Impact"""
 
 
+class TrackerCreationError(BTSException):
+    """
+    exception class for the cases of unsuccessful tracker creation
+    """
+
+
 class UnsupportedTrackerError(BTSException):
     """
     exception class for the cases of the unsupported tracker filing

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -145,13 +145,4 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         Generates the summary of a tracker
         """
-        # TODO support multi-flaw tracker
-        flaw = self.tracker.affects.filter(flaw__cve_id__isnull=False).first().flaw
-        cve_id = flaw.cve_id + " "
-        if not flaw:
-            flaw = self.tracker.affects[0].flaw
-            cve_id = ""
-        self._query["fields"]["summary"] = (
-            f"{cve_id}{self.ps_component}: "
-            f"{flaw.title} [{self.tracker.ps_update_stream}]"
-        )
+        self._query["fields"]["summary"] = self.summary

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -1,0 +1,282 @@
+"""
+tracker common functionality test cases
+"""
+import pytest
+
+from apps.trackers.common import TrackerQueryBuilder
+from osidb.models import Affect, Flaw, Tracker
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+    TrackerFactory,
+)
+
+
+class TestTrackerQueryBuilderSummary:
+    """
+    TrackerQueryBuilder summary related test cases
+    """
+
+    def test_basic(self):
+        """
+        test basic tracker summary generation
+        """
+        ps_module = PsModuleFactory()
+        ps_update_stream = PsUpdateStreamFactory(
+            name="deep-stream", ps_module=ps_module
+        )
+        flaw = FlawFactory(
+            cve_id="CVE-2020-12345",
+            embargoed=False,
+            major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+            title="serious flaw",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
+            ps_component="large-component",
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+
+        tqb = TrackerQueryBuilder()
+        tqb.instance = tracker
+
+        assert (
+            tqb.summary == "CVE-2020-12345 large-component: serious flaw [deep-stream]"
+        )
+
+    @pytest.mark.parametrize(
+        "cves,summary_cves",
+        [
+            ([None, None], ""),  # no CVEs
+            ([None, "CVE-2000-1234"], "CVE-2000-1234 "),
+            (["CVE-2000-11111", "CVE-2000-1234"], "CVE-2000-1234 CVE-2000-11111 "),
+            (
+                ["CVE-2003-1111", "CVE-2002-2222", "CVE-2001-3333"],
+                "CVE-2001-3333 CVE-2002-2222 CVE-2003-1111 ",
+            ),
+            (
+                ["CVE-2003-1111", "CVE-2002-2222", "CVE-2001-3333", None],
+                "CVE-2001-3333 CVE-2002-2222 CVE-2003-1111 ",
+            ),
+            # too many CVEs to fit in the summary should be trimmed
+            (
+                [
+                    "CVE-2000-11111",
+                    "CVE-2000-11112",
+                    "CVE-2000-11113",
+                    "CVE-2000-11114",
+                    "CVE-2000-11115",
+                    "CVE-2000-11116",
+                    "CVE-2000-11117",
+                    "CVE-2000-11118",
+                    "CVE-2000-11119",
+                    "CVE-2000-11120",
+                    "CVE-2000-11121",
+                    "CVE-2000-11122",
+                    "CVE-2000-11123",
+                    "CVE-2000-11124",
+                    "CVE-2000-11125",
+                    "CVE-2000-11126",
+                    "CVE-2000-11127",
+                    "CVE-2000-11128",
+                    "CVE-2000-11129",
+                    "CVE-2000-11130",
+                ],
+                "CVE-2000-11111 CVE-2000-11112 CVE-2000-11113 CVE-2000-11114 "
+                "CVE-2000-11115 CVE-2000-11116 CVE-2000-11117 CVE-2000-11118 CVE-2000-11119 "
+                "CVE-2000-11120 CVE-2000-11121 CVE-2000-11122 CVE-2000-11123 ... ",
+            ),
+        ],
+    )
+    def test_multiple_flaws(self, cves, summary_cves):
+        """
+        test tracker with multiple flaws summary generation
+        """
+        ps_module = PsModuleFactory()
+        ps_update_stream = PsUpdateStreamFactory(
+            name="deep-stream", ps_module=ps_module
+        )
+
+        affects = []
+        for cve in cves:
+            flaw = FlawFactory(
+                cve_id=cve,
+                embargoed=False,
+                major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+            )
+            affects.append(
+                AffectFactory(
+                    flaw=flaw,
+                    affectedness=Affect.AffectAffectedness.AFFECTED,
+                    resolution=Affect.AffectResolution.DELEGATED,
+                    ps_module=ps_module.name,
+                    ps_component="large-component",
+                )
+            )
+
+        tracker = TrackerFactory(
+            affects=affects,
+            embargoed=False,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+
+        tqb = TrackerQueryBuilder()
+        tqb.instance = tracker
+
+        assert (
+            tqb.summary == summary_cves + "large-component: various flaws [deep-stream]"
+        )
+
+    def test_description_too_long(self):
+        """
+        test tracker summary generation when the description is too long
+        """
+        ps_module = PsModuleFactory()
+        ps_update_stream = PsUpdateStreamFactory(
+            name="deep-stream", ps_module=ps_module
+        )
+        flaw = FlawFactory(
+            cve_id="CVE-2020-12345",
+            embargoed=False,
+            major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+            title="Lorem ipsum dolor sit amet, consectetur "
+            "adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore "
+            "magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco "
+            "laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor "
+            "in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla "
+            "pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa "
+            "qui officia deserunt mollit anim id est laborum.",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
+            ps_component="large-component",
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+
+        tqb = TrackerQueryBuilder()
+        tqb.instance = tracker
+
+        assert (
+            tqb.summary
+            == "CVE-2020-12345 large-component: Lorem ipsum dolor sit amet, "
+            "consectetur adipiscing elit, sed do eiusmod tempor incididunt ut "
+            "labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud "
+            "exercitation ullamco laboris nisi ut aliqui ... [deep-stream]"
+        )
+
+    @pytest.mark.parametrize(
+        "cve_id,embargoed,major_incident_state,summary_prefix",
+        [
+            (None, False, Flaw.FlawMajorIncident.NOVALUE, ""),
+            (
+                "CVE-2000-1234",
+                False,
+                Flaw.FlawMajorIncident.REQUESTED,
+                "CVE-2000-1234 ",
+            ),
+            (None, True, Flaw.FlawMajorIncident.REJECTED, "EMBARGOED "),
+            (
+                "CVE-2000-1234",
+                True,
+                Flaw.FlawMajorIncident.NOVALUE,
+                "EMBARGOED CVE-2000-1234 ",
+            ),
+            (None, False, Flaw.FlawMajorIncident.APPROVED, "[Major Incident] "),
+            (
+                "CVE-2000-1234",
+                False,
+                Flaw.FlawMajorIncident.APPROVED,
+                "[Major Incident] CVE-2000-1234 ",
+            ),
+            (
+                None,
+                True,
+                Flaw.FlawMajorIncident.APPROVED,
+                "EMBARGOED [Major Incident] ",
+            ),
+            (
+                "CVE-2000-1234",
+                True,
+                Flaw.FlawMajorIncident.APPROVED,
+                "EMBARGOED [Major Incident] CVE-2000-1234 ",
+            ),
+            (
+                None,
+                False,
+                Flaw.FlawMajorIncident.CISA_APPROVED,
+                "[CISA Major Incident] ",
+            ),
+            (
+                "CVE-2000-1234",
+                False,
+                Flaw.FlawMajorIncident.CISA_APPROVED,
+                "[CISA Major Incident] CVE-2000-1234 ",
+            ),
+            (
+                None,
+                True,
+                Flaw.FlawMajorIncident.CISA_APPROVED,
+                "EMBARGOED [CISA Major Incident] ",
+            ),
+            (
+                "CVE-2000-1234",
+                True,
+                Flaw.FlawMajorIncident.CISA_APPROVED,
+                "EMBARGOED [CISA Major Incident] CVE-2000-1234 ",
+            ),
+        ],
+    )
+    def test_prefixes(self, cve_id, embargoed, major_incident_state, summary_prefix):
+        """
+        test tracker summary prefix generation
+        """
+        ps_module = PsModuleFactory()
+        ps_update_stream = PsUpdateStreamFactory(
+            name="deep-stream", ps_module=ps_module
+        )
+        flaw = FlawFactory(
+            cve_id=cve_id,
+            embargoed=embargoed,
+            major_incident_state=major_incident_state,
+            title="serious flaw",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
+            ps_component="large-component",
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+
+        tqb = TrackerQueryBuilder()
+        tqb.instance = tracker
+
+        assert (
+            tqb.summary
+            == summary_prefix + "large-component: serious flaw [deep-stream]"
+        )

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -7,7 +7,7 @@ import pytest
 
 from apps.trackers.jira.query import JiraPriority, TrackerJiraQueryBuilder
 from apps.trackers.models import JiraProjectFields
-from osidb.models import Affect, Impact, Tracker
+from osidb.models import Affect, Flaw, Impact, Tracker
 from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
@@ -58,7 +58,7 @@ class TestTrackerJiraQueryBuilder:
                 "priority": {"name": expected_impact},
                 "project": {"key": "FOOPROJECT"},
                 "issuetype": {"name": "Bug"},
-                "summary": "CVE-2999-1000 foo-component: CVE-2999-1000 kernel: some description [bar-1.2.3]",
+                "summary": "CVE-2999-1000 foo-component: some description [bar-1.2.3]",
                 "labels": [
                     "CVE-2999-1000",
                     "pscomponent:foo-component",
@@ -68,7 +68,12 @@ class TestTrackerJiraQueryBuilder:
             }
         }
         flaw = FlawFactory(
-            embargoed=False, bz_id="123", cve_id="CVE-2999-1000", impact=flaw_impact
+            embargoed=False,
+            bz_id="123",
+            cve_id="CVE-2999-1000",
+            impact=flaw_impact,
+            major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+            title="some description",
         )
         affect = AffectFactory(
             flaw=flaw,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement additional tracker validations (OSIDB-787)
 - Validate NIST RH CVSS feedback loop (OSIDB-334)
 - Validate nist_cvss_validation and cvss_scores (OSIDB-1165)
+- Implement tracker summary generation (OSIDB-1172)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -4,6 +4,7 @@ Helpers for direct or development shell usage
 
 import json
 import logging
+import re
 import sys
 import warnings
 from distutils.util import strtobool
@@ -15,6 +16,18 @@ from django.db import models
 from django_deprecate_fields import DeprecatedField, logger
 
 from .exceptions import OSIDBException
+
+
+def cve_id_comparator(cve_id):
+    """
+    comparator to sort CVE IDs by
+
+        1) the year
+        2) the sequence
+    """
+    digits = re.sub(r"[^0-9]", "", cve_id)
+    # stress the value of the year above the sequence
+    return int(digits[:4]) ** 2 + int(digits[4:])
 
 
 def ensure_list(item):


### PR DESCRIPTION
This PR implements the full tracker summary generation. It is highly based on the SFM2 implementation

https://git.prodsec.redhat.com/devops/sfm2/-/blob/master/sfm2/text_generators/tracker.py

but hopefully simpler and more readable. There is a lot of magic but the basic structure of the summary is

`{prefixes}{cves}{component}: {description} [{stream}]`

where `prefixes` and `cves` are optional depending on the flaw(s), `component` is simply taken from the affect, `description` is taken from the flaw or it is `various flaws` when more than one and the `stream` is the tracker attribute.

There is a bit of safeguarding against exceeding the maximum length of 255 characters (this is overly complicated in SFM2 while there are very few cases where it applies so I decided to simplify it greatly).

Closes OSIDB-1172