### PR TITLE
Update valid affectedness-resolution combinations

### DIFF
--- a/apps/bbsync/tests/cassettes/test_integration/TestBBSyncIntegration.test_affect_create.yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestBBSyncIntegration.test_affect_create.yaml
@@ -158,7 +158,7 @@ interactions:
       ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc": {"add":
       [], "remove": []}, "cf_srtnotes": "{\"affects\": [{\"ps_module\": \"rhel-8\",
       \"ps_component\": \"kernel\", \"affectedness\": \"affected\", \"resolution\":
-      \"fix\", \"impact\": null, \"cvss2\": null, \"cvss3\": null}], \"public\": \"2000-01-01T22:03:26Z\",
+      \"delegated\", \"impact\": null, \"cvss2\": null, \"cvss3\": null}], \"public\": \"2000-01-01T22:03:26Z\",
       \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"important\", \"source\":
       \"google\", \"cvss3\": \"3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\",
       \"cwe\": \"CWE-1\", \"statement\": \"Statement for CVE-2021-0773\"}", "ids":
@@ -185,13 +185,13 @@ interactions:
         "severity": {"removed": "medium", "added": "high"}, "priority": {"removed":
         "medium", "added": "high"}, "cf_release_notes": {"added": "", "removed": "foo"},
         "cf_srtnotes": {"added": "{\"affects\": [{\"ps_module\": \"rhel-8\", \"ps_component\":
-        \"kernel\", \"affectedness\": \"affected\", \"resolution\": \"fix\", \"impact\":
+        \"kernel\", \"affectedness\": \"affected\", \"resolution\": \"delegated\", \"impact\":
         null, \"cvss2\": null, \"cvss3\": null}], \"public\": \"2000-01-01T22:03:26Z\",
         \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"important\", \"source\":
         \"google\", \"cvss3\": \"3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\",
         \"cwe\": \"CWE-1\", \"statement\": \"Statement for CVE-2021-0773\"}", "removed":
         "{\"affects\": [{\"ps_module\": \"rhel-8\", \"ps_component\": \"kernel\",
-        \"affectedness\": \"affected\", \"resolution\": \"fix\", \"impact\": \"critical\",
+        \"affectedness\": \"affected\", \"resolution\": \"delegated\", \"impact\": \"critical\",
         \"cvss2\": null, \"cvss3\": null}], \"public\": \"2000-01-01T22:03:26Z\",
         \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"moderate\", \"source\":
         \"xchat\", \"cvss3\": \"3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\",
@@ -360,7 +360,7 @@ interactions:
         "partner": false, "email": "osoukup@redhat.com", "real_name": "Ondrej Soukup",
         "insider": true, "id": 412888, "active": true}, "cf_clone_of": null, "cc":
         [], "cf_srtnotes": "{\"affects\": [{\"ps_module\": \"rhel-8\", \"ps_component\":
-        \"kernel\", \"affectedness\": \"affected\", \"resolution\": \"fix\", \"impact\":
+        \"kernel\", \"affectedness\": \"affected\", \"resolution\": \"delegated\", \"impact\":
         null, \"cvss2\": null, \"cvss3\": null}], \"public\": \"2000-01-01T22:03:26Z\",
         \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"important\", \"source\":
         \"google\", \"cvss3\": \"3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\",
@@ -453,7 +453,7 @@ interactions:
         {"partner": false, "email": "nobody@redhat.com", "name": "nobody@redhat.com",
         "active": true, "real_name": "Nobody", "insider": false, "id": 29451}, "cf_srtnotes":
         "{\"affects\": [{\"ps_module\": \"rhel-8\", \"ps_component\": \"kernel\",
-        \"affectedness\": \"affected\", \"resolution\": \"fix\", \"impact\": null,
+        \"affectedness\": \"affected\", \"resolution\": \"delegated\", \"impact\": null,
         \"cvss2\": null, \"cvss3\": null}], \"public\": \"2000-01-01T22:03:26Z\",
         \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"important\", \"source\":
         \"google\", \"cvss3\": \"3.7/CVSS:3.0/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:L/A:N\",

--- a/apps/bbsync/tests/test_cc.py
+++ b/apps/bbsync/tests/test_cc.py
@@ -49,7 +49,7 @@ class TestCCBuilder:
                     else Affect.AffectAffectedness.AFFECTED,
                     "resolution": affect[3]
                     if len(affect) > 3
