### PR TITLE
Add gunicorn config for logging access

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement endpoint for suggesting trackers to file (OSIDB-90)
 - Add shipped date to erratum model (OSIDB-1197)
 - Flaw creation and update triggers a Jira task sync (OSIDB-861)
+- Config gunicorn access log file depending on environment (OSIDB-879)
 
 ## [3.4.2] - 2023-08-31
 ### Changed

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -4,7 +4,6 @@ worker_class = "gevent"
 proc_name = "osidb"
 timeout = 300
 
-accesslog = "-"
 errorlog = "-"
 # Make sure wsgi.url_scheme gets set to HTTPS, by trusting the X_FORWARDED_PROTO header set by the proxy
 forwarded_allow_ips = "*"

--- a/scripts/run-service.sh
+++ b/scripts/run-service.sh
@@ -9,6 +9,15 @@ python3 manage.py collectstatic \
     --ignore 'tmp*' \
     --noinput
 
+# Defaults to stdout for local development
+ACCESS_LOG_FILE="-"
+
+if [ "$DJANGO_SETTINGS_MODULE" = "config.settings_stage" ]; then
+    ACCESS_LOG_FILE="/var/log/stage-access.log"
+elif [ "$DJANGO_SETTINGS_MODULE" = "config.settings_prod" ]; then
+    ACCESS_LOG_FILE="/var/log/prod-access.log"
+fi
+
 # start gunicorn
 pkill gunicorn || true
-exec gunicorn config.wsgi --config gunicorn_config.py
+exec gunicorn config.wsgi --config gunicorn_config.py --access-logfile $ACCESS_LOG_FILE


### PR DESCRIPTION
This PR introduces access log files for stage and prod environment.

This config should be enough since `/var/log` is already configured and monitored.

Closes OSIDB-879.