### PR TITLE
Adjust CONN_MAX_AGE

### DIFF
--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -86,6 +86,7 @@ DATABASES = {
             # the database or role level in managed databases such as AWS RDS
             "options": "-c osidb.acl=00000000-0000-0000-0000-000000000000",
         },
+        "CONN_MAX_AGE": 120,
     }
 }
 

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -93,7 +93,7 @@ DATABASES = {
             # the database or role level in managed databases such as AWS RDS
             "options": "-c osidb.acl=00000000-0000-0000-0000-000000000000",
         },
-        "CONN_MAX_AGE": 300,
+        "CONN_MAX_AGE": 120,
     }
 }
 

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -93,7 +93,7 @@ DATABASES = {
             # the database or role level in managed databases such as AWS RDS
             "options": "-c osidb.acl=00000000-0000-0000-0000-000000000000",
         },
-        "CONN_MAX_AGE": 300,
+        "CONN_MAX_AGE": 120,
     }
 }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change settings to allow regex in CORS policy in stage environment (OSIDB-1737)
 - Enhanced prefetches on Flaw, Affect, and Tracker api querysets
 - Change default pg configs 
+- Adjust CONN_MAX_AGE and CONN_MAX_CONNS to maintain a minimal pool of idle db conns (OSIDB-1620)
 
 ### Removed
 - Remove daily monitoring email for failed tasks / collectors (OSIDB-1215)


### PR DESCRIPTION
After running 24 hours, tweaked the CONN_MAX_AGE to balance off number of idle conns from pool to be minimal. This will probably be different on prod but we will set once we run for a while there.