### PR TITLE
integrate TrackerSaver with the Tracker model

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -165,7 +165,7 @@
         "filename": "apps/trackers/tests/test_save.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 63,
+        "line_number": 68,
         "is_secret": false
       }
     ],
@@ -221,7 +221,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 74,
         "is_secret": false
       }
     ],
@@ -261,7 +261,7 @@
         "filename": "osidb/models.py",
         "hashed_secret": "c7e672880d394aa5dd924e04465c986652ba7291",
         "is_verified": false,
-        "line_number": 228,
+        "line_number": 229,
         "is_secret": false
       }
     ],
@@ -294,5 +294,5 @@
       }
     ]
   },
-  "generated_at": "2023-09-11T07:28:32Z"
+  "generated_at": "2023-09-14T16:28:49Z"
 }

--- a/apps/trackers/constants.py
+++ b/apps/trackers/constants.py
@@ -1,8 +1,13 @@
 """
 common tracker constants
 """
+from osidb.helpers import get_env
 
 TRACKERS_API_VERSION = "v1"
+
+# switch to enable or disable the Jira tracker sync
+# - the one controlling the Bugzilla sync is defined in the BBSync app
+SYNC_TO_JIRA = get_env("TRACKERS_SYNC_TO_JIRA", default="False", is_bool=True)
 
 # tracker summary constants
 MAX_SUMMARY_LENGTH = 255

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -70,3 +70,23 @@ def fake_triage() -> None:
     yield
     # cleanup after the test run
     setattr(Tracker, "is_triage", is_triage)
+
+
+@pytest.fixture
+def enable_bugzilla_sync(monkeypatch) -> None:
+    """
+    enable the sync to Bugzilla
+    """
+    import osidb.models as models
+
+    monkeypatch.setattr(models, "SYNC_TO_BZ", True)
+
+
+@pytest.fixture
+def enable_jira_sync(monkeypatch) -> None:
+    """
+    enable the sync to Jira
+    """
+    import osidb.models as models
+
+    monkeypatch.setattr(models, "SYNC_TO_JIRA", True)

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -57,6 +57,10 @@ RH_CERT_URL="https://foo.bar"
 # otherwise all the writes are performed only locally in OSIDB
 BBSYNC_SYNC_TO_BZ=1
 
+# enable Jira tracker sync to propagate writes to Jira
+# otherwise all the writes are performed only locally in OSIDB
+TRACKERS_SYNC_TO_JIRA=1
+
 # Run taskman tests behind a proxy (optional)
 # This variable is only necessary if rewriting the taskman cassettes locally and using the Stage Red Hat JIRA instance, which requires a proxy to be accessed.
 HTTPS_TASKMAN_PROXY="http://foo.bar"


### PR DESCRIPTION
Similarly to the other models we should only call `Tracker.save` and everything else including the potential sync to Bugzilla or Jira should be done automatically. The other models are so far all stored in Bugzilla (as part of the flaw data). The trackers are bit different as they may be in either Bugzilla or Jira and therefore cannot use the `BugzillaSyncMixin` unlike the other models so I implemented `save` with the special handling directly on the model class.

OSIDB-1179