### PR TITLE
fix auto-timestamp issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecate the "is_major_incident" field in Flaw (OSIDB-1103)
 - Change CORS policy to allow credentials (OSIDB-1115)
 - Validate MI and CISA MI separately (OSIDB-1104)
+- Fix auto-timestamp issues (OSIDB-1171)
 
 ## [3.3.0] - 2023-06-28
 ### Added

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1367,8 +1367,8 @@ class Flaw(
         self = bs.save()
         # save in case a new Bugzilla ID was obtained
         # so the flaw is later matched in BZ import
-        # and do not care for validations here
-        kwargs["raise_validation_error"] = False
+        kwargs["auto_timestamps"] = False  # the timestamps will be get from Bugzilla
+        kwargs["raise_validation_error"] = False  # the validations were already run
         self.save(*args, **kwargs)
         # fetch from Bugzilla
         fc = FlawCollector()


### PR DESCRIPTION
I was investigating the issue with the integration tests failing on master and found out that the origin of this issue is at

https://github.com/RedHatProductSecurity/osidb/pull/277/commits/dea9773f2b1c363fe4f476cb6405d065cf0290dd#diff-8d7ea87df8ca210c5df403a76b8228d0d1e1d2ae7fc99f54b5c6f7e02d396deeR632

where the order of the `BugzillaSyncMixin` and the `TrackingMixin` changed. Therefore the `TrackingMixin.save` is run twice which results in `DataInconsistencyException` because of seemingly non-refreshed/outdated model.

FYI @Elkasitu but no blame as I approved it. @jobselko this should be the issue you were referring to on the chat. @jsvob I think this might be the reason why your changes on the stage suddenly stopped working.

Closes OSIDB-1171