### PR TITLE
Add PS_CONSTANTS_URL env var in flower

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -196,6 +196,7 @@ services:
         ET_URL: ${ET_URL}
         OSIDB_DEBUG: ${OSIDB_DEBUG}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
+        PS_CONSTANTS_URL: ${PS_CONSTANTS_URL}
       depends_on: ["redis", "osidb-data"]
 
     redis:


### PR DESCRIPTION
The flower container errors out upon startup due to the missing env var.

The env var was added to the celery containers but not to flower, but since the container is based on the same image, it is also required there.