-                    else Affect.AffectResolution.FIX,
+                    else Affect.AffectResolution.DELEGATED,
                 }
             else:
                 return affect
@@ -100,7 +100,7 @@ class TestCCBuilder:
         assert flaw.meta_attr["cc"] == '["email@redhat.com", "someone@gmail.com"]'
         assert (
             flaw.meta_attr["original_srtnotes"]
-            == '{"affects": [{"ps_module": "rhel-6", "ps_component": "kernel", "affectedness": "AFFECTED", "resolution": "FIX"}]}'
+            == '{"affects": [{"ps_module": "rhel-6", "ps_component": "kernel", "affectedness": "AFFECTED", "resolution": "DELEGATED"}]}'
         )
         assert flaw.affects.count() == 2
         assert flaw.affects.filter(ps_module="rhel-6", ps_component="kernel").exists()
@@ -135,7 +135,7 @@ class TestCCBuilder:
         AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         cc_builder = CCBuilder(flaw)
@@ -151,7 +151,7 @@ class TestCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         ps_product = PsProductFactory(business_unit="Community")
         PsModuleFactory(
@@ -378,7 +378,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             name=affect.ps_module,
@@ -399,7 +399,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             name=affect.ps_module,
@@ -420,7 +420,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             name=affect.ps_module,
@@ -441,7 +441,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             name=affect.ps_module,
@@ -465,7 +465,7 @@ class TestAffectCCBuilder:
         affect1 = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             bts_name="bugzilla",
@@ -480,7 +480,7 @@ class TestAffectCCBuilder:
         affect2 = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             bts_name="jboss",
@@ -522,7 +522,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         PsModuleFactory(
             name=affect.ps_module,
@@ -616,7 +616,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component=ps_component,
         )
         PsModuleFactory(
@@ -682,7 +682,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="brick",
         )
         PsModuleFactory(
@@ -712,7 +712,7 @@ class TestAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         bz_product = BugzillaProductFactory()
         BugzillaComponentFactory(
@@ -745,7 +745,7 @@ class TestRHSCLAffectCCBuilder:
         affect1 = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="brick-collection",
         )
         ps_module1 = PsModuleFactory(
@@ -769,7 +769,7 @@ class TestRHSCLAffectCCBuilder:
         affect2 = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="apple-juice",
         )
         ps_module2 = PsModuleFactory(
@@ -805,7 +805,7 @@ class TestRHSCLAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="stick",
         )
         ps_module = PsModuleFactory(
@@ -840,7 +840,7 @@ class TestRHSCLAffectCCBuilder:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="stick-brick",
         )
         ps_module = PsModuleFactory(

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -258,7 +258,7 @@ class TestBBSyncIntegration:
             ps_module="rhel-9",
             ps_component="samba",
             affectedness="AFFECTED",
-            resolution="FIX",
+            resolution="DELEGATED",
             impact=None,
             cvss2=None,
             cvss3=None,
@@ -513,7 +513,7 @@ class TestBBSyncIntegration:
             "ps_module": "rhel-8",
             "ps_component": "kernel",
             "affectedness": "AFFECTED",
-            "resolution": "FIX",
+            "resolution": "DELEGATED",
             "embargoed": False,
         }
         response = auth_client().post(
@@ -531,7 +531,7 @@ class TestBBSyncIntegration:
         assert response.json()["ps_module"] == "rhel-8"
         assert response.json()["ps_component"] == "kernel"
         assert response.json()["affectedness"] == "AFFECTED"
-        assert response.json()["resolution"] == "FIX"
+        assert response.json()["resolution"] == "DELEGATED"
 
     @pytest.mark.vcr
     def test_affect_update(self, auth_client, test_api_uri):
@@ -556,7 +556,7 @@ class TestBBSyncIntegration:
             ps_module="rhel-8",
             ps_component="kernel",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             updated_dt="2023-03-17T15:33:54Z",
         )
 

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -224,7 +224,7 @@ class TestGenerateSRTNotes:
                     "impact": null,
                     "ps_component": "libssh",
                     "ps_module": "fedora-all",
-                    "resolution": "fix"
+                    "resolution": "delegated"
                 }
             ],
             "impact": "moderate",
