### PR TITLE
Set migrated/duplicated delegated resolution to not affected

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)
 - Included workflow fields in OpenAPI document for filtering (OSIDB-2083)
+- Set migrated/duplicated delegated resolution to not affected (OSIDB-1406)
 
 ## [3.6.2] - 2024-02-02
 ### Fixed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2615,7 +2615,13 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             if self.resolution in ("won't do", "won't fix", "wontfix", "obsolete"):
                 return Affect.AffectFix.WONTFIX
             # Added rejected to code inherited from SDEngine because samples such as MGDSTRM-4153
-            elif self.resolution in ("notabug", "not a bug", "rejected"):
+            elif self.resolution in (
+                "duplicate",
+                "migrated",
+                "notabug",
+                "not a bug",
+                "rejected",
+            ):
                 return Affect.AffectFix.NOTAFFECTED
             elif self.resolution in ("eol", "out of date"):
                 return Affect.AffectFix.OOSS

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -399,6 +399,29 @@ class TestFlaw:
         )
         assert undelegated_affect.delegated_resolution is None
 
+        # Migrated/duplicate trackers should be ignored
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
+            flaw__embargoed=False,
+        )
+        TrackerFactory(
+            affects=(affect,),
+            status="closed",
+            resolution="migrated",
+            embargoed=affect.flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+        TrackerFactory(
+            affects=(affect,),
+            status="closed",
+            resolution="won't do",
+            embargoed=affect.flaw.is_embargoed,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+        assert affect.delegated_resolution == Affect.AffectFix.WONTFIX
+
     def test_tracker_fix_state(self):
         ps_module = PsModuleFactory(bts_name="bugzilla")
         affect = AffectFactory(
@@ -427,6 +450,20 @@ class TestFlaw:
             type=Tracker.TrackerType.BUGZILLA,
         )
         assert empty_tracker.fix_state == Affect.AffectFix.AFFECTED
+        migrated_tracker = TrackerFactory(
+            status="closed",
+            resolution="migrated",
+            affects=[affect],
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+        assert migrated_tracker.fix_state == Affect.AffectFix.NOTAFFECTED
+        duplicate_tracker = TrackerFactory(
+            status="closed",
+            resolution="duplicate",
+            affects=[affect],
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+        assert duplicate_tracker.fix_state == Affect.AffectFix.NOTAFFECTED
 
     def test_flawmeta_create_or_update(self):
         flaw = FlawFactory()


### PR DESCRIPTION
Before this commit, the MIGRATED and DUPLICATE resolutions which can come from BZ were not contemplated in osidb, and in these cases, they get assigned a state of AFFECTED by default. Since AFFECTED has the highest precedence, even if there is another tracker that says it's not a bug, the delegated resolution is AFFECTED which is wrong.

With this commit, trackers with MIGRATED/DUPLICATE resolutions are set a NOTAFFECTED state, since it is assumed that if there is such a tracker, then there is at least another one with actual information about the state, and since NOTAFFECTED has the lowest precedence, the final delegated resolution will be that of the other tracker with a valid state.

Closes OSIDB-1406