### PR TITLE
Introduce usage of redbeat celery task scheduler

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -299,10 +299,10 @@
         "filename": "tox.ini",
         "hashed_secret": "5a4fe08359c7f97380e408c717ef42c86939cd86",
         "is_verified": false,
-        "line_number": 53,
+        "line_number": 48,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2023-11-30T16:49:03Z"
+  "generated_at": "2023-12-01T16:00:23Z"
 }

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,7 @@
 backoff
 celery[gevent]
+# alternative scheduler for celery
+celery-redbeat
 cvss
 django
 django-auth-ldap

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,8 +48,13 @@ celery[gevent]==5.2.7 \
     --hash=sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d
     # via
     #   -r requirements.in
+    #   celery-redbeat
     #   flower
     #   rhubarb
+celery-redbeat==2.1.1 \
+    --hash=sha256:2bd5932fb8830bcc7fb63be506c64c80bcb3da8bf6e48ac8a34df4212966fcfa \
+    --hash=sha256:7fa582c0e1624f94c11536f00734d11011b31df520ffa3531e9e2aebdc8639fd
+    # via -r requirements.in
 certifi==2023.7.22 \
     --hash=sha256:539cc1d13202e33ca466e88b2807e29f4c13049d6d87031a3c110744495cb082 \
     --hash=sha256:92d6037539857d8206b8f6ae472e8b77db8058fec5937a1ef3f54304089edbb9
@@ -544,7 +549,9 @@ python-bugzilla==3.2.0 \
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
-    # via django-postgres-extra
+    # via
+    #   celery-redbeat
+    #   django-postgres-extra
 python-ldap==3.4.0 \
     --hash=sha256:60464c8fc25e71e0fd40449a24eae482dcd0fb7fcf823e7de627a6525b3e0d12
     # via
@@ -599,6 +606,7 @@ redis[hiredis]==4.5.4 \
     --hash=sha256:73ec35da4da267d6847e47f68730fdd5f62e2ca69e3ef5885c6a78a9374c3893
     # via
     #   -r requirements.in
+    #   celery-redbeat
     #   rhubarb
 requests==2.31.0 \
     --hash=sha256:58cd2187c01e70e6e26505bca751777aa9f2ee0b7f4300988b709f44e013003f \
@@ -724,6 +732,10 @@ structlog==21.2.0 \
     --hash=sha256:63a7111a32e5b615671536bb745692ea02cebfea2b39dcb7d2617eed19437cfe \
     --hash=sha256:7ac42b565e1295712313f91edbcb64e0840a9037d888c8954f11fa6c43270e99
     # via django-postgres-extra
+tenacity==8.2.3 \
+    --hash=sha256:5398ef0d78e63f40007c1fb4c0bff96e1911394d2fa8d194f77619c05ff6cc8a \
+    --hash=sha256:ce510e327a630c9e1beaf17d42e6ffacc88185044ad85cf74c0a8887c6a0f88c
+    # via celery-redbeat
 tornado==6.3.3 \
     --hash=sha256:1bd19ca6c16882e4d37368e0152f99c099bad93e0950ce55e71daed74045908f \
     --hash=sha256:22d3c2fa10b5793da13c807e6fc38ff49a4f6e1e3868b0a6f4164768bb8e20f5 \

--- a/scripts/run-celery-beat-standalone.sh
+++ b/scripts/run-celery-beat-standalone.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 rm -f /tmp/celery_beat.pid
-exec celery -A config beat
+exec celery -A config beat -S redbeat.RedBeatScheduler

--- a/scripts/run-celery-beat.sh
+++ b/scripts/run-celery-beat.sh
@@ -15,12 +15,5 @@ echo
 # Postgresql makes the port available after the db is available, but wait some more to be sure. This can be removed if the real pg_isready is used.
 sleep 2
 
-echo "Waiting for http://osidb-service:8000/osidb/healthy to become available"
-while ! ( { curl -f http://osidb-service:8000/osidb/healthy >/dev/null 2>&1 || exit 1 ; } ) ; do echo -n "." ; sleep 2 ; done
-echo
-
-
-# custom run script for starting osidb celery-beat service in osidb-stage and osidb-prod environments.
-
-rm -f /tmp/celery_beat.pid
-exec celery -A config beat
+# Reuse existing standalone version
+exec ./scripts/run-celery-beat-standalone.sh

--- a/tox.ini
+++ b/tox.ini
@@ -9,40 +9,35 @@ setenv =
     OSIDB_DEBUG = 1
     DJANGO_SETTINGS_MODULE=config.settings_local
     DJANGO_SECRET_KEY = local
+# the --no-deps flag tells pip not to install package dependencies, this is OK
+# because we use pip-tools to create an explicit whitelist of all dependencies
+# used by the project, both direct and indirect,and it's a workaround to a pip
+# bug (https://github.com/pypa/pip/issues/9644)
+deps = --no-deps
+       -rrequirements.txt
+       -rdevel-requirements.txt
 
 [testenv:unit-tests]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest -m "unit" {posargs}
 
 [testenv:integration-tests]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest -m "integration" {posargs}
 
 [testenv:tests]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest {posargs}
 
 [testenv:record-new]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest --record-mode=once {posargs}
 
 [testenv:record-rewrite]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest --record-mode=rewrite {posargs}
 
 [testenv:krb5-auth]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest krb5_auth/
 
@@ -51,8 +46,6 @@ setenv =
     OSIDB_DEBUG = 1
     DJANGO_SETTINGS_MODULE=config.settings_ci
     DJANGO_SECRET_KEY = ci
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands =
         pytest -m "unit"
 
@@ -78,8 +71,6 @@ deps = bandit
 commands = bandit -x osidb/tests,collectors/bzimport/tests,collectors/jiraffe/tests,apps/osim/tests --ini .bandit -r osidb collectors apps
 
 [testenv:mypy]
-deps = -rdevel-requirements.txt
-       -rrequirements.txt
 commands = mypy --html-report mypyreport --config-file .mypy.ini --exclude "^.*\b(migrations)\b.*$" --exclude "^.*\b(tests)\b.*$" osidb/ collectors/ apps/
 
 [testenv:secrets]
@@ -88,12 +79,10 @@ allowlist_externals = bash
 commands = /usr/bin/bash -c 'detect-secrets-hook --baseline .secrets.baseline $(git ls-files)'
 
 [testenv:migrations]
-deps = -rrequirements.txt
 allowlist_externals = bash
 commands = /usr/bin/bash -c './scripts/migrations-check.sh'
 
 [testenv:schema]
-deps = -rrequirements.txt
 allowlist_externals = bash
 commands = /usr/bin/bash -c './scripts/schema-check.sh'
 


### PR DESCRIPTION
This commit adds celery-redbeat as a dependency of the project and sets it as the default scheduler for celery tasks.

Unlike celery-beat, redbeat uses a Redis instance for keeping track of task schedules and uses a distributed mutex lock in order to ensure that only one instance of the scheduler can actually schedule tasks.

This comes with the following benefits:

* The scheduler can have high availability without compromising scheduling, meaning that we can have e.g. 3 pods of the scheduler running but only one will be actively doing work at any given time, if two Availability Zones happen to go down, the remaining pod will pick up the slack.
* The schedule is stored in Redis, meaning that even if there are scheduler restarts, the work to be done can be picked up immediately without delays.
* Tasks can be dynamically created/modified.
* Faster startup.

This commit also simplifies the way that the celery-beat scripts work.

Closes OSIDB-1524