### PR TITLE
Update BBSync to read data from FlawCVSS and AffectCVSS

### DIFF
--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -7,11 +7,20 @@ from freezegun import freeze_time
 
 from apps.bbsync.exceptions import SRTNotesValidationError
 from apps.bbsync.query import FlawBugzillaQueryBuilder, SRTNotesBuilder
-from osidb.models import Affect, Flaw, FlawComment, FlawSource, Impact, Tracker
+from osidb.models import (
+    Affect,
+    Flaw,
+    FlawComment,
+    FlawCVSS,
+    FlawSource,
+    Impact,
+    Tracker,
+)
 from osidb.tests.factories import (
     AffectFactory,
     FlawAcknowledgmentFactory,
     FlawCommentFactory,
+    FlawCVSSFactory,
     FlawFactory,
     FlawReferenceFactory,
     PsModuleFactory,
@@ -373,84 +382,36 @@ class TestGenerateSRTNotes:
         assert reference["url"] == "https://httpd.apache.org/link123"
         assert reference["description"] == "link description"
 
-    @pytest.mark.parametrize(
-        "osidb_cvss2,osidb_cvss3,srtnotes,bz_cvss2_present,bz_cvss3_present,bz_cvss2,bz_cvss3",
-        [
-            (
-                "5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
-                "7.5/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-                """
-                {
-                    "cvss2": "5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
-                    "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
-                }
-                """,
-                True,
-                True,
-                "5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
-                "7.5/CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
-            ),
-            (
-                "5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
-                None,
-                "",
-                True,
-                False,
-                "5.2/AV:L/AC:H/Au:N/C:P/I:P/A:C",
-                None,
-            ),
-            (
-                None,
-                None,
-                """
-                {
-                    "cvss3": "3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N"
-                }
-                """,
-                False,
-                True,
-                None,
-                None,
-            ),
-        ],
-    )
-    def test_cvss(
-        self,
-        osidb_cvss2,
-        osidb_cvss3,
-        srtnotes,
-        bz_cvss2_present,
-        bz_cvss3_present,
-        bz_cvss2,
-        bz_cvss3,
-    ):
+    @pytest.mark.enable_signals
+    def test_generate_flaw_cvss(self):
         """
         test generating of SRT notes CVSS attributes
         """
-        flaw = FlawFactory.build(
-            cvss2=osidb_cvss2,
-            cvss3=osidb_cvss3,
-            meta_attr={"original_srtnotes": srtnotes},
+        # do not care about cvss2 and cvss3 as they will be deprecated
+        flaw = FlawFactory(cvss2="", cvss3="")
+
+        FlawCVSSFactory(
+            flaw=flaw,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            vector="CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",  # 7.8
+            version=FlawCVSS.CVSSVersion.VERSION3,
+            comment="text",
         )
-        flaw.save(raise_validation_error=False)
-        FlawCommentFactory(flaw=flaw)
-        AffectFactory(flaw=flaw)
+        # no CVSSv2
 
         bbq = FlawBugzillaQueryBuilder(flaw)
         cf_srtnotes = bbq.query.get("cf_srtnotes")
         assert cf_srtnotes
         cf_srtnotes_json = json.loads(cf_srtnotes)
 
-        if bz_cvss2_present:
-            assert "cvss2" in cf_srtnotes_json
-            assert cf_srtnotes_json["cvss2"] == bz_cvss2
-        else:
-            assert "cvss2" not in cf_srtnotes_json
-        if bz_cvss3_present:
-            assert "cvss3" in cf_srtnotes_json
-            assert cf_srtnotes_json["cvss3"] == bz_cvss3
-        else:
-            assert "cvss3" not in cf_srtnotes_json
+        assert "cvss3" in cf_srtnotes_json
+        assert (
+            cf_srtnotes_json["cvss3"]
+            == "7.8/CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+        )
+        assert "cvss3_comment" in cf_srtnotes_json
+        assert cf_srtnotes_json["cvss3_comment"] == "text"
+        assert "cvss2" not in cf_srtnotes_json
 
     @pytest.mark.parametrize(
         "osidb_cwe,srtnotes,bz_present,bz_cwe",


### PR DESCRIPTION
This PR updates BBSync to read cvss scores for flaws and affects from their new `FlawCVSS` and `AffectCVSS` models. The relevant APIs are currently WIP.

Related to OSIDB-1105