### PR TITLE
Fix typo in NVD collector

### DIFF
--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -201,7 +201,7 @@ class NVDCollector(Collector, NVDQuerier):
         # process data
         for item in batch_data:
 
-            if self.snippet_creation:
+            if self.snippet_creation_enabled:
                 try:
                     Snippet.objects.get(
                         source=Snippet.Source.NVD, content__cve_ids=[item["cve"]]


### PR DESCRIPTION
This PR fixes incorrect `snippet_creation` to `snippet_creation_enabled` (introduced by mistake in #374).