### PR TITLE
Introduce ALL_GROUPS setting and simplify RLS bypass

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -185,7 +185,7 @@
         "filename": "config/settings_ci.py",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 48,
+        "line_number": 57,
         "is_secret": false
       },
       {
@@ -193,7 +193,7 @@
         "filename": "config/settings_ci.py",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 90,
         "is_secret": false
       }
     ],
@@ -203,7 +203,7 @@
         "filename": "config/settings_local.py",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 56,
         "is_secret": false
       },
       {
@@ -211,7 +211,7 @@
         "filename": "config/settings_local.py",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 90,
         "is_secret": false
       }
     ],
@@ -304,5 +304,5 @@
       }
     ]
   },
-  "generated_at": "2023-10-18T10:52:32Z"
+  "generated_at": "2023-10-20T15:25:17Z"
 }

--- a/apps/exploits/helpers.py
+++ b/apps/exploits/helpers.py
@@ -51,14 +51,7 @@ def set_exploit_collector_acls():
     """
     Exploit collectors need access to all flaws, so they can be correctly linked to exploit objects.
     """
-    set_user_acls(
-        settings.PUBLIC_READ_GROUPS
-        + [
-            settings.PUBLIC_WRITE_GROUP,
-            settings.EMBARGO_READ_GROUP,
-            settings.EMBARGO_WRITE_GROUP,
-        ]
-    )
+    set_user_acls(settings.ALL_GROUPS)
 
 
 class ExploitResult:

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -519,14 +519,7 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
         self._tracker_jiras = tracker_jiras
         # set osidb.acl to be able to CRUD database properly and essentially bypass ACLs as
         # celery workers should be able to read/write any information in order to fulfill their jobs
-        set_user_acls(
-            settings.PUBLIC_READ_GROUPS
-            + [
-                settings.PUBLIC_WRITE_GROUP,
-                settings.EMBARGO_READ_GROUP,
-                settings.EMBARGO_WRITE_GROUP,
-            ]
-        )
+        set_user_acls(settings.ALL_GROUPS)
 
     @property
     def bug(self):

--- a/collectors/errata/core.py
+++ b/collectors/errata/core.py
@@ -11,7 +11,6 @@ from requests_gssapi import HTTPSPNEGOAuth
 from osidb.core import set_user_acls
 from osidb.models import Erratum, Tracker
 
-from ..bzimport.constants import BZ_ENABLE_IMPORT_EMBARGOED
 from ..utils import BACKOFF_KWARGS, fatal_code
 from .constants import (
     ERRATA_TOOL_SERVER,
@@ -183,16 +182,8 @@ def search(query):
 
 def set_acls_for_et_collector() -> None:
     """Set the ACLs to allow embargo processing, if enabled on server"""
-    groups = settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]
-
-    # Using embargo groups because ET collector must link errata to possibly-embargoed flaws
-    # Note that if an erratum has embargoed flaws / trackers, and below is not set, we will skip linking these
-    # The ET collector will not see the embargoed objects in the DB, so assumes they do not exist
-    if BZ_ENABLE_IMPORT_EMBARGOED:
-        groups += [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]
-
     # celery host is a different host then osidb-service so we need to set osidb.acl independently
     # to be able to CRUD database properly
     # READ_GROUPS and WRITE_GROUPS shouldn't contain overlapping groups
     # i.e. it's safe to add them together without deduplication.
-    set_user_acls(groups)
+    set_user_acls(settings.ALL_GROUPS)

