### PR TITLE
Fix rendering of git commit id on the main page

### DIFF
--- a/osidb/views.py
+++ b/osidb/views.py
@@ -3,6 +3,7 @@ index page
 """
 
 import logging
+import os
 
 from django.views.generic import TemplateView
 
@@ -19,4 +20,5 @@ class index(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["version"] = __version__
+        context["revision"] = os.getenv("OPENSHIFT_BUILD_COMMIT") or "unknown"
         return context


### PR DESCRIPTION
This PR is a follow-up to #410 and enables the correct rendering of git commit id on the main page.

Closes OSIDB-2235