### PR TITLE
Introduce SNIPPET_CREATION_START_DATE to NVD and OSV

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -258,7 +258,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 110,
+        "line_number": 111,
         "is_secret": false
       }
     ],
@@ -421,5 +421,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-09T10:36:48Z"
+  "generated_at": "2024-02-16T11:55:35Z"
 }

--- a/collectors/constants.py
+++ b/collectors/constants.py
@@ -1,3 +1,4 @@
-from osidb.helpers import get_env
+from osidb.helpers import get_env, get_env_date
 
 SNIPPET_CREATION_ENABLED = get_env("SNIPPET_CREATION", default="False", is_bool=True)
+SNIPPET_CREATION_START_DATE = get_env_date("SNIPPET_CREATION_START")

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
@@ -19,7 +19,7 @@ interactions:
       string: '{"resultsPerPage": 1, "startIndex": 0, "totalResults": 1, "format":
         "NVD_CVE", "version": "2.0", "timestamp": "2023-12-07T16:50:54.380", "vulnerabilities":
         [{"cve": {"id": "CVE-2017-7542", "sourceIdentifier": "secalert@redhat.com",
-        "published": "2017-07-21T16:29:00.393", "lastModified": "2023-02-12T23:30:40.070",
+        "published": "2024-01-21T16:29:00.393", "lastModified": "2023-02-12T23:30:40.070",
         "vulnStatus": "Modified", "descriptions": [{"lang": "en", "value": "The ip6_find_1stfragopt
         function allows local users to cause a denial of service."}, {"lang": "es", "value":
         "La funci\u00f3n ip6_find_1stfragopt en el archivo net/ipv6/output_core.c

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
@@ -21,9 +21,7 @@ interactions:
         [{"cve": {"id": "CVE-2017-7542", "sourceIdentifier": "secalert@redhat.com",
         "published": "2017-07-21T16:29:00.393", "lastModified": "2023-02-12T23:30:40.070",
         "vulnStatus": "Modified", "descriptions": [{"lang": "en", "value": "The ip6_find_1stfragopt
-        function in net/ipv6/output_core.c in the Linux kernel through 4.12.3 allows
-        local users to cause a denial of service (integer overflow and infinite loop)
-        by leveraging the ability to open a raw socket."}, {"lang": "es", "value":
+        function allows local users to cause a denial of service."}, {"lang": "es", "value":
         "La funci\u00f3n ip6_find_1stfragopt en el archivo net/ipv6/output_core.c
         en el kernel de Linux hasta la versi\u00f3n 4.12.3, permite a los usuarios
         locales causar una denegaci\u00f3n de servicio (desbordamiento de enteros
@@ -34,33 +32,13 @@ interactions:
         "LOW", "userInteraction": "NONE", "scope": "UNCHANGED", "confidentialityImpact":
         "NONE", "integrityImpact": "NONE", "availabilityImpact": "HIGH", "baseScore":
         5.5, "baseSeverity": "MEDIUM"}, "exploitabilityScore": 1.8, "impactScore":
-        3.6}], "cvssMetricV2": [{"source": "nvd@nist.gov", "type": "Primary", "cvssData":
-        {"version": "2.0", "vectorString": "AV:L/AC:L/Au:N/C:N/I:N/A:C", "accessVector":
-        "LOCAL", "accessComplexity": "LOW", "authentication": "NONE", "confidentialityImpact":
-        "NONE", "integrityImpact": "NONE", "availabilityImpact": "COMPLETE", "baseScore":
-        4.9}, "baseSeverity": "MEDIUM", "exploitabilityScore": 3.9, "impactScore":
-        6.9, "acInsufInfo": false, "obtainAllPrivilege": false, "obtainUserPrivilege":
-        false, "obtainOtherPrivilege": false, "userInteractionRequired": false}]},
-        "weaknesses": [{"source": "secalert@redhat.com", "type": "Primary", "description":
+        3.6}]}, "weaknesses": [{"source": "secalert@redhat.com", "type": "Primary", "description":
         [{"lang": "en", "value": "CWE-190"}]}, {"source": "nvd@nist.gov", "type":
         "Secondary", "description": [{"lang": "en", "value": "CWE-190"}, {"lang":
         "en", "value": "CWE-835"}]}], "configurations": [{"nodes": [{"operator": "OR",
         "negate": false, "cpeMatch": [{"vulnerable": true, "criteria": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
         "versionEndIncluding": "4.12.3", "matchCriteriaId": "93B616B9-0E9C-48F4-B663-8278767861FB"}]}]}],
-        "references": [{"url": "http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=6399f1fae4ec29fab5ec76070435555e256ca3a6",
-        "source": "secalert@redhat.com", "tags": ["Issue Tracking", "Patch", "Third
-        Party Advisory"]}, {"url": "http://www.debian.org/security/2017/dsa-3927",
-        "source": "secalert@redhat.com"}, {"url": "http://www.debian.org/security/2017/dsa-3945",
-        "source": "secalert@redhat.com"}, {"url": "http://www.securityfocus.com/bid/99953",
-        "source": "secalert@redhat.com"}, {"url": "https://access.redhat.com/errata/RHSA-2017:2918",
-        "source": "secalert@redhat.com"}, {"url": "https://access.redhat.com/errata/RHSA-2017:2930",
-        "source": "secalert@redhat.com"}, {"url": "https://access.redhat.com/errata/RHSA-2017:2931",
-        "source": "secalert@redhat.com"}, {"url": "https://access.redhat.com/errata/RHSA-2018:0169",
-        "source": "secalert@redhat.com"}, {"url": "https://github.com/torvalds/linux/commit/6399f1fae4ec29fab5ec76070435555e256ca3a6",
-        "source": "secalert@redhat.com", "tags": ["Issue Tracking", "Patch", "Third
-        Party Advisory"]}, {"url": "https://help.ecostruxureit.com/display/public/UADCE725/Security+fixes+in+StruxureWare+Data+Center+Expert+v7.6.0",
-        "source": "secalert@redhat.com"}, {"url": "https://usn.ubuntu.com/3583-1/",
-        "source": "secalert@redhat.com"}, {"url": "https://usn.ubuntu.com/3583-2/",
+        "references": [{"url": "http://www.debian.org/security/2017/dsa-3927",
         "source": "secalert@redhat.com"}]}}]}'
     headers:
       access-control-allow-credentials:

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9627-False].yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9627-False].yaml
@@ -21,7 +21,7 @@ interactions:
         [{"cve": {"id": "CVE-2017-9627", "sourceIdentifier": "ics-cert@hq.dhs.gov",
         "published": "2017-07-07T17:29:00.370", "lastModified": "2023-02-01T17:38:59.000",
         "vulnStatus": "Analyzed", "descriptions": [{"lang": "en", "value": "An Uncontrolled
-        Resource Consumption issue was discovered in Schneider Electric Wonderware
+        Resource Consumption issue was discovered in Spring Schneider Electric Wonderware
         ArchestrA Logger, versions 2017.426.2307.1 and prior. The uncontrolled resource
         consumption vulnerability could allow an attacker to exhaust the memory resources
         of the machine, causing a denial of service."}, {"lang": "es", "value": "Un

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9627-False].yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9627-False].yaml
@@ -19,7 +19,7 @@ interactions:
       string: '{"resultsPerPage": 1, "startIndex": 0, "totalResults": 1, "format":
         "NVD_CVE", "version": "2.0", "timestamp": "2023-12-07T16:52:03.737", "vulnerabilities":
         [{"cve": {"id": "CVE-2017-9627", "sourceIdentifier": "ics-cert@hq.dhs.gov",
-        "published": "2017-07-07T17:29:00.370", "lastModified": "2023-02-01T17:38:59.000",
+        "published": "2024-01-07T17:29:00.370", "lastModified": "2023-02-01T17:38:59.000",
         "vulnStatus": "Analyzed", "descriptions": [{"lang": "en", "value": "An Uncontrolled
         Resource Consumption issue was discovered in Spring Schneider Electric Wonderware
         ArchestrA Logger, versions 2017.426.2307.1 and prior. The uncontrolled resource

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9629-True].yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9629-True].yaml
@@ -19,7 +19,7 @@ interactions:
       string: '{"resultsPerPage": 1, "startIndex": 0, "totalResults": 1, "format":
         "NVD_CVE", "version": "2.0", "timestamp": "2023-12-07T16:52:10.160", "vulnerabilities":
         [{"cve": {"id": "CVE-2017-9629", "sourceIdentifier": "ics-cert@hq.dhs.gov",
-        "published": "2017-07-07T17:29:00.403", "lastModified": "2023-02-02T01:04:47.087",
+        "published": "2024-01-07T17:29:00.403", "lastModified": "2023-02-02T01:04:47.087",
         "vulnStatus": "Analyzed", "descriptions": [{"lang": "en", "value": "A Stack-Based
         Buffer Overflow issue was discovered in Schneider Electric Wonderware ArchestrA
         Logger, versions 2017.426.2307.1 and prior. The stack-based buffer overflow

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9630-True].yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_not_created[CVE-2017-9630-True].yaml
@@ -1,0 +1,135 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+      content-type:
+      - application/json
+    method: GET
+    uri: https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2017-9630
+  response:
+    body:
+      string: '{"resultsPerPage": 1, "startIndex": 0, "totalResults": 1, "format":
+        "NVD_CVE", "version": "2.0", "timestamp": "2024-02-12T11:57:18.020", "vulnerabilities":
+        [{"cve": {"id": "CVE-2017-9630", "sourceIdentifier": "ics-cert@hq.dhs.gov",
+        "published": "2017-08-07T08:29:00.370", "lastModified": "2019-10-09T23:30:43.690",
+        "vulnStatus": "Modified", "descriptions": [{"lang": "en", "value": "An Improper
+        Authentication issue was discovered in PDQ Manufacturing LaserWash G5 and
+        G5 S Series all versions, LaserWash M5, all versions, LaserWash 360 and 360
+        Plus, all versions, LaserWash AutoXpress and AutoExpress Plus, all versions,
+        LaserJet, all versions, ProTouch Tandem, all versions, ProTouch ICON, all
+        versions, and ProTouch AutoGloss, all versions. The web server does not properly
+        verify that provided authentication information is correct."}, {"lang": "es",
+        "value": "Se ha descubierto un error de autenticaci\u00f3n incorrecta en PDQ
+        Manufacturing LaserWash G5 y G5 S Series en todas las versiones; LaserWash
+        M5, todas las versiones; LaserWash 360 y 360 Plus, todas las versiones; LaserWash
+        AutoXpress y AutoExpress Plus, todas las versiones; LaserJet, todas las versiones;
+        ProTouch Tandem, todas las versiones; ProTouch ICON, todas las versiones;
+        y ProTouch AutoGloss, todas las versiones. El servidor web no verifica adecuadamente
+        que la informaci\u00f3n de autenticaci\u00f3n proporcionada sea correcta."}],
+        "metrics": {"cvssMetricV30": [{"source": "nvd@nist.gov", "type": "Primary",
+        "cvssData": {"version": "3.0", "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H",
+        "attackVector": "NETWORK", "attackComplexity": "LOW", "privilegesRequired":
+        "NONE", "userInteraction": "NONE", "scope": "UNCHANGED", "confidentialityImpact":
+        "LOW", "integrityImpact": "HIGH", "availabilityImpact": "HIGH", "baseScore":
+        9.4, "baseSeverity": "CRITICAL"}, "exploitabilityScore": 3.9, "impactScore":
+        5.5}], "cvssMetricV2": [{"source": "nvd@nist.gov", "type": "Primary", "cvssData":
+        {"version": "2.0", "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P", "accessVector":
+        "NETWORK", "accessComplexity": "LOW", "authentication": "NONE", "confidentialityImpact":
+        "PARTIAL", "integrityImpact": "PARTIAL", "availabilityImpact": "PARTIAL",
+        "baseScore": 7.5}, "baseSeverity": "HIGH", "exploitabilityScore": 10.0, "impactScore":
+        6.4, "acInsufInfo": false, "obtainAllPrivilege": false, "obtainUserPrivilege":
+        false, "obtainOtherPrivilege": false, "userInteractionRequired": false}]},
+        "weaknesses": [{"source": "nvd@nist.gov", "type": "Primary", "description":
+        [{"lang": "en", "value": "CWE-287"}]}, {"source": "ics-cert@hq.dhs.gov", "type":
+        "Secondary", "description": [{"lang": "en", "value": "CWE-287"}]}], "configurations":
+        [{"operator": "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch":
+        [{"vulnerable": true, "criteria": "cpe:2.3:o:pdqinc:laserwash_g5_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "D5214117-D2A6-4CBE-92AB-1C10FFF53960"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_g5:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "478D29EF-F2EB-4FC2-8021-64A98DCFC278"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserwash_g5_s_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "B8345743-9E9B-4B22-950F-B8D16B2DD389"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_g5_s:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "9418A71C-C776-42D1-8C49-8E7A5A35510F"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserwash_m5_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "526E3009-4341-4510-87EF-6579B2016EA6"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_m5:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "556B3850-9721-4338-BAE8-0E6827EE967F"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserwash_360_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "AF481571-EA78-4915-9B56-6E20B423CA5B"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_360:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "BA3E7B3B-0A5A-4643-949B-ECA1771A67EF"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserwash_360_plus_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "215A6BA3-1AE7-4452-9F09-1D47D46314F3"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_360_plus:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "A3FC978B-25DE-4BFC-8B35-349CB0C49059"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserwash_autoxpress_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "E4D824F5-77FA-4664-A37C-AC5810102262"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_autoxpress:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "A0E1E23A-1A79-4863-9981-DF0E1AA971A0"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserwash_autoxpress_plus_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "6E34E8DC-2ADE-4100-BC53-C8E632C57BE2"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserwash_autoxpress_plus:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "5AEF583E-6F5B-42E4-B3D1-536E9497BDC2"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:laserjet_firmware:-:*:*:*:*:*:*:*", "matchCriteriaId":
+        "7FD3B5D6-773B-40BC-AFB4-39877E300D78"}]}, {"operator": "OR", "negate": false,
+        "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:laserjet:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "53FAAE69-1553-4C1D-B447-FDA4AE980417"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:protouch_tandem_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "4030F5FE-0CE3-4604-A4A4-F88E219CA466"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:protouch_tandem:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "AC802696-788D-48C2-B4E4-37DC0D733BEE"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:protouch_icon_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "8C00C452-C834-4E78-8CEF-92C4B69FB0E3"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:protouch_icon:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "FA832AF8-2250-4EF8-85DF-C6DA40CC471D"}]}]}, {"operator":
+        "AND", "nodes": [{"operator": "OR", "negate": false, "cpeMatch": [{"vulnerable":
+        true, "criteria": "cpe:2.3:o:pdqinc:protouch_autogloss_firmware:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "C57FFA51-B5B4-4817-9047-B7F3A74CCA31"}]}, {"operator":
+        "OR", "negate": false, "cpeMatch": [{"vulnerable": false, "criteria": "cpe:2.3:h:pdqinc:protouch_autogloss:-:*:*:*:*:*:*:*",
+        "matchCriteriaId": "FC6A40A9-F759-4D9F-9237-1C4BACE79D07"}]}]}], "references":
+        [{"url": "https://ics-cert.us-cert.gov/advisories/ICSA-17-208-03", "source":
+        "ics-cert@hq.dhs.gov", "tags": ["Mitigation", "Third Party Advisory", "US
+        Government Resource"]}]}}]}'
+    headers:
+      access-control-allow-credentials:
+      - 'false'
+      access-control-allow-headers:
+      - accept, apiKey, content-type, origin, x-requested-with
+      access-control-allow-methods:
+      - GET, HEAD, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      apikey:
+      - 'No'
+      content-length:
+      - '7270'
+      content-type:
+      - application/json
+      date:
+      - Mon, 12 Feb 2024 11:57:17 GMT
+      strict-transport-security:
+      - max-age=31536000
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/collectors/nvd/tests/conftest.py
+++ b/collectors/nvd/tests/conftest.py
@@ -1,6 +1,21 @@
+import uuid
+
 import pytest
+from django.conf import settings
+
+from osidb.core import generate_acls
 
 
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
+
+
+@pytest.fixture
+def internal_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
+
+
+@pytest.fixture
+def internal_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -1,10 +1,11 @@
 import pytest
 from django.utils import timezone
 
+from apps.workflows.workflow import WorkflowModel
 from collectors.framework.models import CollectorMetadata
 from collectors.nvd.collectors import NVDCollector
-from osidb.models import Flaw, FlawCVSS, FlawReference, FlawSource, Snippet
-from osidb.tests.factories import FlawCVSSFactory, FlawFactory
+from osidb.models import Flaw, FlawCVSS, FlawReference, FlawSource, FlawType, Snippet
+from osidb.tests.factories import FlawCVSSFactory, FlawFactory, FlawReferenceFactory
 
 pytestmark = pytest.mark.integration
 
@@ -225,6 +226,8 @@ class TestNVDCollector:
             else:
                 assert flaw.cvss_scores.filter(version=version).first() is None
 
+    # NOTE: cassette updates may be required to comply with keywords
+    @pytest.mark.enable_signals
     @pytest.mark.default_cassette("TestNVDCollector.test_snippet_and_flaw_created.yaml")
     @pytest.mark.vcr
     @pytest.mark.parametrize(
@@ -236,19 +239,15 @@ class TestNVDCollector:
             # (True, False) cannot happen (if a snippet is present, a flaw must be too)
         ],
     )
-    def test_snippet_and_flaw_created(self, has_flaw, has_snippet):
+    def test_snippet_and_flaw_created(
+        self, has_flaw, has_snippet, internal_read_groups, internal_write_groups
+    ):
         """
         Test that a snippet and flaw are created if they do not exist.
         """
         snippet_content = {
             "cve_id": "CVE-2017-7542",
             "cvss_scores": [
-                {
-                    "score": 4.9,
-                    "issuer": FlawCVSS.CVSSIssuer.NIST,
-                    "vector": "AV:L/AC:L/Au:N/C:N/I:N/A:C",
-                    "version": FlawCVSS.CVSSVersion.VERSION2,
-                },
                 {
                     "score": 5.5,
                     "issuer": FlawCVSS.CVSSIssuer.NIST,
@@ -257,55 +256,14 @@ class TestNVDCollector:
                 },
             ],
             "cwe_id": "(CWE-190|CWE-835)",
-            "description": "The ip6_find_1stfragopt function in net/ipv6/output_core.c in the Linux kernel through 4.12.3 allows local users to cause a denial of service (integer overflow and infinite loop) by leveraging the ability to open a raw socket.",
+            "description": "The ip6_find_1stfragopt function allows local users to cause a denial of service.",
             "references": [
                 {
                     "url": "https://nvd.nist.gov/vuln/detail/CVE-2017-7542",
                     "type": FlawReference.FlawReferenceType.SOURCE,
                 },
                 {
-                    "url": "http://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=6399f1fae4ec29fab5ec76070435555e256ca3a6",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "http://www.debian.org/security/2017/dsa-3927",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "http://www.debian.org/security/2017/dsa-3945",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {"url": "http://www.securityfocus.com/bid/99953", "type": "EXTERNAL"},
-                {
-                    "url": "https://access.redhat.com/errata/RHSA-2017:2918",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://access.redhat.com/errata/RHSA-2017:2930",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://access.redhat.com/errata/RHSA-2017:2931",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://access.redhat.com/errata/RHSA-2018:0169",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://github.com/torvalds/linux/commit/6399f1fae4ec29fab5ec76070435555e256ca3a6",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://help.ecostruxureit.com/display/public/UADCE725/Security+fixes+in+StruxureWare+Data+Center+Expert+v7.6.0",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://usn.ubuntu.com/3583-1/",
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                },
-                {
-                    "url": "https://usn.ubuntu.com/3583-2/",
+                    "url": "https://example.com/security/2017/dsa-3927",
                     "type": FlawReference.FlawReferenceType.EXTERNAL,
                 },
             ],
@@ -316,7 +274,20 @@ class TestNVDCollector:
 
         # Default data
         if has_flaw:
-            FlawFactory(cve_id=cve_id, source=FlawSource.NVD)
+            data = dict(snippet_content)
+            for i in ["cvss_scores", "references"]:
+                data.pop(i)
+
+            f = FlawFactory(
+                **data,
+                type=FlawType.VULNERABILITY,
+                embargoed=False,
+                acl_write=internal_write_groups,
+                acl_read=internal_read_groups,
+            )
+            FlawCVSSFactory(flaw=f, **snippet_content["cvss_scores"][0])
+            for i in snippet_content["references"]:
+                FlawReferenceFactory(flaw=f, **i)
 
         if has_snippet:
             snippet = Snippet(
@@ -329,26 +300,62 @@ class TestNVDCollector:
         nvdc.snippet_creation_enabled = True
         nvdc.collect(cve_id)
 
-        snippets = Snippet.objects.filter(
-            content__cve_id=cve_id, source=Snippet.Source.NVD
-        )
-        snippet = snippets.first()
-
         flaws = Flaw.objects.filter(cve_id=cve_id, source=FlawSource.NVD)
         flaw = flaws.first()
 
-        assert len(snippets) == len(flaws) == 1
-        assert snippet.flaw == flaw
+        snippets = Snippet.objects.filter(external_id=cve_id, source=Snippet.Source.NVD)
+        snippet = snippets.first()
+
+        assert len(flaws) == len(snippets) == 1
+        assert flaw.cvss_scores.count() == len(snippet_content["cvss_scores"]) == 1
+        assert flaw.references.count() == len(snippet_content["references"]) == 2
         assert flaw.snippets.count() == 1
         assert flaw.snippets.first() == snippet
+        assert snippet.flaw == flaw
 
+        # Check Flaw
+        assert flaw.acl_read == internal_read_groups
+        assert flaw.acl_write == internal_write_groups
+        assert flaw.cve_id == cve_id
+        assert flaw.cwe_id == snippet_content["cwe_id"]
+        assert flaw.description == snippet_content["description"]
+        assert flaw.source == snippet_content["source"]
+        assert flaw.title == snippet_content["title"]
+        assert flaw.type == FlawType.VULNERABILITY
+        assert flaw.workflow_state == WorkflowModel.WorkflowState.NEW
+
+        # Check FlawCVSS
+        cvss = flaw.cvss_scores.first()
+        assert cvss.acl_read == internal_read_groups
+        assert cvss.acl_write == internal_write_groups
+        assert {
+            "issuer": cvss.issuer,
+            "score": cvss.score,
+            "vector": cvss.vector,
+            "version": cvss.version,
+        } in snippet_content["cvss_scores"]
+
+        # Check FlawReference
+        for i in flaw.references.all():
+            assert i.acl_read == internal_read_groups
+            assert i.acl_write == internal_write_groups
+            assert {"type": i.type, "url": i.url} in snippet_content["references"]
+
+        # Check Snippet
+        assert snippet.acl_read == internal_read_groups
+        assert snippet.acl_write == internal_write_groups
+        assert snippet.content == snippet_content
+        assert snippet.external_id == cve_id
+        assert snippet.source == snippet_content["source"]
+
+    # NOTE: cassette updates may be required to comply with keywords
     @pytest.mark.vcr
     @pytest.mark.parametrize(
         "cve_id,snippet_enabled",
         [
-            # CVE complies with the keywords check, but snippet creation is disabled
+            # snippet creation disabled (passing keywords)
             ("CVE-2017-9627", False),
-            # snippet creation is enabled, but CVE does not comply with the keywords check
+            # non-passing keywords (snippet creation enabled)
             ("CVE-2017-9629", True),
         ],
     )

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_multi_cve_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_multi_cve_osv_record.yaml
@@ -20,7 +20,7 @@ interactions:
         sets the Content-Disposition header of a FileResponse when the filename is
         derived from user-supplied input.", "aliases": ["BIT-django-2022-36359", "CVE-2022-36359",
         "CVE-2022-45442", "GHSA-2x8x-jmrp-phxw", "GHSA-8x94-hmjh-97hq"], "modified":
-        "2023-12-06T01:02:30.144615Z", "published": "2022-08-03T14:15:00Z", "references":
+        "2023-12-06T01:02:30.144615Z", "published": "2024-01-03T14:15:00Z", "references":
         [{"type": "WEB", "url": "https://docs.djangoproject.com/en/4.0/releases/security/"},
         {"type": "ARTICLE", "url": "https://www.djangoproject.com/weblog/2022/aug/03/security-releases/"},
         {"type": "WEB", "url": "https://groups.google.com/g/django-announce/c/8cz--gvaJr4"},

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record.yaml
@@ -18,7 +18,7 @@ interactions:
         "details": "An unauthenticated attacker can obtain arbitrary permissions within
         the application under certain conditions.", "aliases": ["CVE-2023-50424",
         "GHSA-92cg-ghq6-9587", "GHSA-m8rw-rcpq-2vp2"], "modified": "2023-12-16T04:56:23.602460Z",
-        "published": "2023-12-16T04:35:08Z", "database_specific": {"url": "https://pkg.go.dev/vuln/GO-2023-2400"},
+        "published": "2024-01-16T04:35:08Z", "database_specific": {"url": "https://pkg.go.dev/vuln/GO-2023-2400"},
         "references": [{"type": "WEB", "url": "https://me.sap.com/notes/3411067"},
         {"type": "WEB", "url": "https://www.sap.com/documents/2022/02/fa865ea4-167e-0010-bca6-c68f7e60039b.html"},
         {"type": "WEB", "url": "https://blogs.sap.com/2023/12/12/unveiling-critical-security-updates-sap-btp-security-note-3411067/"},

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_historical_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_historical_osv_record.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://api.osv.dev/v1/vulns/GO-2023-1602
+  response:
+    body:
+      string: '{"id": "GO-2023-1602", "summary": "Denial of service via deflate decompression
+        bomb in github.com/russellhaering/gosaml2", "details": "A bug in SAML authentication
+        library can result in Denial of Service attacks.\n\nAttackers can craft a
+        \"deflate\"-compressed request which will consume significantly more memory
+        during processing than the size of the original request. This may eventually
+        lead to memory exhaustion and the process being killed.", "aliases": ["CVE-2023-26483",
+        "GHSA-6gc3-crp7-25w5"], "modified": "2023-12-14T15:52:23Z", "published": "2023-03-03T17:17:54Z",
+        "database_specific": {"url": "https://pkg.go.dev/vuln/GO-2023-1602"}, "references":
+        [{"type": "ADVISORY", "url": "https://github.com/advisories/GHSA-6gc3-crp7-25w5"},
+        {"type": "FIX", "url": "https://github.com/russellhaering/gosaml2/commit/f9d66040241093e8702649baff50cc70d2c683c0"},
+        {"type": "WEB", "url": "https://github.com/russellhaering/gosaml2/releases/tag/v0.9.0"}],
+        "affected": [{"package": {"name": "github.com/russellhaering/gosaml2", "ecosystem":
+        "Go", "purl": "pkg:golang/github.com/russellhaering/gosaml2"}, "ranges": [{"type":
+        "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.9.0"}]}], "ecosystem_specific":
+        {"imports": [{"symbols": ["DecodeUnverifiedBaseResponse", "DecodeUnverifiedLogoutResponse",
+        "SAMLServiceProvider.RetrieveAssertionInfo", "SAMLServiceProvider.ValidateEncodedLogoutRequestPOST",
+        "SAMLServiceProvider.ValidateEncodedLogoutResponsePOST", "SAMLServiceProvider.ValidateEncodedResponse",
+        "SAMLServiceProvider.validationContext", "maybeDeflate", "parseResponse"],
+        "path": "github.com/russellhaering/gosaml2"}]}, "database_specific": {"source":
+        "https://vuln.go.dev/ID/GO-2023-1602.json"}}], "schema_version": "1.6.0"}'
+    headers:
+      Content-Length:
+      - '1666'
+      Date:
+      - Tue, 13 Feb 2024 16:10:29 GMT
+      Server:
+      - Google Frontend
+      X-Cloud-Trace-Context:
+      - 9e777dfdc33abe49524a87b211e68409
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-type:
+      - application/json
+      grpc-accept-encoding:
+      - identity, deflate, gzip
+      grpc-message:
+      - ''
+      grpc-status:
+      - '0'
+      x-envoy-decorator-operation:
+      - ingress GetVulnById
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -1,4 +1,5 @@
 import pytest
+from django.utils.timezone import datetime, make_aware
 
 from collectors.osv.collectors import OSVCollector
 from osidb.models import Snippet
@@ -7,11 +8,16 @@ pytestmark = pytest.mark.integration
 
 
 class TestOSVCollector:
+    # NOTE: cassette updates may be required to comply with published date
     @pytest.mark.vcr
-    def test_collect_osv_record(self):
+    @pytest.mark.default_cassette("TestOSVCollector.test_collect_osv_record.yaml")
+    @pytest.mark.parametrize("start_date", [None, make_aware(datetime(2024, 1, 1))])
+    def test_collect_osv_record(self, start_date):
         """Test fetching a single OSV record."""
         osvc = OSVCollector()
         osvc.snippet_creation_enabled = True
+        # when start date is set to None, all snippets are collected
+        osvc.snippet_creation_start_date = start_date
         osvc.collect(osv_id="GO-2023-2400")
 
         snippet = Snippet.objects.last()
@@ -20,6 +26,7 @@ class TestOSVCollector:
         assert snippet.content["references"]
         assert snippet.content["cve_id"] == "CVE-2023-50424"
 
+    # NOTE: cassette updates may be required to comply with published date
     @pytest.mark.vcr
     def test_collect_multi_cve_osv_record(self):
         """Test fetching a single OSV record that points to multiple CVEs."""
@@ -35,3 +42,12 @@ class TestOSVCollector:
         assert snippet_2.content["cve_id"] == "CVE-2022-45442"
 
         assert snippet_1.content["title"] == snippet_2.content["title"]
+
+    @pytest.mark.vcr
+    def test_historical_osv_record(self):
+        """Test not fetching a historical OSV record."""
+        osvc = OSVCollector()
+        osvc.snippet_creation_enabled = True
+        osvc.snippet_creation_start_date = make_aware(datetime(2024, 1, 1))
+        osvc.collect(osv_id="GO-2023-1602")  # published in 2023
+        assert Snippet.objects.count() == 0

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -54,6 +54,7 @@ services:
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
         PS_CONSTANTS_URL: ${PS_CONSTANTS_URL}
         SNIPPET_CREATION: ${SNIPPET_CREATION}
+        SNIPPET_CREATION_START: ${SNIPPET_CREATION_START}
       volumes:
         - ${PWD}:/opt/app-root/src:z
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,6 +85,7 @@ services:
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
         PS_CONSTANTS_URL: ${PS_CONSTANTS_URL}
         SNIPPET_CREATION: ${SNIPPET_CREATION}
+        SNIPPET_CREATION_START: ${SNIPPET_CREATION_START}
         TRACKERS_SYNC_TO_JIRA: ${TRACKERS_SYNC_TO_JIRA}
       command: ./scripts/setup-osidb-service.sh
       volumes:

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -13,6 +13,7 @@ from typing import Any, List, Type, Union
 
 from celery._state import get_current_task
 from django.db import models
+from django.utils.timezone import datetime, make_aware
 from django_deprecate_fields import DeprecatedField, logger
 
 from .exceptions import OSIDBException
@@ -78,6 +79,12 @@ def get_env(
         value = json.loads(value)
 
     return value
+
+
+def get_env_date(key: str) -> Union[datetime, None]:
+    """get a date environment variable of the ISO format (YYYY-MM-DD)"""
+    if value := getenv(key):
+        return make_aware(datetime.fromisoformat(value))
 
 
 def get_unique_meta_attr_keys(model: Type[models.Model]) -> List[str]:


### PR DESCRIPTION
This PR introduces the `SNIPPET_CREATION_START_DATE` constant, which sets the date from which the collectors should create snippets (and their respective flaws if they do not exist). This date will be adjusted again in the future to reflect the time when we switch from Assembler to OSIDB.
It also updates and extends tests in the NVD collector, so the snippet and flaw creation are additionally tested.

Closes OSIDB-2085