--- a/collectors/framework/README.md
+++ b/collectors/framework/README.md
@@ -73,7 +73,5 @@ appropriately. Default ACL groups can be observed [here](../../config/settings_l
 # set permissions to public read-only access
 from django.conf import settings
 from osidb.core import set_user_acls
-set_user_acls(
-    settings.PUBLIC_READ_GROUPS
-)
+set_user_acls(settings.ALL_GROUPS)
 ```

--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -32,14 +32,7 @@ class TrackerConvertor:
         self.tracker_data = self._normalize()
         # set osidb.acl to be able to CRUD database properly and essentially bypass ACLs as
         # celery workers should be able to read/write any information in order to fulfill their jobs
-        set_user_acls(
-            settings.PUBLIC_READ_GROUPS
-            + [
-                settings.PUBLIC_WRITE_GROUP,
-                settings.EMBARGO_READ_GROUP,
-                settings.EMBARGO_WRITE_GROUP,
-            ]
-        )
+        set_user_acls(settings.ALL_GROUPS)
 
     @property
     def type(self):

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -128,14 +128,7 @@ class NVDCollector(Collector, NVDQuerier):
         """
         # set osidb.acl to be able to CRUD database properly and essentially bypass ACLs as
         # celery workers should be able to read/write any information in order to fulfill their jobs
-        set_user_acls(
-            settings.PUBLIC_READ_GROUPS
-            + [
-                settings.PUBLIC_WRITE_GROUP,
-                settings.EMBARGO_READ_GROUP,
-                settings.EMBARGO_WRITE_GROUP,
-            ]
-        )
+        set_user_acls(settings.ALL_GROUPS)
 
         logger.info("Fetching NVD CVSS")
         start_dt = timezone.now()

--- a/config/settings_ci.py
+++ b/config/settings_ci.py
@@ -33,6 +33,15 @@ EMBARGO_WRITE_GROUP = "data-topsecret-write"
 INTERNAL_READ_GROUP = "data-internal-read"
 # Minimal group for write access of internal flaws in OSIDB
 INTERNAL_WRITE_GROUP = "data-internal-write"
+# Contains all non-admin groups
+ALL_GROUPS = [
+    *PUBLIC_READ_GROUPS,
+    PUBLIC_WRITE_GROUP,
+    EMBARGO_READ_GROUP,
+    EMBARGO_WRITE_GROUP,
+    INTERNAL_READ_GROUP,
+    INTERNAL_WRITE_GROUP,
+]
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-service-manage"
 

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -32,6 +32,15 @@ EMBARGO_WRITE_GROUP = "data-topsecret-write"
 INTERNAL_READ_GROUP = "data-internal-read"
 # Minimal group for write access of internal flaws in OSIDB
 INTERNAL_WRITE_GROUP = "data-internal-write"
+# Contains all non-admin groups
+ALL_GROUPS = [
+    *PUBLIC_READ_GROUPS,
+    PUBLIC_WRITE_GROUP,
+    EMBARGO_READ_GROUP,
+    EMBARGO_WRITE_GROUP,
+    INTERNAL_READ_GROUP,
+    INTERNAL_WRITE_GROUP,
+]
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-service-manage"
 

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -28,6 +28,15 @@ EMBARGO_WRITE_GROUP = "osidb-prod-embargo-write"
 INTERNAL_READ_GROUP = "osidb-prod-internal-read"
 # Minimal group for write access of internal flaws in OSIDB
 INTERNAL_WRITE_GROUP = "osidb-prod-internal-write"
+# Contains all non-admin groups
+ALL_GROUPS = [
+    *PUBLIC_READ_GROUPS,
+    PUBLIC_WRITE_GROUP,
+    EMBARGO_READ_GROUP,
+    EMBARGO_WRITE_GROUP,
+    INTERNAL_READ_GROUP,
+    INTERNAL_WRITE_GROUP,
+]
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-prod-manage"
 

--- a/config/settings_shell.py
+++ b/config/settings_shell.py
@@ -26,6 +26,15 @@ EMBARGO_WRITE_GROUP = "data-topsecret-write"
 INTERNAL_READ_GROUP = "data-internal-read"
 # Minimal group for write access of internal flaws in OSIDB
 INTERNAL_WRITE_GROUP = "data-internal-write"
+# Contains all non-admin groups
+ALL_GROUPS = [
+    *PUBLIC_READ_GROUPS,
+    PUBLIC_WRITE_GROUP,
+    EMBARGO_READ_GROUP,
+    EMBARGO_WRITE_GROUP,
+    INTERNAL_READ_GROUP,
+    INTERNAL_WRITE_GROUP,
+]
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-service-manage"
 

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -31,6 +31,15 @@ EMBARGO_WRITE_GROUP = "osidb-stage-embargo-write"
 INTERNAL_READ_GROUP = "osidb-stage-internal-read"
 # Minimal group for write access of internal flaws in OSIDB
 INTERNAL_WRITE_GROUP = "osidb-stage-internal-write"
+# Contains all non-admin groups
+ALL_GROUPS = [
+    *PUBLIC_READ_GROUPS,
+    PUBLIC_WRITE_GROUP,
+    EMBARGO_READ_GROUP,
+    EMBARGO_WRITE_GROUP,
+    INTERNAL_READ_GROUP,
+    INTERNAL_WRITE_GROUP,
+]
 # Minimal group for managing the OSIDB service
 SERVICE_MANAGE_GROUP = "osidb-stage-manage"
 

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -857,16 +857,10 @@ from django.conf import settings
 
 def forwards_func(...):
     # set up user acls so that we can read/write to the database
-    set_user_acls(settings.PUBLIC_READ_GROUPS + [
-        settings.PUBLIC_WRITE_GROUP,
-        settings.EMBARGO_READ_GROUP,
-        settings.EMBARGO_WRITE_GROUP,
-        settings.INTERNAL_READ_GROUP,
-        settings.INTERNAL_WRITE_GROUP,
-    ])
+    set_user_acls(settings.ALL_GROUPS)
     # execute migration logic
     ...
 ```
 
-The `setup_user_acls` is the important part here, you should apply it to both
+The `set_user_acls` is the important part here, you should apply it to both
 the forwards and backwards function before performing any database operations.


### PR DESCRIPTION
Bypassing RLS in certain scenarios is a recurring pattern which requires developers to manually call `set_user_acls` and pass to it all necessary groups for their code to do its job.

As the number of groups grows this becomes a PITA, introducing an `ALL_GROUPS` setting which includes all user groups (admin/management groups are not included) makes this process easier and less error-prone.

While a `bypass_rls` helper or systematic RLS bypass within the collector framework were considered, these options either provide very little gain over calling `set_user_acls(settings.ALL_GROUPS)` or be too magic.

The correct long-term solution would be to have a database user which bypasses RLS and use that for both migrations and celery workers.