### PR TITLE
Improve performance of include_fields filter

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -309,7 +309,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1231,
+        "line_number": 1257,
         "is_secret": false
       }
     ],
@@ -392,5 +392,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-18T14:07:12Z"
+  "generated_at": "2024-01-22T12:53:55Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -373,6 +373,16 @@
         "is_secret": false
       }
     ],
+    "perf/main.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "perf/main.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 19,
+        "is_secret": false
+      }
+    ],
     "tox.ini": [
       {
         "type": "Secret Keyword",
@@ -392,5 +402,5 @@
       }
     ]
   },
-  "generated_at": "2024-01-22T12:53:55Z"
+  "generated_at": "2024-01-23T11:27:31Z"
 }

--- a/apps/taskman/tests/test_service.py
+++ b/apps/taskman/tests/test_service.py
@@ -22,6 +22,7 @@ class TestTaskmanService(object):
         assert JiraTaskmanQuerier(token=user_token).jira_conn
 
     @pytest.mark.vcr
+    @pytest.mark.enable_signals
     def test_create_or_update_task(self, user_token):
         """
         Test that service is able to create and update regular fields, team, assignment and status

--- a/apps/workflows/apps.py
+++ b/apps/workflows/apps.py
@@ -11,3 +11,6 @@ class Workflows(AppConfig):
     """django name"""
 
     name = "apps.workflows"
+
+    def ready(self):
+        from . import signals  # noqa: F401

--- a/apps/workflows/signals.py
+++ b/apps/workflows/signals.py
@@ -1,0 +1,11 @@
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from apps.workflows.workflow import WorkflowModel
+
+
+@receiver(pre_save)
+def auto_adjust_classification(sender, instance, **kwargs):
+    if issubclass(sender, WorkflowModel):
+        if not all([instance.workflow_name, instance.workflow_state]):
+            instance.adjust_classification(save=False)

--- a/apps/workflows/tests/test_endpoints.py
+++ b/apps/workflows/tests/test_endpoints.py
@@ -92,6 +92,7 @@ class TestEndpoints(object):
         assert response.status_code == 401
 
     # workflows/{flaw}/adjust
+    @pytest.mark.enable_signals
     def test_workflows_uuid_adjusting(self, auth_client, test_api_uri):
         """test flaw classification adjustion after metadata change"""
         workflow_framework = WorkflowFramework()
@@ -180,6 +181,7 @@ class TestEndpoints(object):
             "state": "DONE",
         }
 
+    @pytest.mark.enable_signals
     def test_workflows_uuid_adjusting_no_modification(self, auth_client, test_api_uri):
         """
         test authenticated workflow classification adjusting API endpoint with no flaw modification
@@ -209,6 +211,7 @@ class TestEndpoints(object):
         response = client.post(f"{test_api_uri}/{flaw.uuid}/adjust")
         assert response.status_code == 401
 
+    @pytest.mark.enable_signals
     def test_promote_endpoint(self, auth_client, test_api_uri_osidb, user_token):
         """test flaw state promotion after data change"""
         workflow_framework = WorkflowFramework()
@@ -304,6 +307,7 @@ class TestEndpoints(object):
         body = response.json()
         assert "already in the last state" in body["errors"]
 
