### PR TITLE
Introduce BZ component for flaw drafts

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -94,6 +94,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         generate query
         """
         self.generate_base()
+        self.generate_component()
         self.generate_unconditional()
         self.generate_summary()
         self.generate_description()
@@ -118,11 +119,18 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         """
         self._query = {
             "product": ANALYSIS_TASK_PRODUCT,
-            "component": "vulnerability",
             "op_sys": "Linux",
             "platform": "All",
             "version": "unspecified",
         }
+
+    def generate_component(self):
+        """
+        generate component to differentiate between flaw and flaw draft
+        """
+        self._query["component"] = (
+            "vulnerability-draft" if self.flaw.is_draft else "vulnerability"
+        )
 
     def generate_unconditional(self):
         """
@@ -332,6 +340,9 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
             )
 
             groups = self._standardize_embargoed_groups(module_groups)
+
+        elif self.flaw.is_internal:
+            groups = ["redhat"]
 
         # on creation we provide a list of groups
         if self.creation:

--- a/collectors/bzimport/collectors.py
+++ b/collectors/bzimport/collectors.py
@@ -178,7 +178,7 @@ class BugzillaQuerier(BugzillaConnector):
         """general query for all flaws"""
         return {
             "product": "Security Response",
-            "component": "vulnerability",
+            "component": ["vulnerability", "vulnerability-draft"],
             "include_fields": ["id", "last_change_time", "summary"],
         }
 

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -746,6 +746,7 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
         meta_attr["status"] = self.flaw_bug["status"]
         meta_attr["resolution"] = self.flaw_bug["resolution"]
         meta_attr["fixed_in"] = self.flaw_bug["fixed_in"]
+        meta_attr["bz_component"] = self.flaw_bug["component"]
         return meta_attr
 
     ##############################

--- a/collectors/bzimport/tests/cassettes/test_collectors/TestBZImportCollector.test_get_batch.yaml
+++ b/collectors/bzimport/tests/cassettes/test_collectors/TestBZImportCollector.test_get_batch.yaml
@@ -115,7 +115,7 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?component=vulnerability&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2000-01-01+00%3A00%3A00%2B00%3A00&v2=2005-01-01+00%3A00%3A00%2B00%3A00
+    uri: https://example.com/rest/bug?component=vulnerability&component=vulnerability-draft&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2000-01-01+00%3A00%3A00%2B00%3A00&v2=2005-01-01+00%3A00%3A00%2B00%3A00
   response:
     body:
       string: '{"offset": 0, "bugs": [], "total_matches": 0, "limit": "100"}'
@@ -165,7 +165,7 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?component=vulnerability&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2000-01-01+00%3A00%3A00%2B00%3A00&v2=2010-01-01+00%3A00%3A00%2B00%3A00
+    uri: https://example.com/rest/bug?component=vulnerability&component=vulnerability-draft&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2000-01-01+00%3A00%3A00%2B00%3A00&v2=2010-01-01+00%3A00%3A00%2B00%3A00
   response:
     body:
       string: '{"limit": "100", "total_matches": 199, "bugs": [{"id": 240155, "data_category":
@@ -409,7 +409,7 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?component=vulnerability&f1=delta_ts&f2=delta_ts&f98=bug_id&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&o98=greaterthan&product=Security+Response&query_format=advanced&v1=2000-01-01+00%3A00%3A00%2B00%3A00&v2=2010-01-01+00%3A00%3A00%2B00%3A00&v98=437037
+    uri: https://example.com/rest/bug?component=vulnerability&component=vulnerability-draft&f1=delta_ts&f2=delta_ts&f98=bug_id&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&o98=greaterthan&product=Security+Response&query_format=advanced&v1=2000-01-01+00%3A00%3A00%2B00%3A00&v2=2010-01-01+00%3A00%3A00%2B00%3A00&v98=437037
   response:
     body:
       string: '{"total_matches": 99, "bugs": [{"data_category": "Public", "last_change_time":
@@ -627,8 +627,6 @@ interactions:
       - private, must-revalidate
       Connection:
       - keep-alive
-      Content-Security-Policy:
-      - frame-ancestors 'self' bugzilla.redhat.com
       Content-Type:
       - application/json; charset=UTF-8
       Date:
@@ -666,7 +664,7 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?component=vulnerability&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2009-12-17+21%3A27%3A37%2B00%3A00&v2=2014-12-17+21%3A27%3A37%2B00%3A00
+    uri: https://example.com/rest/bug?component=vulnerability&component=vulnerability-draft&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2009-12-17+21%3A27%3A37%2B00%3A00&v2=2014-12-17+21%3A27%3A37%2B00%3A00
   response:
     body:
       string: '{"bugs": [{"summary": "at_console isn''t respected in some cases",
@@ -906,7 +904,7 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?component=vulnerability&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2009-12-17+21%3A27%3A37%2B00%3A00&v2=2015-12-17+21%3A27%3A37%2B00%3A00
+    uri: https://example.com/rest/bug?component=vulnerability&component=vulnerability-draft&f1=delta_ts&f2=delta_ts&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&product=Security+Response&query_format=advanced&v1=2009-12-17+21%3A27%3A37%2B00%3A00&v2=2015-12-17+21%3A27%3A37%2B00%3A00
   response:
     body:
       string: '{"limit": "100", "bugs": [{"last_change_time": "2015-03-02T10:30:21Z",
@@ -1155,7 +1153,7 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?component=vulnerability&f1=delta_ts&f2=delta_ts&f98=bug_id&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&o98=greaterthan&product=Security+Response&query_format=advanced&v1=2009-12-17+21%3A27%3A37%2B00%3A00&v2=2015-12-17+21%3A27%3A37%2B00%3A00&v98=837956
+    uri: https://example.com/rest/bug?component=vulnerability&component=vulnerability-draft&f1=delta_ts&f2=delta_ts&f98=bug_id&include_fields=id&include_fields=last_change_time&include_fields=summary&limit=100&o1=greaterthan&o2=lessthaneq&o98=greaterthan&product=Security+Response&query_format=advanced&v1=2009-12-17+21%3A27%3A37%2B00%3A00&v2=2015-12-17+21%3A27%3A37%2B00%3A00&v98=837956
   response:
     body:
       string: '{"total_matches": 29, "bugs": [{"last_change_time": "2012-07-10T21:41:02Z",

--- a/collectors/bzimport/tests/test_convertors.py
+++ b/collectors/bzimport/tests/test_convertors.py
@@ -860,6 +860,7 @@ class TestFlawConvertor:
                 "CVE-2000-1234",
             ],
             "cf_release_notes": None,
+            "component": "vulnerability",
             "creation_time": "2000-01-01T12:12:12Z",
             "depends_on": [],
             "description": "text",
@@ -1593,6 +1594,26 @@ class TestFlawConvertor:
         assert affect.cvss2_score is None
         assert affect.cvss3 == ""
         assert affect.cvss3_score is None
+
+    def test_component_meta_attr(self):
+        """
+        Test that the "component" BZ field is saved as "bz_component" in Flaw.meta_attr
+        """
+        flaw_bug = self.get_flaw_bug()
+        fbc = FlawConvertor(
+            flaw_bug,
+            [],
+            None,
+            None,
+            [],
+            [],
+        )
+        [flaw] = fbc.bug2flaws()
+        flaw.save()
+        flaw = Flaw.objects.first()
+
+        assert "bz_component" in flaw.meta_attr
+        assert flaw.meta_attr["bz_component"] == flaw_bug["component"]
 
     def test_summary_meta_attr(self):
         """

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -283,6 +283,7 @@ class TestNVDCollector:
                 **data,
                 type=FlawType.VULNERABILITY,
                 embargoed=False,
