### PR TITLE
writable tracker api

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -159,6 +159,16 @@
         "is_secret": false
       }
     ],
+    "apps/trackers/tests/test_integration.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/trackers/tests/test_integration.py",
+        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
+        "is_verified": false,
+        "line_number": 217,
+        "is_secret": false
+      }
+    ],
     "apps/trackers/tests/test_save.py": [
       {
         "type": "Secret Keyword",

--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -192,7 +192,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         """
         groups = []
 
-        if self.tracker.embargoed:
+        if self.tracker.is_embargoed:
             groups = self.ps_module.bts_groups["embargoed"]
             if not groups:
                 # safety check for the theoretical case of misconfigured PS module

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -22,6 +22,22 @@ class TrackerQueryBuilder:
     """
 
     @property
+    def query(self):
+        """
+        query getter shorcut
+        """
+        if self._query is None:
+            self.generate()
+
+        return self._query
+
+    def generate(self):
+        """
+        generate query
+        """
+        raise NotImplementedError
+
+    @property
     def tracker(self):
         """
         concrete name shortcut

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -118,6 +118,8 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         self._query["fields"]["description"] = self.description
 
+    # TODO we should not delete other labels
+    # because the engineeting may use them
     def generate_labels(self):
         """
         generate query for Jira labels

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -50,7 +50,7 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
         init stuff
         """
         self.instance = instance
-        self._query = {}
+        self._query = None
 
     @cached_property
     def impact(self):

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -124,13 +124,15 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         generate query for Jira labels
         """
-        cve_ids = self.tracker.affects.all().values_list("flaw__cve_id", flat=True)
-        self._query["fields"]["labels"] = {
-            *cve_ids,
+        self._query["fields"]["labels"] = [
             "SecurityTracking",
             "Security",
             f"pscomponent:{self.ps_component}",
-        }
+        ] + list(  # add all linked non-empty CVE IDs
+            self.tracker.affects.exclude(flaw__cve_id__isnull=True).values_list(
+                "flaw__cve_id", flat=True
+            )
+        )
 
     def generate_summary(self):
         """

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -94,7 +94,6 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
         allowed_values = JiraProjectFields.objects.get(
             project_key=self.ps_module.bts_key, field_id="priority"
         ).allowed_values
-        allowed_values = [value["name"] for value in allowed_values]
         for priority in IMPACT_TO_JIRA_PRIORITY[self.impact]:
             if priority in allowed_values:
                 self._query["fields"]["priority"] = {"name": priority}

--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -44,7 +44,7 @@ class TrackerJiraSaver(JiraQuerier):
         """
         create a representation of tracker model in Jira
         """
-        query = TrackerJiraQueryBuilder(tracker).generate()
+        query = TrackerJiraQueryBuilder(tracker).query
         issue = self.jira_conn.create_issue(fields=query["fields"], prefetch=True)
         tracker.external_system_id = issue["key"]
         return tracker
@@ -53,6 +53,7 @@ class TrackerJiraSaver(JiraQuerier):
         """
         update an existing representation of tracker model in Jira
         """
-        query = TrackerJiraQueryBuilder(tracker).generate()
+        query = TrackerJiraQueryBuilder(tracker).query
         url = f"{self.jira_conn._get_url('issue')}/{query['key']}"
         self.jira_conn._session.put(url, json.dumps(query))
+        return tracker

--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -46,7 +46,7 @@ class TrackerJiraSaver(JiraQuerier):
         """
         query = TrackerJiraQueryBuilder(tracker).query
         issue = self.jira_conn.create_issue(fields=query["fields"], prefetch=True)
-        tracker.external_system_id = issue["key"]
+        tracker.external_system_id = issue.key
         return tracker
 
     def update(self, tracker):

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_create_bugzilla.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_create_bugzilla.yaml
@@ -1,0 +1,366 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh92"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Sep 2023 14:53:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694530422.1c16447
+      x-rh-edge-request-id:
+      - 1c16447
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"id": 1, "real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "email": "aander07@packetmaster.com", "can_login": true}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Sep 2023 14:53:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694530422.1c164b2
+      x-rh-edge-request-id:
+      - 1c164b2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Red Hat Certification Program", "version": "1.0", "priority":
+      "urgent", "severity": "urgent", "blocks": ["2013494"], "component": "redhat-certification",
+      "description": "rhcertification-6 tracking bug for openssl: see the bugs linked
+      in the \"Blocks\" field of this bug for full details of the security issue(s).\n\nThis
+      bug is never intended to be made public, please put any public notes in the
+      blocked bugs.", "comment_is_private": false, "flags": [], "groups": ["devel"],
+      "keywords": ["Security", "SecurityTracking"], "summary": "[CISA Major Incident]
+      openssl: sample title [rhcertification-6]"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '612'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: POST
+    uri: https://squid.corp.redhat.com:3128/rest/bug
+  response:
+    body:
+      string: '{"id": 2017676}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Sep 2023 14:53:43 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694530423.1c165e5
+      x-rh-edge-request-id:
+      - 1c165e5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh92"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Sep 2023 14:53:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694530424.1c16c6d
+      x-rh-edge-request-id:
+      - 1c16c6d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"can_login": true, "name": "aander07@packetmaster.com",
+        "email": "aander07@packetmaster.com", "id": 1, "real_name": "Need Real Name"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Sep 2023 14:53:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694530424.1c16d13
+      x-rh-edge-request-id:
+      - 1c16d13
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017676
+  response:
+    body:
+      string: '{"total_matches": 1, "bugs": [{"cf_release_notes": "", "sub_components":
+        {}, "cf_major_incident": null, "version": ["1.0"], "qa_contact_detail": {"email":
+        "rhcert-qe@redhat.com", "name": "rhcert-qe@redhat.com", "insider": false,
+        "id": 408554, "partner": false, "real_name": "rhcert qe", "active": false},
+        "keywords": ["Security", "SecurityTracking"], "resolution": "", "is_creator_accessible":
+        true, "cf_pgm_internal": "", "cf_embargoed": null, "whiteboard": "", "assigned_to_detail":
+        {"name": "jweng@redhat.com", "email": "jweng@redhat.com", "active": true,
+        "partner": false, "real_name": "Jianwei Weng", "insider": true, "id": 283338},
+        "cf_internal_whiteboard": "", "qa_contact": "rhcert-qe@redhat.com", "blocks":
+        [2013494], "cf_doc_type": "No Doc Update", "url": "", "priority": "urgent",
+        "component": ["redhat-certification"], "external_bugs": [], "dupe_of": null,
+        "tags": [], "status": "NEW", "severity": "urgent", "cf_conditional_nak": [],
+        "cf_qa_whiteboard": "", "product": "Red Hat Certification Program", "op_sys":
+        "Unspecified", "creator_detail": {"active": true, "insider": true, "id": 412888,
+        "real_name": "Ondrej Soukup", "partner": false, "name": "osoukup@redhat.com",
+        "email": "osoukup@redhat.com"}, "description": "rhcertification-6 tracking
+        bug for openssl: see the bugs linked in the \"Blocks\" field of this bug for
+        full details of the security issue(s).\n\nThis bug is never intended to be
+        made public, please put any public notes in the blocked bugs.", "cc_detail":
+        [], "actual_time": 0, "docs_contact": "", "creation_time": "2023-09-12T14:53:43Z",
+        "id": 2017676, "cf_devel_whiteboard": "", "cf_qe_conditional_nak": [], "groups":
+        ["devel"], "cf_build_id": "", "cf_environment": "", "cf_cust_facing": "---",
+        "is_confirmed": true, "alias": [], "cf_verified": [], "cf_partner": [], "estimated_time":
+        0, "is_cc_accessible": true, "platform": "Unspecified", "depends_on": [],
+        "cf_pm_score": "0", "comments": [{"creator_id": 412888, "tags": [], "creator":
+        "osoukup@redhat.com", "id": 15664136, "is_private": false, "creation_time":
+        "2023-09-12T14:53:43Z", "text": "rhcertification-6 tracking bug for openssl:
+        see the bugs linked in the \"Blocks\" field of this bug for full details of
+        the security issue(s).\n\nThis bug is never intended to be made public, please
+        put any public notes in the blocked bugs.", "time": "2023-09-12T14:53:43Z",
+        "attachment_id": null, "count": 0, "bug_id": 2017676, "private_groups": []}],
+        "data_category": "Engineering", "summary": "[CISA Major Incident] openssl:
+        sample title [rhcertification-6]", "assigned_to": "jweng@redhat.com", "cf_fixed_in":
+        "", "remaining_time": 0, "creator": "osoukup@redhat.com", "deadline": null,
+        "is_open": true, "last_change_time": "2023-09-12T14:53:43Z", "cf_target_upstream_version":
+        "", "target_milestone": "---", "cf_clone_of": null, "cc": [], "flags": [{"setter":
+        "bugzilla@redhat.com", "is_active": 1, "id": 5237995, "creation_date": "2023-09-12T14:53:43Z",
+        "name": "requires_doc_text", "modification_date": "2023-09-12T14:53:43Z",
+        "status": "-", "type_id": 415}], "classification": "Red Hat", "cf_last_closed":
+        null, "target_release": ["---"]}], "limit": "20", "offset": 0}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 12 Sep 2023 14:53:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2934'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694530425.1c16e4e
+      x-rh-edge-request-id:
+      - 1c16e4e
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_create_jira.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_create_jira.yaml
@@ -1,0 +1,377 @@
+interactions:
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "OSIDB"},
+      "priority": {"name": "Minor"}, "description": "Security Tracking Issue\n\nDo
+      not make this issue public.\n\nFlaw:\n-----\n\nsample title\nhttps://bugzilla.redhat.com/show_bug.cgi?id=1997880\n\nDescription
+      for None\n\n~~~", "labels": ["SecurityTracking", "Security", "pscomponent:openshift"],
+      "summary": "openshift: sample title [openshift-4.8.z]"}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '425'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "15297717", "key": "OSIDB-925", "self": "https://issues.redhat.com/rest/api/2/issue/15297717"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - close
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 14 Sep 2023 15:36:25 GMT
+      Expires:
+      - Thu, 14 Sep 2023 15:36:25 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '102'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 936x35834x1
+      x-asessionid:
+      - 10lxh7c
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694705785.3702013
+      x-rh-edge-request-id:
+      - '3702013'
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIDB-925
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "15297717", "self": "https://issues.redhat.com/rest/api/2/issue/15297717",
+        "key": "OSIDB-925", "fields": {"issuetype": {"self": "https://issues.redhat.com/rest/api/2/issuetype/1",
+        "id": "1", "description": "A problem which impairs or prevents the functions
+        of the product.", "iconUrl": "https://issues.redhat.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12322244":
+        null, "customfield_12318341": null, "timespent": null, "customfield_12320940":
+        null, "project": {"self": "https://issues.redhat.com/rest/api/2/project/12332734",
+        "id": "12332734", "key": "OSIDB", "name": "Open Security Issue Database",
+        "projectTypeKey": "software", "avatarUrls": {"48x48": "https://issues.redhat.com/secure/projectavatar?pid=12332734&avatarId=10010",
+        "24x24": "https://issues.redhat.com/secure/projectavatar?size=small&pid=12332734&avatarId=10010",
+        "16x16": "https://issues.redhat.com/secure/projectavatar?size=xsmall&pid=12332734&avatarId=10010",
+        "32x32": "https://issues.redhat.com/secure/projectavatar?size=medium&pid=12332734&avatarId=10010"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@174a1071[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2572b4e8[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7567147f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@45822bcf[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ae2aa18[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2ed4904[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4fe461ca[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1becf7aa[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@74312ca5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1cfcee4e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70fa362a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@cd7de38[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12310183": null, "resolutiondate": null, "workratio": -1, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12315950": null, "customfield_12316841":
+        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
+        null, "watches": {"self": "https://issues.redhat.com/rest/api/2/issue/OSIDB-925/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2023-09-14T15:36:25.080+0000",
+        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
+        "https://issues.redhat.com/rest/api/2/priority/4", "iconUrl": "https://issues.redhat.com/images/icons/priorities/minor.svg",
+        "name": "Minor", "id": "4"}, "labels": ["Security", "SecurityTracking", "pscomponent:openshift"],
+        "customfield_12320947": [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        null, "updated": "2023-09-14T15:36:25.825+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://issues.redhat.com/rest/api/2/component/12367567",
+        "id": "12367567", "name": "osidb"}], "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nsample
+        title\nhttps://bugzilla.redhat.com/show_bug.cgi?id=1997880\n\nDescription
+        for None\n\n~~~", "customfield_12314040": null, "customfield_12320844": null,
+        "archiveddate": null, "timetracking": {}, "customfield_12320842": null, "attachment":
+        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "openshift: sample title [openshift-4.8.z]", "customfield_12323640":
+        null, "customfield_12323642": null, "creator": {"self": "https://issues.redhat.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.redhat.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://issues.redhat.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://issues.redhat.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://issues.redhat.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "Europe/Prague"},
+        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12323647": [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/34762",
+        "value": "en-US (English)", "id": "34762", "disabled": false}], "reporter":
+        {"self": "https://issues.redhat.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.redhat.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://issues.redhat.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://issues.redhat.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://issues.redhat.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "Europe/Prague"},
+        "customfield_12320850": null, "aggregateprogress": {"progress": 0, "total":
+        0}, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "customfield_12310211": null, "environment":
+        null, "customfield_12315542": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "customfield_12313240": null, "duedate":
+        null, "customfield_12311140": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "comment": {"comments": [], "maxResults": 0,
+        "total": 0, "startAt": 0}, "votes": {"self": "https://issues.redhat.com/rest/api/2/issue/OSIDB-925/votes",
+        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
+        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
+        null, "archivedby": null, "customfield_12311940": "1|zbmts4:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 14 Sep 2023 15:36:42 GMT
+      Expires:
+      - Thu, 14 Sep 2023 15:36:42 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '9032'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 936x35844x1
+      x-asessionid:
+      - d1nrtk
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694705802.370742c
+      x-rh-edge-request-id:
+      - 370742c
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIDB-925
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "15297717", "self": "https://issues.redhat.com/rest/api/2/issue/15297717",
+        "key": "OSIDB-925", "fields": {"issuetype": {"self": "https://issues.redhat.com/rest/api/2/issuetype/1",
+        "id": "1", "description": "A problem which impairs or prevents the functions
+        of the product.", "iconUrl": "https://issues.redhat.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12322244":
+        null, "customfield_12318341": null, "timespent": null, "customfield_12320940":
+        null, "project": {"self": "https://issues.redhat.com/rest/api/2/project/12332734",
+        "id": "12332734", "key": "OSIDB", "name": "Open Security Issue Database",
+        "projectTypeKey": "software", "avatarUrls": {"48x48": "https://issues.redhat.com/secure/projectavatar?pid=12332734&avatarId=10010",
+        "24x24": "https://issues.redhat.com/secure/projectavatar?size=small&pid=12332734&avatarId=10010",
+        "16x16": "https://issues.redhat.com/secure/projectavatar?size=xsmall&pid=12332734&avatarId=10010",
+        "32x32": "https://issues.redhat.com/secure/projectavatar?size=medium&pid=12332734&avatarId=10010"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6cbe58c9[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4e4d57b[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1a3fc9ef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@38d288de[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@872c09f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@416f4ce5[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@25fb8596[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@9437d8f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@17ab2200[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2c984c74[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5536ab44[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@470b0b68[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12310183": null, "resolutiondate": null, "workratio": -1, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12315950": null, "customfield_12316841":
+        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
+        null, "watches": {"self": "https://issues.redhat.com/rest/api/2/issue/OSIDB-925/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2023-09-14T15:36:25.080+0000",
+        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
+        "https://issues.redhat.com/rest/api/2/priority/4", "iconUrl": "https://issues.redhat.com/images/icons/priorities/minor.svg",
+        "name": "Minor", "id": "4"}, "labels": ["Security", "SecurityTracking", "pscomponent:openshift"],
+        "customfield_12320947": [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        null, "updated": "2023-09-14T15:36:25.825+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://issues.redhat.com/rest/api/2/component/12367567",
+        "id": "12367567", "name": "osidb"}], "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nsample
+        title\nhttps://bugzilla.redhat.com/show_bug.cgi?id=1997880\n\nDescription
+        for None\n\n~~~", "customfield_12314040": null, "customfield_12320844": null,
+        "archiveddate": null, "timetracking": {}, "customfield_12320842": null, "attachment":
+        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "openshift: sample title [openshift-4.8.z]", "customfield_12323640":
+        null, "customfield_12323642": null, "creator": {"self": "https://issues.redhat.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.redhat.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://issues.redhat.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://issues.redhat.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://issues.redhat.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "Europe/Prague"},
+        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12323647": [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/34762",
+        "value": "en-US (English)", "id": "34762", "disabled": false}], "reporter":
+        {"self": "https://issues.redhat.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.redhat.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://issues.redhat.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://issues.redhat.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://issues.redhat.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "Europe/Prague"},
+        "customfield_12320850": null, "aggregateprogress": {"progress": 0, "total":
+        0}, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "customfield_12310211": null, "environment":
+        null, "customfield_12315542": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "customfield_12313240": null, "duedate":
+        null, "customfield_12311140": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "comment": {"comments": [], "maxResults": 0,
+        "total": 0, "startAt": 0}, "votes": {"self": "https://issues.redhat.com/rest/api/2/issue/OSIDB-925/votes",
+        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
+        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
+        null, "archivedby": null, "customfield_12311940": "1|zbmts4:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 14 Sep 2023 15:36:42 GMT
+      Expires:
+      - Thu, 14 Sep 2023 15:36:42 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '9031'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 936x35845x1
+      x-asessionid:
+      - 1xdnvv8
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694705802.3707514
+      x-rh-edge-request-id:
+      - '3707514'
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_update_bugzilla.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_update_bugzilla.yaml
@@ -1,0 +1,423 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh92"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1694594142.1179a278
+      x-rh-edge-request-id:
+      - 1179a278
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"can_login": true, "email": "aander07@packetmaster.com",
+        "name": "aander07@packetmaster.com", "real_name": "Need Real Name", "id":
+        1}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1694594142.1179a32c
+      x-rh-edge-request-id:
+      - 1179a32c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017676&include_fields=id&include_fields=last_change_time
+  response:
+    body:
+      string: '{"limit": "20", "bugs": [{"id": 2017676, "data_category": "Engineering",
+        "last_change_time": "2023-09-13T08:34:21Z"}], "offset": 0, "total_matches":
+        1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '139'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:43 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1694594143.1179a5b2
+      x-rh-edge-request-id:
+      - 1179a5b2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Red Hat Certification Program", "version": "1.0", "priority":
+      "urgent", "severity": "urgent", "blocks": {"add": ["2013494"], "remove": []},
+      "component": "redhat-certification", "keywords": {"add": ["Security", "SecurityTracking"]},
+      "summary": "CVE-2020-0000 openssl: CVE-2020-0000 kernel: some description [rhcertification-6-default]",
+      "ids": ["2017676"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '368'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: PUT
+    uri: https://squid.corp.redhat.com:3128/rest/bug/2017676
+  response:
+    body:
+      string: '{"bugs": [{"last_change_time": "2023-09-13T08:35:44Z", "changes": {"summary":
+        {"added": "CVE-2020-0000 openssl: CVE-2020-0000 kernel: some description [rhcertification-6-default]",
+        "removed": "[Major Incident] CVE-2020-0000 openssl: CVE-2020-0000 kernel:
+        some description [rhcertification-6]"}, "priority": {"added": "urgent", "removed":
+        "high"}, "severity": {"removed": "high", "added": "urgent"}}, "alias": [],
+        "id": 2017676}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '407'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1694594144.1179a955
+      x-rh-edge-request-id:
+      - 1179a955
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh92"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694594145.401778c
+      x-rh-edge-request-id:
+      - 401778c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "id": 1, "can_login": true,
+        "name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:46 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694594146.4017a1b
+      x-rh-edge-request-id:
+      - 4017a1b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017676
+  response:
+    body:
+      string: '{"total_matches": 1, "offset": 0, "limit": "20", "bugs": [{"creation_time":
+        "2023-09-12T14:53:43Z", "docs_contact": "", "actual_time": 0, "cc_detail":
+        [], "id": 2017676, "creator_detail": {"partner": false, "real_name": "Ondrej
+        Soukup", "id": 412888, "insider": true, "active": true, "email": "osoukup@redhat.com",
+        "name": "osoukup@redhat.com"}, "description": "rhcertification-6 tracking
+        bug for openssl: see the bugs linked in the \"Blocks\" field of this bug for
+        full details of the security issue(s).\n\nThis bug is never intended to be
+        made public, please put any public notes in the blocked bugs.", "op_sys":
+        "Unspecified", "severity": "urgent", "cf_conditional_nak": [], "product":
+        "Red Hat Certification Program", "cf_qa_whiteboard": "", "status": "NEW",
+        "dupe_of": null, "external_bugs": [], "tags": [], "priority": "urgent", "cf_doc_type":
+        "No Doc Update", "url": "", "blocks": [2013494], "qa_contact": "rhcert-qe@redhat.com",
+        "component": ["redhat-certification"], "cf_pgm_internal": "", "cf_internal_whiteboard":
+        "", "assigned_to_detail": {"active": true, "real_name": "Jianwei Weng", "partner":
+        false, "insider": true, "id": 283338, "name": "jweng@redhat.com", "email":
+        "jweng@redhat.com"}, "cf_embargoed": null, "whiteboard": "", "qa_contact_detail":
+        {"id": 408554, "insider": false, "partner": false, "real_name": "rhcert qe",
+        "active": false, "email": "rhcert-qe@redhat.com", "name": "rhcert-qe@redhat.com"},
+        "version": ["1.0"], "cf_major_incident": null, "sub_components": {}, "cf_release_notes":
+        "", "is_creator_accessible": true, "resolution": "", "keywords": ["Security",
+        "SecurityTracking"], "classification": "Red Hat", "flags": [{"setter": "bugzilla@redhat.com",
+        "is_active": 1, "id": 5237995, "creation_date": "2023-09-12T14:53:43Z", "name":
+        "requires_doc_text", "modification_date": "2023-09-12T14:53:43Z", "status":
+        "-", "type_id": 415}], "cc": [], "cf_clone_of": null, "target_release": ["---"],
+        "cf_last_closed": null, "cf_target_upstream_version": "", "last_change_time":
+        "2023-09-13T08:35:44Z", "is_open": true, "target_milestone": "---", "assigned_to":
+        "jweng@redhat.com", "cf_fixed_in": "", "summary": "CVE-2020-0000 openssl:
+        CVE-2020-0000 kernel: some description [rhcertification-6-default]", "deadline":
+        null, "creator": "osoukup@redhat.com", "remaining_time": 0, "data_category":
+        "Engineering", "cf_pm_score": "0", "comments": [{"time": "2023-09-12T14:53:43Z",
+        "count": 0, "attachment_id": null, "private_groups": [], "bug_id": 2017676,
+        "is_private": false, "id": 15664136, "tags": [], "creator_id": 412888, "creator":
+        "osoukup@redhat.com", "text": "rhcertification-6 tracking bug for openssl:
+        see the bugs linked in the \"Blocks\" field of this bug for full details of
+        the security issue(s).\n\nThis bug is never intended to be made public, please
+        put any public notes in the blocked bugs.", "creation_time": "2023-09-12T14:53:43Z"}],
+        "depends_on": [], "platform": "Unspecified", "cf_partner": [], "estimated_time":
+        0, "is_cc_accessible": true, "alias": [], "is_confirmed": true, "cf_verified":
+        [], "cf_environment": "", "cf_build_id": "", "groups": ["devel"], "cf_qe_conditional_nak":
+        [], "cf_devel_whiteboard": "", "cf_cust_facing": "---"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 13 Sep 2023 08:35:47 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2960'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1694594147.4017c7d
+      x-rh-edge-request-id:
+      - 4017c7d
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_update_jira.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_update_jira.yaml
@@ -1,0 +1,223 @@
+interactions:
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "OSIDB"},
+      "priority": {"name": "Minor"}, "description": "Public Security Tracking Issue\n\nFlaw:\n-----\n\nsample
+      title\nhttps://bugzilla.redhat.com/show_bug.cgi?id=1997880\n\nDescription
+      for None\n\n~~~", "labels": ["SecurityTracking", "Security", "pscomponent:openshift"],
+      "summary": "[Major Incident] openshift: sample title [openshift-4.9.z]"}, "key":
+      "OSIDB-920"}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIDB-920
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 14 Sep 2023 15:54:44 GMT
+      Expires:
+      - Thu, 14 Sep 2023 15:54:44 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 954x23476x1
+      x-asessionid:
+      - tkele
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1694706884.1847f669
+      x-rh-edge-request-id:
+      - 1847f669
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/api/2/issue/OSIDB-920
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "15297716", "self": "https://issues.redhat.com/rest/api/2/issue/15297716",
+        "key": "OSIDB-920", "fields": {"issuetype": {"self": "https://issues.redhat.com/rest/api/2/issuetype/1",
+        "id": "1", "description": "A problem which impairs or prevents the functions
+        of the product.", "iconUrl": "https://issues.redhat.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12322244":
+        null, "customfield_12318341": null, "timespent": null, "customfield_12320940":
+        null, "project": {"self": "https://issues.redhat.com/rest/api/2/project/12332734",
+        "id": "12332734", "key": "OSIDB", "name": "Open Security Issue Database",
+        "projectTypeKey": "software", "avatarUrls": {"48x48": "https://issues.redhat.com/secure/projectavatar?pid=12332734&avatarId=10010",
+        "24x24": "https://issues.redhat.com/secure/projectavatar?size=small&pid=12332734&avatarId=10010",
+        "16x16": "https://issues.redhat.com/secure/projectavatar?size=xsmall&pid=12332734&avatarId=10010",
+        "32x32": "https://issues.redhat.com/secure/projectavatar?size=medium&pid=12332734&avatarId=10010"}},
+        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
+        "resolution": null, "customfield_12310220": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@23e734b0[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@756c411c[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@72925f6b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@65e18484[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@17397761[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2a6d9874[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4a64e355[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@23489b39[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f96624e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@39fefbf0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@546dd9d1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@339b1136[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12310183": null, "resolutiondate": null, "workratio": -1, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12315950": null, "customfield_12316841":
+        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
+        "2023-09-14T15:54:35.852+0000", "watches": {"self": "https://issues.redhat.com/rest/api/2/issue/OSIDB-920/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2023-09-14T15:12:41.610+0000",
+        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
+        "https://issues.redhat.com/rest/api/2/priority/4", "iconUrl": "https://issues.redhat.com/images/icons/priorities/minor.svg",
+        "name": "Minor", "id": "4"}, "labels": ["Security", "SecurityTracking", "pscomponent:openshift"],
+        "customfield_12320947": [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/27714",
+        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/27705",
+        "value": "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
+        null, "updated": "2023-09-14T15:54:44.103+0000", "customfield_12313942": null,
+        "customfield_12313941": null, "status": {"self": "https://issues.redhat.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://issues.redhat.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://issues.redhat.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://issues.redhat.com/rest/api/2/component/12367567",
+        "id": "12367567", "name": "osidb"}], "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "Public Security Tracking Issue\n\nFlaw:\n-----\n\nsample
+        title\nhttps://bugzilla.redhat.com/show_bug.cgi?id=1997880\n\nDescription
+        for None\n\n~~~", "customfield_12314040": null, "customfield_12320844": null,
+        "archiveddate": null, "timetracking": {}, "customfield_12320842": null, "attachment":
+        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://issues.redhat.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12317313":
+        null, "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "[Major Incident] openshift: sample title [openshift-4.9.z]", "customfield_12323640":
+        null, "customfield_12323642": null, "creator": {"self": "https://issues.redhat.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.redhat.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://issues.redhat.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://issues.redhat.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://issues.redhat.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "Europe/Prague"},
+        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12323647": [{"self": "https://issues.redhat.com/rest/api/2/customFieldOption/34762",
+        "value": "en-US (English)", "id": "34762", "disabled": false}], "reporter":
+        {"self": "https://issues.redhat.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://issues.redhat.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://issues.redhat.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://issues.redhat.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://issues.redhat.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "Europe/Prague"},
+        "customfield_12320850": null, "aggregateprogress": {"progress": 0, "total":
+        0}, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "customfield_12310211": null, "environment":
+        null, "customfield_12315542": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "customfield_12313240": null, "duedate":
+        null, "customfield_12311140": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "comment": {"comments": [], "maxResults": 0,
+        "total": 0, "startAt": 0}, "votes": {"self": "https://issues.redhat.com/rest/api/2/issue/OSIDB-920/votes",
+        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
+        "total": 0, "worklogs": []}, "customfield_12319743": null, "customfield_12310213":
+        null, "archivedby": null, "customfield_12311940": "1|zbmtr0:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - sandbox
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 14 Sep 2023 15:54:44 GMT
+      Expires:
+      - Thu, 14 Sep 2023 15:54:44 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '9050'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 954x23478x1
+      x-asessionid:
+      - kjmbn3
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1694706884.1847f84c
+      x-rh-edge-request-id:
+      - 1847f84c
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerSaver.test_tracker_create_bugzilla.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerSaver.test_tracker_create_bugzilla.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh91"}'
+      string: '{"version": "5.0.4.rh93"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -33,7 +33,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:14 GMT
+      - Wed, 11 Oct 2023 15:48:02 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -45,9 +45,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693839914.30f35c7
+      - 0.64f06e68.1697039282.3762590
       x-rh-edge-request-id:
-      - 30f35c7
+      - '3762590'
     status:
       code: 200
       message: OK
@@ -68,8 +68,8 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"email": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "id": 1, "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "id": 1, "name":
+        "aander07@packetmaster.com", "real_name": "Need Real Name", "can_login": true}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:14 GMT
+      - Wed, 11 Oct 2023 15:48:02 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -98,9 +98,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693839914.30f36c0
+      - 0.64f06e68.1697039282.376265b
       x-rh-edge-request-id:
-      - 30f36c0
+      - 376265b
     status:
       code: 200
       message: OK
@@ -111,8 +111,8 @@ interactions:
       in the \"Blocks\" field of this bug for full details of the security issue(s).\n\nThis
       bug is never intended to be made public, please put any public notes in the
       blocked bugs.", "comment_is_private": false, "flags": [], "groups": ["devel"],
-      "keywords": ["Security", "SecurityTracking"], "summary": "openssl: sample title
-      [rhcertification-6]"}'
+      "keywords": ["Security", "SecurityTracking"], "summary": "[Major Incident] openssl:
+      sample title [rhcertification-6]"}'
     headers:
       Accept:
       - '*/*'
@@ -121,7 +121,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '586'
+      - '603'
       Content-Type:
       - application/json
       User-Agent:
@@ -130,7 +130,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug
   response:
     body:
-      string: '{"id": 2017149}'
+      string: '{"id": 2018651}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -147,7 +147,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:15 GMT
+      - Wed, 11 Oct 2023 15:48:03 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -159,9 +159,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693839915.30f380e
+      - 0.64f06e68.1697039283.3762ae3
       x-rh-edge-request-id:
-      - 30f380e
+      - 3762ae3
     status:
       code: 200
       message: OK
@@ -182,7 +182,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh91"}'
+      string: '{"version": "5.0.4.rh93"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -199,7 +199,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:16 GMT
+      - Wed, 11 Oct 2023 15:48:04 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -211,9 +211,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839916.310b2d3c
+      - 0.64f06e68.1697039284.3763844
       x-rh-edge-request-id:
-      - 310b2d3c
+      - '3763844'
     status:
       code: 200
       message: OK
@@ -234,8 +234,8 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"id": 1, "email": "aander07@packetmaster.com", "name":
-        "aander07@packetmaster.com", "real_name": "Need Real Name", "can_login": true}]}'
+      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "id": 1, "email": "aander07@packetmaster.com", "can_login": true}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -252,7 +252,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:16 GMT
+      - Wed, 11 Oct 2023 15:48:04 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -264,9 +264,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839916.310b2f19
+      - 0.64f06e68.1697039284.37638e7
       x-rh-edge-request-id:
-      - 310b2f19
+      - 37638e7
     status:
       code: 200
       message: OK
@@ -287,65 +287,66 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2013494
   response:
     body:
-      string: '{"bugs": [{"cf_qa_whiteboard": "", "cf_pm_score": "0", "cf_environment":
-        "", "groups": [], "is_cc_accessible": true, "cf_build_id": "", "platform":
-        "All", "cf_srtnotes": "{\"affects\": [{\"affectedness\": \"affected\", \"cvss2\":
+      string: '{"bugs": [{"alias": [], "cf_clone_of": null, "classification": "Other",
+        "flags": [{"name": "requires_doc_text", "modification_date": "2023-06-07T07:02:07Z",
+        "is_active": 1, "id": 5222989, "type_id": 415, "creation_date": "2023-06-07T07:02:07Z",
+        "setter": "osoukup@redhat.com", "status": "?"}], "is_creator_accessible":
+        true, "cf_environment": "", "deadline": null, "dupe_of": null, "is_confirmed":
+        true, "status": "NEW", "cf_doc_type": "If docs needed, set a value", "platform":
+        "All", "cf_cust_facing": "---", "description": "triage", "url": "", "creator":
+        "osoukup@redhat.com", "actual_time": 0, "creator_detail": {"active": true,
+        "insider": true, "email": "osoukup@redhat.com", "name": "osoukup@redhat.com",
+        "id": 412888, "real_name": "Ondrej Soukup", "partner": false}, "cf_last_closed":
+        null, "summary": "openssl: sample title", "cf_release_notes": "", "cf_internal_whiteboard":
+        "", "assigned_to_detail": {"email": "nobody@redhat.com", "insider": false,
+        "active": true, "real_name": "Nobody", "partner": false, "name": "nobody@redhat.com",
+        "id": 29451}, "whiteboard": "", "cf_pm_score": "0", "groups": [], "qa_contact":
+        "", "severity": "high", "is_open": true, "estimated_time": 0, "priority":
+        "high", "id": 2013494, "op_sys": "Linux", "docs_contact": "", "cc_detail":
+        [{"insider": true, "email": "cfu@redhat.com", "active": true, "partner": false,
+        "real_name": "Christina Fu", "id": 172340, "name": "cfu@redhat.com"}, {"id":
+        323620, "name": "csutherl@redhat.com", "partner": false, "real_name": "Coty
+        Sutherland", "active": true, "insider": true, "email": "csutherl@redhat.com"},
+        {"active": true, "email": "dsirrine@redhat.com", "insider": true, "id": 328816,
+        "name": "dsirrine@redhat.com", "partner": false, "real_name": "David Sirrine"},
+        {"name": "edewata@redhat.com", "id": 268649, "real_name": "Endi Sukma Dewata",
+        "partner": false, "active": true, "insider": true, "email": "edewata@redhat.com"},
+        {"insider": true, "email": "jclere@redhat.com", "active": true, "real_name":
+        "Jean-frederic Clere", "partner": false, "name": "jclere@redhat.com", "id":
+        207159}, {"active": true, "email": "jmagne@redhat.com", "insider": true, "name":
+        "jmagne@redhat.com", "id": 172343, "real_name": "Jack Magne", "partner": false},
+        {"real_name": "Matthew Harmsen", "partner": false, "name": "mharmsen@redhat.com",
+        "id": 172338, "email": "mharmsen@redhat.com", "insider": true, "active": true},
+        {"active": true, "insider": true, "email": "mturk@redhat.com", "id": 203655,
+        "name": "mturk@redhat.com", "partner": false, "real_name": "Mladen Turk"},
+        {"active": true, "email": "peholase@redhat.com", "insider": true, "id": 459204,
+        "name": "peholase@redhat.com", "partner": false, "real_name": "Petr Holasek"},
+        {"partner": false, "real_name": "Socrates Zappis", "id": 415516, "name": "szappis@redhat.com",
+        "insider": false, "email": "szappis@redhat.com", "active": true}], "creation_time":
+        "2023-06-07T07:02:07Z", "target_milestone": "---", "cf_fixed_in": "", "cf_devel_whiteboard":
+        "", "cf_embargoed": null, "external_bugs": [], "component": ["vulnerability"],
+        "product": "Security Response", "sub_components": {}, "is_cc_accessible":
+        true, "cf_srtnotes": "{\"affects\": [{\"affectedness\": \"affected\", \"cvss2\":
         null, \"cvss3\": null, \"impact\": null, \"ps_component\": \"openssl\", \"ps_module\":
         \"rhcertification-6\", \"resolution\": \"fix\"}], \"impact\": \"important\",
         \"jira_trackers\": [], \"public\": \"2023-06-07T07:01:00Z\", \"reported\":
-        \"2023-06-07\", \"source\": \"customer\"}", "docs_contact": "", "deadline":
-        null, "last_change_time": "2023-09-04T15:05:15Z", "remaining_time": 0, "actual_time":
-        0, "id": 2013494, "status": "NEW", "version": ["unspecified"], "flags": [{"setter":
-        "osoukup@redhat.com", "name": "requires_doc_text", "modification_date": "2023-06-07T07:02:07Z",
-        "status": "?", "id": 5222989, "creation_date": "2023-06-07T07:02:07Z", "is_active":
-        1, "type_id": 415}], "keywords": ["Security"], "cf_last_closed": null, "resolution":
-        "", "is_creator_accessible": true, "summary": "openssl: sample title", "cf_devel_whiteboard":
-        "", "target_release": ["---"], "depends_on": [2017145, 2017146, 2017147, 2017148,
-        2017149], "cf_major_incident": null, "cf_clone_of": null, "blocks": [2013606],
-        "whiteboard": "", "cf_pgm_internal": "", "external_bugs": [], "target_milestone":
-        "---", "estimated_time": 0, "cf_qe_conditional_nak": [], "cf_doc_type": "If
-        docs needed, set a value", "product": "Security Response", "comments": [{"time":
-        "2023-06-07T07:02:07Z", "bug_id": 2013494, "creation_time": "2023-06-07T07:02:07Z",
-        "tags": [], "is_private": false, "count": 0, "text": "triage", "attachment_id":
-        null, "creator": "osoukup@redhat.com", "id": 15574231, "creator_id": 412888},
-        {"creator_id": 412888, "id": 15575051, "tags": [], "creator": "osoukup@redhat.com",
-        "attachment_id": null, "text": "test", "count": 17, "is_private": false, "bug_id":
-        2013494, "creation_time": "2023-06-08T14:03:51Z", "time": "2023-06-08T14:03:51Z"}],
-        "severity": "high", "creator_detail": {"active": true, "real_name": "Ondrej
-        Soukup", "email": "osoukup@redhat.com", "id": 412888, "insider": true, "name":
-        "osoukup@redhat.com", "partner": false}, "tags": [], "description": "triage",
-        "url": "", "qa_contact": "", "data_category": "Public", "assigned_to": "nobody@redhat.com",
-        "creation_time": "2023-06-07T07:02:07Z", "cc": ["cfu@redhat.com", "csutherl@redhat.com",
+        \"2023-06-07\", \"source\": \"customer\"}", "cf_major_incident": null, "comments":
+        [{"creation_time": "2023-06-07T07:02:07Z", "creator_id": 412888, "tags": [],
+        "id": 15574231, "text": "triage", "is_private": false, "bug_id": 2013494,
+        "count": 0, "creator": "osoukup@redhat.com", "private_groups": [], "attachment_id":
+        null, "time": "2023-06-07T07:02:07Z"}, {"creation_time": "2023-06-08T14:03:51Z",
+        "tags": [], "creator_id": 412888, "id": 15575051, "text": "test", "bug_id":
+        2013494, "is_private": false, "count": 17, "attachment_id": null, "private_groups":
+        [], "time": "2023-06-08T14:03:51Z", "creator": "osoukup@redhat.com"}], "blocks":
+        [2013606], "keywords": ["Security"], "cc": ["cfu@redhat.com", "csutherl@redhat.com",
         "dsirrine@redhat.com", "edewata@redhat.com", "jclere@redhat.com", "jmagne@redhat.com",
         "mharmsen@redhat.com", "mturk@redhat.com", "peholase@redhat.com", "szappis@redhat.com"],
-        "sub_components": {}, "creator": "osoukup@redhat.com", "assigned_to_detail":
-        {"insider": false, "name": "nobody@redhat.com", "partner": false, "active":
-        true, "email": "nobody@redhat.com", "real_name": "Nobody", "id": 29451}, "priority":
-        "high", "cf_internal_whiteboard": "", "cf_fixed_in": "", "alias": [], "cf_embargoed":
-        null, "op_sys": "Linux", "cc_detail": [{"active": true, "email": "cfu@redhat.com",
-        "real_name": "Christina Fu", "id": 172340, "insider": true, "partner": false,
-        "name": "cfu@redhat.com"}, {"id": 323620, "email": "csutherl@redhat.com",
-        "real_name": "Coty Sutherland", "active": true, "partner": false, "name":
-        "csutherl@redhat.com", "insider": true}, {"email": "dsirrine@redhat.com",
-        "active": true, "real_name": "David Sirrine", "id": 328816, "insider": true,
-        "name": "dsirrine@redhat.com", "partner": false}, {"partner": false, "name":
-        "edewata@redhat.com", "insider": true, "id": 268649, "real_name": "Endi Sukma
-        Dewata", "active": true, "email": "edewata@redhat.com"}, {"insider": true,
-        "partner": false, "name": "jclere@redhat.com", "active": true, "real_name":
-        "Jean-frederic Clere", "email": "jclere@redhat.com", "id": 207159}, {"real_name":
-        "Jack Magne", "active": true, "email": "jmagne@redhat.com", "id": 172343,
-        "insider": true, "partner": false, "name": "jmagne@redhat.com"}, {"insider":
-        true, "partner": false, "name": "mharmsen@redhat.com", "real_name": "Matthew
-        Harmsen", "active": true, "email": "mharmsen@redhat.com", "id": 172338}, {"id":
-        203655, "active": true, "email": "mturk@redhat.com", "real_name": "Mladen
-        Turk", "partner": false, "name": "mturk@redhat.com", "insider": true}, {"id":
-        459204, "email": "peholase@redhat.com", "real_name": "Petr Holasek", "active":
-        true, "name": "peholase@redhat.com", "partner": false, "insider": true}, {"real_name":
-        "Socrates Zappis", "active": true, "email": "szappis@redhat.com", "id": 415516,
-        "insider": false, "name": "szappis@redhat.com", "partner": false}], "is_confirmed":
-        true, "cf_release_notes": "", "classification": "Other", "cf_conditional_nak":
-        [], "component": ["vulnerability"], "cf_cust_facing": "---", "dupe_of": null,
-        "is_open": true}], "offset": 0, "limit": "20", "total_matches": 1}'
+        "data_category": "Public", "cf_conditional_nak": [], "remaining_time": 0,
+        "cf_qe_conditional_nak": [], "last_change_time": "2023-10-11T15:48:03Z", "resolution":
+        "", "target_release": ["---"], "cf_qa_whiteboard": "", "cf_build_id": "",
+        "version": ["unspecified"], "tags": [], "assigned_to": "nobody@redhat.com",
+        "depends_on": [2018651], "cf_pgm_internal": ""}], "limit": "20", "offset":
+        0, "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -360,7 +361,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:17 GMT
+      - Wed, 11 Oct 2023 15:48:05 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -372,13 +373,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '11684'
+      - '12336'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839917.310b30b5
+      - 0.64f06e68.1697039285.3763a9b
       x-rh-edge-request-id:
-      - 310b30b5
+      - 3763a9b
     status:
       code: 200
       message: OK
@@ -399,65 +400,66 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2013494
   response:
     body:
-      string: '{"total_matches": 1, "limit": "20", "offset": 0, "bugs": [{"cf_pgm_internal":
-        "", "whiteboard": "", "blocks": [2013606], "cf_clone_of": null, "cf_major_incident":
-        null, "target_release": ["---"], "depends_on": [2017145, 2017146, 2017147,
-        2017148, 2017149], "summary": "openssl: sample title", "cf_devel_whiteboard":
-        "", "is_creator_accessible": true, "resolution": "", "estimated_time": 0,
-        "target_milestone": "---", "external_bugs": [], "flags": [{"is_active": 1,
-        "creation_date": "2023-06-07T07:02:07Z", "id": 5222989, "status": "?", "type_id":
-        415, "name": "requires_doc_text", "setter": "osoukup@redhat.com", "modification_date":
-        "2023-06-07T07:02:07Z"}], "status": "NEW", "version": ["unspecified"], "id":
-        2013494, "actual_time": 0, "cf_last_closed": null, "keywords": ["Security"],
-        "platform": "All", "remaining_time": 0, "last_change_time": "2023-09-04T15:05:15Z",
-        "deadline": null, "docs_contact": "", "cf_srtnotes": "{\"affects\": [{\"affectedness\":
-        \"affected\", \"cvss2\": null, \"cvss3\": null, \"impact\": null, \"ps_component\":
-        \"openssl\", \"ps_module\": \"rhcertification-6\", \"resolution\": \"fix\"}],
-        \"impact\": \"important\", \"jira_trackers\": [], \"public\": \"2023-06-07T07:01:00Z\",
-        \"reported\": \"2023-06-07\", \"source\": \"customer\"}", "cf_environment":
-        "", "cf_pm_score": "0", "cf_qa_whiteboard": "", "cf_build_id": "", "is_cc_accessible":
-        true, "groups": [], "cf_cust_facing": "---", "cf_conditional_nak": [], "component":
-        ["vulnerability"], "classification": "Other", "is_confirmed": true, "cf_release_notes":
-        "", "cc_detail": [{"email": "cfu@redhat.com", "active": true, "real_name":
-        "Christina Fu", "id": 172340, "insider": true, "partner": false, "name": "cfu@redhat.com"},
-        {"active": true, "email": "csutherl@redhat.com", "real_name": "Coty Sutherland",
-        "id": 323620, "insider": true, "partner": false, "name": "csutherl@redhat.com"},
-        {"insider": true, "partner": false, "name": "dsirrine@redhat.com", "active":
-        true, "real_name": "David Sirrine", "email": "dsirrine@redhat.com", "id":
-        328816}, {"partner": false, "name": "edewata@redhat.com", "insider": true,
-        "id": 268649, "active": true, "email": "edewata@redhat.com", "real_name":
-        "Endi Sukma Dewata"}, {"email": "jclere@redhat.com", "active": true, "real_name":
-        "Jean-frederic Clere", "id": 207159, "insider": true, "partner": false, "name":
-        "jclere@redhat.com"}, {"id": 172343, "real_name": "Jack Magne", "active":
-        true, "email": "jmagne@redhat.com", "name": "jmagne@redhat.com", "partner":
-        false, "insider": true}, {"email": "mharmsen@redhat.com", "real_name": "Matthew
-        Harmsen", "active": true, "id": 172338, "insider": true, "partner": false,
-        "name": "mharmsen@redhat.com"}, {"insider": true, "name": "mturk@redhat.com",
-        "partner": false, "real_name": "Mladen Turk", "active": true, "email": "mturk@redhat.com",
-        "id": 203655}, {"partner": false, "name": "peholase@redhat.com", "insider":
-        true, "id": 459204, "real_name": "Petr Holasek", "email": "peholase@redhat.com",
-        "active": true}, {"active": true, "email": "szappis@redhat.com", "real_name":
-        "Socrates Zappis", "id": 415516, "insider": false, "name": "szappis@redhat.com",
-        "partner": false}], "op_sys": "Linux", "is_open": true, "dupe_of": null, "assigned_to_detail":
-        {"active": true, "email": "nobody@redhat.com", "real_name": "Nobody", "id":
-        29451, "insider": false, "partner": false, "name": "nobody@redhat.com"}, "priority":
-        "high", "creator": "osoukup@redhat.com", "sub_components": {}, "cc": ["cfu@redhat.com",
-        "csutherl@redhat.com", "dsirrine@redhat.com", "edewata@redhat.com", "jclere@redhat.com",
-        "jmagne@redhat.com", "mharmsen@redhat.com", "mturk@redhat.com", "peholase@redhat.com",
-        "szappis@redhat.com"], "cf_embargoed": null, "alias": [], "cf_fixed_in": "",
-        "cf_internal_whiteboard": "", "tags": [], "creation_time": "2023-06-07T07:02:07Z",
-        "assigned_to": "nobody@redhat.com", "data_category": "Public", "qa_contact":
-        "", "url": "", "description": "triage", "product": "Security Response", "cf_doc_type":
-        "If docs needed, set a value", "cf_qe_conditional_nak": [], "creator_detail":
-        {"id": 412888, "active": true, "email": "osoukup@redhat.com", "real_name":
-        "Ondrej Soukup", "name": "osoukup@redhat.com", "partner": false, "insider":
-        true}, "severity": "high", "comments": [{"tags": [], "count": 0, "is_private":
-        false, "attachment_id": null, "text": "triage", "creator": "osoukup@redhat.com",
-        "id": 15574231, "creator_id": 412888, "time": "2023-06-07T07:02:07Z", "bug_id":
-        2013494, "creation_time": "2023-06-07T07:02:07Z"}, {"creator_id": 412888,
-        "id": 15575051, "tags": [], "creator": "osoukup@redhat.com", "attachment_id":
-        null, "text": "test", "is_private": false, "count": 17, "bug_id": 2013494,
-        "creation_time": "2023-06-08T14:03:51Z", "time": "2023-06-08T14:03:51Z"}]}]}'
+      string: '{"limit": "20", "bugs": [{"cf_conditional_nak": [], "severity": "high",
+        "cf_srtnotes": "{\"affects\": [{\"affectedness\": \"affected\", \"cvss2\":
+        null, \"cvss3\": null, \"impact\": null, \"ps_component\": \"openssl\", \"ps_module\":
+        \"rhcertification-6\", \"resolution\": \"fix\"}], \"impact\": \"important\",
+        \"jira_trackers\": [], \"public\": \"2023-06-07T07:01:00Z\", \"reported\":
+        \"2023-06-07\", \"source\": \"customer\"}", "cf_qe_conditional_nak": [], "creator_detail":
+        {"real_name": "Ondrej Soukup", "name": "osoukup@redhat.com", "partner": false,
+        "id": 412888, "email": "osoukup@redhat.com", "insider": true, "active": true},
+        "product": "Security Response", "external_bugs": [], "cf_pgm_internal": "",
+        "cf_embargoed": null, "whiteboard": "", "cf_release_notes": "", "creator":
+        "osoukup@redhat.com", "flags": [{"setter": "osoukup@redhat.com", "name": "requires_doc_text",
+        "status": "?", "is_active": 1, "id": 5222989, "creation_date": "2023-06-07T07:02:07Z",
+        "type_id": 415, "modification_date": "2023-06-07T07:02:07Z"}], "is_open":
+        true, "platform": "All", "qa_contact": "", "dupe_of": null, "is_cc_accessible":
+        true, "cf_clone_of": null, "docs_contact": "", "cf_environment": "", "cc":
+        ["cfu@redhat.com", "csutherl@redhat.com", "dsirrine@redhat.com", "edewata@redhat.com",
+        "jclere@redhat.com", "jmagne@redhat.com", "mharmsen@redhat.com", "mturk@redhat.com",
+        "peholase@redhat.com", "szappis@redhat.com"], "keywords": ["Security"], "alias":
+        [], "estimated_time": 0, "target_release": ["---"], "cf_fixed_in": "", "data_category":
+        "Public", "url": "", "cf_devel_whiteboard": "", "classification": "Other",
+        "cf_last_closed": null, "resolution": "", "comments": [{"time": "2023-06-07T07:02:07Z",
+        "creation_time": "2023-06-07T07:02:07Z", "bug_id": 2013494, "creator": "osoukup@redhat.com",
+        "tags": [], "attachment_id": null, "creator_id": 412888, "is_private": false,
+        "id": 15574231, "private_groups": [], "text": "triage", "count": 0}, {"is_private":
+        false, "id": 15575051, "private_groups": [], "text": "test", "count": 17,
+        "creator_id": 412888, "attachment_id": null, "creator": "osoukup@redhat.com",
+        "bug_id": 2013494, "creation_time": "2023-06-08T14:03:51Z", "tags": [], "time":
+        "2023-06-08T14:03:51Z"}], "priority": "high", "target_milestone": "---", "actual_time":
+        0, "status": "NEW", "version": ["unspecified"], "id": 2013494, "assigned_to":
+        "nobody@redhat.com", "cf_cust_facing": "---", "remaining_time": 0, "cf_qa_whiteboard":
+        "", "cf_pm_score": "0", "is_creator_accessible": true, "op_sys": "Linux",
+        "tags": [], "cf_build_id": "", "summary": "openssl: sample title", "last_change_time":
+        "2023-10-11T15:48:03Z", "blocks": [2013606], "cf_major_incident": null, "depends_on":
+        [2018651], "description": "triage", "cc_detail": [{"partner": false, "insider":
+        true, "active": true, "id": 172340, "email": "cfu@redhat.com", "name": "cfu@redhat.com",
+        "real_name": "Christina Fu"}, {"real_name": "Coty Sutherland", "name": "csutherl@redhat.com",
+        "email": "csutherl@redhat.com", "id": 323620, "insider": true, "active": true,
+        "partner": false}, {"name": "dsirrine@redhat.com", "real_name": "David Sirrine",
+        "active": true, "insider": true, "id": 328816, "email": "dsirrine@redhat.com",
+        "partner": false}, {"partner": false, "email": "edewata@redhat.com", "id":
+        268649, "insider": true, "active": true, "real_name": "Endi Sukma Dewata",
+        "name": "edewata@redhat.com"}, {"real_name": "Jean-frederic Clere", "name":
+        "jclere@redhat.com", "partner": false, "id": 207159, "email": "jclere@redhat.com",
+        "active": true, "insider": true}, {"id": 172343, "email": "jmagne@redhat.com",
+        "active": true, "insider": true, "partner": false, "real_name": "Jack Magne",
+        "name": "jmagne@redhat.com"}, {"name": "mharmsen@redhat.com", "real_name":
+        "Matthew Harmsen", "partner": false, "insider": true, "active": true, "id":
+        172338, "email": "mharmsen@redhat.com"}, {"partner": false, "id": 203655,
+        "email": "mturk@redhat.com", "active": true, "insider": true, "real_name":
+        "Mladen Turk", "name": "mturk@redhat.com"}, {"name": "peholase@redhat.com",
+        "real_name": "Petr Holasek", "active": true, "insider": true, "id": 459204,
+        "email": "peholase@redhat.com", "partner": false}, {"real_name": "Socrates
+        Zappis", "name": "szappis@redhat.com", "id": 415516, "email": "szappis@redhat.com",
+        "active": true, "insider": false, "partner": false}], "component": ["vulnerability"],
+        "assigned_to_detail": {"name": "nobody@redhat.com", "real_name": "Nobody",
+        "partner": false, "insider": false, "active": true, "email": "nobody@redhat.com",
+        "id": 29451}, "creation_time": "2023-06-07T07:02:07Z", "cf_internal_whiteboard":
+        "", "deadline": null, "is_confirmed": true, "cf_doc_type": "If docs needed,
+        set a value", "sub_components": {}, "groups": []}], "total_matches": 1, "offset":
+        0}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -472,7 +474,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:18 GMT
+      - Wed, 11 Oct 2023 15:48:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -484,13 +486,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '11684'
+      - '12336'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839918.310b3501
+      - 0.64f06e68.1697039286.3763ef9
       x-rh-edge-request-id:
-      - 310b3501
+      - 3763ef9
     status:
       code: 200
       message: OK
@@ -511,14 +513,14 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug/2013494/comment
   response:
     body:
-      string: '{"bugs": {"2013494": {"comments": [{"bug_id": 2013494, "attachment_id":
-        null, "count": 0, "is_private": false, "id": 15574231, "text": "triage", "creation_time":
-        "2023-06-07T07:02:07Z", "creator_id": 412888, "creator": "osoukup@redhat.com",
-        "time": "2023-06-07T07:02:07Z", "tags": []}, {"count": 17, "attachment_id":
-        null, "bug_id": 2013494, "creation_time": "2023-06-08T14:03:51Z", "text":
-        "test", "id": 15575051, "is_private": false, "creator_id": 412888, "tags":
-        [], "time": "2023-06-08T14:03:51Z", "creator": "osoukup@redhat.com"}]}}, "comments":
-        {}}'
+      string: '{"comments": {}, "bugs": {"2013494": {"comments": [{"id": 15574231,
+        "text": "triage", "bug_id": 2013494, "is_private": false, "count": 0, "creator":
+        "osoukup@redhat.com", "attachment_id": null, "private_groups": [], "time":
+        "2023-06-07T07:02:07Z", "creation_time": "2023-06-07T07:02:07Z", "creator_id":
+        412888, "tags": []}, {"creation_time": "2023-06-08T14:03:51Z", "tags": [],
+        "creator_id": 412888, "text": "test", "id": 15575051, "is_private": false,
+        "bug_id": 2013494, "count": 17, "private_groups": [], "attachment_id": null,
+        "time": "2023-06-08T14:03:51Z", "creator": "osoukup@redhat.com"}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -533,7 +535,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:19 GMT
+      - Wed, 11 Oct 2023 15:48:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -545,13 +547,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '7820'
+      - '8504'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839919.310b3893
+      - 0.64f06e68.1697039286.376447f
       x-rh-edge-request-id:
-      - 310b3893
+      - 376447f
     status:
       code: 200
       message: OK
@@ -573,9 +575,9 @@ interactions:
   response:
     body:
       string: '{"offset": 0, "limit": "20", "total_matches": 1, "bugs": [{"id": 2013606,
-        "assigned_to": "osoukup@redhat.com", "assigned_to_detail": {"name": "osoukup@redhat.com",
-        "partner": false, "insider": true, "id": 412888, "real_name": "Ondrej Soukup",
-        "active": true, "email": "osoukup@redhat.com"}, "product": "Security Response",
+        "product": "Security Response", "assigned_to": "osoukup@redhat.com", "assigned_to_detail":
+        {"real_name": "Ondrej Soukup", "name": "osoukup@redhat.com", "partner": false,
+        "email": "osoukup@redhat.com", "id": 412888, "active": true, "insider": true},
         "data_category": "Security Restricted"}]}'
     headers:
       Access-Control-Allow-Headers:
@@ -593,7 +595,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:20 GMT
+      - Wed, 11 Oct 2023 15:48:07 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -605,9 +607,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839920.310b3d3a
+      - 0.64f06e68.1697039287.37646e8
       x-rh-edge-request-id:
-      - 310b3d3a
+      - 37646e8
     status:
       code: 200
       message: OK
@@ -625,48 +627,48 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017145
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2018651
   response:
     body:
-      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"cf_fixed_in":
-        "", "cf_internal_whiteboard": "", "cf_embargoed": null, "alias": [], "cc":
-        [], "creator": "osoukup@redhat.com", "sub_components": {}, "priority": "high",
-        "assigned_to_detail": {"name": "jweng@redhat.com", "partner": false, "insider":
-        true, "id": 283338, "active": true, "real_name": "Jianwei Weng", "email":
-        "jweng@redhat.com"}, "dupe_of": null, "is_open": true, "cc_detail": [], "op_sys":
-        "Unspecified", "is_confirmed": true, "cf_release_notes": "", "classification":
-        "Red Hat", "cf_cust_facing": "---", "cf_conditional_nak": [], "component":
-        ["redhat-certification"], "comments": [{"creation_time": "2023-09-04T14:57:17Z",
-        "bug_id": 2017145, "time": "2023-09-04T14:57:17Z", "creator_id": 412888, "id":
-        15643634, "text": "rhcertification-6 tracking bug for openssl: see the bugs
+      string: '{"limit": "20", "bugs": [{"creation_time": "2023-10-11T15:48:03Z",
+        "cf_partner": [], "target_milestone": "---", "cf_fixed_in": "", "cf_devel_whiteboard":
+        "", "cf_embargoed": null, "external_bugs": [], "product": "Red Hat Certification
+        Program", "component": ["redhat-certification"], "sub_components": {}, "is_cc_accessible":
+        true, "comments": [{"attachment_id": null, "private_groups": [], "time": "2023-10-11T15:48:03Z",
+        "creator": "osoukup@redhat.com", "count": 0, "is_private": false, "bug_id":
+        2018651, "text": "rhcertification-6 tracking bug for openssl: see the bugs
         linked in the \"Blocks\" field of this bug for full details of the security
         issue(s).\n\nThis bug is never intended to be made public, please put any
-        public notes in the blocked bugs.", "attachment_id": null, "creator": "osoukup@redhat.com",
-        "is_private": false, "count": 0, "tags": []}], "creator_detail": {"insider":
-        true, "name": "osoukup@redhat.com", "partner": false, "email": "osoukup@redhat.com",
-        "real_name": "Ondrej Soukup", "active": true, "id": 412888}, "severity": "high",
-        "qa_contact_detail": {"active": false, "email": "rhcert-qe@redhat.com", "real_name":
-        "rhcert qe", "id": 408554, "insider": false, "partner": false, "name": "rhcert-qe@redhat.com"},
-        "cf_qe_conditional_nak": [], "cf_doc_type": "No Doc Update", "product": "Red
-        Hat Certification Program", "cf_target_upstream_version": "", "description":
-        "rhcertification-6 tracking bug for openssl: see the bugs linked in the \"Blocks\"
-        field of this bug for full details of the security issue(s).\n\nThis bug is
-        never intended to be made public, please put any public notes in the blocked
-        bugs.", "data_category": "Engineering", "qa_contact": "rhcert-qe@redhat.com",
-        "url": "", "assigned_to": "jweng@redhat.com", "creation_time": "2023-09-04T14:57:17Z",
-        "tags": [], "keywords": ["Security", "SecurityTracking"], "cf_last_closed":
-        null, "actual_time": 0, "version": ["1.0"], "status": "NEW", "id": 2017145,
-        "flags": [{"modification_date": "2023-09-04T14:57:17Z", "setter": "bugzilla@redhat.com",
-        "name": "requires_doc_text", "type_id": 415, "creation_date": "2023-09-04T14:57:17Z",
-        "id": 5236830, "status": "-", "is_active": 1}], "external_bugs": [], "target_milestone":
-        "---", "estimated_time": 0, "cf_partner": [], "is_creator_accessible": true,
-        "resolution": "", "target_release": ["---"], "depends_on": [], "cf_devel_whiteboard":
-        "", "summary": "[Major Incident] openssl: sample title [rhcertification-6]",
-        "cf_clone_of": null, "cf_major_incident": null, "cf_pgm_internal": "", "blocks":
-        [2013494], "whiteboard": "", "groups": ["devel"], "is_cc_accessible": true,
-        "cf_verified": [], "cf_build_id": "", "cf_pm_score": "0", "cf_qa_whiteboard":
-        "", "cf_environment": "", "docs_contact": "", "last_change_time": "2023-09-04T14:57:17Z",
-        "deadline": null, "remaining_time": 0, "platform": "Unspecified"}]}'
+        public notes in the blocked bugs.", "id": 15671700, "tags": [], "creator_id":
+        412888, "creation_time": "2023-10-11T15:48:03Z"}], "cf_major_incident": null,
+        "blocks": [2013494], "keywords": ["Security", "SecurityTracking"], "cc": [],
+        "data_category": "Engineering", "cf_conditional_nak": [], "remaining_time":
+        0, "last_change_time": "2023-10-11T15:48:03Z", "cf_qe_conditional_nak": [],
+        "resolution": "", "target_release": ["---"], "cf_qa_whiteboard": "", "cf_build_id":
+        "", "version": ["1.0"], "tags": [], "assigned_to": "jweng@redhat.com", "depends_on":
+        [], "cf_pgm_internal": "", "alias": [], "cf_clone_of": null, "classification":
+        "Red Hat", "flags": [{"type_id": 415, "creation_date": "2023-10-11T15:48:03Z",
+        "status": "-", "setter": "bugzilla@redhat.com", "id": 5241544, "is_active":
+        1, "modification_date": "2023-10-11T15:48:03Z", "name": "requires_doc_text"}],
+        "is_creator_accessible": true, "cf_environment": "", "deadline": null, "dupe_of":
+        null, "is_confirmed": true, "cf_doc_type": "No Doc Update", "status": "NEW",
+        "cf_verified": [], "platform": "Unspecified", "description": "rhcertification-6
+        tracking bug for openssl: see the bugs linked in the \"Blocks\" field of this
+        bug for full details of the security issue(s).\n\nThis bug is never intended
+        to be made public, please put any public notes in the blocked bugs.", "cf_cust_facing":
+        "---", "url": "", "creator": "osoukup@redhat.com", "actual_time": 0, "creator_detail":
+        {"partner": false, "real_name": "Ondrej Soukup", "id": 412888, "name": "osoukup@redhat.com",
+        "email": "osoukup@redhat.com", "insider": true, "active": true}, "cf_last_closed":
+        null, "summary": "[Major Incident] openssl: sample title [rhcertification-6]",
+        "cf_release_notes": "", "cf_internal_whiteboard": "", "cf_target_upstream_version":
+        "", "assigned_to_detail": {"id": 283338, "name": "jweng@redhat.com", "partner":
+        false, "real_name": "Jianwei Weng", "active": true, "insider": true, "email":
+        "jweng@redhat.com"}, "whiteboard": "", "cf_pm_score": "0", "qa_contact": "rhcert-qe@redhat.com",
+        "groups": ["devel"], "severity": "high", "priority": "high", "estimated_time":
+        0, "is_open": true, "qa_contact_detail": {"partner": false, "real_name": "rhcert
+        qe", "id": 408554, "name": "rhcert-qe@redhat.com", "email": "rhcert-qe@redhat.com",
+        "insider": false, "active": false}, "id": 2018651, "op_sys": "Unspecified",
+        "cc_detail": [], "docs_contact": ""}], "offset": 0, "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -681,7 +683,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:05:21 GMT
+      - Wed, 11 Oct 2023 15:48:08 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -693,381 +695,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2905'
+      - '2925'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693839921.310b3f76
+      - 0.64f06e68.1697039288.3764a51
       x-rh-edge-request-id:
-      - 310b3f76
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017146
-  response:
-    body:
-      string: '{"offset": 0, "limit": "20", "total_matches": 1, "bugs": [{"docs_contact":
-        "", "platform": "Unspecified", "assigned_to_detail": {"active": true, "partner":
-        false, "real_name": "Jianwei Weng", "insider": true, "name": "jweng@redhat.com",
-        "email": "jweng@redhat.com", "id": 283338}, "external_bugs": [], "id": 2017146,
-        "cf_clone_of": null, "last_change_time": "2023-09-04T15:00:00Z", "qa_contact_detail":
-        {"partner": false, "active": false, "real_name": "rhcert qe", "insider": false,
-        "name": "rhcert-qe@redhat.com", "email": "rhcert-qe@redhat.com", "id": 408554},
-        "cc_detail": [], "cf_doc_type": "No Doc Update", "op_sys": "Unspecified",
-        "cf_embargoed": null, "assigned_to": "jweng@redhat.com", "data_category":
-        "Engineering", "product": "Red Hat Certification Program", "flags": [{"creation_date":
-        "2023-09-04T15:00:00Z", "id": 5236831, "setter": "bugzilla@redhat.com", "name":
-        "requires_doc_text", "type_id": 415, "is_active": 1, "modification_date":
-        "2023-09-04T15:00:00Z", "status": "-"}], "target_release": ["---"], "sub_components":
-        {}, "dupe_of": null, "cf_build_id": "", "comments": [{"creator_id": 412888,
-        "creator": "osoukup@redhat.com", "time": "2023-09-04T15:00:00Z", "tags": [],
-        "bug_id": 2017146, "count": 0, "attachment_id": null, "is_private": false,
-        "id": 15643635, "text": "rhcertification-6 tracking bug for openssl: see the
-        bugs linked in the \"Blocks\" field of this bug for full details of the security
-        issue(s).\n\nThis bug is never intended to be made public, please put any
-        public notes in the blocked bugs.", "creation_time": "2023-09-04T15:00:00Z"}],
-        "cc": [], "cf_conditional_nak": [], "cf_pgm_internal": "", "alias": [], "remaining_time":
-        0, "cf_qa_whiteboard": "", "component": ["redhat-certification"], "cf_cust_facing":
-        "---", "cf_qe_conditional_nak": [], "summary": "openssl: sample title [rhcertification-6]",
-        "groups": ["devel"], "cf_environment": "", "cf_fixed_in": "", "estimated_time":
-        0, "classification": "Red Hat", "cf_devel_whiteboard": "", "severity": "high",
-        "priority": "high", "is_confirmed": true, "url": "", "status": "NEW", "cf_verified":
-        [], "creator_detail": {"name": "osoukup@redhat.com", "email": "osoukup@redhat.com",
-        "id": 412888, "partner": false, "active": true, "insider": true, "real_name":
-        "Ondrej Soukup"}, "version": ["1.0"], "creation_time": "2023-09-04T15:00:00Z",
-        "cf_target_upstream_version": "", "is_open": true, "is_creator_accessible":
-        true, "whiteboard": "", "keywords": ["Security", "SecurityTracking"], "cf_last_closed":
-        null, "depends_on": [], "blocks": [2013494], "cf_release_notes": "", "description":
-        "rhcertification-6 tracking bug for openssl: see the bugs linked in the \"Blocks\"
-        field of this bug for full details of the security issue(s).\n\nThis bug is
-        never intended to be made public, please put any public notes in the blocked
-        bugs.", "resolution": "", "tags": [], "qa_contact": "rhcert-qe@redhat.com",
-        "is_cc_accessible": true, "cf_pm_score": "0", "target_milestone": "---", "cf_partner":
-        [], "deadline": null, "cf_major_incident": null, "actual_time": 0, "creator":
-        "osoukup@redhat.com", "cf_internal_whiteboard": ""}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:05:22 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2888'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693839922.310b4238
-      x-rh-edge-request-id:
-      - 310b4238
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017147
-  response:
-    body:
-      string: '{"limit": "20", "total_matches": 1, "bugs": [{"cf_pm_score": "0", "is_cc_accessible":
-        true, "qa_contact": "rhcert-qe@redhat.com", "tags": [], "resolution": "",
-        "cf_release_notes": "", "description": "rhcertification-6 tracking bug for
-        openssl: see the bugs linked in the \"Blocks\" field of this bug for full
-        details of the security issue(s).\n\nThis bug is never intended to be made
-        public, please put any public notes in the blocked bugs.", "cf_internal_whiteboard":
-        "", "creator": "osoukup@redhat.com", "actual_time": 0, "cf_partner": [], "target_milestone":
-        "---", "cf_major_incident": null, "deadline": null, "version": ["1.0"], "creator_detail":
-        {"id": 412888, "email": "osoukup@redhat.com", "name": "osoukup@redhat.com",
-        "real_name": "Ondrej Soukup", "insider": true, "active": true, "partner":
-        false}, "cf_verified": [], "status": "NEW", "priority": "high", "is_confirmed":
-        true, "url": "", "cf_devel_whiteboard": "", "severity": "high", "estimated_time":
-        0, "classification": "Red Hat", "depends_on": [], "blocks": [2013494], "keywords":
-        ["Security", "SecurityTracking"], "whiteboard": "", "cf_last_closed": null,
-        "is_open": true, "is_creator_accessible": true, "cf_target_upstream_version":
-        "", "creation_time": "2023-09-04T15:04:19Z", "cf_conditional_nak": [], "cf_pgm_internal":
-        "", "comments": [{"time": "2023-09-04T15:04:19Z", "tags": [], "creator": "osoukup@redhat.com",
-        "creator_id": 412888, "creation_time": "2023-09-04T15:04:19Z", "is_private":
-        false, "id": 15643637, "text": "rhcertification-6 tracking bug for openssl:
-        see the bugs linked in the \"Blocks\" field of this bug for full details of
-        the security issue(s).\n\nThis bug is never intended to be made public, please
-        put any public notes in the blocked bugs.", "bug_id": 2017147, "count": 0,
-        "attachment_id": null}], "cc": [], "cf_build_id": "", "dupe_of": null, "target_release":
-        ["---"], "sub_components": {}, "cf_environment": "", "cf_fixed_in": "", "summary":
-        "[Major Incident] openssl: sample title [rhcertification-6]", "groups": ["devel"],
-        "cf_cust_facing": "---", "cf_qe_conditional_nak": [], "cf_qa_whiteboard":
-        "", "component": ["redhat-certification"], "remaining_time": 0, "alias": [],
-        "assigned_to_detail": {"id": 283338, "email": "jweng@redhat.com", "name":
-        "jweng@redhat.com", "real_name": "Jianwei Weng", "insider": true, "active":
-        true, "partner": false}, "platform": "Unspecified", "docs_contact": "", "product":
-        "Red Hat Certification Program", "flags": [{"name": "requires_doc_text", "setter":
-        "bugzilla@redhat.com", "id": 5236832, "creation_date": "2023-09-04T15:04:19Z",
-        "is_active": 1, "type_id": 415, "status": "-", "modification_date": "2023-09-04T15:04:19Z"}],
-        "assigned_to": "jweng@redhat.com", "data_category": "Engineering", "op_sys":
-        "Unspecified", "cf_embargoed": null, "cf_doc_type": "No Doc Update", "qa_contact_detail":
-        {"name": "rhcert-qe@redhat.com", "id": 408554, "email": "rhcert-qe@redhat.com",
-        "active": false, "partner": false, "real_name": "rhcert qe", "insider": false},
-        "cc_detail": [], "last_change_time": "2023-09-04T15:04:19Z", "id": 2017147,
-        "cf_clone_of": null, "external_bugs": []}], "offset": 0}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:05:23 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2905'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693839923.310b467d
-      x-rh-edge-request-id:
-      - 310b467d
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017148
-  response:
-    body:
-      string: '{"total_matches": 1, "bugs": [{"cf_embargoed": null, "op_sys": "Unspecified",
-        "cf_doc_type": "No Doc Update", "flags": [{"status": "-", "modification_date":
-        "2023-09-04T15:04:40Z", "is_active": 1, "type_id": 415, "name": "requires_doc_text",
-        "setter": "bugzilla@redhat.com", "id": 5236833, "creation_date": "2023-09-04T15:04:40Z"}],
-        "product": "Red Hat Certification Program", "data_category": "Engineering",
-        "assigned_to": "jweng@redhat.com", "id": 2017148, "cf_clone_of": null, "external_bugs":
-        [], "cc_detail": [], "qa_contact_detail": {"real_name": "rhcert qe", "insider":
-        false, "active": false, "partner": false, "email": "rhcert-qe@redhat.com",
-        "id": 408554, "name": "rhcert-qe@redhat.com"}, "last_change_time": "2023-09-04T15:04:40Z",
-        "platform": "Unspecified", "docs_contact": "", "assigned_to_detail": {"id":
-        283338, "email": "jweng@redhat.com", "name": "jweng@redhat.com", "real_name":
-        "Jianwei Weng", "insider": true, "active": true, "partner": false}, "cf_qe_conditional_nak":
-        [], "cf_cust_facing": "---", "component": ["redhat-certification"], "cf_qa_whiteboard":
-        "", "cf_fixed_in": "", "cf_environment": "", "groups": ["devel"], "summary":
-        "openssl: sample title [rhcertification-6]", "alias": [], "remaining_time":
-        0, "cc": [], "comments": [{"time": "2023-09-04T15:04:40Z", "tags": [], "creator":
-        "osoukup@redhat.com", "creator_id": 412888, "creation_time": "2023-09-04T15:04:40Z",
-        "is_private": false, "id": 15643638, "text": "rhcertification-6 tracking bug
-        for openssl: see the bugs linked in the \"Blocks\" field of this bug for full
-        details of the security issue(s).\n\nThis bug is never intended to be made
-        public, please put any public notes in the blocked bugs.", "bug_id": 2017148,
-        "attachment_id": null, "count": 0}], "cf_pgm_internal": "", "cf_conditional_nak":
-        [], "sub_components": {}, "target_release": ["---"], "cf_build_id": "", "dupe_of":
-        null, "cf_last_closed": null, "keywords": ["Security", "SecurityTracking"],
-        "whiteboard": "", "is_creator_accessible": true, "is_open": true, "blocks":
-        [2013494], "depends_on": [], "creation_time": "2023-09-04T15:04:40Z", "cf_target_upstream_version":
-        "", "status": "NEW", "version": ["1.0"], "creator_detail": {"insider": true,
-        "real_name": "Ondrej Soukup", "active": true, "partner": false, "email": "osoukup@redhat.com",
-        "id": 412888, "name": "osoukup@redhat.com"}, "cf_verified": [], "cf_devel_whiteboard":
-        "", "severity": "urgent", "classification": "Red Hat", "estimated_time": 0,
-        "url": "", "is_confirmed": true, "priority": "urgent", "creator": "osoukup@redhat.com",
-        "actual_time": 0, "cf_internal_whiteboard": "", "cf_major_incident": null,
-        "deadline": null, "target_milestone": "---", "cf_partner": [], "is_cc_accessible":
-        true, "qa_contact": "rhcert-qe@redhat.com", "tags": [], "cf_pm_score": "0",
-        "description": "rhcertification-6 tracking bug for openssl: see the bugs linked
-        in the \"Blocks\" field of this bug for full details of the security issue(s).\n\nThis
-        bug is never intended to be made public, please put any public notes in the
-        blocked bugs.", "cf_release_notes": "", "resolution": ""}], "limit": "20",
-        "offset": 0}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:05:24 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2892'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693839924.310b4a4b
-      x-rh-edge-request-id:
-      - 310b4a4b
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017149
-  response:
-    body:
-      string: '{"bugs": [{"docs_contact": "", "deadline": null, "last_change_time":
-        "2023-09-04T15:05:15Z", "remaining_time": 0, "platform": "Unspecified", "groups":
-        ["devel"], "is_cc_accessible": true, "cf_build_id": "", "cf_verified": [],
-        "cf_qa_whiteboard": "", "cf_pm_score": "0", "cf_environment": "", "external_bugs":
-        [], "target_milestone": "---", "estimated_time": 0, "cf_partner": [], "resolution":
-        "", "is_creator_accessible": true, "cf_devel_whiteboard": "", "summary": "openssl:
-        sample title [rhcertification-6]", "depends_on": [], "target_release": ["---"],
-        "cf_major_incident": null, "cf_clone_of": null, "blocks": [2013494], "whiteboard":
-        "", "cf_pgm_internal": "", "keywords": ["Security", "SecurityTracking"], "cf_last_closed":
-        null, "actual_time": 0, "id": 2017149, "version": ["1.0"], "status": "NEW",
-        "flags": [{"name": "requires_doc_text", "setter": "bugzilla@redhat.com", "modification_date":
-        "2023-09-04T15:05:15Z", "is_active": 1, "id": 5236834, "creation_date": "2023-09-04T15:05:15Z",
-        "status": "-", "type_id": 415}], "description": "rhcertification-6 tracking
-        bug for openssl: see the bugs linked in the \"Blocks\" field of this bug for
-        full details of the security issue(s).\n\nThis bug is never intended to be
-        made public, please put any public notes in the blocked bugs.", "url": "",
-        "data_category": "Engineering", "qa_contact": "rhcert-qe@redhat.com", "assigned_to":
-        "jweng@redhat.com", "creation_time": "2023-09-04T15:05:15Z", "tags": [], "comments":
-        [{"id": 15643639, "creator_id": 412888, "tags": [], "count": 0, "is_private":
-        false, "creator": "osoukup@redhat.com", "text": "rhcertification-6 tracking
-        bug for openssl: see the bugs linked in the \"Blocks\" field of this bug for
-        full details of the security issue(s).\n\nThis bug is never intended to be
-        made public, please put any public notes in the blocked bugs.", "attachment_id":
-        null, "bug_id": 2017149, "creation_time": "2023-09-04T15:05:15Z", "time":
-        "2023-09-04T15:05:15Z"}], "creator_detail": {"real_name": "Ondrej Soukup",
-        "active": true, "email": "osoukup@redhat.com", "id": 412888, "insider": true,
-        "partner": false, "name": "osoukup@redhat.com"}, "severity": "high", "qa_contact_detail":
-        {"id": 408554, "email": "rhcert-qe@redhat.com", "active": false, "real_name":
-        "rhcert qe", "name": "rhcert-qe@redhat.com", "partner": false, "insider":
-        false}, "cf_qe_conditional_nak": [], "cf_doc_type": "No Doc Update", "product":
-        "Red Hat Certification Program", "cf_target_upstream_version": "", "dupe_of":
-        null, "is_open": true, "op_sys": "Unspecified", "cc_detail": [], "cf_release_notes":
-        "", "is_confirmed": true, "classification": "Red Hat", "component": ["redhat-certification"],
-        "cf_conditional_nak": [], "cf_cust_facing": "---", "cf_internal_whiteboard":
-        "", "cf_fixed_in": "", "alias": [], "cf_embargoed": null, "cc": [], "sub_components":
-        {}, "creator": "osoukup@redhat.com", "assigned_to_detail": {"insider": true,
-        "name": "jweng@redhat.com", "partner": false, "email": "jweng@redhat.com",
-        "real_name": "Jianwei Weng", "active": true, "id": 283338}, "priority": "high"}],
-        "limit": "20", "offset": 0, "total_matches": 1}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:05:25 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2888'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693839925.310b4df6
-      x-rh-edge-request-id:
-      - 310b4df6
+      - 3764a51
     status:
       code: 200
       message: OK

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerSaver.test_tracker_update_bugzilla.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerSaver.test_tracker_update_bugzilla.yaml
@@ -16,7 +16,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh91"}'
+      string: '{"version": "5.0.4.rh93"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -33,7 +33,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:13 GMT
+      - Wed, 11 Oct 2023 15:50:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -45,9 +45,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693840093.31220ef
+      - 0.64f06e68.1697039447.37a5de0
       x-rh-edge-request-id:
