### PR TITLE
Fix Bugzilla summary for first flaw creation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix Jira sync when bugzilla token is present (OSIDB-2171)
+- Fix Bugzilla summary for first flaw creation (OSIDB-2190)
 
 ## [3.6.2] - 2024-02-02
 ### Fixed


### PR DESCRIPTION
This PR changes Bugzilla query builder to consider the first flaw creation into summary.

Closes OSIDB-2190.