@@ -250,7 +250,7 @@ class TestGenerateSRTNotes:
         AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="libssh",
             ps_module="fedora-all",
             impact=Impact.NOVALUE,
@@ -322,7 +322,7 @@ class TestGenerateSRTNotes:
             ps_module="rhel-6",
             ps_component="ImageMagick",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             impact=Impact.CRITICAL,
             # do not care about cvss2 and cvss3 as they will be deprecated
             cvss2="",
@@ -387,7 +387,7 @@ class TestGenerateSRTNotes:
 
         assert rhel6affect["ps_component"] == "ImageMagick"
         assert rhel6affect["affectedness"] == "affected"
-        assert rhel6affect["resolution"] == "fix"
+        assert rhel6affect["resolution"] == "delegated"
         assert rhel6affect["impact"] == "critical"
         assert rhel6affect["cvss2"] == "6.8/AV:N/AC:M/Au:N/C:P/I:P/A:P"
         assert (
@@ -878,7 +878,7 @@ class TestGenerateSRTNotes:
                     "impact": "moderate",
                     "ps_component": "libssh",
                     "ps_module": "fedora-all",
-                    "resolution": "fix"
+                    "resolution": "delegated"
                 }
             ],
             "cwe": "CWE-123",
@@ -914,7 +914,7 @@ class TestGenerateSRTNotes:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="libssh",
             ps_module="fedora-all",
             impact=Impact.MODERATE,

--- a/apps/exploits/tests/test_api.py
+++ b/apps/exploits/tests/test_api.py
@@ -47,7 +47,7 @@ def load_data():
     )
 
     a1 = AffectFactory(
-        resolution=Affect.AffectResolution.FIX,
+        resolution=Affect.AffectResolution.DELEGATED,
         affectedness=Affect.AffectAffectedness.AFFECTED,
         flaw=f1,
         ps_module="ps-module-1",
@@ -324,7 +324,7 @@ class TestAPI(object):
                         "ps_module": "ps-module-1",
                         "ps_component": "ps-component-1",
                         "affectedness": "AFFECTED",
-                        "resolution": "FIX",
+                        "resolution": "DELEGATED",
                         "trackers": [
                             {
                                 "type": "BUGZILLA",

--- a/apps/trackers/tests/test_file_offer.py
+++ b/apps/trackers/tests/test_file_offer.py
@@ -23,19 +23,17 @@ class TestTrackerSuggestions:
     @pytest.mark.parametrize(
         "affectedness,resolution,is_valid",
         [
-            (Affect.AffectAffectedness.AFFECTED, Affect.AffectResolution.FIX, True),
             (
                 Affect.AffectAffectedness.AFFECTED,
                 Affect.AffectResolution.DELEGATED,
                 True,
             ),
-            (Affect.AffectAffectedness.AFFECTED, Affect.AffectResolution.DEFER, False),
             (
                 Affect.AffectAffectedness.AFFECTED,
                 Affect.AffectResolution.WONTFIX,
                 False,
             ),
-            (Affect.AffectAffectedness.NEW, Affect.AffectResolution.DEFER, False),
+            (Affect.AffectAffectedness.NEW, Affect.AffectResolution.WONTFIX, False),
         ],
     )
     def test_trackers_file_offer_invalid(
@@ -107,7 +105,7 @@ class TestTrackerSuggestions:
         AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="component-1",
             ps_module="regular-module",
         )
@@ -128,7 +126,7 @@ class TestTrackerSuggestions:
         affect_embargoed = AffectFactory(
             flaw=flaw_embargoed,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="component-1",
             ps_module="public-only-module",
         )
@@ -163,7 +161,7 @@ class TestTrackerSuggestions:
             impact=Impact.MODERATE,
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="component-1",
             ps_module="ubi-module",
         )
@@ -245,7 +243,7 @@ class TestTrackerSuggestions:
             impact=Impact.LOW,
             flaw=flaw1,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="ubi-component",
             ps_module="ubi-module",
         )
@@ -267,7 +265,7 @@ class TestTrackerSuggestions:
             impact=Impact.MODERATE,
             flaw=flaw2,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="ubi-component",
             ps_module="ubi-module",
         )