-      - 31220ef
+      - 37a5de0
     status:
       code: 200
       message: OK
@@ -68,9 +68,8 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "email": "aander07@packetmaster.com", "id":
-        1}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "can_login": true,
+        "id": 1, "name": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -87,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:13 GMT
+      - Wed, 11 Oct 2023 15:50:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -99,9 +98,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693840093.312216c
+      - 0.64f06e68.1697039448.37a5eb5
       x-rh-edge-request-id:
-      - 312216c
+      - 37a5eb5
     status:
       code: 200
       message: OK
@@ -119,11 +118,12 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017149&include_fields=id&include_fields=last_change_time
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2018651&include_fields=id&include_fields=last_change_time
   response:
     body:
-      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"id": 2017149,
-        "last_change_time": "2023-09-04T15:05:15Z", "data_category": "Engineering"}]}'
+      string: '{"limit": "20", "bugs": [{"last_change_time": "2023-10-11T15:48:03Z",
+        "data_category": "Engineering", "id": 2018651}], "total_matches": 1, "offset":
+        0}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -140,7 +140,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:14 GMT
+      - Wed, 11 Oct 2023 15:50:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -152,9 +152,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693840094.3122293
+      - 0.64f06e68.1697039448.37a623d
       x-rh-edge-request-id:
