### PR TITLE
Set AFFECTED as highest precedence for delegated_resolution

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Reduce the total amount of records per page when querying Bugzilla (OSIDB-1232)
+- Set AFFECTED as highest precedence resolution when calculating Affect.delegated_resolution (OSIDB-1230)
 
 ## [3.4.1] - 2023-08-21
 ### Changed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1718,12 +1718,17 @@ class Affect(
             return Affect.AffectFix.AFFECTED
 
         statuses = [tracker.fix_state for tracker in trackers]
+        # order is **very** important here, if there are multiple trackers
+        # the order of these statuses determines which tracker status takes
+        # precedence over all the rest, meaning that if one tracker is affected
+        # and another is not affected, the overall affect delegated_resolution
+        # will be affected and not notaffected.
         for status in (
-            Affect.AffectFix.NOTAFFECTED,
             Affect.AffectFix.AFFECTED,
             Affect.AffectFix.WONTFIX,
             Affect.AffectFix.OOSS,
             Affect.AffectFix.DEFER,
+            Affect.AffectFix.NOTAFFECTED,
         ):
             if status in statuses:
                 return status


### PR DESCRIPTION
For Affects that have a resolution of DELEGATED, we look at its trackers' own state/resolution to determine the actual delegated resolution of the Affect.

If there's more than a single Tracker for an Affect, we take the Tracker's state/resolution with highest precedence or "weight" and this precedence is determined by a list of possible resolutions.

Before this commit, said list was ordered in such a way that the NOTAFFECTED resolution had highest precedence however this is a mistake, as if we have 5 trackers, 4 with NOTAFFECTED and 1 with AFFECTED resolution we should determine that the Affect is AFFECTED, not NOTAFFECTED.

This commit solves the issue by swapping the order of the AFFECTED and NOTAFFECTED resolutions in the aforementioned list.

Closes OSIDB-1230