### PR TITLE
Turn errors into warnings when running tests

### DIFF
--- a/apps/trackers/product_definition_handlers/unacked_handler.py
+++ b/apps/trackers/product_definition_handlers/unacked_handler.py
@@ -6,7 +6,7 @@ from .base import ProductDefinitionHandler
 class UnackedHandler(ProductDefinitionHandler):
     def get_offer(self, affect: Affect, impact: Impact, ps_module: PsModule, offers):
 
-        unacked_preselected = not affect.flaw.is_major_incident and impact in [
+        unacked_preselected = not affect.flaw.is_major_incident_temp() and impact in [
             Impact.MODERATE,
             Impact.LOW,
         ]

--- a/collectors/framework/models.py
+++ b/collectors/framework/models.py
@@ -3,7 +3,6 @@ collector framework models
 """
 import logging
 import re
-from datetime import datetime
 from functools import wraps
 from typing import Dict, List, Optional, Type
 
@@ -449,7 +448,7 @@ class Collector(LockableTask):
         # before run actions
         logger.info(f"Collector {self.name} run initiated")
         self.metadata.collector_state = CollectorMetadata.CollectorState.RUNNING
-        self.metadata.last_run_dt = datetime.now()
+        self.metadata.last_run_dt = timezone.now()
         self.metadata.save()
 
     def on_success(self, retval, task_id, args, kwargs) -> None:

--- a/collectors/jiraffe/core.py
+++ b/collectors/jiraffe/core.py
@@ -31,12 +31,15 @@ class JiraConnector:
         """
         Returns the JIRA connection object on which to perform queries to the JIRA API.
         """
-        options = {
-            "server": self._jira_server,
-            # avoid the JIRA lib auto-updating
-            "check_update": False,
-        }
-        return JIRA(options, token_auth=self._jira_token, get_server_info=False)
+        return JIRA(
+            options={
+                "server": self._jira_server,
+                # avoid the JIRA lib auto-updating
+                "check_update": False,
+            },
+            token_auth=self._jira_token,
+            get_server_info=False,
+        )
 
     @property
     def jira_conn(self) -> JIRA:

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -184,7 +184,7 @@ class TestMetadataCollector:
         ps_module = PsModuleFactory(
             bts_name="jira",
             bts_key="OSIM",
-            supported_until_dt=timezone.datetime(2020, 12, 12),
+            supported_until_dt=timezone.make_aware(timezone.datetime(2020, 12, 12)),
         )
         PsUpdateStreamFactory(ps_module=ps_module)
 

--- a/collectors/product_definitions/core.py
+++ b/collectors/product_definitions/core.py
@@ -2,6 +2,7 @@ from typing import Tuple
 
 import requests
 from django.conf import settings
+from django.utils.timezone import datetime, make_aware
 from requests_gssapi import HTTPSPNEGOAuth
 
 from osidb.helpers import ensure_list, get_model_fields
@@ -137,6 +138,14 @@ def sync_ps_products_modules(ps_products_data: dict, ps_modules_data: dict):
             # TODO note that the following is probably incorrect somehow as
             # we're attempting to set multiple related objects with string
             # values but Django doesn't seem to care?
+
+            # convert string date to an object aware of a given time zone
+            for supported_dt in ["supported_from_dt", "supported_until_dt"]:
+                if date := filtered_module_data.get(supported_dt):
+                    filtered_module_data[supported_dt] = make_aware(
+                        datetime.strptime(date, "%Y-%m-%d")
+                    )
+
             ps_module, _ = PsModule.objects.update_or_create(
                 name=module_name,
                 defaults={"ps_product": ps_product, **filtered_module_data},

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -831,7 +831,7 @@ class Flaw(
         # TODO
         # we currently do not have this information available
         # so we assume that this was always Major Incident
-        if self.is_major_incident:
+        if self.is_major_incident_temp():
             return self.reported_dt
 
     # non operational meta data

--- a/osidb/signals.py
+++ b/osidb/signals.py
@@ -38,7 +38,7 @@ def get_jira_user_id(email: str) -> str:
     jira_url = get_env("JIRA_URL", "https://issues.redhat.com")
     try:
         jira_api = JIRA(
-            {
+            options={
                 "server": jira_url,
                 # avoid auto-updating the lib
                 "check_update": False,

--- a/osidb/tests/test_endpoints.py
+++ b/osidb/tests/test_endpoints.py
@@ -6,7 +6,7 @@ import pytest
 from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.timezone import datetime
+from django.utils.timezone import datetime, make_aware
 from freezegun import freeze_time
 from rest_framework import status
 from rest_framework.exceptions import ValidationError
@@ -405,7 +405,7 @@ class TestEndpoints(object):
     @freeze_time(datetime(2021, 11, 23))
     def test_changed_before_from_tracker(self, auth_client, test_api_uri):
         ps_module = PsModuleFactory(bts_name="bugzilla")
-        flaw = FlawFactory(updated_dt=datetime(2021, 11, 23))
+        flaw = FlawFactory(updated_dt=make_aware(datetime(2021, 11, 23)))
         affect = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
@@ -443,7 +443,7 @@ class TestEndpoints(object):
 
     @freeze_time(datetime(2021, 11, 23))
     def test_changed_before_from_affect(self, auth_client, test_api_uri):
-        flaw = FlawFactory(updated_dt=datetime(2021, 11, 23))
+        flaw = FlawFactory(updated_dt=make_aware(datetime(2021, 11, 23)))
         affect = AffectFactory(flaw=flaw, updated_dt=datetime(2021, 11, 23))
         past_dt = datetime(2019, 11, 27)
 
@@ -466,7 +466,7 @@ class TestEndpoints(object):
     @freeze_time(datetime(2021, 11, 23))
     def test_changed_before_from_multi_tracker(self, auth_client, test_api_uri):
         ps_module = PsModuleFactory(bts_name="bugzilla")
-        flaw = FlawFactory(updated_dt=datetime(2021, 11, 23))
+        flaw = FlawFactory(updated_dt=make_aware(datetime(2021, 11, 23)))
         affect1 = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,

--- a/osidb/tests/test_users.py
+++ b/osidb/tests/test_users.py
@@ -36,7 +36,7 @@ class TestUsers:
         jira_url = get_env("JIRA_URL", "https://issues.redhat.com")
         bz_api = Bugzilla(bz_url, api_key=bz_token, force_rest=True)
         jira_api = JIRA(
-            {
+            options={
                 "server": jira_url,
                 # avoid auto-updating the lib
                 "check_update": False,

--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,8 @@ markers =
     integration: marks a test that requires access to running environment.
     enable_signals: enables django signals to run.
     enable_rls: enables row-level-security in the database during testing.
+
+filterwarnings =
+    error
+    default::django.utils.deprecation.RemovedInDjango41Warning
+    default:.*accessing deprecated field.*:DeprecationWarning


### PR DESCRIPTION
This PR fixes several warnings that pop up when running all tests in CI/locally and updates the `pytest.ini` file to treat some warnings as errors (everything except `RemovedInDjango41Warning` and `DeprecationWarning` containing `accessing deprecated field`).

Closes OSIDB-1717