### PR TITLE
Workaround for `ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze'`

### DIFF
--- a/devel-requirements.txt
+++ b/devel-requirements.txt
@@ -480,9 +480,9 @@ packaging==21.3 \
     #   pytest
     #   pytest-sugar
     #   tox
-pip-tools==6.14.0 \
-    --hash=sha256:06366be0e08d86b416407333e998b4d305d5bd925151b08942ed149380ba3e47 \
-    --hash=sha256:c5ad042cd27c0b343b10db1db7f77a7d087beafbec59ae6df1bba4d3368dfe8c
+pip-tools==7.3.0 \
+    --hash=sha256:8717693288720a8c6ebd07149c93ab0be1fced0b5191df9e9decd3263e20d85e \
+    --hash=sha256:8e9c99127fe024c025b46a0b2d15c7bd47f18f33226cf7330d35493663fc1d1d
     # via -r devel-requirements.in
 platformdirs==2.4.0 \
     --hash=sha256:367a5e80b3d04d2428ffa76d33f124cf11e8fff2acdaa9b43d545f5c7d661ef2 \

--- a/mk/setup.mk
+++ b/mk/setup.mk
@@ -70,6 +70,9 @@ sync-deps: check-venv-active
 	$(ps) requirements.txt devel-requirements.txt $$([ -f local-requirements.txt ] && echo 'local-requirements.txt')
 
 
+#***********************************
+### Upgrade pinned package selectively. Read DEVELOP.md for details. Example: make upgrade-dep package=requests==2.0.0 reqfile=requirements.in
+#***********************************
 .PHONY : upgrade-dep
 upgrade-dep: check-venv-active
 	@echo ">upgrading specified packages"


### PR DESCRIPTION
- Workaround for `ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze'` when setting up a local dev environment or when applying requirements.txt.
- Fix display of `make help` for `make upgrade-dep`, which is relevant in updating pinned packages.