### PR TITLE
Refactor internal ACLs and change their using in Snippet

### DIFF
--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -493,7 +493,7 @@ class ACLMixin(models.Model):
         """
         get set of all ACLs
         """
-        return self.acls_read | self.acls_write | self.acls_internal
+        return self.acls_read | self.acls_write
 
     def _validate_acls_known(self):
         """

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1535,10 +1535,10 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
         NVD = "NVD"
         OSV = "OSV"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def save(self, *args, **kwargs):
         # set internal ACLs
         self.set_internal()
+        super().save(*args, **kwargs)
 
     # internal primary key
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -1627,11 +1627,10 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
 
     def _validate_acl_identical_to_parent_flaw(self) -> None:
         """
-        No validations are run for snippet's flaw as its ACLs can be different.
+        No ACL validations are run for snippet's flaw as its ACLs can be different.
         However, snippet should always have internal ACLs.
         """
-        if {self.acl_read[0], self.acl_write[0]} != self.acls_internal:
-            raise ValidationError("Snippet must have internal ACLs.")
+        pass
 
 
 class AffectManager(ACLMixinManager, TrackingMixinManager):

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -57,43 +57,33 @@ def good_cve_id2():
 
 
 @pytest.fixture
-def public_read_group():
-    return generate_acls(settings.PUBLIC_READ_GROUPS)
+def public_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)]
 
 
 @pytest.fixture
-def embargo_read_group():
-    return generate_acls([settings.EMBARGO_READ_GROUP])
+def embargoed_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])]
 
 
 @pytest.fixture
-def public_read_groups(public_read_group):
-    return [uuid.UUID(acl) for acl in public_read_group]
+def internal_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
 
 
 @pytest.fixture
-def embargoed_read_groups(embargo_read_group):
-    return [uuid.UUID(acl) for acl in embargo_read_group]
+def public_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])]
 
 
 @pytest.fixture
-def public_write_group():
-    return generate_acls([settings.PUBLIC_WRITE_GROUP])
+def embargoed_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])]
 
 
 @pytest.fixture
-def embargo_write_group():
-    return generate_acls([settings.EMBARGO_WRITE_GROUP])
-
-
-@pytest.fixture
-def public_write_groups(public_write_group):
-    return [uuid.UUID(acl) for acl in public_write_group]
-
-
-@pytest.fixture
-def embargoed_write_groups(embargo_write_group):
-    return [uuid.UUID(acl) for acl in embargo_write_group]
+def internal_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]
 
 
 @pytest.fixture

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -29,7 +29,7 @@ def enable_db_access_for_all_tests(db):
 
 @pytest.fixture
 def root_url():
-    return "http://osdib-service:8000"
+    return "http://osidb-service:8000"
 
 
 @pytest.fixture

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -1,11 +1,7 @@
-import uuid
-
 import pytest
-from django.conf import settings
 from django.core.exceptions import ValidationError
 
 from apps.workflows.workflow import WorkflowModel
-from osidb.core import generate_acls
 from osidb.models import Flaw, FlawCVSS, FlawReference, FlawSource, FlawType, Snippet
 
 pytestmark = pytest.mark.unit
@@ -44,38 +40,34 @@ def get_snippet(cve_id="CVE-2023-0001"):
 
 
 class TestSnippet:
-    def test_create_snippet(self):
+    def test_create_snippet(self, internal_read_groups, internal_write_groups):
         """
         Tests the creation of a snippet.
         """
         snippet = get_snippet()
 
         assert snippet
-        assert snippet.acl_read == [
-            uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])
-        ]
-        assert snippet.acl_write == [
-            uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])
-        ]
+        assert snippet.acl_read == internal_read_groups
+        assert snippet.acl_write == internal_write_groups
         assert Snippet.objects.count() == 1
 
-    def test_snippet_with_wrong_acls(self):
+    def test_snippet_with_wrong_acls(
+        self, embargoed_read_groups, embargoed_write_groups
+    ):
         """
         Tests that a snippet with non-internal ACLs raises an error.
         """
         snippet = get_snippet()
 
-        snippet.acl_read = [
-            uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])
-        ]
-        snippet.acl_write = [
-            uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])
-        ]
+        snippet.acl_read = embargoed_read_groups
+        snippet.acl_write = embargoed_write_groups
 
         with pytest.raises(ValidationError, match="Snippet must have internal ACLs."):
             snippet.save()
 
-    def test_create_flaw_from_snippet(self):
+    def test_create_flaw_from_snippet(
+        self, internal_read_groups, internal_write_groups
+    ):
         """
         Tests the creation of a flaw from a snippet.
         """
@@ -111,14 +103,20 @@ class TestSnippet:
         assert flaw_ref.url == "https://nvd.nist.gov/vuln/detail/CVE-2023-0001"
 
         # check ACLs
-        assert flaw.acl_read == [
-            uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])
-        ]
-        assert flaw.acl_write == [
-            uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])
-        ]
-        assert flaw.acl_read == flaw_cvss.acl_read == flaw_ref.acl_read
-        assert flaw.acl_write == flaw_cvss.acl_write == flaw_ref.acl_write
+        assert (
+            internal_read_groups
+            == snippet.acl_read
+            == flaw.acl_read
+            == flaw_cvss.acl_read
+            == flaw_ref.acl_read
+        )
+        assert (
+            internal_write_groups
+            == snippet.acl_write
+            == flaw.acl_write
+            == flaw_cvss.acl_write
+            == flaw_ref.acl_write
+        )
 
     @pytest.mark.parametrize(
         "cve_id,has_flaw,has_snippet",

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -1,5 +1,4 @@
 import pytest
-from django.core.exceptions import ValidationError
 
 from apps.workflows.workflow import WorkflowModel
 from osidb.models import Flaw, FlawCVSS, FlawReference, FlawSource, FlawType, Snippet
@@ -50,20 +49,6 @@ class TestSnippet:
         assert snippet.acl_read == internal_read_groups
         assert snippet.acl_write == internal_write_groups
         assert Snippet.objects.count() == 1
-
-    def test_snippet_with_wrong_acls(
-        self, embargoed_read_groups, embargoed_write_groups
-    ):
-        """
-        Tests that a snippet with non-internal ACLs raises an error.
-        """
-        snippet = get_snippet()
-
-        snippet.acl_read = embargoed_read_groups
-        snippet.acl_write = embargoed_write_groups
-
-        with pytest.raises(ValidationError, match="Snippet must have internal ACLs."):
-            snippet.save()
 
     def test_create_flaw_from_snippet(
         self, internal_read_groups, internal_write_groups


### PR DESCRIPTION
This PR updates the setting of internal ACLs for the `Snippet` model to avoid overriding the `__init__` method, as mentioned in https://docs.djangoproject.com/en/3.2/ref/models/instances/#creating-objects. 
It also reworks the usage of ACLs and fixes a typo in the `root_url` fixture.