### PR TITLE
Skip changelog check for Depandabot

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -20,6 +20,7 @@ jobs:
         run: oasdiff -fail-on-diff -fail-on-warns -check-breaking -base base/openapi.yml -revision head/openapi.yml
   changelog:
     runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - uses: actions/checkout@v3
       - name: Check existence of CHANGELOG entry


### PR DESCRIPTION
This PR updates GH's workflows to avoid running a `changelog` check for PRs created by Dependabot (every update is technical). 

Related to OSIDB-2170