-      - '3122293'
+      - 37a623d
     status:
       code: 200
       message: OK
@@ -163,7 +163,7 @@ interactions:
       "high", "severity": "high", "blocks": {"add": ["2013494"], "remove": []}, "component":
       "redhat-certification", "keywords": {"add": ["Security", "SecurityTracking"]},
       "summary": "CVE-2020-0000 openssl: CVE-2020-0000 kernel: some description [rhcertification-6]",
-      "ids": ["2017149"]}'
+      "ids": ["2018651"]}'
     headers:
       Accept:
       - '*/*'
@@ -178,13 +178,13 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: PUT
-    uri: https://squid.corp.redhat.com:3128/rest/bug/2017149
+    uri: https://squid.corp.redhat.com:3128/rest/bug/2018651
   response:
     body:
-      string: '{"bugs": [{"alias": [], "id": 2017149, "changes": {"summary": {"removed":
-        "openssl: sample title [rhcertification-6]", "added": "CVE-2020-0000 openssl:
-        CVE-2020-0000 kernel: some description [rhcertification-6]"}}, "last_change_time":
-        "2023-09-04T15:08:15Z"}]}'
+      string: '{"bugs": [{"id": 2018651, "last_change_time": "2023-10-11T15:50:49Z",
+        "alias": [], "changes": {"summary": {"removed": "[Major Incident] openssl:
+        sample title [rhcertification-6]", "added": "CVE-2020-0000 openssl: CVE-2020-0000
+        kernel: some description [rhcertification-6]"}}}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -195,13 +195,13 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '248'
+      - '265'
       Content-Security-Policy:
       - frame-ancestors 'self' bugzilla.redhat.com
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:15 GMT
+      - Wed, 11 Oct 2023 15:50:49 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -213,9 +213,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1693840095.312247f
+      - 0.64f06e68.1697039449.37a65d9
       x-rh-edge-request-id:
-      - 312247f
+      - 37a65d9
     status:
       code: 200
       message: OK
@@ -236,7 +236,7 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh91"}'
+      string: '{"version": "5.0.4.rh93"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:16 GMT
+      - Wed, 11 Oct 2023 15:50:51 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -265,9 +265,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693840096.310e2f32
+      - 0.7df06e68.1697039451.8681c82
       x-rh-edge-request-id:
-      - 310e2f32
+      - 8681c82
     status:
       code: 200
       message: OK
@@ -288,8 +288,8 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"id": 1, "real_name": "Need Real Name", "can_login": true,
-        "email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "email": "aander07@packetmaster.com", "can_login": true, "id": 1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -306,7 +306,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:16 GMT
+      - Wed, 11 Oct 2023 15:50:51 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -318,9 +318,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693840096.310e2fb8
+      - 0.7df06e68.1697039451.8681cb2
       x-rh-edge-request-id:
-      - 310e2fb8
+      - 8681cb2
     status:
       code: 200
       message: OK
@@ -341,64 +341,179 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2013494
   response:
     body:
-      string: '{"total_matches": 1, "limit": "20", "offset": 0, "bugs": [{"cf_qe_conditional_nak":
-        [], "cf_doc_type": "If docs needed, set a value", "product": "Security Response",
-        "comments": [{"bug_id": 2013494, "creation_time": "2023-06-07T07:02:07Z",
-        "time": "2023-06-07T07:02:07Z", "id": 15574231, "creator_id": 412888, "tags":
-        [], "count": 0, "is_private": false, "text": "triage", "creator": "osoukup@redhat.com",
-        "attachment_id": null}, {"bug_id": 2013494, "creation_time": "2023-06-08T14:03:51Z",
-        "time": "2023-06-08T14:03:51Z", "id": 15575051, "creator_id": 412888, "tags":
-        [], "is_private": false, "count": 17, "attachment_id": null, "creator": "osoukup@redhat.com",
-        "text": "test"}], "creator_detail": {"id": 412888, "active": true, "real_name":
-        "Ondrej Soukup", "email": "osoukup@redhat.com", "name": "osoukup@redhat.com",
-        "partner": false, "insider": true}, "severity": "high", "tags": [], "description":
-        "triage", "data_category": "Public", "qa_contact": "", "url": "", "assigned_to":
-        "nobody@redhat.com", "creation_time": "2023-06-07T07:02:07Z", "cc": ["cfu@redhat.com",
-        "csutherl@redhat.com", "dsirrine@redhat.com", "edewata@redhat.com", "jclere@redhat.com",
-        "jmagne@redhat.com", "mharmsen@redhat.com", "mturk@redhat.com", "peholase@redhat.com",
-        "szappis@redhat.com"], "creator": "osoukup@redhat.com", "sub_components":
-        {}, "assigned_to_detail": {"insider": false, "name": "nobody@redhat.com",
-        "partner": false, "real_name": "Nobody", "active": true, "email": "nobody@redhat.com",
-        "id": 29451}, "priority": "high", "cf_internal_whiteboard": "", "cf_fixed_in":
-        "", "cf_embargoed": null, "alias": [], "cc_detail": [{"insider": true, "partner":
-        false, "name": "cfu@redhat.com", "email": "cfu@redhat.com", "active": true,
-        "real_name": "Christina Fu", "id": 172340}, {"id": 323620, "active": true,
-        "real_name": "Coty Sutherland", "email": "csutherl@redhat.com", "name": "csutherl@redhat.com",
-        "partner": false, "insider": true}, {"partner": false, "name": "dsirrine@redhat.com",
-        "insider": true, "id": 328816, "active": true, "email": "dsirrine@redhat.com",
-        "real_name": "David Sirrine"}, {"insider": true, "name": "edewata@redhat.com",
-        "partner": false, "active": true, "real_name": "Endi Sukma Dewata", "email":
-        "edewata@redhat.com", "id": 268649}, {"partner": false, "name": "jclere@redhat.com",
-        "insider": true, "id": 207159, "real_name": "Jean-frederic Clere", "email":
-        "jclere@redhat.com", "active": true}, {"name": "jmagne@redhat.com", "partner":
-        false, "insider": true, "id": 172343, "active": true, "email": "jmagne@redhat.com",
-        "real_name": "Jack Magne"}, {"insider": true, "name": "mharmsen@redhat.com",
-        "partner": false, "email": "mharmsen@redhat.com", "active": true, "real_name":
-        "Matthew Harmsen", "id": 172338}, {"name": "mturk@redhat.com", "partner":
-        false, "insider": true, "id": 203655, "real_name": "Mladen Turk", "active":
-        true, "email": "mturk@redhat.com"}, {"email": "peholase@redhat.com", "real_name":
-        "Petr Holasek", "active": true, "id": 459204, "insider": true, "name": "peholase@redhat.com",
-        "partner": false}, {"name": "szappis@redhat.com", "partner": false, "insider":
-        false, "id": 415516, "email": "szappis@redhat.com", "active": true, "real_name":
-        "Socrates Zappis"}], "op_sys": "Linux", "cf_release_notes": "", "is_confirmed":
-        true, "classification": "Other", "cf_cust_facing": "---", "component": ["vulnerability"],
-        "cf_conditional_nak": [], "dupe_of": null, "is_open": true, "cf_pm_score":
-        "0", "cf_qa_whiteboard": "", "cf_environment": "", "groups": [], "is_cc_accessible":
-        true, "cf_build_id": "", "platform": "All", "docs_contact": "", "cf_srtnotes":
-        "{\"affects\": [{\"affectedness\": \"affected\", \"cvss2\": null, \"cvss3\":
-        null, \"impact\": null, \"ps_component\": \"openssl\", \"ps_module\": \"rhcertification-6\",
+      string: '{"offset": 0, "total_matches": 1, "limit": "20", "bugs": [{"cf_cust_facing":
+        "---", "url": "", "description": "triage", "creator": "osoukup@redhat.com",
+        "platform": "All", "is_creator_accessible": true, "flags": [{"modification_date":
+        "2023-06-07T07:02:07Z", "name": "requires_doc_text", "type_id": 415, "creation_date":
+        "2023-06-07T07:02:07Z", "setter": "osoukup@redhat.com", "status": "?", "is_active":
+        1, "id": 5222989}], "classification": "Other", "cf_clone_of": null, "alias":
+        [], "dupe_of": null, "cf_doc_type": "If docs needed, set a value", "status":
+        "NEW", "is_confirmed": true, "cf_environment": "", "deadline": null, "priority":
+        "high", "estimated_time": 0, "is_open": true, "cf_pm_score": "0", "severity":
+        "high", "qa_contact": "", "groups": [], "op_sys": "Linux", "cc_detail": [{"partner":
+        false, "real_name": "Christina Fu", "id": 172340, "name": "cfu@redhat.com",
+        "insider": true, "email": "cfu@redhat.com", "active": true}, {"insider": true,
+        "email": "csutherl@redhat.com", "active": true, "partner": false, "real_name":
+        "Coty Sutherland", "id": 323620, "name": "csutherl@redhat.com"}, {"insider":
+        true, "email": "dsirrine@redhat.com", "active": true, "partner": false, "real_name":
+        "David Sirrine", "id": 328816, "name": "dsirrine@redhat.com"}, {"active":
+        true, "insider": true, "email": "edewata@redhat.com", "id": 268649, "name":
+        "edewata@redhat.com", "partner": false, "real_name": "Endi Sukma Dewata"},
+        {"real_name": "Jean-frederic Clere", "partner": false, "name": "jclere@redhat.com",
+        "id": 207159, "email": "jclere@redhat.com", "insider": true, "active": true},
+        {"active": true, "insider": true, "email": "jmagne@redhat.com", "id": 172343,
+        "name": "jmagne@redhat.com", "partner": false, "real_name": "Jack Magne"},
+        {"active": true, "email": "mharmsen@redhat.com", "insider": true, "name":
+        "mharmsen@redhat.com", "id": 172338, "real_name": "Matthew Harmsen", "partner":
+        false}, {"real_name": "Mladen Turk", "partner": false, "name": "mturk@redhat.com",
+        "id": 203655, "email": "mturk@redhat.com", "insider": true, "active": true},
+        {"name": "peholase@redhat.com", "id": 459204, "real_name": "Petr Holasek",
+        "partner": false, "active": true, "email": "peholase@redhat.com", "insider":
+        true}, {"active": true, "email": "szappis@redhat.com", "insider": false, "name":
+        "szappis@redhat.com", "id": 415516, "real_name": "Socrates Zappis", "partner":
+        false}], "docs_contact": "", "id": 2013494, "cf_last_closed": null, "summary":
+        "openssl: sample title", "actual_time": 0, "creator_detail": {"id": 412888,
+        "name": "osoukup@redhat.com", "partner": false, "real_name": "Ondrej Soukup",
+        "active": true, "email": "osoukup@redhat.com", "insider": true}, "assigned_to_detail":
+        {"partner": false, "real_name": "Nobody", "id": 29451, "name": "nobody@redhat.com",
+        "insider": false, "email": "nobody@redhat.com", "active": true}, "whiteboard":
+        "", "cf_internal_whiteboard": "", "cf_release_notes": "", "blocks": [2013606],
+        "cf_major_incident": null, "comments": [{"text": "triage", "id": 15574231,
+        "is_private": false, "bug_id": 2013494, "count": 0, "time": "2023-06-07T07:02:07Z",
+        "private_groups": [], "attachment_id": null, "creator": "osoukup@redhat.com",
+        "creation_time": "2023-06-07T07:02:07Z", "tags": [], "creator_id": 412888},
+        {"tags": [], "creator_id": 412888, "creation_time": "2023-06-08T14:03:51Z",
+        "attachment_id": null, "time": "2023-06-08T14:03:51Z", "private_groups": [],
+        "creator": "osoukup@redhat.com", "count": 17, "bug_id": 2013494, "is_private":
+        false, "text": "test", "id": 15575051}], "keywords": ["Security"], "is_cc_accessible":
+        true, "cf_srtnotes": "{\"affects\": [{\"affectedness\": \"affected\", \"cvss2\":
+        null, \"cvss3\": null, \"impact\": null, \"ps_component\": \"openssl\", \"ps_module\":
+        \"rhcertification-6\", \"resolution\": \"fix\"}], \"impact\": \"important\",
+        \"jira_trackers\": [], \"public\": \"2023-06-07T07:01:00Z\", \"reported\":
+        \"2023-06-07\", \"source\": \"customer\"}", "data_category": "Public", "cc":
+        ["cfu@redhat.com", "csutherl@redhat.com", "dsirrine@redhat.com", "edewata@redhat.com",
+        "jclere@redhat.com", "jmagne@redhat.com", "mharmsen@redhat.com", "mturk@redhat.com",
+        "peholase@redhat.com", "szappis@redhat.com"], "cf_devel_whiteboard": "", "cf_fixed_in":
+        "", "target_milestone": "---", "creation_time": "2023-06-07T07:02:07Z", "component":
+        ["vulnerability"], "product": "Security Response", "sub_components": {}, "cf_embargoed":
+        null, "external_bugs": [], "tags": [], "assigned_to": "nobody@redhat.com",
+        "cf_build_id": "", "version": ["unspecified"], "cf_pgm_internal": "", "depends_on":
+        [2018651], "cf_qe_conditional_nak": [], "last_change_time": "2023-10-11T15:48:03Z",
+        "remaining_time": 0, "cf_conditional_nak": [], "target_release": ["---"],
+        "cf_qa_whiteboard": "", "resolution": ""}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Security-Policy:
+      - frame-ancestors 'self' bugzilla.redhat.com
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 11 Oct 2023 15:50:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-frame-options:
+      - ALLOW-FROM=https://bugzilla.redhat.com/
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '12336'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1697039452.8681d30
+      x-rh-edge-request-id:
+      - 8681d30
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2013494
+  response:
+    body:
+      string: '{"offset": 0, "limit": "20", "bugs": [{"cf_last_closed": null, "resolution":
+        "", "classification": "Other", "comments": [{"creator": "osoukup@redhat.com",
+        "creation_time": "2023-06-07T07:02:07Z", "bug_id": 2013494, "tags": [], "time":
+        "2023-06-07T07:02:07Z", "is_private": false, "id": 15574231, "private_groups":
+        [], "text": "triage", "count": 0, "creator_id": 412888, "attachment_id": null},
+        {"time": "2023-06-08T14:03:51Z", "tags": [], "creation_time": "2023-06-08T14:03:51Z",
+        "creator": "osoukup@redhat.com", "bug_id": 2013494, "attachment_id": null,
+        "creator_id": 412888, "text": "test", "count": 17, "is_private": false, "id":
+        15575051, "private_groups": []}], "data_category": "Public", "url": "", "cf_fixed_in":
+        "", "cf_devel_whiteboard": "", "keywords": ["Security"], "target_release":
+        ["---"], "estimated_time": 0, "alias": [], "cf_clone_of": null, "cf_environment":
+        "", "cc": ["cfu@redhat.com", "csutherl@redhat.com", "dsirrine@redhat.com",
+        "edewata@redhat.com", "jclere@redhat.com", "jmagne@redhat.com", "mharmsen@redhat.com",
+        "mturk@redhat.com", "peholase@redhat.com", "szappis@redhat.com"], "docs_contact":
+        "", "dupe_of": null, "qa_contact": "", "is_cc_accessible": true, "cf_pgm_internal":
+        "", "is_open": true, "platform": "All", "flags": [{"id": 5222989, "setter":
+        "osoukup@redhat.com", "name": "requires_doc_text", "status": "?", "is_active":
+        1, "type_id": 415, "modification_date": "2023-06-07T07:02:07Z", "creation_date":
+        "2023-06-07T07:02:07Z"}], "whiteboard": "", "cf_release_notes": "", "creator":
+        "osoukup@redhat.com", "cf_embargoed": null, "cf_srtnotes": "{\"affects\":
+        [{\"affectedness\": \"affected\", \"cvss2\": null, \"cvss3\": null, \"impact\":
+        null, \"ps_component\": \"openssl\", \"ps_module\": \"rhcertification-6\",
         \"resolution\": \"fix\"}], \"impact\": \"important\", \"jira_trackers\": [],
         \"public\": \"2023-06-07T07:01:00Z\", \"reported\": \"2023-06-07\", \"source\":
-        \"customer\"}", "deadline": null, "last_change_time": "2023-09-04T15:05:15Z",
-        "remaining_time": 0, "actual_time": 0, "status": "NEW", "version": ["unspecified"],
-        "id": 2013494, "flags": [{"type_id": 415, "status": "?", "id": 5222989, "creation_date":
-        "2023-06-07T07:02:07Z", "is_active": 1, "modification_date": "2023-06-07T07:02:07Z",
-        "setter": "osoukup@redhat.com", "name": "requires_doc_text"}], "keywords":
-        ["Security"], "cf_last_closed": null, "is_creator_accessible": true, "resolution":
-        "", "target_release": ["---"], "depends_on": [2017145, 2017146, 2017147, 2017148,
-        2017149], "summary": "openssl: sample title", "cf_devel_whiteboard": "", "cf_major_incident":
-        null, "cf_clone_of": null, "cf_pgm_internal": "", "blocks": [2013606], "whiteboard":
-        "", "external_bugs": [], "target_milestone": "---", "estimated_time": 0}]}'
+        \"customer\"}", "external_bugs": [], "creator_detail": {"partner": false,
+        "active": true, "insider": true, "id": 412888, "email": "osoukup@redhat.com",
+        "name": "osoukup@redhat.com", "real_name": "Ondrej Soukup"}, "product": "Security
+        Response", "cf_qe_conditional_nak": [], "cf_conditional_nak": [], "severity":
+        "high", "sub_components": {}, "groups": [], "assigned_to_detail": {"name":
+        "nobody@redhat.com", "real_name": "Nobody", "partner": false, "insider": false,
+        "active": true, "id": 29451, "email": "nobody@redhat.com"}, "is_confirmed":
+        true, "cf_doc_type": "If docs needed, set a value", "deadline": null, "cf_internal_whiteboard":
+        "", "creation_time": "2023-06-07T07:02:07Z", "cc_detail": [{"partner": false,
+        "id": 172340, "email": "cfu@redhat.com", "insider": true, "active": true,
+        "real_name": "Christina Fu", "name": "cfu@redhat.com"}, {"name": "csutherl@redhat.com",
+        "real_name": "Coty Sutherland", "insider": true, "active": true, "email":
+        "csutherl@redhat.com", "id": 323620, "partner": false}, {"name": "dsirrine@redhat.com",
+        "real_name": "David Sirrine", "partner": false, "active": true, "insider":
+        true, "id": 328816, "email": "dsirrine@redhat.com"}, {"active": true, "insider":
+        true, "id": 268649, "email": "edewata@redhat.com", "partner": false, "name":
+        "edewata@redhat.com", "real_name": "Endi Sukma Dewata"}, {"real_name": "Jean-frederic
+        Clere", "name": "jclere@redhat.com", "email": "jclere@redhat.com", "id": 207159,
+        "insider": true, "active": true, "partner": false}, {"partner": false, "insider":
+        true, "active": true, "email": "jmagne@redhat.com", "id": 172343, "name":
+        "jmagne@redhat.com", "real_name": "Jack Magne"}, {"real_name": "Matthew Harmsen",
+        "name": "mharmsen@redhat.com", "email": "mharmsen@redhat.com", "id": 172338,
+        "insider": true, "active": true, "partner": false}, {"real_name": "Mladen
+        Turk", "name": "mturk@redhat.com", "partner": false, "id": 203655, "email":
+        "mturk@redhat.com", "active": true, "insider": true}, {"active": true, "insider":
+        true, "email": "peholase@redhat.com", "id": 459204, "partner": false, "name":
+        "peholase@redhat.com", "real_name": "Petr Holasek"}, {"real_name": "Socrates
+        Zappis", "name": "szappis@redhat.com", "partner": false, "id": 415516, "email":
+        "szappis@redhat.com", "active": true, "insider": false}], "description": "triage",
+        "component": ["vulnerability"], "depends_on": [2018651], "cf_major_incident":
+        null, "blocks": [2013606], "last_change_time": "2023-10-11T15:48:03Z", "cf_build_id":
+        "", "summary": "openssl: sample title", "cf_pm_score": "0", "is_creator_accessible":
+        true, "cf_qa_whiteboard": "", "remaining_time": 0, "tags": [], "op_sys": "Linux",
+        "version": ["unspecified"], "status": "NEW", "cf_cust_facing": "---", "assigned_to":
+        "nobody@redhat.com", "id": 2013494, "priority": "high", "actual_time": 0,
+        "target_milestone": "---"}], "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -413,7 +528,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:17 GMT
+      - Wed, 11 Oct 2023 15:50:53 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -425,125 +540,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '11684'
+      - '12336'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693840097.310e31a0
+      - 0.7df06e68.1697039453.8681e92
       x-rh-edge-request-id:
