### PR TITLE
adjust the delegated resolution handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)
 - Included workflow fields in OpenAPI document for filtering (OSIDB-2083)
-- Set migrated/duplicated delegated resolution to not affected (OSIDB-1406)
+- Set migrated/duplicated delegated resolution to be ignored (OSIDB-1406)
 - Update valid affectedness-resolution combinations (OSIDB-2143)
 - Change Flaw API filter to allow a list of workflow_state (OSIDB-2208)
 

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2092,7 +2092,8 @@ class Affect(
         ):
             return None
 
-        trackers = self.trackers.all()
+        # exclude the trackers closed as duplicate or migrated from Bugzilla
+        trackers = self.trackers.exclude(resolution__iregex=r"(duplicate|migrated)")
         if not trackers:
             return Affect.AffectFix.AFFECTED
 
@@ -2669,8 +2670,6 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
                 return Affect.AffectFix.WONTFIX
             # Added rejected to code inherited from SDEngine because samples such as MGDSTRM-4153
             elif self.resolution in (
-                "duplicate",
-                "migrated",
                 "notabug",
                 "not a bug",
                 "rejected",


### PR DESCRIPTION
I first understood OSIDB-1406 wrong and this fixes it - the duplicate and migrated resolutions are now ignored