+                meta_attr={},
                 acl_write=internal_write_groups,
                 acl_read=internal_read_groups,
             )
@@ -322,6 +323,7 @@ class TestNVDCollector:
         assert flaw.cve_id == cve_id
         assert flaw.cwe_id == snippet_content["cwe_id"]
         assert flaw.description == snippet_content["description"]
+        assert flaw.meta_attr == {}
         assert flaw.source == snippet_content["source"]
         assert flaw.title == snippet_content["title"]
         assert flaw.type == FlawType.VULNERABILITY

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -295,6 +295,10 @@ class ACLMixin(models.Model):
     def is_embargoed(self):
         return self.acl_read == ACLMixin.get_embargoed_acl()
 
+    @property
+    def is_internal(self):
+        return set(self.acl_read + self.acl_write) == self.acls_internal
+
     def acl2group(self, acl):
         """
         transform back to human readable group name or

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -835,6 +835,24 @@ class Flaw(
         if self.is_major_incident_temp():
             return self.reported_dt
 
+    @property
+    def is_draft(self) -> bool:
+        """
+        Returns True if a flaw is a draft, False otherwise.
+
+        A flaw is a draft in the following situations:
+        1. it comes directly from OSIDB and not from BZ, i.e. it does not have "bz_id" in "meta_attr"
+        2. it comes from BZ, and "bz_component" is "vulnerability-draft" and "workflow_state" is "NEW"
+        """
+        new_flaw_draft = not self.meta_attr.get("bz_id")
+        existing_flaw_draft = (
+            self.meta_attr.get("bz_id")
+            and self.meta_attr.get("bz_component") == "vulnerability-draft"
+            and self.workflow_state == WorkflowModel.WorkflowState.NEW
+        )
+
+        return new_flaw_draft or existing_flaw_draft
+
     # non operational meta data
     meta_attr = HStoreField(default=dict)
 

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -381,6 +381,7 @@ class TestTrackingMixin:
         return {
             "id": 12345,
             "alias": ["CVE-2020-12345"],
+            "component": "vulnerability",
             "summary": "summary",
             "description": "description",
             "fixed_in": None,

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -30,6 +30,7 @@ def get_snippet(cve_id="CVE-2023-0001"):
         ],
         "source": Snippet.Source.NVD,
         "title": "placeholder only, see description",
+        "published_in_nvd": "2024-01-21T16:29:00.393Z",
     }
 
     snippet = Snippet(source=Snippet.Source.NVD, external_id=cve_id, content=content)
@@ -71,12 +72,13 @@ class TestSnippet:
         assert flaw.cvss_scores.count() == 1
         assert flaw.cwe_id == content["cwe_id"]
         assert flaw.description == content["description"]
-        assert flaw.workflow_state == WorkflowModel.WorkflowState.NEW
+        assert flaw.meta_attr == {}
         assert flaw.references.count() == 1
         assert flaw.snippets.count() == 0
         assert flaw.source == snippet.source
         assert flaw.title == content["title"]
         assert flaw.type == FlawType.VULNERABILITY
+        assert flaw.workflow_state == WorkflowModel.WorkflowState.NEW
 
         flaw_cvss = flaw.cvss_scores.all().first()
         assert flaw_cvss.issuer == FlawCVSS.CVSSIssuer.NIST


### PR DESCRIPTION
This PR introduces a new BZ component, `vulnerability-draft`. If a flaw comes from OSIDB (i.e. from collectors) and not from BZ, this component is set together with `workflow_state="NEW"`. If such a flaw changes its state, `vulnerability-draft` is changed back to `vulnerability`, as it is no longer a flaw draft but a regular flaw.

I will thoroughly test the final intended logic in the next sprint, as I am now struggling with OSIDB-Jira integration.

Closes OSIDB-860