-      - 310e31a0
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2013494
-  response:
-    body:
-      string: '{"offset": 0, "limit": "20", "bugs": [{"status": "NEW", "creator_detail":
-        {"id": 412888, "email": "osoukup@redhat.com", "name": "osoukup@redhat.com",
-        "insider": true, "real_name": "Ondrej Soukup", "active": true, "partner":
-        false}, "version": ["unspecified"], "cf_devel_whiteboard": "", "severity":
-        "high", "classification": "Other", "estimated_time": 0, "url": "", "is_confirmed":
-        true, "priority": "high", "keywords": ["Security"], "cf_last_closed": null,
-        "whiteboard": "", "is_open": true, "is_creator_accessible": true, "blocks":
-        [2013606], "depends_on": [2017145, 2017146, 2017147, 2017148, 2017149], "creation_time":
-        "2023-06-07T07:02:07Z", "is_cc_accessible": true, "qa_contact": "", "tags":
-        [], "cf_pm_score": "0", "cf_release_notes": "", "description": "triage", "resolution":
-        "", "creator": "osoukup@redhat.com", "cf_srtnotes": "{\"affects\": [{\"affectedness\":
-        \"affected\", \"cvss2\": null, \"cvss3\": null, \"impact\": null, \"ps_component\":
-        \"openssl\", \"ps_module\": \"rhcertification-6\", \"resolution\": \"fix\"}],
-        \"impact\": \"important\", \"jira_trackers\": [], \"public\": \"2023-06-07T07:01:00Z\",
-        \"reported\": \"2023-06-07\", \"source\": \"customer\"}", "actual_time": 0,
-        "cf_internal_whiteboard": "", "deadline": null, "cf_major_incident": null,
-        "target_milestone": "---", "platform": "All", "docs_contact": "", "assigned_to_detail":
-        {"active": true, "partner": false, "insider": false, "real_name": "Nobody",
-        "name": "nobody@redhat.com", "id": 29451, "email": "nobody@redhat.com"}, "op_sys":
-        "Linux", "cf_embargoed": null, "cf_doc_type": "If docs needed, set a value",
-        "flags": [{"name": "requires_doc_text", "setter": "osoukup@redhat.com", "creation_date":
-        "2023-06-07T07:02:07Z", "id": 5222989, "is_active": 1, "type_id": 415, "status":
-        "?", "modification_date": "2023-06-07T07:02:07Z"}], "product": "Security Response",
-        "data_category": "Public", "assigned_to": "nobody@redhat.com", "cf_clone_of":
-        null, "id": 2013494, "external_bugs": [], "cc_detail": [{"real_name": "Christina
-        Fu", "insider": true, "active": true, "partner": false, "email": "cfu@redhat.com",
-        "id": 172340, "name": "cfu@redhat.com"}, {"insider": true, "real_name": "Coty
-        Sutherland", "partner": false, "active": true, "email": "csutherl@redhat.com",
-        "id": 323620, "name": "csutherl@redhat.com"}, {"active": true, "partner":
-        false, "insider": true, "real_name": "David Sirrine", "name": "dsirrine@redhat.com",
-        "email": "dsirrine@redhat.com", "id": 328816}, {"partner": false, "active":
-        true, "insider": true, "real_name": "Endi Sukma Dewata", "name": "edewata@redhat.com",
-        "email": "edewata@redhat.com", "id": 268649}, {"id": 207159, "email": "jclere@redhat.com",
-        "name": "jclere@redhat.com", "insider": true, "real_name": "Jean-frederic
-        Clere", "active": true, "partner": false}, {"email": "jmagne@redhat.com",
-        "id": 172343, "name": "jmagne@redhat.com", "real_name": "Jack Magne", "insider":
-        true, "partner": false, "active": true}, {"real_name": "Matthew Harmsen",
-        "insider": true, "active": true, "partner": false, "email": "mharmsen@redhat.com",
-        "id": 172338, "name": "mharmsen@redhat.com"}, {"name": "mturk@redhat.com",
-        "id": 203655, "email": "mturk@redhat.com", "partner": false, "active": true,
-        "real_name": "Mladen Turk", "insider": true}, {"id": 459204, "email": "peholase@redhat.com",
-        "name": "peholase@redhat.com", "insider": true, "real_name": "Petr Holasek",
-        "active": true, "partner": false}, {"active": true, "partner": false, "insider":
-        false, "real_name": "Socrates Zappis", "name": "szappis@redhat.com", "email":
-        "szappis@redhat.com", "id": 415516}], "last_change_time": "2023-09-04T15:05:15Z",
-        "cc": ["cfu@redhat.com", "csutherl@redhat.com", "dsirrine@redhat.com", "edewata@redhat.com",
-        "jclere@redhat.com", "jmagne@redhat.com", "mharmsen@redhat.com", "mturk@redhat.com",
-        "peholase@redhat.com", "szappis@redhat.com"], "comments": [{"creator_id":
-        412888, "creator": "osoukup@redhat.com", "tags": [], "time": "2023-06-07T07:02:07Z",
-        "bug_id": 2013494, "attachment_id": null, "count": 0, "is_private": false,
-        "text": "triage", "id": 15574231, "creation_time": "2023-06-07T07:02:07Z"},
-        {"creator_id": 412888, "time": "2023-06-08T14:03:51Z", "tags": [], "creator":
-        "osoukup@redhat.com", "count": 17, "attachment_id": null, "bug_id": 2013494,
-        "creation_time": "2023-06-08T14:03:51Z", "text": "test", "id": 15575051, "is_private":
-        false}], "cf_pgm_internal": "", "cf_conditional_nak": [], "sub_components":
-        {}, "target_release": ["---"], "cf_build_id": "", "dupe_of": null, "cf_qe_conditional_nak":
-        [], "cf_cust_facing": "---", "component": ["vulnerability"], "cf_qa_whiteboard":
-        "", "cf_fixed_in": "", "cf_environment": "", "groups": [], "summary": "openssl:
-        sample title", "alias": [], "remaining_time": 0}], "total_matches": 1}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:08:18 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '11684'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693840098.310e3548
-      x-rh-edge-request-id:
-      - 310e3548
+      - 8681e92
     status:
       code: 200
       message: OK
