### PR TITLE
tracker description

### DIFF
--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -128,10 +128,10 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
 
     def generate_description(self):
         """
-        generate query for flaw description on create
+        generate query for flaw description
         """
         if self.creation:
-            self._query["description"] = "TODO"
+            self._query["description"] = self.description
             # auto-created description should be always public
             self._query["comment_is_private"] = False
 

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -2,14 +2,18 @@
 common tracker functionality shared between BTSs
 """
 from functools import cached_property
+from urllib.parse import urljoin
 
 from apps.trackers.constants import (
+    KERNEL_PACKAGES,
     MAX_SUMMARY_LENGTH,
     MULTIPLE_DESCRIPTIONS_SUBSTITUTION,
+    VIRTUALIZATION_PACKAGES,
 )
 from apps.trackers.exceptions import TrackerCreationError
+from collectors.bzimport.constants import BZ_URL
 from osidb.helpers import cve_id_comparator
-from osidb.models import Flaw, PsModule, PsUpdateStream
+from osidb.models import Flaw, PsModule, PsUpdateStream, Tracker
 
 
 class TrackerQueryBuilder:
@@ -145,3 +149,249 @@ class TrackerQueryBuilder:
             description = description[0:-5] + " ..."
 
         return cves, description
+
+    @cached_property
+    def description(self):
+        """
+        tracker description getter
+        """
+        # the old-tooling tracker description creation is basically long if-else
+        # adding more and more parts into an exising description base so we mimic
+        # it by composing an array of parts to be joined together at the very end
+        description_parts = []
+
+        # TODO
+        # 1) use the template instead if any
+        # tracked in https://issues.redhat.com/browse/OSIDB-1191
+
+        # 2) special community comment header
+        if self.ps_module.ps_product.is_community:
+            description_parts.extend(self._description_community())
+
+        # 3) compose the regular tracker description
+        #    considering all the relevant conditions
+        #
+        #    Bugzilla and Jira parts are obviously mutulally
+        #    exclusive but other parts are not and the order
+        #    even though it may seem random is taken from
+        #    SFM2 exactly the way it was defined there
+        else:
+
+            # 3a) Jira header
+            if self.tracker.type == Tracker.TrackerType.JIRA:
+                description_parts.extend(self._description_jira_header())
+
+            # 3b) triage text
+            if self.tracker.is_triage:
+                description_parts.extend(self._description_triage())
+
+            # 3c) Bugzilla header
+            if self.tracker.type == Tracker.TrackerType.BUGZILLA:
+                description_parts.extend(self._description_bugzilla_header())
+
+            # 3d) SLA text
+            if self.ps_update_stream.rhsa_sla_applicable:
+                pass  # TODO
+
+            # 3e) embargo text
+            if self.tracker.is_embargoed:
+                description_parts.extend(self._description_embargoed())
+
+            # 3f) Jira footer
+            if self.tracker.type == Tracker.TrackerType.JIRA:
+                description_parts.extend(self._description_jira_footer())
+
+            # 3g) Bugzilla footer
+            if self.tracker.type == Tracker.TrackerType.BUGZILLA:
+                description_parts.extend(self._description_bugzilla_footer())
+
+        # 4) another extra bit for kernel
+        if self.ps_component in KERNEL_PACKAGES:
+            description_parts.extend(self._description_kernel())
+
+        # 5) join the parts by empty lines
+        return "\n\n".join(description_parts)
+
+    def _description_bugzilla_footer(self):
+        """
+        generate Bugzilla tracker description footer
+        """
+        description_parts = []
+
+        if self.tracker.is_embargoed:
+
+            if self.ps_component in KERNEL_PACKAGES:
+                description_parts.append(
+                    "Information with regards to this bug is considered Red Hat Confidential "
+                    "until the embargo has lifted. Please post the patch only to the "
+                    "'rhkernel-team-list' mailing list for review and acks."
+                )
+
+            if self.ps_component in VIRTUALIZATION_PACKAGES:
+                description_parts.append(
+                    "Information with regards to this bug is considered Red Hat Confidential "
+                    "until the embargo has lifted. Please post the patch only to the "
+                    "'rhkernel-team-list' and/or 'virt-devel' mailing lists for review and acks."
+                )
+
+        if self.ps_module.name.startswith("rhel-"):
+            description_parts.append(
+                "For the Enterprise Linux security issues handling process overview see:\n"
+                "https://source.redhat.com/groups/public/product-security/content/product_security_wiki/eus_z_stream_and_security_bugs"
+            )
+
+        return description_parts
+
+    def _description_bugzilla_header(self):
+        """
+        generate Bugzilla tracker description header
+        """
+        description_parts = []
+
+        header = ""
+        if self.tracker.is_triage:
+            header += "Potential "
+
+        header += (
+            f"{self.ps_module.name} tracking bug for {self.ps_component}: "
+            'see the bugs linked in the "Blocks" field of this bug '
+            "for full details of the security issue(s)."
+        )
+        description_parts.append(header)
+
+        description_parts.append(
+            "This bug is never intended to be made public, "
+            "please put any public notes in the blocked bugs."
+        )
+        return description_parts
+
+    # TODO this should be eventually replaced by the OSIM/OSIDB link
+    def _description_bugzilla_link(self, bz_id):
+        """
+        generate link to Bugzilla bug with the given ID
+        """
+        return urljoin(BZ_URL, f"show_bug.cgi?id={bz_id}")
+
+    def _description_community(self):
+        """
+        generate community tracker description text
+        """
+        description_parts = []
+        description_parts.append(
+            "More information about this security flaw is available in the following bug:"
+            if len(self.flaws) == 1
+            else "More information about these security flaws is available in the following bugs:"
+        )
+        description_parts.append(
+            "\n".join(
+                [self._description_bugzilla_link(flaw.bz_id) for flaw in self.flaws]
+            )
+        )
+        description_parts.append(
+            "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
+            "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
+            "affects their package, before starting the update process."
+        )
+        return description_parts
+
+    def _description_embargoed(self):
+        """
+        generate embargoed tracker description text
+        """
+        description_parts = []
+        description_parts.append(
+            "NOTE THIS ISSUE IS CURRENTLY EMBARGOED, "
+            "DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE."
+        )
+
+        if self.tracker.type == Tracker.TrackerType.JIRA:
+            description_parts.append(
+                "WARNING: NOTICE THAT CHANGING THE SECURITY LEVEL FROM "
+                '"SECURITY ISSUE" TO "RED HAT INTERNAL" MAY BREAK THE EMBARGO.'
+            )
+
+        if self.tracker.type == Tracker.TrackerType.BUGZILLA:
+            description_parts.append(
+                'WARNING: NOTICE THAT REMOVING THE "SECURITY" '
+                "GROUP FROM THIS TRACKER MAY BREAK THE EMBARGO."
+            )
+
+        return description_parts
+
+    def _description_jira_footer(self):
+        """
+        generate Jira tracker description footer
+        """
+        description_parts = []
+        description_parts.append(
+            "Flaw:\n-----" if len(self.flaws) == 1 else "Flaws:\n------"
+        )
+
+        for flaw in self.flaws:
+            reference_url = self._description_bugzilla_link(flaw.bz_id)
+
+            description_parts.append(f"{flaw.title}\n{reference_url}")
+            description_parts.append(flaw.description)
+
+        description_parts.append("~~~")
+        return description_parts
+
+    def _description_jira_header(self):
+        """
+        generate Jira tracker description header
+        """
+        description_parts = []
+
+        header = ""
+        # private trackers are not allow so we are public
+        if not self.ps_module.private_trackers_allowed:
+            header += "Public "
+
+        header += (
+            "Security Issue Notification"
+            if self.tracker.is_triage
+            else "Security Tracking Issue"
+        )
+        description_parts.append(header)
+
+        if self.ps_module.private_trackers_allowed:
+            description_parts.append("Do not make this issue public.")
+
+        return description_parts
+
+    def _description_kernel(self):
+        """
+        generate kernel tracker description text
+        """
+        return [
+            "Reproducers, if any, will remain confidential and never be made public, "
+            "unless done so by the security team."
+        ]
+
+    def _description_triage(self):
+        """
+        generate triage tracker description text
+        """
+        description_parts = []
+        description_parts.append(
+            "This is a preliminary notification of a potential vulnerability under "
+            'the accelerated "Triage Tracker" program introduced between Product Security '
+            "and Engineering to allow deeper collaboration."
+        )
+        description_parts.append(
+            "The in-depth analysis is ongoing, and details are expected to change until "
+            "such time as it concludes."
+        )
+        description_parts.append(
+            "Be aware that someone other than the analyst performing the Secondary Assessment "
+            "will usually create the triage tracker. The best option is to comment in the "
+            "tracker and wait for a reply. Based on your regular interactions, "
+            "if you know the Incident Response Analyst for your offering, you can reach out "
+            "to them directly or add a private comment in the triage tracker or in "
+            "the flaw bug for their attention."
+        )
+        description_parts.append(
+            "Please refer to the FAQ page for more information - "
+            "https://source.redhat.com/departments/products_and_global_engineering/product_security/content/product_security_wiki/incident_response_coordination_faq"
+        )
+        return description_parts

--- a/apps/trackers/constants.py
+++ b/apps/trackers/constants.py
@@ -7,3 +7,7 @@ TRACKER_API_VERSION = "v1"
 # tracker summary constants
 MAX_SUMMARY_LENGTH = 255
 MULTIPLE_DESCRIPTIONS_SUBSTITUTION = "various flaws"
+
+# tracker description constants
+KERNEL_PACKAGES = {"kernel", "realtime-kernel", "kernel-rt", "kernel-alt"}
+VIRTUALIZATION_PACKAGES = {"xen", "kvm", "kernel-xen"}

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -114,20 +114,9 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
 
     def generate_description(self):
         """
