### PR TITLE
sync with Griffon on the new API entities before the release

### DIFF
--- a/docs/developer/OPERATIONS.md
+++ b/docs/developer/OPERATIONS.md
@@ -20,6 +20,10 @@ the release branch so that the code can be reviewed.
 Make sure that the stage environment is set to pull from this branch at least until it is merged
 back into the main development branch.
 
+Additionally, if the API was extended with completely new entities, either independent
+or embeded under the others, make sure to raise the corresponding feature request to the
+[Griffon](https://github.com/RedHatProductSecurity/griffon/) project.
+
 ## Release
 
 Follow this procedure when performing OSIDB version X.Y.Z release, this step assumes that


### PR DESCRIPTION
Whenever there is a completely new API or we add some embedded entity (like acknowledgments, comments etc.) the Griffon needs to be adjusted to understand and manipulate it (not necessary when just adding an attribute to an existing entity). We should make this a process of some kind so we do not forget and make sure that with a new OSIDB there is a new Griffon already available and tested.

I am bit vague on where exactly to create the Jira issue etc. as this is not the OPS repo. However, the code freeze which is IMO a good (last) moment for this is described here and the int the OPS repo.