@@ -564,14 +567,14 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug/2013494/comment
   response:
     body:
-      string: '{"bugs": {"2013494": {"comments": [{"time": "2023-06-07T07:02:07Z",
-        "creation_time": "2023-06-07T07:02:07Z", "bug_id": 2013494, "attachment_id":
-        null, "creator": "osoukup@redhat.com", "text": "triage", "is_private": false,
-        "count": 0, "tags": [], "creator_id": 412888, "id": 15574231}, {"creation_time":
-        "2023-06-08T14:03:51Z", "bug_id": 2013494, "time": "2023-06-08T14:03:51Z",
-        "id": 15575051, "creator_id": 412888, "count": 17, "is_private": false, "text":
-        "test", "attachment_id": null, "creator": "osoukup@redhat.com", "tags": []}]}},
-        "comments": {}}'
+      string: '{"comments": {}, "bugs": {"2013494": {"comments": [{"id": 15574231,
+        "text": "triage", "is_private": false, "bug_id": 2013494, "count": 0, "creator":
+        "osoukup@redhat.com", "attachment_id": null, "time": "2023-06-07T07:02:07Z",
+        "private_groups": [], "creation_time": "2023-06-07T07:02:07Z", "creator_id":
+        412888, "tags": []}, {"creation_time": "2023-06-08T14:03:51Z", "tags": [],
+        "creator_id": 412888, "is_private": false, "bug_id": 2013494, "text": "test",
+        "id": 15575051, "private_groups": [], "time": "2023-06-08T14:03:51Z", "attachment_id":
+        null, "creator": "osoukup@redhat.com", "count": 17}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -586,7 +589,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:19 GMT
+      - Wed, 11 Oct 2023 15:50:53 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -598,13 +601,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '7820'
+      - '8504'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693840099.310e3a60
+      - 0.7df06e68.1697039453.8681f9d
       x-rh-edge-request-id:
-      - 310e3a60
+      - 8681f9d
     status:
       code: 200
       message: OK
@@ -625,11 +628,11 @@ interactions:
     uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2013606&include_fields=assigned_to&include_fields=id&include_fields=product
   response:
     body:
-      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"data_category":
-        "Security Restricted", "product": "Security Response", "id": 2013606, "assigned_to":
-        "osoukup@redhat.com", "assigned_to_detail": {"id": 412888, "real_name": "Ondrej
-        Soukup", "active": true, "email": "osoukup@redhat.com", "name": "osoukup@redhat.com",
-        "partner": false, "insider": true}}]}'
+      string: '{"offset": 0, "total_matches": 1, "bugs": [{"assigned_to_detail": {"insider":
+        true, "active": true, "id": 412888, "email": "osoukup@redhat.com", "partner":
+        false, "name": "osoukup@redhat.com", "real_name": "Ondrej Soukup"}, "data_category":
+        "Security Restricted", "id": 2013606, "product": "Security Response", "assigned_to":
+        "osoukup@redhat.com"}], "limit": "20"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -646,7 +649,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:19 GMT
+      - Wed, 11 Oct 2023 15:50:54 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -658,9 +661,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693840099.310e3ccd
+      - 0.7df06e68.1697039454.8681fe7
       x-rh-edge-request-id:
-      - 310e3ccd
+      - 8681fe7
     status:
       code: 200
       message: OK
@@ -678,140 +681,49 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017145
+    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2018651
   response:
     body:
-      string: '{"offset": 0, "limit": "20", "total_matches": 1, "bugs": [{"alias":
-        [], "remaining_time": 0, "component": ["redhat-certification"], "cf_qa_whiteboard":
-        "", "cf_cust_facing": "---", "cf_qe_conditional_nak": [], "groups": ["devel"],
-        "summary": "[Major Incident] openssl: sample title [rhcertification-6]", "cf_fixed_in":
-        "", "cf_environment": "", "sub_components": {}, "target_release": ["---"],
-        "dupe_of": null, "cf_build_id": "", "cc": [], "comments": [{"count": 0, "attachment_id":
-        null, "bug_id": 2017145, "creation_time": "2023-09-04T14:57:17Z", "id": 15643634,
-        "text": "rhcertification-6 tracking bug for openssl: see the bugs linked in
-        the \"Blocks\" field of this bug for full details of the security issue(s).\n\nThis
-        bug is never intended to be made public, please put any public notes in the
-        blocked bugs.", "is_private": false, "creator_id": 412888, "time": "2023-09-04T14:57:17Z",
-        "tags": [], "creator": "osoukup@redhat.com"}], "cf_pgm_internal": "", "cf_conditional_nak":
-        [], "external_bugs": [], "cf_clone_of": null, "id": 2017145, "last_change_time":
-        "2023-09-04T14:57:17Z", "cc_detail": [], "qa_contact_detail": {"real_name":
-        "rhcert qe", "insider": false, "partner": false, "active": false, "email":
-        "rhcert-qe@redhat.com", "id": 408554, "name": "rhcert-qe@redhat.com"}, "cf_doc_type":
-        "No Doc Update", "cf_embargoed": null, "op_sys": "Unspecified", "data_category":
-        "Engineering", "assigned_to": "jweng@redhat.com", "flags": [{"setter": "bugzilla@redhat.com",
-        "id": 5236830, "creation_date": "2023-09-04T14:57:17Z", "name": "requires_doc_text",
-        "modification_date": "2023-09-04T14:57:17Z", "status": "-", "is_active": 1,
-        "type_id": 415}], "product": "Red Hat Certification Program", "docs_contact":
-        "", "platform": "Unspecified", "assigned_to_detail": {"partner": false, "active":
-        true, "real_name": "Jianwei Weng", "insider": true, "name": "jweng@redhat.com",
-        "id": 283338, "email": "jweng@redhat.com"}, "cf_major_incident": null, "deadline":
-        null, "target_milestone": "---", "cf_partner": [], "actual_time": 0, "creator":
-        "osoukup@redhat.com", "cf_internal_whiteboard": "", "cf_release_notes": "",
-        "description": "rhcertification-6 tracking bug for openssl: see the bugs linked
+      string: '{"limit": "20", "bugs": [{"creation_time": "2023-10-11T15:48:03Z",
+        "cf_devel_whiteboard": "", "target_milestone": "---", "cf_partner": [], "cf_fixed_in":
+        "", "cf_embargoed": null, "external_bugs": [], "product": "Red Hat Certification
+        Program", "component": ["redhat-certification"], "sub_components": {}, "is_cc_accessible":
+        true, "blocks": [2013494], "comments": [{"bug_id": 2018651, "is_private":
+        false, "text": "rhcertification-6 tracking bug for openssl: see the bugs linked
         in the \"Blocks\" field of this bug for full details of the security issue(s).\n\nThis
         bug is never intended to be made public, please put any public notes in the
-        blocked bugs.", "resolution": "", "tags": [], "qa_contact": "rhcert-qe@redhat.com",
-        "is_cc_accessible": true, "cf_pm_score": "0", "creation_time": "2023-09-04T14:57:17Z",
-        "cf_target_upstream_version": "", "is_creator_accessible": true, "is_open":
-        true, "cf_last_closed": null, "whiteboard": "", "keywords": ["Security", "SecurityTracking"],
-        "blocks": [2013494], "depends_on": [], "classification": "Red Hat", "estimated_time":
-        0, "severity": "high", "cf_devel_whiteboard": "", "url": "", "is_confirmed":
-        true, "priority": "high", "status": "NEW", "cf_verified": [], "version": ["1.0"],
-        "creator_detail": {"name": "osoukup@redhat.com", "email": "osoukup@redhat.com",
-        "id": 412888, "partner": false, "active": true, "insider": true, "real_name":
-        "Ondrej Soukup"}}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:08:20 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2905'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693840100.310e4045
-      x-rh-edge-request-id:
-      - 310e4045
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017146
-  response:
-    body:
-      string: '{"offset": 0, "bugs": [{"cf_doc_type": "No Doc Update", "op_sys": "Unspecified",
-        "cf_embargoed": null, "data_category": "Engineering", "assigned_to": "jweng@redhat.com",
-        "flags": [{"creation_date": "2023-09-04T15:00:00Z", "id": 5236831, "setter":
-        "bugzilla@redhat.com", "name": "requires_doc_text", "modification_date": "2023-09-04T15:00:00Z",
-        "status": "-", "type_id": 415, "is_active": 1}], "product": "Red Hat Certification
-        Program", "external_bugs": [], "id": 2017146, "cf_clone_of": null, "last_change_time":
-        "2023-09-04T15:00:00Z", "cc_detail": [], "qa_contact_detail": {"email": "rhcert-qe@redhat.com",
-        "id": 408554, "name": "rhcert-qe@redhat.com", "insider": false, "real_name":
-        "rhcert qe", "active": false, "partner": false}, "docs_contact": "", "platform":
-        "Unspecified", "assigned_to_detail": {"name": "jweng@redhat.com", "email":
-        "jweng@redhat.com", "id": 283338, "partner": false, "active": true, "real_name":
-        "Jianwei Weng", "insider": true}, "component": ["redhat-certification"], "cf_qa_whiteboard":
-        "", "cf_cust_facing": "---", "cf_qe_conditional_nak": [], "groups": ["devel"],
-        "summary": "openssl: sample title [rhcertification-6]", "cf_fixed_in": "",
-        "cf_environment": "", "alias": [], "remaining_time": 0, "comments": [{"time":
-        "2023-09-04T15:00:00Z", "tags": [], "creator": "osoukup@redhat.com", "creator_id":
-        412888, "creation_time": "2023-09-04T15:00:00Z", "is_private": false, "id":
-        15643635, "text": "rhcertification-6 tracking bug for openssl: see the bugs
-        linked in the \"Blocks\" field of this bug for full details of the security
-        issue(s).\n\nThis bug is never intended to be made public, please put any
-        public notes in the blocked bugs.", "bug_id": 2017146, "count": 0, "attachment_id":
-        null}], "cc": [], "cf_pgm_internal": "", "cf_conditional_nak": [], "sub_components":
-        {}, "target_release": ["---"], "dupe_of": null, "cf_build_id": "", "is_open":
-        true, "is_creator_accessible": true, "keywords": ["Security", "SecurityTracking"],
-        "whiteboard": "", "cf_last_closed": null, "blocks": [2013494], "depends_on":
-        [], "creation_time": "2023-09-04T15:00:00Z", "cf_target_upstream_version":
-        "", "status": "NEW", "cf_verified": [], "creator_detail": {"name": "osoukup@redhat.com",
-        "email": "osoukup@redhat.com", "id": 412888, "partner": false, "active": true,
-        "real_name": "Ondrej Soukup", "insider": true}, "version": ["1.0"], "classification":
-        "Red Hat", "estimated_time": 0, "severity": "high", "cf_devel_whiteboard":
-        "", "url": "", "priority": "high", "is_confirmed": true, "actual_time": 0,
-        "creator": "osoukup@redhat.com", "cf_internal_whiteboard": "", "deadline":
-        null, "cf_major_incident": null, "target_milestone": "---", "cf_partner":
-        [], "tags": [], "qa_contact": "rhcert-qe@redhat.com", "is_cc_accessible":
-        true, "cf_pm_score": "0", "description": "rhcertification-6 tracking bug for
+        blocked bugs.", "id": 15671700, "private_groups": [], "attachment_id": null,
+        "time": "2023-10-11T15:48:03Z", "creator": "osoukup@redhat.com", "count":
+        0, "creation_time": "2023-10-11T15:48:03Z", "tags": [], "creator_id": 412888}],
+        "cf_major_incident": null, "keywords": ["Security", "SecurityTracking"], "cc":
+        [], "data_category": "Engineering", "remaining_time": 0, "cf_conditional_nak":
+        [], "cf_qe_conditional_nak": [], "last_change_time": "2023-10-11T15:50:49Z",
+        "resolution": "", "target_release": ["---"], "cf_qa_whiteboard": "", "cf_build_id":
+        "", "version": ["1.0"], "tags": [], "assigned_to": "jweng@redhat.com", "cf_pgm_internal":
+        "", "depends_on": [], "classification": "Red Hat", "flags": [{"name": "requires_doc_text",
+        "modification_date": "2023-10-11T15:48:03Z", "is_active": 1, "id": 5241544,
+        "setter": "bugzilla@redhat.com", "status": "-", "creation_date": "2023-10-11T15:48:03Z",
+        "type_id": 415}], "cf_clone_of": null, "alias": [], "is_creator_accessible":
+        true, "cf_environment": "", "deadline": null, "dupe_of": null, "status": "NEW",
+        "cf_doc_type": "No Doc Update", "is_confirmed": true, "cf_verified": [], "platform":
+        "Unspecified", "url": "", "description": "rhcertification-6 tracking bug for
         openssl: see the bugs linked in the \"Blocks\" field of this bug for full
         details of the security issue(s).\n\nThis bug is never intended to be made
