### PR TITLE
Add filters for flaw references in API and fix serializers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement package_versions API (OSIDB-1066)
 - is_up2date to collector status API (OSIDB-1328)
 - Implement flaw filtering based on erratum id in API (OSIDB-1330)
+- Implement filters for flaw references in API (OSIDB-1368)
 
 ### Changed
 - Deprecate various cvss fields in Flaw and Affect APIs (OSIDB-1105)

--- a/openapi.yml
+++ b/openapi.yml
@@ -4869,13 +4869,13 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/FlawReference'
+              $ref: '#/components/schemas/FlawReferencePut'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/FlawReference'
+              $ref: '#/components/schemas/FlawReferencePut'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/FlawReference'
+              $ref: '#/components/schemas/FlawReferencePut'
         required: true
       security:
       - OsidbTokenAuthentication: []
@@ -8462,6 +8462,42 @@ components:
       required:
       - created_dt
       - embargoed
+      - url
+      - uuid
+    FlawReferencePut:
+      type: object
+      description: FlawReference serializer
+      properties:
+        description:
+          type: string
+        type:
+          $ref: '#/components/schemas/FlawReferenceType'
+        url:
+          type: string
+          format: uri
+          maxLength: 2048
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        embargoed:
+          type: boolean
+          description: The embargoed boolean attribute is technically read-only as
+            it just indirectly modifies the ACLs but is mandatory as it controls the
+            access to the resource.
+        created_dt:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_dt:
+          type: string
+          format: date-time
+          description: The updated_dt timestamp attribute is mandatory on update as
+            it is used to detect mit-air collisions.
+      required:
+      - created_dt
+      - embargoed
+      - updated_dt
       - url
       - uuid
     FlawReferenceType:

--- a/openapi.yml
+++ b/openapi.yml
@@ -4677,6 +4677,7 @@ paths:
         name: flaw_id
         schema:
           type: string
+          format: uuid
         required: true
       - in: query
         name: include_fields
@@ -4742,6 +4743,7 @@ paths:
         name: flaw_id
         schema:
           type: string
+          format: uuid
         required: true
       tags:
       - osidb
@@ -4795,6 +4797,7 @@ paths:
         name: flaw_id
         schema:
           type: string
+          format: uuid
         required: true
       - in: path
         name: id
@@ -4853,6 +4856,7 @@ paths:
         name: flaw_id
         schema:
           type: string
+          format: uuid
         required: true
       - in: path
         name: id
@@ -4902,6 +4906,7 @@ paths:
         name: flaw_id
         schema:
           type: string
+          format: uuid
         required: true
       - in: path
         name: id

--- a/openapi.yml
+++ b/openapi.yml
@@ -3005,6 +3005,12 @@ paths:
             - -nist_cvss_validation
             - -nvd_cvss2
             - -nvd_cvss3
+            - -references__created_dt
+            - -references__description
+            - -references__type
+            - -references__updated_dt
+            - -references__url
+            - -references__uuid
             - -reported_dt
             - -requires_summary
             - -source
@@ -3062,6 +3068,12 @@ paths:
             - nist_cvss_validation
             - nvd_cvss2
             - nvd_cvss3
+            - references__created_dt
+            - references__description
+            - references__type
+            - references__updated_dt
+            - references__url
+            - references__uuid
             - reported_dt
             - requires_summary
             - source
@@ -3072,6 +3084,106 @@ paths:
         description: Ordering
         explode: false
         style: form
+      - in: query
+        name: references__created_dt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__created_dt__date
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: references__created_dt__date__gte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: references__created_dt__date__lte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: references__created_dt__gt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__created_dt__gte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__created_dt__lt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__created_dt__lte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__description
+        schema:
+          type: string
+      - in: query
+        name: references__type
+        schema:
+          type: string
+          enum:
+          - ARTICLE
+          - EXTERNAL
+      - in: query
+        name: references__updated_dt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__updated_dt__date
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: references__updated_dt__date__gte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: references__updated_dt__date__lte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: references__updated_dt__gt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__updated_dt__gte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__updated_dt__lt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__updated_dt__lte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: references__url
+        schema:
+          type: string
+      - in: query
+        name: references__uuid
+        schema:
+          type: string
+          format: uuid
       - in: query
         name: reported_dt
         schema:
