### PR TITLE
Update local venv creation to avoid a bug in pip

### DIFF
--- a/mk/setup.mk
+++ b/mk/setup.mk
@@ -131,7 +131,8 @@ build:
 venv:
 	@echo ">Creating venv for local development environment"
 	python3.9 -m venv venv
-	source venv/bin/activate && pip install wheel && pip install -r requirements.txt -r devel-requirements.txt $$([ -f local-requirements.txt ] && echo '-r local-requirements.txt')
+	# --no-deps is a workaround to https://github.com/pypa/pip/issues/9644, see tox.ini for more info
+	source venv/bin/activate && pip install wheel && pip install -r requirements.txt -r devel-requirements.txt $$([ -f local-requirements.txt ] && echo '-r local-requirements.txt') --no-deps
 
 
 #***********************************


### PR DESCRIPTION
This PR fixes an error while creating a local venv due to a bug in pip. It is also a follow-up to the second commit in #393.
For more info, see https://github.com/pypa/pip/issues/9644.