-        public, please put any public notes in the blocked bugs.", "cf_release_notes":
-        "", "resolution": ""}], "total_matches": 1, "limit": "20"}'
+        public, please put any public notes in the blocked bugs.", "cf_cust_facing":
+        "---", "creator": "osoukup@redhat.com", "actual_time": 0, "creator_detail":
+        {"partner": false, "real_name": "Ondrej Soukup", "id": 412888, "name": "osoukup@redhat.com",
+        "email": "osoukup@redhat.com", "insider": true, "active": true}, "cf_last_closed":
+        null, "summary": "CVE-2020-0000 openssl: CVE-2020-0000 kernel: some description
+        [rhcertification-6]", "cf_release_notes": "", "cf_internal_whiteboard": "",
+        "cf_target_upstream_version": "", "assigned_to_detail": {"id": 283338, "name":
+        "jweng@redhat.com", "partner": false, "real_name": "Jianwei Weng", "active":
+        true, "email": "jweng@redhat.com", "insider": true}, "whiteboard": "", "cf_pm_score":
+        "0", "severity": "high", "qa_contact": "rhcert-qe@redhat.com", "groups": ["devel"],
+        "priority": "high", "estimated_time": 0, "is_open": true, "id": 2018651, "qa_contact_detail":
+        {"email": "rhcert-qe@redhat.com", "insider": false, "active": false, "partner":
+        false, "real_name": "rhcert qe", "id": 408554, "name": "rhcert-qe@redhat.com"},
+        "op_sys": "Unspecified", "docs_contact": "", "cc_detail": []}], "total_matches":
+        1, "offset": 0}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -826,7 +738,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 04 Sep 2023 15:08:21 GMT
+      - Wed, 11 Oct 2023 15:50:55 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -838,289 +750,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2888'
+      - '2948'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1693840101.310e43de
+      - 0.7df06e68.1697039455.86820aa
       x-rh-edge-request-id:
-      - 310e43de
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017147
-  response:
-    body:
-      string: '{"offset": 0, "limit": "20", "total_matches": 1, "bugs": [{"description":
-        "rhcertification-6 tracking bug for openssl: see the bugs linked in the \"Blocks\"
-        field of this bug for full details of the security issue(s).\n\nThis bug is
-        never intended to be made public, please put any public notes in the blocked
-        bugs.", "cf_release_notes": "", "resolution": "", "qa_contact": "rhcert-qe@redhat.com",
-        "is_cc_accessible": true, "tags": [], "cf_pm_score": "0", "cf_major_incident":
-        null, "deadline": null, "target_milestone": "---", "cf_partner": [], "creator":
-        "osoukup@redhat.com", "actual_time": 0, "cf_internal_whiteboard": "", "cf_devel_whiteboard":
-        "", "severity": "high", "classification": "Red Hat", "estimated_time": 0,
-        "url": "", "is_confirmed": true, "priority": "high", "status": "NEW", "version":
-        ["1.0"], "creator_detail": {"active": true, "partner": false, "real_name":
-        "Ondrej Soukup", "insider": true, "name": "osoukup@redhat.com", "email": "osoukup@redhat.com",
-        "id": 412888}, "cf_verified": [], "creation_time": "2023-09-04T15:04:19Z",
-        "cf_target_upstream_version": "", "keywords": ["Security", "SecurityTracking"],
-        "whiteboard": "", "cf_last_closed": null, "is_open": true, "is_creator_accessible":
-        true, "blocks": [2013494], "depends_on": [], "sub_components": {}, "target_release":
-        ["---"], "cf_build_id": "", "dupe_of": null, "cc": [], "comments": [{"tags":
-        [], "time": "2023-09-04T15:04:19Z", "creator": "osoukup@redhat.com", "creator_id":
-        412888, "creation_time": "2023-09-04T15:04:19Z", "id": 15643637, "text": "rhcertification-6
-        tracking bug for openssl: see the bugs linked in the \"Blocks\" field of this
-        bug for full details of the security issue(s).\n\nThis bug is never intended
-        to be made public, please put any public notes in the blocked bugs.", "is_private":
-        false, "attachment_id": null, "count": 0, "bug_id": 2017147}], "cf_pgm_internal":
-        "", "cf_conditional_nak": [], "alias": [], "remaining_time": 0, "cf_cust_facing":
-        "---", "cf_qe_conditional_nak": [], "component": ["redhat-certification"],
-        "cf_qa_whiteboard": "", "cf_fixed_in": "", "cf_environment": "", "groups":
-        ["devel"], "summary": "[Major Incident] openssl: sample title [rhcertification-6]",
-        "platform": "Unspecified", "docs_contact": "", "assigned_to_detail": {"name":
-        "jweng@redhat.com", "id": 283338, "email": "jweng@redhat.com", "partner":
-        false, "active": true, "insider": true, "real_name": "Jianwei Weng"}, "cf_clone_of":
-        null, "id": 2017147, "external_bugs": [], "cc_detail": [], "qa_contact_detail":
-        {"active": false, "partner": false, "insider": false, "real_name": "rhcert
-        qe", "name": "rhcert-qe@redhat.com", "email": "rhcert-qe@redhat.com", "id":
-        408554}, "last_change_time": "2023-09-04T15:04:19Z", "op_sys": "Unspecified",
-        "cf_embargoed": null, "cf_doc_type": "No Doc Update", "flags": [{"is_active":
-        1, "type_id": 415, "modification_date": "2023-09-04T15:04:19Z", "status":
-        "-", "setter": "bugzilla@redhat.com", "id": 5236832, "creation_date": "2023-09-04T15:04:19Z",
-        "name": "requires_doc_text"}], "product": "Red Hat Certification Program",
-        "data_category": "Engineering", "assigned_to": "jweng@redhat.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:08:23 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2905'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693840103.310e489f
-      x-rh-edge-request-id:
-      - 310e489f
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017148
-  response:
-    body:
-      string: '{"bugs": [{"platform": "Unspecified", "remaining_time": 0, "docs_contact":
-        "", "deadline": null, "last_change_time": "2023-09-04T15:04:40Z", "cf_environment":
-        "", "cf_qa_whiteboard": "", "cf_pm_score": "0", "is_cc_accessible": true,
-        "cf_build_id": "", "cf_verified": [], "groups": ["devel"], "cf_major_incident":
-        null, "cf_clone_of": null, "blocks": [2013494], "whiteboard": "", "cf_pgm_internal":
-        "", "resolution": "", "is_creator_accessible": true, "summary": "openssl:
-        sample title [rhcertification-6]", "cf_devel_whiteboard": "", "target_release":
-        ["---"], "depends_on": [], "target_milestone": "---", "cf_partner": [], "estimated_time":
-        0, "external_bugs": [], "id": 2017148, "status": "NEW", "version": ["1.0"],
-        "flags": [{"name": "requires_doc_text", "setter": "bugzilla@redhat.com", "modification_date":
-        "2023-09-04T15:04:40Z", "is_active": 1, "id": 5236833, "creation_date": "2023-09-04T15:04:40Z",
-        "status": "-", "type_id": 415}], "actual_time": 0, "cf_last_closed": null,
-        "keywords": ["Security", "SecurityTracking"], "tags": [], "assigned_to": "jweng@redhat.com",
-        "creation_time": "2023-09-04T15:04:40Z", "description": "rhcertification-6
-        tracking bug for openssl: see the bugs linked in the \"Blocks\" field of this
-        bug for full details of the security issue(s).\n\nThis bug is never intended
-        to be made public, please put any public notes in the blocked bugs.", "url":
-        "", "qa_contact": "rhcert-qe@redhat.com", "data_category": "Engineering",
-        "cf_doc_type": "No Doc Update", "product": "Red Hat Certification Program",
-        "cf_target_upstream_version": "", "cf_qe_conditional_nak": [], "severity":
-        "urgent", "creator_detail": {"email": "osoukup@redhat.com", "active": true,
-        "real_name": "Ondrej Soukup", "id": 412888, "insider": true, "partner": false,
-        "name": "osoukup@redhat.com"}, "qa_contact_detail": {"insider": false, "partner":
-        false, "name": "rhcert-qe@redhat.com", "real_name": "rhcert qe", "active":
-        false, "email": "rhcert-qe@redhat.com", "id": 408554}, "comments": [{"bug_id":
-        2017148, "creation_time": "2023-09-04T15:04:40Z", "time": "2023-09-04T15:04:40Z",
-        "creator_id": 412888, "id": 15643638, "tags": [], "attachment_id": null, "creator":
-        "osoukup@redhat.com", "text": "rhcertification-6 tracking bug for openssl:
-        see the bugs linked in the \"Blocks\" field of this bug for full details of
-        the security issue(s).\n\nThis bug is never intended to be made public, please
-        put any public notes in the blocked bugs.", "is_private": false, "count":
-        0}], "classification": "Red Hat", "cf_conditional_nak": [], "component": ["redhat-certification"],
-        "cf_cust_facing": "---", "op_sys": "Unspecified", "cc_detail": [], "is_confirmed":
-        true, "cf_release_notes": "", "is_open": true, "dupe_of": null, "priority":
-        "urgent", "assigned_to_detail": {"email": "jweng@redhat.com", "active": true,
-        "real_name": "Jianwei Weng", "id": 283338, "insider": true, "partner": false,
-        "name": "jweng@redhat.com"}, "cc": [], "sub_components": {}, "creator": "osoukup@redhat.com",
-        "alias": [], "cf_embargoed": null, "cf_internal_whiteboard": "", "cf_fixed_in":
-        ""}], "total_matches": 1, "offset": 0, "limit": "20"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:08:24 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2892'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693840104.310e4dae
-      x-rh-edge-request-id:
-      - 310e4dae
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://squid.corp.redhat.com:3128/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2017149
-  response:
-    body:
-      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"remaining_time":
-        0, "docs_contact": "", "last_change_time": "2023-09-04T15:08:15Z", "deadline":
-        null, "platform": "Unspecified", "is_cc_accessible": true, "cf_build_id":
-        "", "cf_verified": [], "groups": ["devel"], "cf_environment": "", "cf_qa_whiteboard":
-        "", "cf_pm_score": "0", "target_milestone": "---", "cf_partner": [], "estimated_time":
-        0, "external_bugs": [], "cf_clone_of": null, "cf_major_incident": null, "whiteboard":
-        "", "blocks": [2013494], "cf_pgm_internal": "", "resolution": "", "is_creator_accessible":
-        true, "cf_devel_whiteboard": "", "summary": "CVE-2020-0000 openssl: CVE-2020-0000
-        kernel: some description [rhcertification-6]", "depends_on": [], "target_release":
-        ["---"], "cf_last_closed": null, "keywords": ["Security", "SecurityTracking"],
-        "id": 2017149, "status": "NEW", "version": ["1.0"], "flags": [{"name": "requires_doc_text",
-        "setter": "bugzilla@redhat.com", "modification_date": "2023-09-04T15:05:15Z",
-        "is_active": 1, "id": 5236834, "creation_date": "2023-09-04T15:05:15Z", "status":
-        "-", "type_id": 415}], "actual_time": 0, "assigned_to": "jweng@redhat.com",
-        "creation_time": "2023-09-04T15:05:15Z", "description": "rhcertification-6
-        tracking bug for openssl: see the bugs linked in the \"Blocks\" field of this
-        bug for full details of the security issue(s).\n\nThis bug is never intended
-        to be made public, please put any public notes in the blocked bugs.", "url":
-        "", "data_category": "Engineering", "qa_contact": "rhcert-qe@redhat.com",
-        "tags": [], "creator_detail": {"active": true, "email": "osoukup@redhat.com",
-        "real_name": "Ondrej Soukup", "id": 412888, "insider": true, "name": "osoukup@redhat.com",
-        "partner": false}, "severity": "high", "qa_contact_detail": {"id": 408554,
-        "active": false, "email": "rhcert-qe@redhat.com", "real_name": "rhcert qe",
-        "partner": false, "name": "rhcert-qe@redhat.com", "insider": false}, "comments":
-        [{"creator_id": 412888, "id": 15643639, "text": "rhcertification-6 tracking
-        bug for openssl: see the bugs linked in the \"Blocks\" field of this bug for
-        full details of the security issue(s).\n\nThis bug is never intended to be
-        made public, please put any public notes in the blocked bugs.", "attachment_id":
-        null, "creator": "osoukup@redhat.com", "count": 0, "is_private": false, "tags":
-        [], "creation_time": "2023-09-04T15:05:15Z", "bug_id": 2017149, "time": "2023-09-04T15:05:15Z"}],
-        "cf_doc_type": "No Doc Update", "product": "Red Hat Certification Program",
-        "cf_target_upstream_version": "", "cf_qe_conditional_nak": [], "is_open":
-        true, "dupe_of": null, "classification": "Red Hat", "component": ["redhat-certification"],
-        "cf_conditional_nak": [], "cf_cust_facing": "---", "op_sys": "Unspecified",
-        "cc_detail": [], "is_confirmed": true, "cf_release_notes": "", "alias": [],
-        "cf_embargoed": null, "cf_internal_whiteboard": "", "cf_fixed_in": "", "assigned_to_detail":
-        {"id": 283338, "email": "jweng@redhat.com", "real_name": "Jianwei Weng", "active":
-        true, "name": "jweng@redhat.com", "partner": false, "insider": true}, "priority":
-        "high", "cc": [], "sub_components": {}, "creator": "osoukup@redhat.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Mon, 04 Sep 2023 15:08:24 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-frame-options:
-      - ALLOW-FROM=https://bugzilla.redhat.com/
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2928'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1693840104.310e50be
-      x-rh-edge-request-id:
-      - 310e50be
+      - 86820aa
     status:
       code: 200
       message: OK

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -46,7 +46,7 @@ def stage_jira_project() -> str:
 
 
 @pytest.fixture
-def test_scheme_host() -> str:
+def test_app_scheme_host() -> str:
     return "http://osidb-service:8000/trackers"
 
 
@@ -56,8 +56,8 @@ def api_version() -> str:
 
 
 @pytest.fixture
-def test_api_uri(test_scheme_host, api_version) -> str:
-    return f"{test_scheme_host}/api/{api_version}"
+def test_app_api_uri(test_app_scheme_host, api_version) -> str:
+    return f"{test_app_scheme_host}/api/{api_version}"
 
 
 @pytest.fixture

--- a/apps/trackers/tests/factories.py
+++ b/apps/trackers/tests/factories.py
@@ -1,0 +1,13 @@
+import factory
+
+from apps.trackers.models import JiraProjectFields
+
+
+class JiraProjectFieldsFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = JiraProjectFields
+
+    project_key = factory.Faker("word")
+    field_id = factory.Faker("word")
+    field_name = factory.Faker("word")
+    allowed_values = factory.List([{"name": factory.Faker("word")} for _ in range(3)])

--- a/apps/trackers/tests/test_file_offer.py
+++ b/apps/trackers/tests/test_file_offer.py
@@ -39,7 +39,13 @@ class TestTrackerSuggestions:
         ],
     )
     def test_trackers_file_offer_invalid(
-        self, affectedness, resolution, is_valid, user_token, auth_client, test_api_uri
+        self,
+        affectedness,
+        resolution,
+        is_valid,
+        user_token,
+        auth_client,
+        test_app_api_uri,
     ):
         """
         Test auto tracker auto filing defined in product
@@ -64,7 +70,7 @@ class TestTrackerSuggestions:
 
         headers = {"HTTP_JiraAuthentication": user_token}
         response = auth_client.post(
-            f"{test_api_uri}/file",
+            f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw.uuid]},
             format="json",
             **headers,
@@ -83,7 +89,9 @@ class TestTrackerSuggestions:
             assert res["not_applicable"][0]["uuid"] == str(affect.uuid)
             assert len(res["modules_components"]) == 0
 
-    def test_trackers_file_offer_embargoed(self, user_token, auth_client, test_api_uri):
+    def test_trackers_file_offer_embargoed(
+        self, user_token, auth_client, test_app_api_uri
+    ):
         """
         Test auto tracker auto filing defined in product
         definition rules related to embargo status
@@ -127,7 +135,7 @@ class TestTrackerSuggestions:
 
         headers = {"HTTP_JiraAuthentication": user_token}
         response = auth_client.post(
-            f"{test_api_uri}/file",
+            f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw.uuid, flaw_embargoed.uuid]},
             format="json",
             **headers,
@@ -142,7 +150,7 @@ class TestTrackerSuggestions:
             == "regular-stream-1"
         )
 
-    def test_trackers_file_offer_ubi(self, user_token, auth_client, test_api_uri):
+    def test_trackers_file_offer_ubi(self, user_token, auth_client, test_app_api_uri):
         """
         Test auto tracker auto filing defined in product
         definition rules related to ubi special rules
@@ -181,7 +189,7 @@ class TestTrackerSuggestions:
 
         headers = {"HTTP_JiraAuthentication": user_token}
         response = auth_client.post(
-            f"{test_api_uri}/file",
+            f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw.uuid]},
             format="json",
             **headers,
@@ -202,7 +210,9 @@ class TestTrackerSuggestions:
         )
         assert "stream-2.1" in streams_dict and streams_dict["stream-2.1"]["selected"]
 
-    def test_trackers_file_offer_unacked(self, user_token, auth_client, test_api_uri):
+    def test_trackers_file_offer_unacked(
+        self, user_token, auth_client, test_app_api_uri
+    ):
         """
         Test auto tracker auto filing defined in product
         definition rules related to unacked_ps_update_stream flag
@@ -250,7 +260,7 @@ class TestTrackerSuggestions:
 
         headers = {"HTTP_JiraAuthentication": user_token}
         response = auth_client.post(
-            f"{test_api_uri}/file",
+            f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw1.uuid, flaw2.uuid]},
             format="json",
             **headers,
@@ -296,7 +306,7 @@ class TestTrackerSuggestions:
 
         headers = {"HTTP_JiraAuthentication": user_token}
         response = auth_client.post(
-            f"{test_api_uri}/file",
+            f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw3.uuid]},
             format="json",
             **headers,

--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -4,8 +4,11 @@ tracker app integration tests
 
 import pytest
 from django.utils import timezone
+from rest_framework import status
 
+from apps.trackers.jira.query import JiraPriority
 from apps.trackers.save import TrackerSaver
+from apps.trackers.tests.factories import JiraProjectFieldsFactory
 from collectors.bzimport.collectors import FlawCollector
 from collectors.bzimport.constants import BZ_DT_FMT
 from osidb.models import Affect, Impact, Tracker
@@ -161,3 +164,331 @@ class TestTrackerSaver:
         # 7) check that the update actually happened
         assert "updated_dt" in loaded_tracker.meta_attr
         assert updated_dt != loaded_tracker.meta_attr["updated_dt"]