@@ -312,7 +310,7 @@ class TestTrackerSuggestions:
         AffectFactory(
             flaw=flaw3,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_component="regular-component",
             ps_module="regular-module",
         )

--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -54,7 +54,7 @@ class TestTrackerSaver:
             ps_module=ps_module.name,
             ps_component="openssl",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         tracker = TrackerFactory(
             affects=[affect],
@@ -118,7 +118,7 @@ class TestTrackerSaver:
             ps_module=ps_module.name,
             ps_component="openssl",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         # 2) define a tracker model instance
@@ -200,7 +200,7 @@ class TestTrackerAPI:
             ps_module=ps_module.name,
             ps_component="openssl",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         # 2) create tracker in OSIDB and Bugzilla
@@ -270,7 +270,7 @@ class TestTrackerAPI:
             ps_module=ps_module.name,
             ps_component="openssl",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         # 2) define a tracker model instance
@@ -356,7 +356,7 @@ class TestTrackerAPI:
             ps_module=ps_module.name,
             ps_component="openshift",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw.impact,
         )
         JiraProjectFieldsFactory(
@@ -450,7 +450,7 @@ class TestTrackerAPI:
             ps_module=ps_module.name,
             ps_component="openshift",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw1.impact,
         )
         # flaw to unlink
@@ -467,7 +467,7 @@ class TestTrackerAPI:
             ps_module=ps_module.name,
             ps_component="openshift",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw2.impact,
         )
         # flaw to link
@@ -484,7 +484,7 @@ class TestTrackerAPI:
             ps_module=ps_module.name,
             ps_component="openshift",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw3.impact,
         )
 

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -293,14 +293,12 @@ class TestTrackerJiraQueryBuilder:
             ps_module=ps_module.name,
             ps_component="component",
             affectedness=affectedness,
-            resolution=Affect.AffectResolution.DEFER,
         )
         affect2 = AffectFactory(
             flaw=flaw2,
             ps_module=ps_module.name,
             ps_component="component",
             affectedness=affectedness,
-            resolution=Affect.AffectResolution.DEFER,
         )
         ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
 

--- a/apps/trackers/tests/test_save.py
+++ b/apps/trackers/tests/test_save.py
@@ -42,14 +42,14 @@ class TestTrackerSaver:
         affect1 = AffectFactory(
             flaw=flaw1,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
         affect2 = AffectFactory(
             flaw=flaw2,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=affect1.ps_module,
             ps_component=affect1.ps_component,
         )
@@ -76,7 +76,7 @@ class TestTrackerSaver:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -102,7 +102,7 @@ class TestTrackerSaver:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -129,7 +129,7 @@ class TestTrackerSaver:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -155,7 +155,7 @@ class TestTrackerSaver:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -189,7 +189,7 @@ class TestTrackerModelSave:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -223,7 +223,7 @@ class TestTrackerModelSave:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -257,7 +257,7 @@ class TestTrackerModelSave:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )
@@ -289,7 +289,7 @@ class TestTrackerModelSave:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             ps_component="component",
         )

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -585,7 +585,7 @@ class TestWorkflowFramework:
 
         affect = AffectFactory(
             flaw=flaw,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             affectedness=Affect.AffectAffectedness.AFFECTED,
         )
 

--- a/collectors/bzimport/tests/test_convertors.py
+++ b/collectors/bzimport/tests/test_convertors.py
@@ -1056,7 +1056,7 @@ class TestFlawConvertor:
                     "ps_module": "rhel-6.0",
                     "ps_component": "firefox",
                     "affectedness": "affected",
-                    "resolution": "fix"
+                    "resolution": "delegated"
                 }
             ],
             "impact": "moderate",
@@ -1119,12 +1119,12 @@ class TestFlawConvertor:
                     "ps_module": "rhel-6.0",
                     "ps_component": "firefox",
                     "affectedness": "affected",
-                    "resolution": "fix"
+                    "resolution": "delegated"
                 },{
                     "ps_module": "rhel-6.1",
                     "ps_component": "firefox",
                     "affectedness": "affected",
-                    "resolution": "fix"
+                    "resolution": "delegated"
                 }
             ],
             "impact": "moderate",
@@ -1554,7 +1554,7 @@ class TestFlawConvertor:
                     "ps_module": "rhel-8",
                     "ps_component": "ssh",
                     "affectedness": "affected",
