### PR TITLE
Make ps_product property available in affect API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Implement flaw unembargo mechanism (OSIDB-1177)
+- Make ps_product property available in affect API
 
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)

--- a/openapi.yml
+++ b/openapi.yml
@@ -7051,6 +7051,9 @@ components:
         ps_module:
           type: string
           maxLength: 100
+        ps_product:
+          type: string
+          readOnly: true
         ps_component:
           type: string
           maxLength: 255
@@ -7102,6 +7105,8 @@ components:
               type: string
             ps_module:
               type: string
+            ps_product:
+              type: string
             resolution:
               type: string
           readOnly: true
@@ -7136,6 +7141,7 @@ components:
       - meta_attr
       - ps_component
       - ps_module
+      - ps_product
       - trackers
       - updated_dt
       - uuid
@@ -7287,6 +7293,9 @@ components:
         ps_module:
           type: string
           maxLength: 100
+        ps_product:
+          type: string
+          readOnly: true
         ps_component:
           type: string
           maxLength: 255
@@ -7338,6 +7347,8 @@ components:
               type: string
             ps_module:
               type: string
+            ps_product:
+              type: string
             resolution:
               type: string
           readOnly: true
@@ -7367,6 +7378,7 @@ components:
       - meta_attr
       - ps_component
       - ps_module
+      - ps_product
       - trackers
       - uuid
     AffectReportData:

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2162,6 +2162,13 @@ class Affect(
         """
         return not PsModule.objects.filter(name=self.ps_module).exists()
 
+    @property
+    def ps_product(self):
+        ps_module = PsModule.objects.filter(name=self.ps_module).first()
+        if not ps_module:
+            return None
+        return ps_module.ps_product.name
+
     def bzsync(self, *args, bz_api_key, **kwargs):
         """
         Bugzilla sync of the Affect instance

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -808,6 +808,7 @@ class AffectSerializer(
         "module_stream",
         "ps_component",
         "ps_module",
+        "ps_product",
         "resolution",
     )
 
@@ -850,6 +851,7 @@ class AffectSerializer(
                 "affectedness",
                 "resolution",
                 "ps_module",
+                "ps_product",
                 "ps_component",
                 "impact",
                 "cvss2",

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -664,6 +664,28 @@ class TestFlaw:
         )
         assert flaw.is_draft is is_draft
 
+    @pytest.mark.parametrize(
+        "ps_module_name,ps_product_name",
+        [
+            ("rhel-8", "Red Hat Enterprise Linux"),
+            ("jbcs-1", "Red Hat JBoss Core Services"),
+            ("", None),
+        ],
+    )
+    def test_ps_product_affect(self, ps_module_name, ps_product_name):
+        """
+        Test that the ps_product property in Affect correctly maps to the
+        one given by the ps_module of the Affect.
+        """
+        if ps_module_name:
+            PsModuleFactory(
+                name=ps_module_name, ps_product=PsProductFactory(name=ps_product_name)
+            )
+            affect = AffectFactory(ps_module=ps_module_name)
+        else:
+            affect = AffectFactory()
+        assert affect.ps_product == ps_product_name
+
 
 class TestImpact:
     @pytest.mark.parametrize(


### PR DESCRIPTION
The `ps_product` is not an attribute of Affect itself, but rather an attribute of its `ps_module`. With this commit, we make the `ps_product` property directly available from the affect API by linking to its module's product. This is useful e.g. for grouping affects by their PS product names instead of the modules.

Closes OSIDB-2217