### PR TITLE
Deprecate cvss fields in APIs and use FlawCVSS model for validations

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Link tracker to flaw(s) on create/update (OSIDB-1182)
 - Implement FlawCVSS and AffectCVSS APIs with filters (OSIDB-1105)
 
+### Changed
+- Deprecate various cvss fields in Flaw and Affect APIs (OSIDB-1105)
+
 ### Fixed
 - Fix schema wrongly showing status code for DELETE methods being 204
   whereas the actual returned status code is 200

--- a/openapi.yml
+++ b/openapi.yml
@@ -741,11 +741,13 @@ paths:
         name: cvss2
         schema:
           type: string
+        deprecated: true
       - in: query
         name: cvss2_score
         schema:
           type: number
           format: float
+        deprecated: true
       - in: query
         name: cvss2_score__gt
         schema:
@@ -770,11 +772,13 @@ paths:
         name: cvss3
         schema:
           type: string
+        deprecated: true
       - in: query
         name: cvss3_score
         schema:
           type: number
           format: float
+        deprecated: true
       - in: query
         name: cvss3_score__gt
         schema:
@@ -2664,11 +2668,13 @@ paths:
         name: cvss2
         schema:
           type: string
+        deprecated: true
       - in: query
         name: cvss2_score
         schema:
           type: number
           format: float
+        deprecated: true
       - in: query
         name: cvss2_score__gt
         schema:
@@ -2693,11 +2699,13 @@ paths:
         name: cvss3
         schema:
           type: string
+        deprecated: true
       - in: query
         name: cvss3_score
         schema:
           type: number
           format: float
+        deprecated: true
       - in: query
         name: cvss3_score__gt
         schema:
@@ -2922,10 +2930,12 @@ paths:
         name: nvd_cvss2
         schema:
           type: string
+        deprecated: true
       - in: query
         name: nvd_cvss3
         schema:
           type: string
+        deprecated: true
       - name: offset
         required: false
         in: query
@@ -6652,17 +6662,21 @@ components:
         cvss2:
           type: string
           maxLength: 100
+          deprecated: true
         cvss2_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         cvss3:
           type: string
           maxLength: 100
+          deprecated: true
         cvss3_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         trackers:
           type: array
           items:
@@ -6884,17 +6898,21 @@ components:
         cvss2:
           type: string
           maxLength: 100
+          deprecated: true
         cvss2_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         cvss3:
           type: string
           maxLength: 100
+          deprecated: true
         cvss3_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         trackers:
           type: array
           items:
@@ -7190,23 +7208,29 @@ components:
         cvss2:
           type: string
           maxLength: 100
+          deprecated: true
         cvss2_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         nvd_cvss2:
           type: string
           maxLength: 100
+          deprecated: true
         cvss3:
           type: string
           maxLength: 100
+          deprecated: true
         cvss3_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         nvd_cvss3:
           type: string
           maxLength: 100
+          deprecated: true
         is_major_incident:
           type: boolean
           deprecated: true
@@ -7759,23 +7783,29 @@ components:
         cvss2:
           type: string
           maxLength: 100
+          deprecated: true
         cvss2_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         nvd_cvss2:
           type: string
           maxLength: 100
+          deprecated: true
         cvss3:
           type: string
           maxLength: 100
+          deprecated: true
         cvss3_score:
           type: number
           format: float
           nullable: true
+          deprecated: true
         nvd_cvss3:
           type: string
           maxLength: 100
+          deprecated: true
         is_major_incident:
           type: boolean
           deprecated: true

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -345,6 +345,42 @@ def include_exclude_fields_extend_schema_view(
                 location=OpenApiParameter.QUERY,
                 deprecated=True,
             ),
+            OpenApiParameter(
+                "cvss2",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss2_score",
+                type=OpenApiTypes.FLOAT,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss3",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss3_score",
+                type=OpenApiTypes.FLOAT,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "nvd_cvss2",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "nvd_cvss3",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
         ],
     ),
     retrieve=extend_schema(
@@ -641,6 +677,30 @@ class FlawCommentView(SubFlawViewGetMixin, ModelViewSet):
             OpenApiParameter(
                 "flaw__is_major_incident",
                 type=OpenApiTypes.BOOL,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss2",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss2_score",
+                type=OpenApiTypes.FLOAT,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss3",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                deprecated=True,
+            ),
+            OpenApiParameter(
+                "cvss3_score",
+                type=OpenApiTypes.FLOAT,
                 location=OpenApiParameter.QUERY,
                 deprecated=True,
             ),

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -598,6 +598,9 @@ class AffectCVSSPutSerializer(AffectCVSSSerializer):
     pass
 
 
+@extend_schema_serializer(
+    deprecate_fields=["cvss2", "cvss2_score", "cvss3", "cvss3_score"]
+)
 class AffectSerializer(
     ACLMixinSerializer,
     BugzillaSyncMixinSerializer,
@@ -817,7 +820,19 @@ class FlawCVSSPutSerializer(FlawCVSSSerializer):
     pass
 
 
-@extend_schema_serializer(deprecate_fields=["state", "resolution", "is_major_incident"])
+@extend_schema_serializer(
+    deprecate_fields=[
+        "state",
+        "resolution",
+        "is_major_incident",
+        "cvss2",
+        "cvss2_score",
+        "cvss3",
+        "cvss3_score",
+        "nvd_cvss2",
+        "nvd_cvss3",
+    ]
+)
 class FlawSerializer(
     ACLMixinSerializer,
     JiraTaskSyncMixinSerializer,


### PR DESCRIPTION
This PR updates the following:
- `cvss2`, `cvss2_score`, `cvss3`, `cvss3_score`, `nvd_cvss2`, and `nvd_cvss3` fields are now deprecated in Flaw API
- `cvss2`, `cvss2_score`, `cvss3`, and `cvss3_score` fields are now deprecated in Affect API
- flaw validations now use the new `FlawCVSS` model instead of `cvss3_score`, `nvd_cvss3`, and `cvss3` fields from the `Flaw` model

Closes OSIDB-1105