### PR TITLE
fix Celery broker URL

### DIFF
--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -89,7 +89,7 @@ STATIC_URL = "/static/"
 # Celery settings
 
 REDIS_PASSWORD = get_env("OSIDB_REDIS_PASSWORD")
-CELERY_BROKER_URL = f"rediss://:{REDIS_PASSWORD}@redis:6379/"
+CELERY_BROKER_URL = f"redis://:{REDIS_PASSWORD}@redis:6379/"
 CELERY_BROKER_USE_SSL = {
     "ssl_keyfile": "/opt/app-root/etc/redis/certs/osidb-redis.key",
     "ssl_certfile": "/opt/app-root/etc/redis/certs/osidb-redis.crt",

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -92,7 +92,7 @@ STATIC_URL = "/static/"
 # Celery settings
 
 REDIS_PASSWORD = get_env("OSIDB_REDIS_PASSWORD")
-CELERY_BROKER_URL = f"rediss://:{REDIS_PASSWORD}@redis:6379/"
+CELERY_BROKER_URL = f"redis://:{REDIS_PASSWORD}@redis:6379/"
 CELERY_BROKER_USE_SSL = {
     "ssl_keyfile": "/opt/app-root/etc/redis/certs/osidb-redis.key",
     "ssl_certfile": "/opt/app-root/etc/redis/certs/osidb-redis.crt",


### PR DESCRIPTION
I believe that this change was done by mistake

https://gitlab.cee.redhat.com/prodsec-dev/osidb/-/commit/14b4dd06cf4160efcb1d04475cc57d8ed3bb6cdf#1376cb8c0673765bf96993bd680158d6cb41003c_82_82

I found that while looking at the Flower issue - not sure whether it is the cause or not.