### PR TITLE
Fix schema

### DIFF
--- a/.github/workflows/bindings_integration.yml
+++ b/.github/workflows/bindings_integration.yml
@@ -1,0 +1,25 @@
+name: OSIDB Bindings integration
+on:
+  pull_request:
+    paths:
+    - "openapi.yml"
+jobs:
+  regenerate-bindings:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: extract_branch
+      - uses: actions/checkout@v3
+        with:
+          repository: "RedHatProductSecurity/osidb-bindings"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: pip install -r devel-requirements.txt
+      - name: Download recent OpenAPI schema
+        run: make download-schema ref=${{ steps.extract_branch.outputs.branch }}
+      - name: Regenerate OSIDB bindings with the new schema file
+        run: make update

--- a/collectors/framework/api.py
+++ b/collectors/framework/api.py
@@ -74,7 +74,7 @@ class status(APIView):
                                 },
                                 "error": {"type": "object", "nullable": True},
                                 "is_complete": {"type": "boolean"},
-                                "is_up2date": {"type": "bool"},
+                                "is_up2date": {"type": "boolean"},
                                 "data_models": {
                                     "type": "array",
                                     "items": {"type": "string"},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix incorrect type bool of is_up2date field in
+  /collectors/api/v1/status endpoint
+
 
 ## [3.5.0] - 2023-10-09
 ### Added

--- a/openapi.yml
+++ b/openapi.yml
@@ -214,7 +214,7 @@ paths:
                         is_complete:
                           type: boolean
                         is_up2date:
-                          type: bool
+                          type: boolean
                         data_models:
                           type: array
                           items:


### PR DESCRIPTION
This PR:
* fixes OpenAPI schema, there was an incorrect type used (bool vs boolean)
* adds new GH action which checkouts the [osidb-bindings](https://github.com/RedHatProductSecurity/osidb-bindings) repository and tries to regenerate the bindings with the schema from branch which the GH action is run against, also it should only run when the `openapi.yml` file is changed.

Partially addresses OSIDB-230