### PR TITLE
Fix several issues around collectors

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -268,7 +268,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 80,
+        "line_number": 84,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-02-26T20:16:29Z"
+  "generated_at": "2024-03-13T16:13:36Z"
 }

--- a/apps/bbsync/srtnotes.py
+++ b/apps/bbsync/srtnotes.py
@@ -2,7 +2,7 @@ import json
 
 import jsonschema
 
-from osidb.models import AffectCVSS, FlawCVSS, Tracker
+from osidb.models import AffectCVSS, FlawCVSS, FlawReference, Tracker
 
 from .constants import DATE_FMT, DATETIME_FMT, SRTNOTES_SCHEMA_PATH
 from .exceptions import SRTNotesValidationError
@@ -186,10 +186,14 @@ class SRTNotesBuilder:
         """
         generate array of references to SRT notes
 
-        OSIDB uses "ARTICLE" and "EXTERNAL",
-        but Bugzilla uses "vuln_response" and "external".
+        OSIDB uses "ARTICLE", "EXTERNAL" and "SOURCE",
+        but Bugzilla uses "vuln_response", "external" and "source".
         """
-        references_mapping = {"ARTICLE": "vuln_response", "EXTERNAL": "external"}
+        references_mapping = {
+            FlawReference.FlawReferenceType.ARTICLE: "vuln_response",
+            FlawReference.FlawReferenceType.EXTERNAL: "external",
+            FlawReference.FlawReferenceType.SOURCE: "source",
+        }
 
         self.add_conditionally(
             "references",

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -1012,9 +1012,11 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
         for reference_json in self.srtnotes.get("references", []):
             _type = reference_json.get("type")
             if _type == "vuln_response":
-                _type = "ARTICLE"
+                _type = FlawReference.FlawReferenceType.ARTICLE
             elif _type == "external":
-                _type = "EXTERNAL"
+                _type = FlawReference.FlawReferenceType.EXTERNAL
+            elif _type == "source":
+                _type = FlawReference.FlawReferenceType.SOURCE
 
             url = reference_json.get("url")
             reference_json["acl_labels"] = self.groups

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -9,6 +9,7 @@ from nvdlib.classes import CVE
 from collectors.constants import SNIPPET_CREATION_ENABLED, SNIPPET_CREATION_START_DATE
 from collectors.framework.models import Collector
 from collectors.nvd.keywords import should_create_snippet
+from collectors.utils import handle_urls
 from osidb.core import set_user_acls
 from osidb.models import Flaw, FlawCVSS, FlawReference, Snippet
 
@@ -125,11 +126,7 @@ class NVDQuerier:
                     "url": f"https://nvd.nist.gov/vuln/detail/{data.id}",
                 }
             ]
-
-            for r in data.references:
-                urls.append(
-                    {"type": FlawReference.FlawReferenceType.EXTERNAL, "url": r.url}
-                )
+            urls.extend(handle_urls([r.url for r in data.references]))
 
             return urls
 

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -155,7 +155,7 @@ class NVDQuerier:
                     "description": get_description(vulnerability.descriptions),
                     "references": get_references(vulnerability),
                     "source": Snippet.Source.NVD,
-                    "title": "placeholder only, see description",
+                    "title": "from NVD collector",
                     # required for ignoring historical data
                     "published_in_nvd": f"{vulnerability.published}Z",
                 }

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -268,7 +268,7 @@ class TestNVDCollector:
                 },
             ],
             "source": Snippet.Source.NVD,
-            "title": "placeholder only, see description",
+            "title": "from NVD collector",
             "published_in_nvd": "2024-01-21T16:29:00.393Z",
         }
         cve_id = snippet_content["cve_id"]

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -167,6 +167,8 @@ class OSVCollector(Collector):
             return 0, 0
 
         if not cve_ids:
+            # This keeps the structure consistent and ease snippets filtering without cve_id
+            content["cve_id"] = None
             _, created = Snippet.objects.update_or_create(
                 source=Snippet.Source.OSV,
                 external_id=osv_id,

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -11,6 +11,7 @@ from django.utils import dateparse, timezone
 
 from collectors.constants import SNIPPET_CREATION_ENABLED, SNIPPET_CREATION_START_DATE
 from collectors.framework.models import Collector
+from collectors.utils import handle_urls
 from osidb.core import set_user_acls
 from osidb.models import FlawCVSS, FlawReference, Snippet
 from osidb.validators import CVE_RE_STR
@@ -216,13 +217,8 @@ class OSVCollector(Collector):
                     "url": f"https://osv.dev/vulnerability/{osv_id}",
                 }
             ]
