### PR TITLE
Set max tasks per worker in settings

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -14,12 +14,14 @@ def on_celery_setup_logging(**kwargs):
     pass
 
 
-@signals.worker_process_init.connect
-def configure_worker_greenthreads(*args, **kwargs):
-    from gevent import monkey
+# Commented out as we are not using gevent worker pools at the moment
 
-    monkey.patch_all()
-
-    from psycogreen import gevent
-
-    gevent.patch_psycopg()
+# @signals.worker_process_init.connect
+# def configure_worker_greenthreads(*args, **kwargs):
+#     from gevent import monkey
+#
+#     monkey.patch_all()
+#
+#     from psycogreen import gevent
+#
+#     gevent.patch_psycopg()

--- a/config/settings.py
+++ b/config/settings.py
@@ -157,6 +157,11 @@ CELERY_TASK_ROUTES = (
 )
 CELERY_BEAT_SCHEDULE = {}
 
+# There are multiple possible memory leaks in Celery.
+# To work around these issues it is recommended to restart Celery workers after set number of tasks.
+# Setting maximum number of tasks per worked to 200 should restart Celery worker after ~1 hour.
+CELERY_WORKER_MAX_TASKS_PER_CHILD = 200
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Implement writable tracker API (OSIDB-1180)
-- Limit Celery worker to fixed amount of tasks (OSIDB-1540)
+- Limit Celery worker to maximum amount of tasks (OSIDB-1540)
 - Command for manual sync of Flaws now also accepts CVEs (OSIDB-1544)
 - Add new SOURCE option into FlawReferenceType (OSIDB-1556)
 

--- a/scripts/run-celery-standalone.sh
+++ b/scripts/run-celery-standalone.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 rm -f /tmp/celery_worker.pid
-exec celery -A config worker --pidfile /tmp/celery_worker.pid -f celery.log --loglevel DEBUG -P gevent --concurrency=1 -Q slow,fast -E --max-tasks-per-child=200
+exec celery -A config worker --pidfile /tmp/celery_worker.pid -f celery.log --loglevel DEBUG --concurrency=1 -Q slow,fast -E

--- a/scripts/run-celery.sh
+++ b/scripts/run-celery.sh
@@ -24,5 +24,5 @@ echo
 # custom run script for starting osidb celery service in osidb-stage and osidb-prod environments.
 
 rm -f /tmp/celery_worker.pid
-exec celery -A config worker --pidfile /tmp/celery_worker.pid -f celery.log --loglevel DEBUG -P gevent --concurrency=1 -Q slow,fast -E --max-tasks-per-child=200
+exec celery -A config worker --pidfile /tmp/celery_worker.pid -f celery.log --loglevel DEBUG --concurrency=1 -Q slow,fast -E
 


### PR DESCRIPTION
Set maximum tasks per worker in settings instead of commandline. Commandline option seem to be ignored in Celery / Django integration.

Closes OSIDB-1540.