@@ -4665,6 +4777,50 @@ paths:
       operationId: osidb_api_v1_flaws_references_list
       parameters:
       - in: query
+        name: created_dt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: created_dt__date
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_dt__date__gte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_dt__date__lte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: created_dt__gt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: created_dt__gte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: created_dt__lt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: created_dt__lte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: description
+        schema:
+          type: string
+      - in: query
         name: exclude_fields
         schema:
           type: array
@@ -4712,6 +4868,62 @@ paths:
         description: The initial index from which to return the results.
         schema:
           type: integer
+      - in: query
+        name: type
+        schema:
+          type: string
+          enum:
+          - ARTICLE
+          - EXTERNAL
+      - in: query
+        name: updated_dt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: updated_dt__date
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: updated_dt__date__gte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: updated_dt__date__lte
+        schema:
+          type: string
+          format: date
+      - in: query
+        name: updated_dt__gt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: updated_dt__gte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: updated_dt__lt
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: updated_dt__lte
+        schema:
+          type: string
+          format: date-time
+      - in: query
+        name: url
+        schema:
+          type: string
+      - in: query
+        name: uuid
+        schema:
+          type: string
+          format: uuid
       tags:
       - osidb
       security:

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -58,6 +58,7 @@ from .serializer import (
     FlawPackageVersionSerializer,
     FlawPostSerializer,
     FlawReferencePostSerializer,
+    FlawReferencePutSerializer,
     FlawReferenceSerializer,
     FlawSerializer,
     TrackerSerializer,
@@ -541,6 +542,9 @@ class FlawAcknowledgmentView(
 @extend_schema_view(
     create=extend_schema(
         request=FlawReferencePostSerializer,
+    ),
+    update=extend_schema(
+        request=FlawReferencePutSerializer,
     ),
 )
 class FlawReferenceView(SubFlawViewDestroyMixin, SubFlawViewGetMixin, ModelViewSet):

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -517,22 +517,6 @@ class SubFlawViewGetMixin:
         return super().get_serializer(*args, **kwargs)
 
 
-class SubFlawViewNoneFormatQuerysetMixin:
-    # This mixin exists so that OpenAPI schema stays unchanged for ModelViewSets
-    # that had a slightly buggy version of get_queryset.
-    # The correct get_queryset generates openapi parameter format "uuid", whereas
-    # this get_queryset generates parameter format "none".
-    # (This is not a docstring because that would appear in the schema.)
-    # TODO: Eliminate this mixin when such API change is allowed.
-
-    def get_queryset(self):
-        """
-        Returns the requested model instances only for the specified flaw.
-        """
-        flaw = self.get_flaw()
-        return self.serializer_class.Meta.model.objects.filter(flaw=flaw)
-
-
 @include_meta_attr_extend_schema_view
 @include_exclude_fields_extend_schema_view
 @extend_schema_view(
@@ -559,12 +543,7 @@ class FlawAcknowledgmentView(
         request=FlawReferencePostSerializer,
     ),
 )
-class FlawReferenceView(
-    SubFlawViewNoneFormatQuerysetMixin,
-    SubFlawViewDestroyMixin,
-    SubFlawViewGetMixin,
-    ModelViewSet,
-):
+class FlawReferenceView(SubFlawViewDestroyMixin, SubFlawViewGetMixin, ModelViewSet):
     serializer_class = FlawReferenceSerializer
     http_method_names = get_valid_http_methods(ModelViewSet)
     permission_classes = [IsAuthenticatedOrReadOnly]

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -36,6 +36,7 @@ from .filters import (
     FlawCVSSFilter,
     FlawFilter,
     FlawPackageVersionFilter,
+    FlawReferenceFilter,
     TrackerFilter,
 )
 from .models import Affect, AffectCVSS, Flaw, Tracker
@@ -551,6 +552,7 @@ class FlawReferenceView(SubFlawViewDestroyMixin, SubFlawViewGetMixin, ModelViewS
     serializer_class = FlawReferenceSerializer
     http_method_names = get_valid_http_methods(ModelViewSet)
     permission_classes = [IsAuthenticatedOrReadOnly]
+    filterset_class = FlawReferenceFilter
 
 
 @include_exclude_fields_extend_schema_view

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -20,6 +20,7 @@ from .models import (
     FlawAcknowledgment,
     FlawComment,
     FlawCVSS,
+    FlawReference,
     Package,
     Tracker,
     search_helper,
@@ -258,6 +259,19 @@ class FlawFilter(DistinctFilterSet):
             + DATE_LOOKUP_EXPRS,
             "cvss_scores__uuid": ["exact"],
             "cvss_scores__vector": ["exact"],
+            # Reference fields
+            "references__created_dt": ["exact"]
+            + LT_GT_LOOKUP_EXPRS
+            + LTE_GTE_LOOKUP_EXPRS
+            + DATE_LOOKUP_EXPRS,
+            "references__description": ["exact"],
+            "references__type": ["exact"],
+            "references__updated_dt": ["exact"]
+            + LT_GT_LOOKUP_EXPRS
+            + LTE_GTE_LOOKUP_EXPRS
+            + DATE_LOOKUP_EXPRS,
+            "references__url": ["exact"],
+            "references__uuid": ["exact"],
         }
 
     order = OrderingFilter(fields=Meta.fields.keys())
@@ -534,6 +548,25 @@ class FlawCVSSFilter(FilterSet):
             + DATE_LOOKUP_EXPRS,
             "uuid": ["exact"],
             "vector": ["exact"],
+        }
+
+
+class FlawReferenceFilter(FilterSet):
+    class Meta:
+        model = FlawReference
+        fields = {
+            "created_dt": ["exact"]
+            + LT_GT_LOOKUP_EXPRS
+            + LTE_GTE_LOOKUP_EXPRS
+            + DATE_LOOKUP_EXPRS,
+            "description": ["exact"],
+            "type": ["exact"],
+            "updated_dt": ["exact"]
+            + LT_GT_LOOKUP_EXPRS
+            + LTE_GTE_LOOKUP_EXPRS
+            + DATE_LOOKUP_EXPRS,
+            "url": ["exact"],
+            "uuid": ["exact"],
         }
 
 

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -984,6 +984,13 @@ class FlawReferencePostSerializer(FlawReferenceSerializer):
     pass
 
 
+@extend_schema_serializer(exclude_fields=["flaw"])
+class FlawReferencePutSerializer(FlawReferenceSerializer):
+    # Extra serializer for PUT request because flaw shouldn't be
+    # required in the body (already included in the path).
+    pass
+
+
 class FlawCVSSSerializer(
     ACLMixinSerializer,
     BugzillaSyncMixinSerializer,


### PR DESCRIPTION
This PR updates several things around flaw references:
- `SubFlawViewNoneFormatQuerysetMixin` was removed from `FlawReferenceView` because its `get_queryset` method was incorrect. This method did not provide a fallback that allows the call of `get_queryset` in a situation when `get_queryset` depends on attributes not available at schema generation time. This also caused the `openapi.yml` file to contain the `flaw_id` parameter's incorrect format - unspecified `string` instead of `string($uuid)`.
- `FlawReferencePutSerializer` decorated by `@extend_schema_serializer(exclude_fields=["flaw"])` was added to `FlawReferenceView`. Without this serializer, the PUT request contained the `flaw` in two places - in its parameters and in its body, which might be confusing. The same problem was in the `openapi.yml` file.
- Filters for flaw references were added in API.

Closes OSIDB-1368