### PR TITLE
Validate nist_cvss_validation and cvss_scores

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement nist_cvss_validation in Flaw API (OSIDB-1006)
 - Implement additional tracker validations (OSIDB-787)
 - Validate NIST RH CVSS feedback loop (OSIDB-334)
+- Validate nist_cvss_validation and cvss_scores (OSIDB-1165)
 
 ### Changed
 - Change article link validation to be blocking (OSIDB-1060)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -910,9 +910,6 @@ class Flaw(
         * it has no associated NIST feedback loop in progress (see nist_cvss_validation)
         * it has no RH CVSS3 explanation comment
         """
-        if self.cvss_scores.filter(version=FlawCVSS.CVSSVersion.VERSION3).count() != 2:
-            return
-
         nist_cvss = self.cvss_scores.filter(
             issuer=FlawCVSS.CVSSIssuer.NIST,
             version=FlawCVSS.CVSSVersion.VERSION3,

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -940,6 +940,27 @@ class Flaw(
                 f"an explanation comment for RH CVSSv3 score.",
             )
 
+    def _validate_cvss_scores_and_nist_cvss_validation(self):
+        """
+        Checks that if nist_cvss_validation is set, then both NIST CVSSv3 and RH CVSSv3
+        scores need to be present.
+        """
+        nist_cvss = self.cvss_scores.filter(
+            issuer=FlawCVSS.CVSSIssuer.NIST,
+            version=FlawCVSS.CVSSVersion.VERSION3,
+        ).first()
+
+        rh_cvss = self.cvss_scores.filter(
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION3,
+        ).first()
+
+        if self.nist_cvss_validation and not (nist_cvss and rh_cvss):
+            raise ValidationError(
+                "nist_cvss_validation can only be set if a flaw has both "
+                "NIST CVSSv3 and RH CVSSv3 scores assigned.",
+            )
+
     def _validate_nonempty_source(self):
         """
         checks that the source is not empty

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -94,9 +94,12 @@ class FlawFactory(factory.django.DjangoModelFactory):
         "random_element",
         elements=[
             Flaw.FlawNistCvssValidation.NOVALUE,
-            Flaw.FlawNistCvssValidation.REQUESTED,
-            Flaw.FlawNistCvssValidation.APPROVED,
-            Flaw.FlawNistCvssValidation.REJECTED,
+            # TODO: values below are currently commented out because FlawFactory is not
+            #       able to create two cvss via FlawCVSSFactory. Therefore, these values
+            #       are tested in test_validate_cvss_scores_and_nist_cvss_validation.
+            # Flaw.FlawNistCvssValidation.REQUESTED,
+            # Flaw.FlawNistCvssValidation.APPROVED,
+            # Flaw.FlawNistCvssValidation.REJECTED,
         ],
     )
     summary = factory.LazyAttribute(

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -142,7 +142,7 @@ class TestEndpoints(object):
         flaw1 = FlawFactory.build(
             major_incident_state=Flaw.FlawMajorIncident.APPROVED,
             requires_summary=Flaw.FlawRequiresSummary.APPROVED,
-            nist_cvss_validation=Flaw.FlawNistCvssValidation.REJECTED,
+            nist_cvss_validation=Flaw.FlawNistCvssValidation.NOVALUE,
         )
         flaw1.save(raise_validation_error=False)
         FlawMetaFactory(
@@ -163,7 +163,7 @@ class TestEndpoints(object):
         assert response.status_code == 200
         body = response.json()
         assert body["major_incident_state"] == Flaw.FlawMajorIncident.APPROVED
-        assert body["nist_cvss_validation"] == Flaw.FlawNistCvssValidation.REJECTED
+        assert body["nist_cvss_validation"] == Flaw.FlawNistCvssValidation.NOVALUE
         assert len(body["comments"]) == 1
 
     def test_list_flaws(self, auth_client, test_api_uri):


### PR DESCRIPTION
This PR adds validation to check if the combination of `nist_cvss_validation` and `cvss_scores` is set correctly.

Closes OSIDB-1165