-            for ref in data.get("references", []):
-                refs.append(
-                    {
-                        "type": FlawReference.FlawReferenceType.EXTERNAL,
-                        "url": ref["url"],
-                    }
-                )
+            refs.extend(handle_urls([r["url"] for r in data.get("references", [])]))
+
             return refs
 
         def get_description(data: dict) -> str:

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record_without_cve.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record_without_cve.yaml
@@ -1,0 +1,59 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
+    method: GET
+    uri: https://example.com/v1/vulns/GHSA-w4f8-fxq2-j35v
+  response:
+    body:
+      string: '{"id": "GHSA-w4f8-fxq2-j35v", "summary": "Possible privilege escalation
+        via bash completion script", "details": "The bash completion script for `fscrypt`
+        through v0.3.2 allows injection of commands via crafted mountpoint paths,
+        allowing privilege escalation under a specific set of circumstances. A local
+        user who has control over mountpoint paths could potentially escalate their
+        privileges if they create a malicious mountpoint path and if the system administrator
+        happens to be using the `fscrypt` bash completion script to complete mountpoint
+        paths. We recommend upgrading to v0.3.3 or above.\n\nFor more details, see
+        [CVE-2022-25328](https://example.com/CVERecord?id=CVE-2022-25328).", "modified":
+        "2022-03-01T21:04:57Z", "published": "2022-03-01T21:04:57Z", "database_specific":
+        {"cwe_ids": [], "github_reviewed": true, "severity": "MODERATE", "github_reviewed_at":
+        "2022-03-01T21:04:57Z", "nvd_published_at": null}, "references": [{"type":
+        "WEB", "url": "https://example.com/google/fscrypt/security/advisories/GHSA-w4f8-fxq2-j35v"},
+        {"type": "PACKAGE", "url": "github.com/google/fscrypt"}], "affected": [{"package":
+        {"name": "github.com/google/fscrypt", "ecosystem": "Go", "purl": "pkg:golang/github.com/google/fscrypt"},
+        "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.3.3"}]}],
+        "database_specific": {"source": "https://example.com/github/advisory-database/blob/main/advisories/github-reviewed/2022/03/GHSA-w4f8-fxq2-j35v/GHSA-w4f8-fxq2-j35v.json"}}],
+        "schema_version": "1.6.0"}'
+    headers:
+      Content-Length:
+      - '1461'
+      Date:
+      - Wed, 13 Mar 2024 16:06:58 GMT
+      Server:
+      - Google Frontend
+      X-Cloud-Trace-Context:
+      - b47e512aa5ea7339642549d2098c1d23
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-type:
+      - application/json
+      grpc-accept-encoding:
+      - identity, deflate, gzip
+      grpc-message:
+      - ''
+      grpc-status:
+      - '0'
+      x-envoy-decorator-operation:
+      - ingress GetVulnById
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -26,6 +26,19 @@ class TestOSVCollector:
         assert snippet.content["references"]
         assert snippet.content["cve_id"] == "CVE-2023-50424"
 
+    @pytest.mark.vcr
+    def test_collect_osv_record_without_cve(self):
+        """Test fetching a single OSV record without cve."""
+        osvc = OSVCollector()
+        osvc.snippet_creation_enabled = True
+        osvc.snippet_creation_start_date = None
+        osvc.collect(osv_id="GHSA-w4f8-fxq2-j35v")
+
+        assert Snippet.objects.count() == 1
+        snippet = Snippet.objects.first()
+        assert snippet.external_id == "GHSA-w4f8-fxq2-j35v"
+        assert snippet.content["cve_id"] is None
+
     # NOTE: cassette updates may be required to comply with published date
     @pytest.mark.vcr
     def test_collect_multi_cve_osv_record(self):

--- a/collectors/tests/test_utils.py
+++ b/collectors/tests/test_utils.py
@@ -1,6 +1,7 @@
 import pytest
 
-from collectors.utils import tracker_parse_update_stream_component
+from collectors.utils import handle_urls, tracker_parse_update_stream_component
+from osidb.models import FlawReference
 
 pytestmark = pytest.mark.unit
 
@@ -88,3 +89,20 @@ class TestParseUpdateStreamComponent:
         test parsing of update stream and component from an incorrect summary
         """
         assert (None, None) == tracker_parse_update_stream_component(title)
+
+
+class TestHandleURLs:
+    def test_handle_urls(self):
+        result = handle_urls(
+            ["https://www.google1.com", "google2.com", "htt://www.google3.com"]
+        )
+
+        assert len(result) == 2
+        assert {
+            "type": FlawReference.FlawReferenceType.EXTERNAL,
+            "url": "https://www.google1.com",
+        } in result
+        assert {
+            "type": FlawReference.FlawReferenceType.EXTERNAL,
+            "url": "http://google2.com",
+        } in result

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -73,6 +73,10 @@ HTTPS_PROXY="http://foo.bar"
 OSIDB_CORS_ALLOWED_ORIGINS='["http://localhost:8000", "http://127.0.0.1:8000", "http://0.0.0.0:8000"]'
 # Custom headers allowed by OSIDB CORS policy
 OSIDB_CORS_ALLOW_HEADERS='["bugzilla-api-key", "jira-api-key"]'
+
+# To enable snippets creation in collectors (when date is not set, all snippets are created)
+SNIPPET_CREATION=1
+SNIPPET_CREATION_START="2024-01-01"
 ```
 
 The `.env` file is loaded automatically by podman-compose. It is also loaded as environment variables in a few Makefile targets (run `grep -rF '.env ' mk/` to see which ones).

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -29,7 +29,7 @@ def get_snippet(cve_id="CVE-2023-0001"):
             },
         ],
         "source": Snippet.Source.NVD,
-        "title": "placeholder only, see description",
+        "title": "from NVD collector",
         "published_in_nvd": "2024-01-21T16:29:00.393Z",
     }
 


### PR DESCRIPTION
This PR fixes the following:
- BZ code ignored the `SOURCE` reference and failed to write a new flaw
- NVD ans OSV collectors created references that may be invalid and could not be stored in `FlawReference`
- NVD collector had an inappropriate `title`
- OSV collector did not always create snippets with `cve_id`
- `.env` section in `DEVELOP.md` did not contain new "snippet" variables


