### PR TITLE
Fix Erratum shipped_dt schema

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrect type bool of is_up2date field in
   /collectors/api/v1/status endpoint
 - fix PS contact model (OSIDB-1445)
+- fix schema to reflect Erratum shipped_dt to be nullable
 
 ## [3.5.0] - 2023-10-09
 ### Added

--- a/openapi.yml
+++ b/openapi.yml
@@ -7744,6 +7744,7 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         created_dt:
           type: string
           format: date-time

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -250,7 +250,7 @@ class ErratumSerializer(
 
     et_id = serializers.IntegerField(read_only=True)
     advisory_name = serializers.CharField(read_only=True)
-    shipped_dt = serializers.DateTimeField(read_only=True)
+    shipped_dt = serializers.DateTimeField(read_only=True, allow_null=True)
 
     class Meta:
         """filter fields"""


### PR DESCRIPTION
Erratum `shipped_dt` in OpenAPI schema is marked as required, however it should also be nullable as we allow null values in the database for this field.