-        Generates a text description for the vulnerability being tracked
+        generates query for the tracker description
         """
-        if self.tracker.embargoed:
-            description = "Security Tracking Issue\n\nDo not make this issue public.\n"
-        else:
-            description = "Public Security Tracking Issue\n"
-
-        description += (
-            f"Impact: {self.impact}.\n"
-            f"Reported Date: {self.reported_dt}.\n\n"
-            "Flaw:\n-----"
-        )
-        for affect in self.tracker.affects.all():
-            description += f"https://osidb.prodsec.redhat.com/osidb/api/v1/flaws/{affect.flaw.uuid}\n"
+        self._query["fields"]["description"] = self.description
 
     def generate_labels(self):
         """

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 
 from apps.trackers.constants import TRACKER_API_VERSION
+from osidb.models import Tracker
 
 
 @pytest.fixture(autouse=True)
@@ -57,3 +58,15 @@ def api_version() -> str:
 @pytest.fixture
 def test_api_uri(test_scheme_host, api_version) -> str:
     return f"{test_scheme_host}/api/{api_version}"
+
+
+@pytest.fixture
+def fake_triage() -> None:
+    """
+    fake triage tracker property to be always True
+    """
+    is_triage = getattr(Tracker, "is_triage")
+    setattr(Tracker, "is_triage", property(lambda self: True))
+    yield
+    # cleanup after the test run
+    setattr(Tracker, "is_triage", is_triage)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement collector for ps-constants project (OSIDB-1199)
 - Validate summary and requires_summary (OSIDB-1164)
 - Validate impact and summary (OSIDB-1164)
