### PR TITLE
remove default_cc from the PsModuleFactory

### DIFF
--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -481,8 +481,6 @@ class PsModuleFactory(factory.django.DjangoModelFactory):
         start_date=factory.SelfAttribute("..supported_from_dt"),
     )
 
-    default_cc = factory.List([factory.Faker("word") for _ in range(3)])
-
     default_component = factory.Faker("word")
 
     ps_product = factory.SubFactory(PsProductFactory)


### PR DESCRIPTION
as it generates random and not really existing Bugzilla users which most of the time only complicates generating the cassettes