### PR TITLE
Fix ubi handler unacked streams enumeration

### DIFF
--- a/apps/trackers/product_definition_handlers/ubi_handler.py
+++ b/apps/trackers/product_definition_handlers/ubi_handler.py
@@ -25,9 +25,10 @@ class UBIHandler(ProductDefinitionHandler):
         is_ubi = UBIHandler.has_ubi_packages(ps_module, affect)
 
         if is_ubi and impact in self.UBI_OVERRIDES:
-            if ps_module.unacked_ps_update_stream:
-                offers[ps_module.unacked_ps_update_stream.name] = {
-                    "ps_update_stream": ps_module.unacked_ps_update_stream.name,
+            unacked_stream = ps_module.unacked_ps_update_stream.first()
+            if unacked_stream:
+                offers[unacked_stream.name] = {
+                    "ps_update_stream": unacked_stream.name,
                     "selected": False,
                     "aus": False,
                     "eus": False,


### PR DESCRIPTION
`UbiHandler` never accessed `ps_module.unacked_ps_update_stream` correctly (used the `RelatedManager` instead of the proper model instance) and the test didn't reveal it.

This updates the test to use a more realistic (RHEL-resembling) structure of streams that results in the unacked stream deselection being tested and the bug revealed, and it updates UbiHandler to fix the bug.

Found during OSIDB-1876

Closes OSIDB-2192