+
+
+class TestTrackerAPI:
+    @pytest.mark.vcr
+    def test_tracker_create_bugzilla(
+        self, auth_client, enable_bugzilla_sync, test_api_uri
+    ):
+        """
+        test the whole stack Bugzilla tracker creation
+        starting on the API and ending in Bugzilla
+        """
+        # 1) define all the context
+        ps_module = PsModuleFactory(
+            bts_name="bugzilla",
+            bts_key="Red Hat Certification Program",
+            bts_groups={"public": ["devel"]},
+            default_component="redhat-certification",
+            name="rhcertification-6",
+        )
+        ps_update_stream = PsUpdateStreamFactory(
+            name="rhcertification-6",
+            ps_module=ps_module,
+            version="1.0",
+        )
+        flaw = FlawFactory(
+            bz_id="2013494",
+            cve_id=None,
+            embargoed=False,
+            impact=Impact.IMPORTANT,
+            title="sample title",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_component="openssl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+
+        # 2) create tracker in OSIDB and Bugzilla
+        tracker_data = {
+            "affects": [affect.uuid],
+            "embargoed": flaw.embargoed,
+            "ps_update_stream": ps_update_stream.name,
+            "status": "NEW",  # this one is mandatory even though ignored in the backend query for now
+        }
+        response = auth_client.post(
+            f"{test_api_uri}/trackers",
+            tracker_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_JIRA_API_KEY="SECRET",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # 3) get the newly loaded tracker from the DB
+        assert Tracker.objects.count() == 1
+        tracker = Tracker.objects.first()
+
+        # 4) check the correct result of the creation and loading
+        assert tracker.bz_id
+        assert not tracker.embargoed
+        assert tracker.type == Tracker.TrackerType.BUGZILLA
+        assert tracker.ps_update_stream == "rhcertification-6"
+        assert tracker.status == "NEW"
+        assert not tracker.resolution
+        assert tracker.affects.count() == 1
+        assert tracker.affects.first() == affect
+        assert not tracker._alerts
+
+    @pytest.mark.vcr
+    def test_tracker_update_bugzilla(
+        self, auth_client, enable_bugzilla_sync, test_api_uri
+    ):
+        """
+        test the whole stack Bugzilla tracker update
+        starting on the API and ending in Bugzilla
+        """
+        # 1) define all the context
+        ps_module = PsModuleFactory(
+            bts_name="bugzilla",
+            bts_key="Red Hat Certification Program",
+            bts_groups={"public": ["devel"]},
+            default_component="redhat-certification",
+            name="rhcertification-6",
+        )
+        ps_update_stream1 = PsUpdateStreamFactory(
+            name="rhcertification-6",
+            ps_module=ps_module,
+            version="1.0",
+        )
+        ps_update_stream2 = PsUpdateStreamFactory(
+            name="rhcertification-6-default",
+            ps_module=ps_module,
+            version="1.0",
+        )
+        flaw = FlawFactory(
+            bz_id="2013494",
+            embargoed=False,
+            impact=Impact.IMPORTANT,
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_component="openssl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+        )
+
+        # 2) define a tracker model instance
+        #    according an exising Bugzilla tracker
+        tracker_id = "2017676"
+        updated_dt = "2023-09-13T08:34:21Z"
+        tracker = TrackerFactory(
+            affects=[affect],
+            bz_id=tracker_id,
+            embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream1.name,
+            type=Tracker.TrackerType.BUGZILLA,
+            meta_attr={"blocks": ["2013494"], "updated_dt": updated_dt},
+            updated_dt=timezone.datetime.strptime(updated_dt, BZ_DT_FMT),
+        )
+
+        # 3) update tracker in OSIDB and Bugzilla
+        tracker_data = {
+            "affects": [affect.uuid],
+            "embargoed": flaw.embargoed,
+            "ps_update_stream": ps_update_stream2.name,  # new value
+            "status": "NEW",  # this one is mandatory even though ignored in the backend query for now
+            "updated_dt": updated_dt,
+        }
+        response = auth_client.put(
+            f"{test_api_uri}/trackers/{tracker.uuid}",
+            tracker_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_JIRA_API_KEY="SECRET",
+        )
+        assert response.status_code == 200
+
+        # 4) get the newly loaded tracker from the DB
+        tracker = Tracker.objects.get(external_system_id=tracker_id)
+
+        # 5) check the correct result of the update and loading
+        assert tracker.bz_id == tracker_id
+        assert not tracker.embargoed
+        assert tracker.type == Tracker.TrackerType.BUGZILLA
+        assert tracker.ps_update_stream == ps_update_stream2.name
+        assert tracker.status == "NEW"
+        assert not tracker.resolution
+        assert tracker.affects.count() == 1
+        assert tracker.affects.first() == affect
+        assert not tracker._alerts
+
+        # 6) check that the update actually happened
+        assert "updated_dt" in tracker.meta_attr
+        assert updated_dt != tracker.meta_attr["updated_dt"]
+
+    @pytest.mark.vcr
+    def test_tracker_create_jira(self, auth_client, enable_jira_sync, test_api_uri):
+        """
+        test the whole stack Jira tracker creation
+        starting on the API and ending in Jira
+        """
+        # 1) define all the context
+        ps_module = PsModuleFactory(
+            bts_name="jboss",
+            bts_key="OSIDB",
+            bts_groups={"public": []},
+            default_component="Security",
+            name="openshift-4",
+        )
+        ps_update_stream = PsUpdateStreamFactory(
+            name="openshift-4.8.z",
+            ps_module=ps_module,
+            version="4.8",
+        )
+        flaw = FlawFactory(
+            bz_id="1997880",
+            cve_id=None,
+            embargoed=False,
+            impact=Impact.LOW,
+            title="sample title",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_component="openshift",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            impact=flaw.impact,
+        )
+        JiraProjectFieldsFactory(
+            project_key="OSIDB",
+            field_id="priority",
+            allowed_values=[
+                {"name": JiraPriority.MINOR},
+            ],
+        )
+
+        # 2) create tracker in OSIDB and Bugzilla
+        tracker_data = {
+            "affects": [affect.uuid],
+            "embargoed": flaw.embargoed,
+            "ps_update_stream": ps_update_stream.name,
+            "status": "New",  # this one is mandatory even though ignored in the backend query for now
+        }
+        response = auth_client.post(
+            f"{test_api_uri}/trackers",
+            tracker_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_JIRA_API_KEY="SECRET",
+        )
+
+        assert response.status_code == status.HTTP_201_CREATED
+
+        # 3) get the newly loaded tracker from the DB
+        assert Tracker.objects.count() == 1
+        tracker = Tracker.objects.first()
+
+        # 4) check the correct result of the creation and loading
+        assert tracker.external_system_id
+        assert "OSIDB" in tracker.external_system_id
+        assert not tracker.embargoed
+        assert tracker.type == Tracker.TrackerType.JIRA
+        assert tracker.ps_update_stream == "openshift-4.8.z"
+        assert tracker.status == "New"
+        assert not tracker.resolution
+        assert tracker.affects.count() == 1
+        assert tracker.affects.first() == affect
+        assert not tracker._alerts
+
+    @pytest.mark.vcr
+    def test_tracker_update_jira(self, auth_client, enable_jira_sync, test_api_uri):
+        """
+        test the whole stack Jira tracker update
+        starting on the API and ending in Jira
+        """
+        # 1) define all the context
+        ps_module = PsModuleFactory(
+            bts_name="jboss",
+            bts_key="OSIDB",
+            bts_groups={"public": []},
+            default_component="Security",
+            name="openshift-4",
+        )
+        ps_update_stream1 = PsUpdateStreamFactory(
+            name="openshift-4.8.z",
+            ps_module=ps_module,
+            version="4.8",
+        )
+        ps_update_stream2 = PsUpdateStreamFactory(
+            name="openshift-4.9.z",
+            ps_module=ps_module,
+            version="4.9",
+        )
+        flaw = FlawFactory(
+            bz_id="1997880",
+            cve_id=None,
+            embargoed=False,
+            impact=Impact.LOW,
+            title="sample title",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_component="openshift",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.FIX,
+            impact=flaw.impact,
+        )
+        JiraProjectFieldsFactory(
+            project_key="OSIDB",
+            field_id="priority",
+            allowed_values=[
+                {"name": JiraPriority.MINOR},
+            ],
+        )
+
+        # 2) define a tracker model instance
+        #    according an exising Bugzilla tracker
+        tracker_id = "OSIDB-920"
+        updated_dt = "2020-01-01T00:00:00Z"  # TODO no mid-air collision detection
+        tracker = TrackerFactory(
+            affects=[affect],
+            bz_id=tracker_id,
+            embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream1.name,
+            type=Tracker.TrackerType.JIRA,
+            updated_dt=timezone.datetime.strptime(updated_dt, BZ_DT_FMT),
+        )
+
+        # 3) update tracker in OSIDB and Bugzilla
+        tracker_data = {
+            "affects": [affect.uuid],
+            "embargoed": flaw.embargoed,
+            "ps_update_stream": ps_update_stream2.name,  # new value
+            "status": "New",  # this one is mandatory even though ignored in the backend query for now
+            "updated_dt": updated_dt,
+        }
+        response = auth_client.put(
+            f"{test_api_uri}/trackers/{tracker.uuid}",
+            tracker_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_JIRA_API_KEY="SECRET",
+        )
+        assert response.status_code == 200
+
+        # 4) get the newly loaded tracker from the DB
+        tracker = Tracker.objects.get(external_system_id=tracker_id)
+
+        # 5) check the correct result of the update and loading
+        assert tracker.external_system_id == tracker_id
+        assert "OSIDB" in tracker.external_system_id
+        assert not tracker.embargoed
+        assert tracker.type == Tracker.TrackerType.JIRA
+        assert tracker.ps_update_stream == ps_update_stream2.name
+        assert tracker.status == "New"
+        assert not tracker.resolution
+        assert tracker.affects.count() == 1
+        assert tracker.affects.first() == affect
+        assert not tracker._alerts
+
+        # 6) check that the update actually happened
+        assert updated_dt != tracker.updated_dt

--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -123,8 +123,8 @@ class TestTrackerSaver:
 
         # 2) define a tracker model instance
         #    according an exising Bugzilla tracker
-        tracker_id = "2017149"
-        updated_dt = "2023-09-04T15:05:15Z"
+        tracker_id = "2018651"
+        updated_dt = "2023-10-11T15:48:03Z"
         tracker = TrackerFactory(
             affects=[affect],
             bz_id=tracker_id,

--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -360,9 +360,7 @@ class TestTrackerAPI:
         JiraProjectFieldsFactory(
             project_key="OSIDB",
             field_id="priority",
-            allowed_values=[
-                {"name": JiraPriority.MINOR},
-            ],
+            allowed_values=[JiraPriority.MINOR],
         )
 
         # 2) create tracker in OSIDB and Bugzilla
@@ -440,9 +438,7 @@ class TestTrackerAPI:
         JiraProjectFieldsFactory(
             project_key="OSIDB",
             field_id="priority",
-            allowed_values=[
-                {"name": JiraPriority.MINOR},
-            ],
+            allowed_values=[JiraPriority.MINOR],
         )
 
         # 2) define a tracker model instance

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -44,12 +44,12 @@ class TestTrackerJiraQueryBuilder:
             field_id="priority",
             field_name="Priority",
             allowed_values=[
-                {"name": "Blocker"},
-                {"name": "Critical"},
-                {"name": "Major"},
-                {"name": "Normal"},
-                {"name": "Minor"},
-                {"name": "Undefined"},
+                "Blocker",
+                "Critical",
+                "Major",
+                "Normal",
+                "Minor",
+                "Undefined",
             ],
         )
         field.save()

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -97,6 +97,46 @@ class TestTrackerJiraQueryBuilder:
         quer_builder.generate()
         validate_minimum_key_value(minimum=expected1, evaluated=quer_builder._query)
 
+    def test_generate_labels(self):
+        """
+        test that the query for the Jira labels is generated correctly
+        """
+        flaw1 = FlawFactory(cve_id="CVE-2000-2000")
+        flaw2 = FlawFactory(embargoed=flaw1.embargoed, cve_id=None)
+        ps_module = PsModuleFactory(bts_name="jboss")
+        affect1 = AffectFactory(
+            flaw=flaw1,
+            ps_module=ps_module.name,
+            ps_component="component",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+        affect2 = AffectFactory(
+            flaw=flaw2,
+            ps_module=ps_module.name,
+            ps_component="component",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+        tracker = TrackerFactory(
+            affects=[affect1, affect2],
+            type=Tracker.TrackerType.JIRA,
+            ps_update_stream=ps_update_stream.name,
+            embargoed=flaw1.is_embargoed,
+        )
+
+        query_builder = TrackerJiraQueryBuilder(tracker)
+        query_builder._query = {"fields": {}}
+        query_builder.generate_labels()
+
+        labels = query_builder.query["fields"]["labels"]
+        assert "SecurityTracking" in labels
+        assert "Security" in labels
+        assert "pscomponent:component" in labels
+        assert "CVE-2000-2000" in labels
+        assert len(labels) == 4
+
 
 def validate_minimum_key_value(minimum: Dict[str, Any], evaluated: Dict[str, Any]):
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,10 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Implement writable tracker API (OSIDB-1180)
+
 ### Fixed
 - Fix incorrect type bool of is_up2date field in
   /collectors/api/v1/status endpoint
-
 
 ## [3.5.0] - 2023-10-09
 ### Added

--- a/openapi.yml
+++ b/openapi.yml
@@ -6283,6 +6283,56 @@ paths:
                     version:
                       type: string
           description: ''
+    post:
+      operationId: osidb_api_v1_trackers_create
+      parameters:
+      - in: header
+        name: Bugzilla-Api-Key
+        schema:
+          type: string
+        description: User generated api key for Bugzilla authentication.
+        required: true
+      - in: header
+        name: Jira-Api-Key
+        schema:
+          type: string
+        description: User generated api key for Jira authentication.
+        required: true
+      tags:
+      - osidb
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TrackerPost'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/TrackerPost'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/TrackerPost'
+        required: true
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/Tracker'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
   /osidb/api/v1/trackers/{uuid}:
     get:
       operationId: osidb_api_v1_trackers_retrieve
@@ -6329,6 +6379,63 @@ paths:
       security:
       - OsidbTokenAuthentication: []
       - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/Tracker'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+    put:
+      operationId: osidb_api_v1_trackers_update
+      parameters:
+      - in: header
+        name: Bugzilla-Api-Key
+        schema:
+          type: string
+        description: User generated api key for Bugzilla authentication.
+        required: true
+      - in: header
+        name: Jira-Api-Key
+        schema:
+          type: string
+        description: User generated api key for Jira authentication.
+        required: true
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Tracker.
+        required: true
+      tags:
+      - osidb
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Tracker'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Tracker'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Tracker'
+        required: true
+      security:
+      - OsidbTokenAuthentication: []
       responses:
         '200':
           content:
@@ -9422,26 +9529,89 @@ components:
       type: object
       description: Tracker serializer
       properties:
-        uuid:
-          type: string
-          format: uuid
-          readOnly: true
-        type:
-          $ref: '#/components/schemas/TrackerType'
-        external_system_id:
-          type: string
-          maxLength: 100
         affects:
           type: array
           items:
             type: string
             format: uuid
+        errata:
+          type: array
+          items:
+            $ref: '#/components/schemas/Erratum'
+          readOnly: true
+        external_system_id:
+          type: string
+          readOnly: true
+        meta_attr:
+          type: object
+          properties:
+            bz_id:
+              type: string
+            owner:
+              type: string
+            qe_owner:
+              type: string
+            ps_component:
+              type: string
+            ps_module:
+              type: string
+            ps_update_stream:
+              type: string
+            resolution:
+              type: string
+            status:
+              type: string
+          readOnly: true
+        ps_update_stream:
+          type: string
+          maxLength: 100
         status:
           type: string
           maxLength: 100
         resolution:
           type: string
           maxLength: 100
+        type:
+          allOf:
+          - $ref: '#/components/schemas/TrackerType'
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        embargoed:
+          type: boolean
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+        created_dt:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_dt:
+          type: string
+          format: date-time
+          description: The updated_dt timestamp attribute is mandatory on update as
+            it is used to detect mit-air collisions.
+      required:
+      - created_dt
+      - embargoed
+      - errata
+      - external_system_id
+      - meta_attr
+      - status
+      - type
+      - updated_dt
+      - uuid
+    TrackerPost:
+      type: object
+      description: Tracker serializer
+      properties:
+        affects:
+          type: array
+          items:
+            type: string
+            format: uuid
         errata:
           type: array
           items:
@@ -9470,6 +9640,25 @@ components:
         ps_update_stream:
           type: string
           maxLength: 100
+        status:
+          type: string
+          maxLength: 100
+        resolution:
+          type: string
+          maxLength: 100
+        type:
+          allOf:
+          - $ref: '#/components/schemas/TrackerType'
+          readOnly: true
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        embargoed:
+          type: boolean
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
         created_dt:
           type: string
           format: date-time
@@ -9481,8 +9670,8 @@ components:
             it is used to detect mit-air collisions.
       required:
       - created_dt
+      - embargoed
       - errata
-      - external_system_id
       - meta_attr
       - status
       - type

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -81,7 +81,11 @@ class TrackingMixinManager(models.Manager):
         auto_timestamps = kwargs.pop("auto_timestamps", None)
         obj = self.model(**kwargs)
         self._for_write = True
-        obj.save(auto_timestamps=auto_timestamps, force_insert=True, using=self.db)
+        # re-add the auto_timestamps argument only if it was actually present before
+        new_kwargs = (
+            {"auto_timestamps": auto_timestamps} if auto_timestamps is not None else {}
+        )
+        obj.save(force_insert=True, using=self.db, **new_kwargs)
         return obj
 
 

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2234,7 +2234,11 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         self.validate(raise_validation_error=kwargs.get("raise_validation_error", True))
 
         # check Bugzilla conditions are met
-        if SYNC_TO_BZ and bz_api_key is not None:
+        if (
+            SYNC_TO_BZ
+            and bz_api_key is not None
+            and self.type == self.TrackerType.BUGZILLA
+        ):
             # sync to Bugzilla
             self = TrackerSaver(self, bz_api_key=bz_api_key).save()
             # save in case a new Bugzilla ID was obtained
@@ -2249,7 +2253,11 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             btc.sync_tracker(self.external_system_id)
 
         # check Jira conditions are met
-        elif SYNC_TO_JIRA and jira_token is not None:
+        elif (
+            SYNC_TO_JIRA
+            and jira_token is not None
+            and self.type == self.TrackerType.JIRA
+        ):
             # sync to Jira
             self = TrackerSaver(self, jira_token=jira_token).save()
             # save in case a new Jira ID was obtained

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2386,6 +2386,20 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
                 f"Tracker type and BTS mismatch: {self.type} versus {ps_module.bts_name}"
             )
 
+    def _validate_tracker_duplicate(self):
+        """
+        validate that there is only one tracker with this update stream associated with each affect
+        """
+        for affect in self.affects.all():
+            if (
+                affect.trackers.filter(ps_update_stream=self.ps_update_stream).count()
+                > 1
+            ):
+                raise ValidationError(
+                    f"Tracker with the update stream {self.ps_update_stream} "
+                    f"is already associated with the affect {affect.uuid}"
+                )
+
     @property
     def aggregated_impact(self):
         """

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1179,13 +1179,6 @@ class FlawSerializer(
         "state",
         "statement",
         "task_owner",
-        # Internal data
-        # "acl_labels",
-        # "bz_trace",
-        # "bzimport_last_imported_dt",
-        # "bzimport_last_job_uuid",
-        # "bzimport_last_jobitem_id",
-        # "bzimport_tracker_dict",
     )
 
     cve_id = serializers.CharField(required=False, allow_null=True)

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -1515,10 +1515,11 @@ class TestEndpoints(object):
             HTTP_BUGZILLA_API_KEY="SECRET",
         )
 
-        assert response.status_code == 409
+        assert response.status_code == status.HTTP_409_CONFLICT
         assert "Save operation based on an outdated model instance" in str(
             response.content
         )
+        assert Flaw.objects.get(uuid=flaw.uuid).title == flaw.title
 
     def test_flaw_comment_create(self, auth_client, test_api_uri):
         """


### PR DESCRIPTION
This PR introduces the writable tracker API and some related fixes. Probably the most important part of this exercise is the integration tests as when creating those I was truly able to create the Bugzilla and Jira trackers in the backends by calling the API.

Closes OSIDB-791
Closes OSIDB-1180