### PR TITLE
Validate summary and requires_summary

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Implement collector for ps-constants project (OSIDB-1199)
+- Validate summary and requires_summary (OSIDB-1164)
 
 ## [3.4.1] - 2023-08-21
 ### Changed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -710,7 +710,7 @@ class Flaw(
               this is the only state where summary is propagated to the flaw's CVE page
         * (-) "REJECTED": summary is not required for this flaw
 
-        Note that if a flaw is MI or CISA MI, summary should be never "REJECTED".
+        Note that if a flaw is MI or CISA MI, requires_summary should be "APPROVED".
         """
 
         NOVALUE = ""
@@ -956,6 +956,20 @@ class Flaw(
             raise ValidationError(
                 "nist_cvss_validation can only be set if a flaw has both "
                 "NIST CVSSv3 and RH CVSSv3 scores assigned.",
+            )
+
+    def _validate_summary_and_requires_summary(self):
+        """
+        Checks that if summary is missing, then requires_summary must not have
+        REQUESTED or APPROVED value set.
+        """
+        if not self.summary and self.requires_summary in [
+            self.FlawRequiresSummary.REQUESTED,
+            self.FlawRequiresSummary.APPROVED,
+        ]:
+            raise ValidationError(
+                f"requires_summary cannot be {self.requires_summary} if summary is "
+                f"missing."
             )
 
     def _validate_nonempty_source(self):


### PR DESCRIPTION
This PR adds validation to check if the combination of `summary` and `requires_summary` is set correctly.

Related to OSIDB-1164