### PR TITLE
Configure CORS_ALLOW_HEADERS

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -316,5 +316,8 @@ DEFAULT_REQUEST_TIMEOUT = get_env(
 # example value: ["https://osidb.example.com", "https://osim.example.com"]
 CORS_ALLOWED_ORIGINS = get_env("OSIDB_CORS_ALLOWED_ORIGINS", default="[]", is_json=True)
 # sets the Access-Control-Allow-Headers response header; lowercase
-CORS_ALLOW_HEADERS = (*default_headers, *get_env("OSIDB_CORS_ALLOW_HEADERS", default='["bugzilla-api-key"]', is_json=True))
+CORS_ALLOW_HEADERS = (
+    *default_headers,
+    *get_env("OSIDB_CORS_ALLOW_HEADERS", default='["bugzilla-api-key"]', is_json=True),
+)
 CORS_ALLOW_CREDENTIALS = True

--- a/config/settings.py
+++ b/config/settings.py
@@ -7,6 +7,7 @@ import socket
 from pathlib import Path
 
 from celery.schedules import crontab
+from corsheaders.defaults import default_headers
 from django.core.management.utils import get_random_secret_key
 
 from osidb.helpers import get_env
@@ -311,5 +312,9 @@ DEFAULT_REQUEST_TIMEOUT = get_env(
     "OSIDB_DEFAULT_REQUEST_TIMEOUT", default="30", is_int=True
 )
 
+# sets the Access-Control-Allow-Origin response header
+# example value: ["https://osidb.example.com", "https://osim.example.com"]
 CORS_ALLOWED_ORIGINS = get_env("OSIDB_CORS_ALLOWED_ORIGINS", default="[]", is_json=True)
+# sets the Access-Control-Allow-Headers response header; lowercase
+CORS_ALLOW_HEADERS = (*default_headers, *get_env("OSIDB_CORS_ALLOW_HEADERS", default='["bugzilla-api-key"]', is_json=True))
 CORS_ALLOW_CREDENTIALS = True

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Deprecate various cvss fields in Flaw and Affect APIs (OSIDB-1105)
+- Update CORS policy to allow bugzilla-api-key request header (OSIDB-1425)
 
 ### Fixed
 - Fix schema wrongly showing status code for DELETE methods being 204


### PR DESCRIPTION
This variable is used by django-cors-headers
to set the Access-Control-Allow-Headers response header.

I haven't tested the change, but I think it should be correct