-                    "resolution": "fix"
+                    "resolution": "delegated"
                 }
             ],
             "impact": "moderate",

--- a/collectors/errata/tests/test_core.py
+++ b/collectors/errata/tests/test_core.py
@@ -73,7 +73,7 @@ class TestErrataToolCollection:
         affect = AffectFactory(
             ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         TrackerFactory.create(
@@ -124,7 +124,7 @@ class TestErrataToolCollection:
         affect = AffectFactory(
             ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         # The test uses the same code as above, but no errata I've checked have both Bugzilla and Jira trackers
@@ -224,7 +224,7 @@ class TestErrataToolCollection:
         affect = AffectFactory(
             ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         TrackerFactory.create(

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -126,7 +126,7 @@ class TestJiraTrackerCollector:
         ps_module = PsModuleFactory(bts_name="jboss")
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         tracker_id = "ENTMQ-755"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore hosts on VCR recording (OSIDB-1678)
 - Included workflow fields in OpenAPI document for filtering (OSIDB-2083)
 - Set migrated/duplicated delegated resolution to not affected (OSIDB-1406)
+- Update valid affectedness-resolution combinations (OSIDB-2143)
 
 ### Fixed
 - Fix Jira sync when bugzilla token is present (OSIDB-2171)

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -66,21 +66,31 @@ SERVICES_PRODUCTS = [
 AFFECTEDNESS_VALID_RESOLUTIONS = {
     Affect.AffectAffectedness.NEW: [
         Affect.AffectResolution.NOVALUE,
-        Affect.AffectResolution.DEFER,
         Affect.AffectResolution.WONTFIX,
         Affect.AffectResolution.OOSS,
     ],
     Affect.AffectAffectedness.AFFECTED: [
-        Affect.AffectResolution.FIX,
-        Affect.AffectResolution.DEFER,
         Affect.AffectResolution.DELEGATED,
-        Affect.AffectResolution.WONTREPORT,
         Affect.AffectResolution.WONTFIX,
         Affect.AffectResolution.OOSS,
     ],
     Affect.AffectAffectedness.NOTAFFECTED: [
         Affect.AffectResolution.NOVALUE,
     ],
+    Affect.AffectAffectedness.NOVALUE: [],
+}
+
+# Historical affectedness/resolution combinations that were valid in the past
+AFFECTEDNESS_HISTORICAL_VALID_RESOLUTIONS = {
+    Affect.AffectAffectedness.NEW: [
+        Affect.AffectResolution.DEFER,
+    ],
+    Affect.AffectAffectedness.AFFECTED: [
+        Affect.AffectResolution.FIX,
+        Affect.AffectResolution.DEFER,
+        Affect.AffectResolution.WONTREPORT,
+    ],
+    Affect.AffectAffectedness.NOTAFFECTED: [],
     Affect.AffectAffectedness.NOVALUE: [
         Affect.AffectResolution.DEFER,
         Affect.AffectResolution.WONTFIX,

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -270,7 +270,7 @@ class TestEndpointsFlaws:
         ps_module = PsModuleFactory(bts_name="bugzilla")
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         tracker = TrackerFactory(
@@ -367,7 +367,7 @@ class TestEndpointsFlaws:
             flaw=flaw,
             ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
         )
         tracker = TrackerFactory(
@@ -448,14 +448,14 @@ class TestEndpointsFlaws:
             flaw=flaw,
             ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
         )
         affect2 = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
         )
         tracker1 = TrackerFactory(
@@ -582,7 +582,7 @@ class TestEndpointsFlaws:
                 flaw=flaw,
                 ps_module=ps_module.name,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
             )
             TrackerFactory(
                 affects=[affect],
@@ -632,7 +632,7 @@ class TestEndpointsFlaws:
                 flaw=flaw,
                 ps_module=ps_module.name,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
             )
             TrackerFactory(
                 affects=[affect],
@@ -692,7 +692,7 @@ class TestEndpointsFlaws:
                 flaw=flaw,
                 ps_module=ps_module.name,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
             )
             TrackerFactory(
                 affects=[affect],
@@ -739,7 +739,7 @@ class TestEndpointsFlaws:
                 flaw=flaw,
                 ps_module=ps_module.name,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
             )
             TrackerFactory(
                 affects=[affect],
@@ -1405,7 +1405,11 @@ class TestEndpointsFlaws:
         Test that updating a Flaw CVE ID by sending a PUT request works.
         """
         flaw = FlawFactory(embargoed=embargoed, cve_id=old_cve_id)
-        AffectFactory(flaw=flaw)
+        AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
         response = auth_client().get(f"{test_api_uri}/flaws/{flaw.uuid}")
         assert response.status_code == 200
         body = response.json()
@@ -1627,7 +1631,7 @@ class TestEndpointsFlaws:
             AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
             for _ in range(5)
@@ -1636,7 +1640,7 @@ class TestEndpointsFlaws:
             AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
             for _ in range(5)

--- a/osidb/tests/endpoints/flaws/test_update_trackers.py
+++ b/osidb/tests/endpoints/flaws/test_update_trackers.py
@@ -33,7 +33,7 @@ class TestEndpointsFlawsUpdateTrackers:
         affect1 = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module1.name,
         )
         tracker1 = TrackerFactory(
@@ -54,7 +54,7 @@ class TestEndpointsFlawsUpdateTrackers:
         affect2 = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module2.name,
         )
         TrackerFactory(
@@ -133,7 +133,7 @@ class TestEndpointsFlawsUpdateTrackers:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         TrackerFactory(

--- a/osidb/tests/endpoints/test_affects.py
+++ b/osidb/tests/endpoints/test_affects.py
@@ -233,7 +233,7 @@ class TestEndpointsAffectsUpdateTrackers:
             flaw=flaw,
             impact="LOW",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module1.name,
         )
         tracker1 = TrackerFactory(
@@ -255,7 +255,7 @@ class TestEndpointsAffectsUpdateTrackers:
             flaw=flaw,
             impact="LOW",
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module2.name,
         )
         TrackerFactory(
@@ -328,7 +328,7 @@ class TestEndpointsAffectsUpdateTrackers:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
             **to_create,
         )
@@ -368,7 +368,7 @@ class TestEndpointsAffectsUpdateTrackers:
         affect = AffectFactory(
             flaw=flaw1,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         TrackerFactory(

--- a/osidb/tests/endpoints/test_trackers.py
+++ b/osidb/tests/endpoints/test_trackers.py
@@ -28,7 +28,7 @@ class TestEndpointsTrackers:
         affect = AffectFactory(
             flaw__embargoed=embargoed,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
 
@@ -63,7 +63,7 @@ class TestEndpointsTrackers:
         affect = AffectFactory(
             flaw__embargoed=embargoed,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         tracker = TrackerFactory(
@@ -97,13 +97,13 @@ class TestEndpointsTrackers:
         affect1 = AffectFactory(
             flaw__embargoed=embargoed,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         affect2 = AffectFactory(
             flaw__embargoed=embargoed,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         tracker = TrackerFactory(
@@ -142,7 +142,7 @@ class TestEndpointsTrackers:
         ps_module = PsModuleFactory(bts_name=bts_name)
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
         tracker = TrackerFactory(

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -43,7 +43,7 @@ class TestTracker:
             affectedness=Affect.AffectAffectedness.AFFECTED,
             flaw=flaw1,
             impact=affect1_impact,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
         affect2 = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
@@ -51,7 +51,7 @@ class TestTracker:
             impact=affect2_impact,
             ps_module=affect1.ps_module,
             ps_component=affect1.ps_component,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
         )
 
         ps_module = PsModuleFactory(name=affect1.ps_module)
@@ -79,7 +79,7 @@ class TestTracker:
 
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
 
@@ -111,7 +111,7 @@ class TestTrackerValidators:
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.FIX,
+                resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
             ps_update_stream = PsUpdateStreamFactory()
@@ -148,7 +148,7 @@ class TestTrackerValidators:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module="unknown",
         )
         ps_update_stream = PsUpdateStreamFactory()
@@ -172,7 +172,7 @@ class TestTrackerValidators:
         affect = AffectFactory(
             flaw=flaw,
             affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.FIX,
+            resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
 


### PR DESCRIPTION
Some affectedness-resolution combinations have been removed to comply with the combinations defined in SFM2.

However, existing data is not to be modified as old combinations may still be pulled from a collector without running the validation, so the original enumerations have not been changed.

Closes OSIDB-2143