### PR TITLE
Make tests independent from env file

### DIFF
--- a/apps/taskman/tests/conftest.py
+++ b/apps/taskman/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from django.conf import settings
 from taskman.constants import JIRA_AUTH_TOKEN, TASKMAN_API_VERSION
 
+import apps.taskman.service as service
 from osidb.constants import OSIDB_API_VERSION
 
 
@@ -51,12 +52,14 @@ def test_api_uri(test_scheme_host, api_version):
 
 
 @pytest.fixture(autouse=True)
-def pin_urls(monkeypatch) -> None:
+def pin_envs(monkeypatch) -> None:
     """
-    the tests should be immune to what .evn you build the testrunner with
+    the tests should be immune to what .env you build the testrunner with
     """
     monkeypatch.setenv("HTTPS_PROXY", "http://squid.corp.redhat.com:3128")
-    monkeypatch.setenv("JIRA_TASKMAN_URL", "https://issues.redhat.com")
+    monkeypatch.setenv("JIRA_TASKMAN_URL", "https://example.com/")
+    monkeypatch.setenv("JIRA_TASKMAN_AUTO_SYNC_FLAW", "1")
+    monkeypatch.setattr(service, "JIRA_TASKMAN_URL", "https://example.com")
 
 
 @pytest.fixture

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -1,5 +1,6 @@
 import pytest
 
+import apps.trackers.common as common
 from apps.sla.framework import SLAFramework
 from apps.trackers.constants import TRACKERS_API_VERSION
 from osidb.models import Tracker
@@ -24,11 +25,12 @@ def enable_db_access_for_all_tests(db) -> None:
 
 
 @pytest.fixture(autouse=True)
-def pin_urls(monkeypatch) -> None:
+def pin_envs(monkeypatch) -> None:
     """
-    the tests should be immune to what .evn you build the testrunner with
+    the tests should be immune to what .env you build the testrunner with
     """
     monkeypatch.setenv("HTTPS_PROXY", "http://squid.corp.redhat.com:3128")
+    monkeypatch.setattr(common, "BZ_URL", "https://example.com")
 
 
 @pytest.fixture

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -496,7 +496,7 @@ until the embargo has lifted. Please post the patch only to the \
                 """\
 More information about this security flaw is available in the following bug:
 
-https://bugzilla.redhat.com/show_bug.cgi?id=0
+https://example.com/show_bug.cgi?id=0
 
 Disclaimer: Community trackers are created by Red Hat Product Security team on a \
 best effort basis. Package maintainers are required to ascertain if the flaw indeed \
@@ -507,8 +507,8 @@ affects their package, before starting the update process."""
                 """\
 More information about these security flaws is available in the following bugs:
 
-https://bugzilla.redhat.com/show_bug.cgi?id=0
-https://bugzilla.redhat.com/show_bug.cgi?id=1
+https://example.com/show_bug.cgi?id=0
+https://example.com/show_bug.cgi?id=1
 
 Disclaimer: Community trackers are created by Red Hat Product Security team on a \
 best effort basis. Package maintainers are required to ascertain if the flaw indeed \
@@ -519,9 +519,9 @@ affects their package, before starting the update process."""
                 """\
 More information about these security flaws is available in the following bugs:
 
-https://bugzilla.redhat.com/show_bug.cgi?id=0
-https://bugzilla.redhat.com/show_bug.cgi?id=1
-https://bugzilla.redhat.com/show_bug.cgi?id=2
+https://example.com/show_bug.cgi?id=0
+https://example.com/show_bug.cgi?id=1
+https://example.com/show_bug.cgi?id=2
 
 Disclaimer: Community trackers are created by Red Hat Product Security team on a \
 best effort basis. Package maintainers are required to ascertain if the flaw indeed \
@@ -577,7 +577,7 @@ Flaw:
 -----
 
 serious flaw
-https://bugzilla.redhat.com/show_bug.cgi?id=12345
+https://example.com/show_bug.cgi?id=12345
 
 this flaw is very hard to fix
 
@@ -637,7 +637,7 @@ Flaw:
 -----
 
 serious flaw
-https://bugzilla.redhat.com/show_bug.cgi?id=12345
+https://example.com/show_bug.cgi?id=12345
 
 this flaw is very hard to fix
 

--- a/collectors/errata/tests/conftest.py
+++ b/collectors/errata/tests/conftest.py
@@ -37,9 +37,9 @@ def sample_search_time():
 
 
 @pytest.fixture(autouse=True)
-def pin_urls(monkeypatch) -> None:
+def pin_envs(monkeypatch) -> None:
     """
-    the tests should be immune to what .evn you build the testrunner with
+    the tests should be immune to what .env you build the testrunner with
     """
     import collectors.errata.core as core
 

--- a/collectors/jiraffe/tests/conftest.py
+++ b/collectors/jiraffe/tests/conftest.py
@@ -7,8 +7,8 @@ def enable_db_access_for_all_tests(db):
 
 
 @pytest.fixture()
-def pin_urls(monkeypatch) -> None:
+def pin_envs(monkeypatch) -> None:
     """