+- Implement tracker description generation (OSIDB-1173)
 
 ## [3.4.1] - 2023-08-21
 ### Changed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2317,6 +2317,15 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             is not None
         )
 
+    @property
+    def is_triage(self):
+        """
+        triage tracker has a non-published flaw state attached
+        """
+        # TODO this is only a placeholder for now
+        # it is to be determined and implemented
+        return False
+
 
 class ErratumManager(TrackingMixinManager):
     """

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2864,6 +2864,13 @@ class PsProduct(models.Model):
     # the business unit to which the product belongs
     business_unit = models.CharField(max_length=50)
 
+    @property
+    def is_community(self):
+        """
+        is community boolean property
+        """
+        return self.business_unit == "Community"
+
 
 class PsModule(NullStrFieldsMixin, ValidateMixin):
 


### PR DESCRIPTION
This PR implements tracker description generation. There are still two missing pieces which are description generation based on the product definitions template as those templates are not yet in OSIDB (tracker in OSIDB-1191) and SLA description text as SLA computation is not yet implemented (tracked in OSIDB-96).

You may notice that the description composition is somewhat random - eg. Jira header goes before the triage text while the Bugzilla header goes afterwards etc. I do not think there is any explanation above that this is how it was generated in SFM2. The SFM2 code corresponding to this functionality is one big mess and a forest of if-else branching. I tried to decompose it a bit but there are limits resulting from that it was all stitched together over many years by many people.

Closes OSIDB-1173