### PR TITLE
Add internal visibility groups and related changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -185,7 +185,7 @@
         "filename": "config/settings_ci.py",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 44,
+        "line_number": 48,
         "is_secret": false
       },
       {
@@ -193,7 +193,7 @@
         "filename": "config/settings_ci.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 81,
         "is_secret": false
       }
     ],
@@ -203,7 +203,7 @@
         "filename": "config/settings_local.py",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 47,
         "is_secret": false
       },
       {
@@ -211,7 +211,7 @@
         "filename": "config/settings_local.py",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 81,
         "is_secret": false
       }
     ],
@@ -304,5 +304,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-05T15:12:48Z"
+  "generated_at": "2023-10-18T10:52:32Z"
 }

--- a/config/settings_ci.py
+++ b/config/settings_ci.py
@@ -29,6 +29,10 @@ PUBLIC_WRITE_GROUP = "data-prodsec-write"
 EMBARGO_READ_GROUP = "data-topsecret"
 # Minimal group for write access of embargoed flaws in OSIDB
 EMBARGO_WRITE_GROUP = "data-topsecret-write"
+# Minimal group for read access of internal flaws in OSIDB
+INTERNAL_READ_GROUP = "data-internal-read"
+# Minimal group for write access of internal flaws in OSIDB
+INTERNAL_WRITE_GROUP = "data-internal-write"
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-service-manage"
 

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -28,6 +28,10 @@ PUBLIC_WRITE_GROUP = "data-prodsec-write"
 EMBARGO_READ_GROUP = "data-topsecret"
 # Minimal group for write access of embargoed flaws in OSIDB
 EMBARGO_WRITE_GROUP = "data-topsecret-write"
+# Minimal group for read access of internal flaws in OSIDB
+INTERNAL_READ_GROUP = "data-internal-read"
+# Minimal group for write access of internal flaws in OSIDB
+INTERNAL_WRITE_GROUP = "data-internal-write"
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-service-manage"
 

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -24,6 +24,10 @@ PUBLIC_WRITE_GROUP = "osidb-prod-public-write"
 EMBARGO_READ_GROUP = "osidb-prod-embargo-read"
 # Minimal group for write access of embargoed flaws in OSIDB
 EMBARGO_WRITE_GROUP = "osidb-prod-embargo-write"
+# Minimal group for read access of internal flaws in OSIDB
+INTERNAL_READ_GROUP = "osidb-prod-internal-read"
+# Minimal group for write access of internal flaws in OSIDB
+INTERNAL_WRITE_GROUP = "osidb-prod-internal-write"
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-prod-manage"
 

--- a/config/settings_shell.py
+++ b/config/settings_shell.py
@@ -22,6 +22,10 @@ PUBLIC_WRITE_GROUP = "data-prodsec-write"
 EMBARGO_READ_GROUP = "data-topsecret"
 # Minimal group for write access of embargoed flaws in OSIDB
 EMBARGO_WRITE_GROUP = "data-topsecret-write"
+# Minimal group for read access of internal flaws in OSIDB
+INTERNAL_READ_GROUP = "data-internal-read"
+# Minimal group for write access of internal flaws in OSIDB
+INTERNAL_WRITE_GROUP = "data-internal-write"
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-service-manage"
 

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -27,6 +27,10 @@ PUBLIC_WRITE_GROUP = "osidb-stage-public-write"
 EMBARGO_READ_GROUP = "osidb-stage-embargo-read"
 # Minimal group for write access of embargoed flaws in OSIDB
 EMBARGO_WRITE_GROUP = "osidb-stage-embargo-write"
+# Minimal group for read access of internal flaws in OSIDB
+INTERNAL_READ_GROUP = "osidb-stage-internal-read"
+# Minimal group for write access of internal flaws in OSIDB
+INTERNAL_WRITE_GROUP = "osidb-stage-internal-write"
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-stage-manage"
 

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -861,6 +861,8 @@ def forwards_func(...):
         settings.PUBLIC_WRITE_GROUP,
         settings.EMBARGO_READ_GROUP,
         settings.EMBARGO_WRITE_GROUP,
+        settings.INTERNAL_READ_GROUP,
+        settings.INTERNAL_WRITE_GROUP,
     ])
     # execute migration logic
     ...

--- a/etc/openldap/local-export.ldif
+++ b/etc/openldap/local-export.ldif
@@ -451,3 +451,13 @@ member: cn=jshepher,ou=users,dc=redhat,dc=com
 member: cn=osoukup,ou=users,dc=redhat,dc=com
 member: cn=atorresj,ou=users,dc=redhat,dc=com
 objectclass: groupOfNames
+
+# internal data
+dn: cn=data-internal-read,ou=users,dc=redhat,dc=com
+cn: data-internal-read
+objectclass: groupOfNames
+
+# internal data
+dn: cn=data-internal-write,ou=users,dc=redhat,dc=com
+cn: data-internal-write
+objectclass: groupOfNames


### PR DESCRIPTION
This commit adds the necessary groundwork to support the new internal visibility groups which are intended for use with the assembler implementation in OSIDB.

Closes OSIDB-1371