### PR TITLE
Enable regex CORS policy

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -283,9 +283,11 @@ DEFAULT_REQUEST_TIMEOUT = get_env(
     "OSIDB_DEFAULT_REQUEST_TIMEOUT", default="30", is_int=True
 )
 
-# sets the Access-Control-Allow-Origin response header
-# example value: ["https://osidb.example.com", "https://workflows.example.com"]
-CORS_ALLOWED_ORIGINS = get_env("OSIDB_CORS_ALLOWED_ORIGINS", default="[]", is_json=True)
+# sets the Access-Control-Allow-Origin response header - accepts regex
+# example value: [ r"^https://([^.]*\.)?\.example\.com$" ]
+CORS_ALLOWED_ORIGIN_REGEXES = get_env(
+    "OSIDB_CORS_ALLOWED_ORIGINS", default="[]", is_json=True
+)
 # sets the Access-Control-Allow-Headers response header; lowercase
 CORS_ALLOW_HEADERS = (
     *default_headers,

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -156,3 +156,9 @@ if get_env("MPP", is_bool=True, default="False"):
             }
         }
     )
+
+# sets the Access-Control-Allow-Origin response header - accepts literal strings
+# example value: ["https://osidb.example.com", "https://workflows.example.com"]
+CORS_ALLOWED_ORIGINS = get_env("OSIDB_CORS_ALLOWED_ORIGINS", default="[]", is_json=True)
+# removes default config that allows regex
+CORS_ALLOWED_ORIGIN_REGEXES = []

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Renamed OSIM module to Workflows (OSIDB-1395)
+- Change settings to allow regex in CORS policy in stage environment (OSIDB-1737)
 
 ### Removed
 - Remove daily monitoring email for failed tasks / collectors (OSIDB-1215)


### PR DESCRIPTION
This PR change CORS settings to allow regex in the policy.

This PR changes removes `CORS_ALLOWED_ORIGINS` from `settings.py` and add CORS policy directly to `settings_prod.py` and `settings_stage.py` to allow different behaviors. Production will continue with the same behaviors while stage will use  `CORS_ALLOWED_ORIGIN_REGEXES` instead of `CORS_ALLOWED_ORIGINS`, allowing regex rules for the CORS policy instead of literal rules.

Partially closes OSIDB-1737. 