+    @pytest.mark.enable_signals
     def test_reject_endpoint(
         self,
         monkeypatch,

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -602,12 +602,14 @@ class TestWorkflowFramework:
 
 
 class TestFlaw:
+    @pytest.mark.enable_signals
     def test_init(self):
         """test that flaw gets workflow:state assigned on creation"""
-        flaw = Flaw()
+        flaw = FlawFactory()
         assert flaw.workflow_name
         assert flaw.workflow_state
 
+    @pytest.mark.enable_signals
     def test_classification(self):
         """test flaw classification property"""
         state_new = {
@@ -662,7 +664,7 @@ class TestFlaw:
         workflow_framework.register_workflow(workflow_main)
         workflow_framework.register_workflow(workflow_reject)
 
-        flaw = Flaw()
+        flaw = FlawFactory()
 
         # stored classification
         assert flaw.workflow_name == flaw.classification["workflow"]
@@ -699,6 +701,7 @@ class TestFlaw:
         assert flaw.workflow_name != new_computed_workflow
         assert flaw.workflow_state != new_computed_state
 
+    @pytest.mark.enable_signals
     def test_adjust(self):
         """test flaw classification adjustion after metadata change"""
         workflow_framework = WorkflowFramework()
@@ -770,6 +773,7 @@ class TestFlaw:
 
         assert flaw.classification["workflow"] == "default workflow"
 
+    @pytest.mark.enable_signals
     def test_adjust_no_change(self):
         """test that adjusting classification has no effect without flaw modification"""
         flaw = FlawFactory()  # random flaw
@@ -777,6 +781,7 @@ class TestFlaw:
         flaw.adjust_classification()
         assert classification == flaw.classification
 
+    @pytest.mark.enable_signals
     def test_promote(self):
         """test flaw state promotion after data change"""
         workflow_framework = WorkflowFramework()

--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -158,14 +158,6 @@ class WorkflowModel(models.Model):
     class Meta:
         abstract = True
 
-    def __init__(self, *args, **kwargs):
-        """initiate workflow model"""
-        super().__init__(*args, **kwargs)
-        # every workflow model has to be always classified and if it is not it means
-        # that it is newly created one so we need to perform initial classification
-        if not all([self.workflow_name, self.workflow_state]):
-            self.adjust_classification(save=False)
-
     def classify(self):
         """computed workflow classification"""
         workflow, state = WorkflowFramework().classify(self)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -64,4 +64,4 @@ services:
         - '9000:8089'
       volumes:
         - ${PWD}/perf/main.py:/mnt/locust/main.py:z
-      command: -f /mnt/locust/main.py -H http://osidb-service:8000 --web-host 0.0.0.0 --modern-ui ChangedIncludeFlawsUser
+      command: -f /mnt/locust/main.py -H http://osidb-service:8000 --web-host 0.0.0.0 --modern-ui SFM2User SDEngineUser GriffonUser

--- a/etc/pg/postgresql.conf
+++ b/etc/pg/postgresql.conf
@@ -61,7 +61,7 @@ listen_addresses = '*'		# what IP address(es) to listen on;
 					# defaults to 'localhost'; use '*' for all
 					# (change requires restart)
 #port = 5432				# (change requires restart)
-max_connections = 100			# (change requires restart)
+max_connections = 200			# (change requires restart)
 #superuser_reserved_connections = 3	# (change requires restart)
 #unix_socket_directories = '/var/run/postgresql, /tmp'	# comma-separated list of directories
 					# (change requires restart)

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -50,6 +50,7 @@ class TestSnippet:
         assert snippet.acl_write == internal_write_groups
         assert Snippet.objects.count() == 1
 
+    @pytest.mark.enable_signals
     def test_create_flaw_from_snippet(
         self, internal_read_groups, internal_write_groups
     ):

--- a/perf/main.py
+++ b/perf/main.py
@@ -1,19 +1,47 @@
-from locust import HttpUser, constant_pacing, task
+from locust import HttpUser, between, constant_pacing, task
 
 
-class ChangedFlawsUser(HttpUser):
-    wait_time = constant_pacing(1)
-
-    @task
-    def changed_after(self):
-        self.client.get("/osidb/api/v1/flaws?changed_after=2022-12-01T00:00:00Z")
-
-
-class ChangedIncludeFlawsUser(HttpUser):
-    wait_time = constant_pacing(1)
+class SFM2User(HttpUser):
+    wait_time = between(1, 3)
+    weight = 3
 
     @task
-    def changed_after(self):
+    def get_nvd_cvss_scores(self):
+        self.client.get("/osidb/api/v1/flaws?include_fields=cve_id,nvd_cvss2,nvd_cvss3")
+
+
+class SDEngineUser(HttpUser):
+    wait_time = between(1, 3)
+    weight = 3
+
+    @task(1)
+    def get_status(self):
+        payload = {"username": "testuser", "password": "password"}
+        headers = {"Content-Type": "application/json"}
+        with self.client.post("/auth/token", json=payload, headers=headers) as r:
+            token = r.json()["access"]
         self.client.get(
-            "/osidb/api/v1/flaws?include_fields=cve_id&changed_after=2022-12-01T00:00:00Z"
+            "/collectors/api/v1/status",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    @task(4)
+    def get_cve_ids(self):
+        self.client.get("/osidb/api/v1/flaws?include_fields=cve_id")
+
+    @task(5)
+    def get_cve_data(self):
+        self.client.get(
+            "/osidb/api/v1/flaws?include_meta_attr=mitigation,cvss3_comment,bz_id,bz_summary&exclude_fields=comments,classification&changed_after=2015-01-01T09:00:00Z&limit=60"
+        )
+
+
+class GriffonUser(HttpUser):
+    wait_time = between(1, 3600)
+    weight = 1
+
+    @task
+    def get_affects_from_ps_product(self):
+        self.client.get(
+            "/osidb/api/v1/flaws?affects__affectedness=AFFECTED&affects__ps_module=cost-management&affects__resolution=FIX&include_fields=cve_id,title,resolution,impact,affects&limit=50"
         )


### PR DESCRIPTION
This PR introduces changes to increase the performance of the `include_fields` filter by leveraging `QuerySet.prefetch_related()` and `QuerySet.only()`.

Before this commit, a query such as `/flaws?include_fields=cve_id` with 10 concurrent users would yield about 5.3 requests per second and have an average response time of 2180ms

![image](https://github.com/RedHatProductSecurity/osidb/assets/4931545/5afdda4a-26ff-45ca-8fbb-be0b59829089)

After this commit, the same query with 10 concurrent users yields 10 requests per second and has an average response time of 179ms.

![image](https://github.com/RedHatProductSecurity/osidb/assets/4931545/45018fee-1acf-42e3-8678-3e50c045213d)


In practice this means that for 10 concurrent users, there is no bottleneck for this particular query, on top of that it means that the performance gains are of around an order of magnitude in the best-case scenario.

The max throughput was also tested, and with 100 concurrent users (unrealistic scenario) the average requests per second is about 30 and the average response time 1200ms, which is manageable.

![image](https://github.com/RedHatProductSecurity/osidb/assets/4931545/43ea3783-e429-43dc-bc56-6b24725538e3)

I believe that at 100 users, the bottleneck is mostly at the CPU/RAM level and could be further improved by scaling horizontally, meaning that code-wise the bottlenecks are unlikely.