-    the tests should be immune to what .evn you build the testrunner with
+    the tests should be immune to what .env you build the testrunner with
     """
     monkeypatch.setenv("HTTPS_PROXY", "http://squid.corp.redhat.com:3128")

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -190,7 +190,7 @@ class TestMetadataCollector:
     @freeze_time(timezone.datetime(2015, 12, 12))
     @pytest.mark.vcr
     @pytest.mark.parametrize("project_key,fields_count", [("RHEL", 120), ("OSIM", 20)])
-    def test_collect(self, pin_urls, project_key, fields_count):
+    def test_collect(self, pin_envs, project_key, fields_count):
         """
         Test that collector is able to get metadata from Jira projects
         """

--- a/collectors/product_definitions/constants.py
+++ b/collectors/product_definitions/constants.py
@@ -4,7 +4,7 @@ product definitions collector constants
 
 from osidb.helpers import get_env
 
-PRODUCT_DEFINITIONS_REPO_URL = get_env("PRODUCT_DEF_URL")
+PRODUCT_DEFINITIONS_REPO_URL = get_env("PRODUCT_DEF_URL", "")
 
 PRODUCT_DEFINITIONS_REPO_BRANCH = "master"
 

--- a/collectors/product_definitions/tests/conftest.py
+++ b/collectors/product_definitions/tests/conftest.py
@@ -4,3 +4,18 @@ import pytest
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
+
+
+@pytest.fixture(autouse=True)
+def pin_envs(monkeypatch) -> None:
+    """
+    the tests should be immune to what .env you build the testrunner with
+    """
+    monkeypatch.setenv(
+        "PRODUCT_DEF_URL", "https://example.com/prodsec/product-definitions"
+    )
+
+
+@pytest.fixture
+def product_definition_url():
+    return "https://example.com/prodsec/product-definitions/-/jobs/artifacts/master/raw/products.json"

--- a/collectors/product_definitions/tests/test_core.py
+++ b/collectors/product_definitions/tests/test_core.py
@@ -94,8 +94,8 @@ class TestProductDefinitionsCollection:
 
     @pytest.mark.default_cassette(PRODUCT_DEFINITIONS_CASSETTE)
     @pytest.mark.vcr
-    def test_sanitize(self):
-        raw_data = fetch_product_definitions()
+    def test_sanitize(self, product_definition_url):
+        raw_data = fetch_product_definitions(url=product_definition_url)
         (
             ps_products,
             ps_modules,
@@ -123,8 +123,10 @@ class TestProductDefinitionsCollection:
 
     @pytest.mark.default_cassette(PRODUCT_DEFINITIONS_CASSETTE)
     @pytest.mark.vcr
-    def test_ps_contacts_sync(self):
-        raw_data = self.sample_data(fetch_product_definitions())
+    def test_ps_contacts_sync(self, product_definition_url):
+        raw_data = self.sample_data(
+            fetch_product_definitions(url=product_definition_url)
+        )
         _, _, _, ps_contacts = sanitize_product_definitions(raw_data)
 
         sync_ps_contacts(ps_contacts)
@@ -137,8 +139,10 @@ class TestProductDefinitionsCollection:
 
     @pytest.mark.default_cassette(PRODUCT_DEFINITIONS_CASSETTE)
     @pytest.mark.vcr
-    def test_ps_update_streams_sync(self):
-        raw_data = self.sample_data(fetch_product_definitions())
+    def test_ps_update_streams_sync(self, product_definition_url):
+        raw_data = self.sample_data(
+            fetch_product_definitions(url=product_definition_url)
+        )
         _, _, ps_update_streams, _ = sanitize_product_definitions(raw_data)
 
         sync_ps_update_streams(ps_update_streams)
@@ -151,8 +155,10 @@ class TestProductDefinitionsCollection:
 
     @pytest.mark.default_cassette(PRODUCT_DEFINITIONS_CASSETTE)
     @pytest.mark.vcr
-    def test_ps_products_modules_sync(self):
-        raw_data = self.sample_data(fetch_product_definitions())
+    def test_ps_products_modules_sync(self, product_definition_url):
+        raw_data = self.sample_data(
+            fetch_product_definitions(url=product_definition_url)
+        )
         ps_products, ps_modules, _, _ = sanitize_product_definitions(raw_data)
 
         sync_ps_products_modules(ps_products, ps_modules)
@@ -167,8 +173,10 @@ class TestProductDefinitionsCollection:
 
     @pytest.mark.default_cassette(PRODUCT_DEFINITIONS_CASSETTE)
     @pytest.mark.vcr
-    def test_additional_ps_update_stream_module_link(self):
-        raw_data = self.sample_data(fetch_product_definitions())
+    def test_additional_ps_update_stream_module_link(self, product_definition_url):
+        raw_data = self.sample_data(
+            fetch_product_definitions(url=product_definition_url)
+        )
         (
             ps_products,
             ps_modules,

--- a/collectors/ps_constants/tests/cassettes/test_core/TestPsConstantsCollection.test_fetch_ps_constants.yaml
+++ b/collectors/ps_constants/tests/cassettes/test_core/TestPsConstantsCollection.test_fetch_ps_constants.yaml
@@ -98,13 +98,31 @@ interactions:
         \ - tuned\n  - tzdata\n  - unbound\n  - usbguard\n  - usermode\n  - userspace-rcu\n
         \ - util-linux\n  - vim\n  - virt-what\n  - WALinuxAgent\n  - wget\n  - which\n
         \ - xfsprogs\n  - xkeyboard-config\n  - xmlsec1\n  - xz\n  - yajl\n  - zlib\n
-        \ - zstd\n  streams:\n  - rhel-8.6.0.z\n  - rhel-8.9.0.z\n\nopenshift-4:\n
-        \ components:\n  - cluster-etcd-operator-container\n  - cluster-monitoring-operator-container\n
-        \ - cluster-network-operator-container\n  - cluster-node-tuning-operator-container\n
-        \ - conmon\n  - console-login-helper-messages\n  - container-selinux\n  -
-        containernetworking-plugins\n  - containers-common\n  - coredns-container\n
-        \ - coreos-installer\n  - cri-o\n  - criu\n  - crun\n  - csi-attacher-container\n
-        \ - csi-livenessprobe-container\n  - csi-node-driver-registrar-container\n
+        \ - zstd\n  - abattis-cantarell-fonts\n  - adwaita-icon-theme\n  - alsa-lib\n
+        \ - at-spi2-atk\n  - at-spi2-core\n  - atk\n  - bc\n  - cairo\n  - cmake\n
+        \ - colord\n  - copy-jdk-configs\n  - dconf\n  - dejavu-fonts\n  - environment-modules\n
+        \ - fontconfig\n  - fontpackages\n  - fribidi\n  - gdk-pixbuf2\n  - git-lfs\n
+        \ - glib-networking\n  - graphite2\n  - grubby\n  - gsettings-desktop-schemas\n
+        \ - gtk2\n  - gtk3\n  - harfbuzz\n  - hicolor-icon-theme\n  - jasper\n  -
+        java-1.8.0-openjdk\n  - java-11-openjdk\n  - javapackages-runtime:201801/javapackages-tools\n
+        \ - jbigkit\n  - lcms2\n  - libdatrie\n  - libepoxy\n  - libfontenc\n  - libjpeg-turbo\n
+        \ - libmodman\n  - libpipeline\n  - libproxy\n  - libsoup\n  - libthai\n  -
+        libtiff\n  - libuv\n  - libX11\n  - libXau\n  - libxcb\n  - libXcomposite\n
+        \ - libXcursor\n  - libXdamage\n  - libXext\n  - libXfixes\n  - libXft\n  -
+        libXi\n  - libXinerama\n  - libXrandr\n  - libXrender\n  - libXtst\n  - lksctp-tools\n
+        \ - man-db\n  - nspr\n  - nss\n  - nss_wrapper\n  - pango\n  - perl-libwww-perl\n
+        \ - postgresql:15/postgresql\n  - rest\n  - scl-utils\n  - tcl\n  - ttmkfdir\n
+        \ - unzip\n  - uuid\n  - wayland\n  - xmlstarlet\n  - xorg-x11-font-utils\n
+        \ - xorg-x11-fonts\n  - zip\n  streams:\n  - rhel-8.6.0.z\n  - rhel-8.9.0.z\n#
+        IMPORTANT NOTE: starting from \"zlib\" component there are components from
+        the IBM FedRAMP environment\n\n# the \"openshift-golang-builder-container\"
+        in the openshift-4 components list is a special entry to help RHEL Golang
+        team with with prioritization\nopenshift-4:\n  components:\n  - cluster-etcd-operator-container\n
+        \ - cluster-monitoring-operator-container\n  - cluster-network-operator-container\n
+        \ - cluster-node-tuning-operator-container\n  - conmon\n  - console-login-helper-messages\n
+        \ - container-selinux\n  - containernetworking-plugins\n  - containers-common\n
+        \ - coredns-container\n  - coreos-installer\n  - cri-o\n  - criu\n  - crun\n
+        \ - csi-attacher-container\n  - csi-livenessprobe-container\n  - csi-node-driver-registrar-container\n
         \ - csi-provisioner-container\n  - fuse-overlayfs\n  - golang-github-openshift-oauth-proxy-container\n
         \ - golang-github-prometheus-alertmanager-container\n  - golang-github-prometheus-node_exporter-container\n
         \ - golang-github-prometheus-prometheus-container\n  - ignition\n  - kube-rbac-proxy-container\n
@@ -113,23 +131,24 @@ interactions:
         \ - openshift-enterprise-cli-container\n  - openshift-enterprise-console-container\n
         \ - openshift-enterprise-console-operator-container\n  - openshift-enterprise-haproxy-router-container\n
         \ - openshift-enterprise-hyperkube-container\n  - openshift-enterprise-registry-container\n
-        \ - openshift-state-metrics-container\n  - openvswitch-selinux-extra-policy\n
-        \ - openvswitch2.13\n  - openvswitch2.17\n  - operator-lifecycle-manager-container\n
-        \ - ose-aws-ebs-csi-driver-container\n  - ose-aws-ebs-csi-driver-operator-container\n
-        \ - ose-aws-pod-identity-webhook-container\n  - ose-cli-artifacts-container\n
-        \ - ose-cloud-credential-operator-container\n  - ose-cloud-network-config-controller-container\n
-        \ - ose-cluster-authentication-operator-container\n  - ose-cluster-autoscaler-operator-container\n
-        \ - ose-cluster-baremetal-operator-container\n  - ose-cluster-cloud-controller-manager-operator-container\n
-        \ - ose-cluster-config-operator-container\n  - ose-cluster-csi-snapshot-controller-operator-container\n
-        \ - ose-cluster-dns-operator-container\n  - ose-cluster-image-registry-operator-container\n
-        \ - ose-cluster-ingress-operator-container\n  - ose-cluster-kube-apiserver-operator-container\n
-        \ - ose-cluster-kube-controller-manager-operator-container\n  - ose-cluster-kube-scheduler-operator-container\n
-        \ - ose-cluster-kube-storage-version-migrator-operator-container\n  - ose-cluster-machine-approver-container\n
-        \ - ose-cluster-openshift-apiserver-operator-container\n  - ose-cluster-openshift-controller-manager-operator-container\n
-        \ - ose-cluster-samples-operator-container\n  - ose-cluster-storage-operator-container\n
-        \ - ose-csi-external-resizer-container\n  - ose-csi-external-snapshotter-container\n
-        \ - ose-csi-snapshot-controller-container\n  - ose-csi-snapshot-validation-webhook-container\n
-        \ - ose-etcd-container\n  - ose-insights-operator-container\n  - ose-kube-storage-version-migrator-container\n
+        \ - openshift-state-metrics-container\n  - openshift-golang-builder-container\n
+        \ - openvswitch-selinux-extra-policy\n  - openvswitch2.13\n  - openvswitch2.17\n
+        \ - operator-lifecycle-manager-container\n  - ose-aws-ebs-csi-driver-container\n
+        \ - ose-aws-ebs-csi-driver-operator-container\n  - ose-aws-pod-identity-webhook-container\n
+        \ - ose-cli-artifacts-container\n  - ose-cloud-credential-operator-container\n
+        \ - ose-cloud-network-config-controller-container\n  - ose-cluster-authentication-operator-container\n
+        \ - ose-cluster-autoscaler-operator-container\n  - ose-cluster-baremetal-operator-container\n
+        \ - ose-cluster-cloud-controller-manager-operator-container\n  - ose-cluster-config-operator-container\n
+        \ - ose-cluster-csi-snapshot-controller-operator-container\n  - ose-cluster-dns-operator-container\n
+        \ - ose-cluster-image-registry-operator-container\n  - ose-cluster-ingress-operator-container\n
+        \ - ose-cluster-kube-apiserver-operator-container\n  - ose-cluster-kube-controller-manager-operator-container\n
+        \ - ose-cluster-kube-scheduler-operator-container\n  - ose-cluster-kube-storage-version-migrator-operator-container\n
+        \ - ose-cluster-machine-approver-container\n  - ose-cluster-openshift-apiserver-operator-container\n
+        \ - ose-cluster-openshift-controller-manager-operator-container\n  - ose-cluster-samples-operator-container\n
+        \ - ose-cluster-storage-operator-container\n  - ose-csi-external-resizer-container\n
+        \ - ose-csi-external-snapshotter-container\n  - ose-csi-snapshot-controller-container\n
+        \ - ose-csi-snapshot-validation-webhook-container\n  - ose-etcd-container\n
+        \ - ose-insights-operator-container\n  - ose-kube-storage-version-migrator-container\n
         \ - ose-machine-api-operator-container\n  - ose-machine-api-provider-aws-container\n
         \ - ose-machine-config-operator-container\n  - ose-multus-admission-controller-container\n
         \ - ose-network-metrics-daemon-container\n  - ose-node-container\n  - ose-oauth-apiserver-container\n
@@ -139,8 +158,179 @@ interactions:
         prometheus-config-reloader-container\n  - prometheus-operator-admission-webhook-container\n
         \ - prometheus-operator-container\n  - runc\n  - rust-afterburn\n  - rust-bootupd\n
         \ - skopeo\n  - slirp4netns\n  - telemeter-container\n  - toolbox\n  streams:\n
-        \ - openshift-4.11.z\n\nfdp-el8-ovs:\n  components:\n  - openvswitch-selinux-extra-policy\n
-        \ - openvswitch2.13\n  - openvswitch2.17\n  streams:\n  - fdp-el8-ovs\n\n"
+        \ - openshift-4.12.z\n\nfdp-el8-ovs:\n  components:\n  - openvswitch-selinux-extra-policy\n
+        \ - openvswitch2.13\n  - openvswitch2.17\n  streams:\n  - fdp-el8-ovs\n\n#
+        IBM FedRAMP components\nocp-tools-4:\n  components:\n  - jenkins\n  - jenkins-2-plugins\n
+        \ - jenkins-agent-base-rhel8-container\n  - openshift-jenkins-2-container\n
+        \ streams:\n  - ocp-tools-4.14\n\n# IBM FedRAMP components\nrhel-9:\n  components:\n
+        \ - alsa-lib\n  - chkconfig\n  - audit\n  - avahi\n  - basesystem\n  - bash\n
+        \ - bzip2\n  - ca-certificates\n  - copy-jdk-configs\n  - coreutils\n  - crypto-policies\n
+        \ - cups\n  - curl\n  - cyrus-sasl\n  - dbus\n  - dejavu-fonts\n  - dnf\n
+        \ - expat\n  - file\n  - filesystem\n  - findutils\n  - fonts-rpm-macros\n
+        \ - gawk\n  - gdbm\n  - glib2\n  - glibc\n  - gmp\n  - gnupg2\n  - gnutls\n
+        \ - gobject-introspection\n  - gpgme\n  - grep\n  - java-17-openjdk\n  - javapackages-tools\n
+        \ - json-c\n  - json-glib\n  - keyutils\n  - krb5\n  - langpacks\n  - acl\n
+        \ - libarchive\n  - libassuan\n  - attr\n  - util-linux\n  - libcap\n  - libcap-ng\n
+        \ - e2fsprogs\n  - libdnf\n  - libevent\n  - libffi\n  - gcc\n  - libgcrypt\n
+        \ - libgpg-error\n  - libidn2\n  - libksba\n  - libmodulemd\n  - nghttp2\n
+        \ - libpeas\n  - librepo\n  - libreport\n  - librhsm\n  - libselinux\n  -
+        libsemanage\n  - libsepol\n  - libsigsegv\n  - libsolv\n  - libtasn1\n  -
+        libunistring\n  - libusbx\n  - libverto\n  - libxcrypt\n  - libxml2\n  - libyaml\n
+        \ - zstd\n  - lksctp-tools\n  - lua\n  - lua-posix\n  - lz4\n  - microdnf\n
+        \ - mpfr\n  - ncurses\n  - nettle\n  - npth\n  - nss\n  - openldap\n  - openssl\n
+        \ - p11-kit\n  - pcre\n  - pcre2\n  - popt\n  - python3.9\n  - python-pip\n
+        \ - python-setuptools\n  - readline\n  - redhat-release\n  - rootfiles\n  -
+        rpm\n  - sed\n  - setup\n  - shadow-utils\n  - sqlite\n  - systemd\n  - tzdata\n
+        \ - xz\n  - zlib\n  streams:\n  - rhel-9.3.0.z\n\n\n# Red Hat Build of Keycloak
+        22 components\nrhbk:\n  components:\n  - aesh\n  - agroal-api\n  - agroal-narayana\n
+        \ - agroal-pool\n  - angus-activation\n  - angus-mail\n  - annotations\n  -
+        antlr4-runtime\n  - aopalliance\n  - apache-mime4j-core\n  - apache-mime4j-dom\n
+        \ - apache-mime4j-storage\n  - apiguardian-api\n  - arc\n  - arc-processor\n
+        \ - asm\n  - asm-analysis\n  - asm-commons\n  - asm-tree\n  - asm-util\n  -
+        asyncutil\n  - awaitility\n  - bcpkix-jdk18on\n  - bcprov-jdk18on\n  - bcutil-jdk18on\n
+        \ - btf\n  - byte-buddy\n  - caffeine\n  - cockroachdb\n  - codemodel\n  -
+        commons-cli\n  - commons-codec\n  - commons-collections4\n  - commons-compress\n
+        \ - commons-io\n  - commons-lang3\n  - commons-logging-jboss-logging\n  -
+        core\n  - database-commons\n  - docker-java-api\n  - docker-java-transport\n
+        \ - docker-java-transport-zerodep\n  - duct-tape\n  - failureaccess\n  - freemarker\n
+        \ - gizmo\n  - graal-sdk\n  - guava\n  - guice\n  - hamcrest-core\n  - hibernate-commons-annotations\n
+        \ - hibernate-core\n  - hibernate-graalvm\n  - httpclient\n  - httpcore\n
+        \ - importmap\n  - infinispan-cachestore-remote\n  - infinispan-client-hotrod-jakarta\n
+        \ - infinispan-commons-jakarta\n  - infinispan-core-jakarta\n  - infinispan-jboss-marshalling\n
+        \ - infinispan-query-dsl\n  - infinispan-remote-query-client\n  - istack-commons-runtime\n
+        \ - istack-commons-tools\n  - jackson-annotations\n  - jackson-core\n  - jackson-coreutils\n
+        \ - jackson-databind\n  - jackson-dataformat-cbor\n  - jackson-dataformat-yaml\n
+        \ - jackson-datatype-jdk8\n  - jackson-datatype-jsr310\n  - jackson-jakarta-rs-base\n
+        \ - jackson-jakarta-rs-json-provider\n  - jackson-module-jakarta-xmlbind-annotations\n
+        \ - jackson-module-parameter-names\n  - jakarta.activation\n  - jakarta.activation-api\n
+        \ - jakarta.annotation-api\n  - jakarta.ejb-api\n  - jakarta.el-api\n  - jakarta.enterprise.cdi-api\n
+        \ - jakarta.enterprise.lang-model\n  - jakarta.inject-api\n  - jakarta.interceptor-api\n
+        \ - jakarta.json-api\n  - jakarta.mail-api\n  - jakarta.persistence-api\n
+        \ - jakarta.resource-api\n  - jakarta.servlet-api\n  - jakarta.transaction-api\n
+        \ - jakarta.validation-api\n  - jakarta.ws.rs-api\n  - jakarta.xml.bind-api\n
+        \ - jakarta.xml.soap-api\n  - jandex\n  - jansi\n  - javase\n  - javassist\n
+        \ - javax.activation-api\n  - javax.annotation-api\n  - javax.inject\n  -
+        jaxb-api\n  - jaxb-core\n  - jaxb-jxc\n  - jaxb-runtime\n  - jaxb-xjc\n  -
+        jboss-invocation\n  - jboss-logging\n  - jboss-logging-annotations\n  - jboss-logmanager-embedded\n
+        \ - jboss-marshalling\n  - jboss-marshalling-river\n  - jboss-metadata-common\n
+        \ - jboss-metadata-web\n  - jboss-threads\n  - jboss-transaction-spi\n  -
+        jdbc\n  - jgroups\n  - jna\n  - jna-platform\n  - json-patch\n  - jts-core\n
+        \ - junit\n  - junit-jupiter\n  - junit-jupiter-api\n  - junit-jupiter-engine\n
+        \ - junit-jupiter-params\n  - junit-platform-commons\n  - junit-platform-engine\n
+        \ - junit-platform-launcher\n  - kerby-asn1\n  - keycloak-account-ui\n  -
+        keycloak-admin-cli\n  - keycloak-admin-ui\n  - keycloak-authz-policy-common\n
+        \ - keycloak-client-cli-dist\n  - keycloak-client-registration-cli\n  - keycloak-common\n
+        \ - keycloak-config-api\n  - keycloak-core\n  - keycloak-crypto-default\n
+        \ - keycloak-crypto-fips1402\n  - keycloak-js-adapter-jar\n  - keycloak-kerberos-federation\n
+        \ - keycloak-ldap-federation\n  - keycloak-model-infinispan\n  - keycloak-model-jpa\n
+        \ - keycloak-model-legacy\n  - keycloak-model-legacy-private\n  - keycloak-model-legacy-services\n
+        \ - keycloak-model-map\n  - keycloak-model-map-file\n  - keycloak-model-map-hot-rod\n
+        \ - keycloak-model-map-jpa\n  - keycloak-quarkus-dist\n  - keycloak-quarkus-server\n
+        \ - keycloak-quarkus-server-app\n  - keycloak-rest-admin-ui-ext\n  - keycloak-saml-core\n
+        \ - keycloak-saml-core-public\n  - keycloak-server-spi\n  - keycloak-server-spi-private\n
+        \ - keycloak-services\n  - keycloak-sssd-federation\n  - keycloak-themes\n
+        \ - liquibase-core\n  - logstash-gelf\n  - mariadb\n  - mariadb-java-client\n
+        \ - maven-api-meta\n  - maven-api-xml\n  - maven-artifact\n  - maven-builder-support\n
+        \ - maven-core\n  - maven-embedder\n  - maven-model\n  - maven-model-builder\n
+        \ - maven-plugin-api\n  - maven-repository-metadata\n  - maven-resolver-api\n
+        \ - maven-resolver-connector-basic\n  - maven-resolver-impl\n  - maven-resolver-named-locks\n
+        \ - maven-resolver-provider\n  - maven-resolver-spi\n  - maven-resolver-transport-http\n
+        \ - maven-resolver-transport-wagon\n  - maven-resolver-util\n  - maven-settings\n
+        \ - maven-settings-builder\n  - maven-shared-utils\n  - maven-xml-impl\n  -
+        micrometer-commons\n  - micrometer-core\n  - micrometer-observation\n  - micrometer-registry-prometheus\n
+        \ - microprofile-config\n  - microprofile-config-api\n  - microprofile-context-propagation-api\n
+        \ - microprofile-health-api\n  - microprofile-openapi-api\n  - microprofile-reactive-streams-operators-api\n
+        \ - msg-simple\n  - mssql-jdbc\n  - mssqlserver\n  - mutiny\n  - mutiny-smallrye-context-propagation\n
+        \ - mutiny-zero-flow-adapters\n  - mxparser\n  - mysql\n  - mysql-connector-java\n
+        \ - narayana-jta\n  - narayana-jts-integration\n  - nashorn-core\n  - netty-buffer\n
+        \ - netty-codec\n  - netty-codec-dns\n  - netty-codec-haproxy\n  - netty-codec-http\n
+        \ - netty-codec-http2\n  - netty-codec-socks\n  - netty-common\n  - netty-handler\n
+        \ - netty-handler-proxy\n  - netty-resolver\n  - netty-resolver-dns\n  - netty-transport\n
+        \ - netty-transport-classes-epoll\n  - netty-transport-native-epoll\n  - netty-transport-native-unix-common\n
+        \ - ojdbc11\n  - opencsv\n  - opentest4j\n  - orai18n\n  - org-crac\n  - org.eclipse.sisu.inject\n
+        \ - org.eclipse.sisu.plexus\n  - owasp-java-html-sanitizer\n  - parsson\n
+        \ - picocli\n  - plexus-cipher\n  - plexus-classworlds\n  - plexus-component-annotations\n
+        \ - plexus-interpolation\n  - plexus-sec-dispatcher\n  - plexus-utils\n  -
+        plexus-xml\n  - postgresql\n  - protoparser\n  - protostream\n  - protostream-types\n
+        \ - quarkus-agroal\n  - quarkus-agroal-deployment\n  - quarkus-agroal-spi\n
+        \ - quarkus-arc\n  - quarkus-arc-deployment\n  - quarkus-bootstrap-app-model\n
+        \ - quarkus-bootstrap-core\n  - quarkus-bootstrap-gradle-resolver\n  - quarkus-bootstrap-maven-resolver\n
+        \ - quarkus-bootstrap-runner\n  - quarkus-builder\n  - quarkus-caffeine\n
+        \ - quarkus-caffeine-deployment\n  - quarkus-class-change-agent\n  - quarkus-core\n
+        \ - quarkus-core-deployment\n  - quarkus-credentials\n  - quarkus-credentials-deployment\n
+        \ - quarkus-datasource\n  - quarkus-datasource-common\n  - quarkus-datasource-deployment\n
+        \ - quarkus-datasource-deployment-spi\n  - quarkus-development-mode-spi\n
+        \ - quarkus-devtools-utilities\n  - quarkus-fs-util\n  - quarkus-hibernate-orm\n
+        \ - quarkus-hibernate-orm-deployment\n  - quarkus-hibernate-orm-deployment-spi\n
+        \ - quarkus-hibernate-validator-spi\n  - quarkus-http-core\n  - quarkus-http-http-core\n
+        \ - quarkus-http-servlet\n  - quarkus-ide-launcher\n  - quarkus-jackson\n
+        \ - quarkus-jackson-deployment\n  - quarkus-jackson-spi\n  - quarkus-jaxrs-spi-deployment\n
+        \ - quarkus-jdbc-h2\n  - quarkus-jdbc-h2-deployment\n  - quarkus-jdbc-mariadb\n
+        \ - quarkus-jdbc-mariadb-deployment\n  - quarkus-jdbc-mssql\n  - quarkus-jdbc-mssql-deployment\n
+        \ - quarkus-jdbc-mysql\n  - quarkus-jdbc-mysql-deployment\n  - quarkus-jdbc-oracle\n
+        \ - quarkus-jdbc-oracle-deployment\n  - quarkus-jdbc-postgresql\n  - quarkus-jdbc-postgresql-deployment\n
+        \ - quarkus-jsonp\n  - quarkus-jsonp-deployment\n  - quarkus-junit5\n  - quarkus-junit5-internal\n
+        \ - quarkus-junit5-properties\n  - quarkus-kubernetes-service-binding-spi\n
+        \ - quarkus-kubernetes-spi\n  - quarkus-local-cache\n  - quarkus-logging-gelf\n
+        \ - quarkus-logging-gelf-deployment\n  - quarkus-logging-json\n  - quarkus-logging-json-deployment\n
+        \ - quarkus-micrometer\n  - quarkus-micrometer-deployment\n  - quarkus-micrometer-registry-prometheus\n
+        \ - quarkus-micrometer-registry-prometheus-deployment\n  - quarkus-mutiny\n
+        \ - quarkus-mutiny-deployment\n  - quarkus-narayana-jta\n  - quarkus-narayana-jta-deployment\n
+        \ - quarkus-netty\n  - quarkus-netty-deployment\n  - quarkus-panache-common\n
+        \ - quarkus-panache-common-deployment\n  - quarkus-panache-hibernate-common\n
+        \ - quarkus-panache-hibernate-common-deployment\n  - quarkus-reactive-routes\n
+        \ - quarkus-reactive-routes-deployment\n  - quarkus-resteasy\n  - quarkus-resteasy-common\n
+        \ - quarkus-resteasy-common-deployment\n  - quarkus-resteasy-common-spi\n
+        \ - quarkus-resteasy-deployment\n  - quarkus-resteasy-jackson\n  - quarkus-resteasy-jackson-deployment\n
+        \ - quarkus-resteasy-reactive-server-spi-deployment\n  - quarkus-resteasy-reactive-spi-deployment\n
+        \ - quarkus-resteasy-server-common\n  - quarkus-resteasy-server-common-deployment\n
+        \ - quarkus-resteasy-server-common-spi\n  - quarkus-security\n  - quarkus-security-runtime-spi\n
+        \ - quarkus-security-spi\n  - quarkus-smallrye-context-propagation\n  - quarkus-smallrye-context-propagation-deployment\n
+        \ - quarkus-smallrye-context-propagation-spi\n  - quarkus-smallrye-health\n
+        \ - quarkus-smallrye-health-deployment\n  - quarkus-smallrye-health-spi\n
+        \ - quarkus-smallrye-openapi-spi\n  - quarkus-test-common\n  - quarkus-transaction-annotations\n
+        \ - quarkus-undertow-spi\n  - quarkus-vertx\n  - quarkus-vertx-deployment\n
+        \ - quarkus-vertx-http\n  - quarkus-vertx-http-deployment\n  - quarkus-vertx-http-deployment-spi\n
+        \ - quarkus-vertx-http-dev-console-runtime-spi\n  - quarkus-vertx-http-dev-console-spi\n
+        \ - quarkus-vertx-http-dev-ui-spi\n  - quarkus-vertx-latebound-mdc-provider\n
+        \ - qute-core\n  - reactive-streams\n  - readline\n  - relaxng-datatype\n
+        \ - resteasy-cdi\n  - resteasy-core\n  - resteasy-core-spi\n  - resteasy-jackson2-provider\n
+        \ - resteasy-jaxb-provider\n  - resteasy-multipart-provider\n  - resteasy-reactive\n
+        \ - resteasy-reactive-common\n  - resteasy-reactive-common-processor\n  -
+        resteasy-reactive-common-types\n  - resteasy-reactive-processor\n  - rngom\n
+        \ - rxjava\n  - saaj-impl\n  - shrinkwrap-api\n  - shrinkwrap-depchain\n  -
+        simpleclient\n  - simpleclient_common\n  - simpleclient_tracer_common\n  -
+        simpleclient_tracer_otel\n  - simpleclient_tracer_otel_agent\n  - slf4j-api\n
+        \ - slf4j-jboss-logmanager\n  - smallrye-beanbag\n  - smallrye-beanbag-maven\n
+        \ - smallrye-beanbag-sisu\n  - smallrye-common-annotation\n  - smallrye-common-classloader\n
+        \ - smallrye-common-constraint\n  - smallrye-common-expression\n  - smallrye-common-function\n
+        \ - smallrye-common-io\n  - smallrye-common-os\n  - smallrye-common-vertx-context\n
+        \ - smallrye-config\n  - smallrye-config-common\n  - smallrye-config-core\n
+        \ - smallrye-config-source-keystore\n  - smallrye-context-propagation\n  -
+        smallrye-context-propagation-api\n  - smallrye-context-propagation-jta\n  -
+        smallrye-context-propagation-storage\n  - smallrye-fault-tolerance-vertx\n
+        \ - smallrye-health\n  - smallrye-health-api\n  - smallrye-health-provided-checks\n
+        \ - smallrye-health-ui\n  - smallrye-mutiny-vertx-auth-common\n  - smallrye-mutiny-vertx-bridge-common\n
+        \ - smallrye-mutiny-vertx-core\n  - smallrye-mutiny-vertx-runtime\n  - smallrye-mutiny-vertx-uri-template\n
+        \ - smallrye-mutiny-vertx-web\n  - smallrye-mutiny-vertx-web-common\n  - smallrye-open-api-core\n
+        \ - smallrye-reactive-converter-api\n  - smallrye-reactive-converter-mutiny\n
+        \ - snakeyaml\n  - snakeyaml-engine\n  - stax-ex\n  - testcontainers\n  -
+        twitter4j-core\n  - txw2\n  - uap-java\n  - vertx-auth-common\n  - vertx-bridge-common\n
+        \ - vertx-codegen\n  - vertx-core\n  - vertx-mutiny-generator\n  - vertx-web\n
+        \ - vertx-web-common\n  - waffle-jna\n  - wagon-file\n  - wagon-http\n  -
+        wagon-http-shared\n  - wagon-provider-api\n  - webauthn4j-core\n  - webauthn4j-util\n
+        \ - weld-api\n  - wildfly-elytron-asn1\n  - wildfly-elytron-auth\n  - wildfly-elytron-auth-server\n
+        \ - wildfly-elytron-base\n  - wildfly-elytron-credential\n  - wildfly-elytron-http\n
+        \ - wildfly-elytron-keystore\n  - wildfly-elytron-mechanism\n  - wildfly-elytron-mechanism-digest\n
+        \ - wildfly-elytron-mechanism-gssapi\n  - wildfly-elytron-mechanism-oauth2\n
+        \ - wildfly-elytron-mechanism-scram\n  - wildfly-elytron-password-impl\n  -
+        wildfly-elytron-permission\n  - wildfly-elytron-provider-util\n  - wildfly-elytron-sasl\n
+        \ - wildfly-elytron-sasl-digest\n  - wildfly-elytron-sasl-external\n  - wildfly-elytron-sasl-gs2\n
+        \ - wildfly-elytron-sasl-gssapi\n  - wildfly-elytron-sasl-oauth2\n  - wildfly-elytron-sasl-plain\n
+        \ - wildfly-elytron-sasl-scram\n  - wildfly-elytron-security-manager-action\n
+        \ - wildfly-elytron-ssl\n  - wildfly-elytron-util\n  - wildfly-elytron-x500\n
+        \ - wildfly-elytron-x500-cert\n  - wildfly-elytron-x500-cert-util\n  - xmlpull\n
+        \ - xmlsec\n  - xsom\n  - xstream\n  streams:\n  - rhbk-22\n"
     headers:
       Cache-Control:
       - max-age=60, public, must-revalidate, stale-while-revalidate=60, stale-if-error=300,
@@ -149,14 +339,12 @@ interactions:
       - keep-alive
       Content-Disposition:
       - inline
-      Content-Length:
-      - '9953'
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Tue, 13 Feb 2024 12:56:00 GMT
+      - Mon, 11 Mar 2024 14:44:09 GMT
       Etag:
-      - '"691674dff94cdf5454ca44b2e77757ce"'
+      - W/"b64753605007cc8644a5d5d16a207709"
       Permissions-Policy:
       - interest-cohort=()
       Referrer-Policy:
@@ -165,7 +353,10 @@ interactions:
       - nginx
       Strict-Transport-Security:
       - max-age=63072000
+      Transfer-Encoding:
+      - chunked
       Vary:
+      - Accept-Encoding
       - Accept
       X-Content-Type-Options:
       - nosniff
@@ -174,17 +365,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Gitlab-Meta:
-      - '{"correlation_id":"01HPH8KPXM17CTG2TMY3E21AJ5","version":"1"}'
+      - '{"correlation_id":"01HRPZH4PYSQXYZ2BP6QVB8AQS","version":"1"}'
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 01HPH8KPXM17CTG2TMY3E21AJ5
+      - 01HRPZH4PYSQXYZ2BP6QVB8AQS
       X-Runtime:
-      - '0.069873'
+      - '0.091745'
       X-Ua-Compatible:
       - IE=edge
       X-Xss-Protection:
       - 1; mode=block
+      content-length:
+      - '25125'
     status:
       code: 200
       message: OK
@@ -236,14 +429,12 @@ interactions:
       - keep-alive
       Content-Disposition:
       - inline
-      Content-Length:
-      - '390'
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Tue, 13 Feb 2024 12:56:00 GMT
+      - Mon, 11 Mar 2024 14:44:09 GMT
       Etag:
-      - '"b213fc4391a512d06e735dc7a67b3d91"'
+      - W/"b213fc4391a512d06e735dc7a67b3d91"
       Permissions-Policy:
       - interest-cohort=()
       Referrer-Policy:
@@ -252,7 +443,10 @@ interactions:
       - nginx
       Strict-Transport-Security:
       - max-age=63072000
+      Transfer-Encoding:
+      - chunked
       Vary:
+      - Accept-Encoding
       - Accept
       X-Content-Type-Options:
       - nosniff
@@ -261,17 +455,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Gitlab-Meta:
-      - '{"correlation_id":"01HPH8KQ66G3HRAY5TN17C3957","version":"1"}'
+      - '{"correlation_id":"01HRPZH5B1GNAG6BDABH4Y691Y","version":"1"}'
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 01HPH8KQ66G3HRAY5TN17C3957
+      - 01HRPZH5B1GNAG6BDABH4Y691Y
       X-Runtime:
-      - '0.075541'
+      - '0.102553'
       X-Ua-Compatible:
       - IE=edge
       X-Xss-Protection:
       - 1; mode=block
+      content-length:
+      - '390'
     status:
       code: 200
       message: OK
@@ -345,14 +541,12 @@ interactions:
       - keep-alive
       Content-Disposition:
       - inline
-      Content-Length:
-      - '3562'
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Tue, 13 Feb 2024 12:56:00 GMT
+      - Mon, 11 Mar 2024 14:44:10 GMT
       Etag:
-      - '"4ce2e18af50d11b4c912fd6d020ee9db"'
+      - W/"4ce2e18af50d11b4c912fd6d020ee9db"
       Permissions-Policy:
       - interest-cohort=()
       Referrer-Policy:
@@ -361,7 +555,10 @@ interactions:
       - nginx
       Strict-Transport-Security:
       - max-age=63072000
+      Transfer-Encoding:
+      - chunked
       Vary:
+      - Accept-Encoding
       - Accept
       X-Content-Type-Options:
       - nosniff
@@ -370,17 +567,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Gitlab-Meta:
-      - '{"correlation_id":"01HPH8KQD92Q1RYCE663KDGS5R","version":"1"}'
+      - '{"correlation_id":"01HRPZH5KRTF302WVJXCA98PJV","version":"1"}'
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 01HPH8KQD92Q1RYCE663KDGS5R
+      - 01HRPZH5KRTF302WVJXCA98PJV
       X-Runtime:
-      - '0.078394'
+      - '0.094147'
       X-Ua-Compatible:
       - IE=edge
       X-Xss-Protection:
       - 1; mode=block
+      content-length:
+      - '3562'
     status:
       code: 200
       message: OK
@@ -450,14 +649,12 @@ interactions:
       - keep-alive
       Content-Disposition:
       - inline
-      Content-Length:
-      - '278'
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Tue, 13 Feb 2024 12:56:01 GMT
+      - Mon, 11 Mar 2024 14:44:10 GMT
       Etag:
-      - '"e421bf00158b35d34131f5f4673f888e"'
+      - W/"e421bf00158b35d34131f5f4673f888e"
       Permissions-Policy:
       - interest-cohort=()
       Referrer-Policy:
@@ -466,7 +663,10 @@ interactions:
       - nginx
       Strict-Transport-Security:
       - max-age=63072000
+      Transfer-Encoding:
+      - chunked
       Vary:
+      - Accept-Encoding
       - Accept
       X-Content-Type-Options:
       - nosniff
@@ -475,17 +675,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Gitlab-Meta:
-      - '{"correlation_id":"01HPH8KQNGEDPGB6EYC7FKK9E0","version":"1"}'
+      - '{"correlation_id":"01HRPZH69JW7772HSYAFHSPER3","version":"1"}'
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 01HPH8KQNGEDPGB6EYC7FKK9E0
+      - 01HRPZH69JW7772HSYAFHSPER3
       X-Runtime:
-      - '0.079549'
+      - '0.077396'
       X-Ua-Compatible:
       - IE=edge
       X-Xss-Protection:
       - 1; mode=block
+      content-length:
+      - '278'
     status:
       code: 200
       message: OK

--- a/collectors/ps_constants/tests/conftest.py
+++ b/collectors/ps_constants/tests/conftest.py
@@ -1,9 +1,6 @@
 import pytest
 
-from collectors.ps_constants.constants import (
-    PS_CONSTANTS_REPO_BRANCH,
-    PS_CONSTANTS_REPO_URL,
-)
+from collectors.ps_constants.constants import PS_CONSTANTS_REPO_BRANCH
 
 
 @pytest.fixture(autouse=True)
@@ -11,11 +8,22 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
+@pytest.fixture(autouse=True)
+def pin_envs(monkeypatch) -> None:
+    """
+    the tests should be immune to what .env you build the testrunner with
+    """
+    monkeypatch.setenv(
+        "PS_CONSTANTS_URL", "https://example.com/prodsec-dev/ps-constants"
+    )
+
+
 @pytest.fixture()
 def ps_constant_base_url():
     return "/".join(
         (
-            PS_CONSTANTS_REPO_URL,
+            # pinned PS_CONSTANTS_REPO_URL for tests
+            "https://example.com/prodsec-dev/ps-constants",
             "-",
             "raw",
             PS_CONSTANTS_REPO_BRANCH,

--- a/collectors/ps_constants/tests/test_core.py
+++ b/collectors/ps_constants/tests/test_core.py
@@ -53,8 +53,11 @@ class TestPsConstantsCollection:
         assert "rhel-8" in compliance_priority
         assert sorted(compliance_priority.keys()) == [
             "fdp-el8-ovs",
+            "ocp-tools-4",
             "openshift-4",
+            "rhbk",
             "rhel-8",
+            "rhel-9",
         ]
 
         url = "/".join((ps_constant_base_url, "contract_priority.yml"))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make ps_product property available in affect API
 - Add Fedramp stream preselection handler (OSIDB-1876)
 - Introduce CVSS v4 (OSIDB-528)
+- Change tests to have default urls strings where it can't be blank (OSIDB-1679)
 
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -27,6 +27,15 @@ def enable_db_access_for_all_tests(db):
     pass
 
 
+@pytest.fixture(autouse=True)
+def pin_envs(monkeypatch) -> None:
+    """
+    the tests should be immune to what .env you build the testrunner with
+    """
+    monkeypatch.setenv("BBSYNC_SYNC_TO_BZ", "0")
+    monkeypatch.setenv("JIRA_TASKMAN_AUTO_SYNC_FLAW", "0")
+
+
 @pytest.fixture
 def root_url():
     return "http://osidb-service:8000"


### PR DESCRIPTION
This PR make tests independent from env file.

In order to achieve that this PR set default strings in constants set from environment variables and can't be blank.
This PR is the second step from #415 that ignores urls in VCRs cassettes.
This PR also set default value for Bugzilla during tracker tests in order to test description generation in a controlled environment.

Closes OSIDB-1679.