### PR TITLE
Expose Alerts to API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Introduce CVSS v4 (OSIDB-528)
 - Change tests to have default urls strings where it can't be blank (OSIDB-1679)
 - Add label compliance-priority to jira trackers based on ps-constants compliance_priority.yml (OSIDB-2062)
+- Expose alerts on API for every model alert supported model,
+  mainly Flaw, Affect, Tracker (OSIDB-2065)
 
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)

--- a/openapi.yml
+++ b/openapi.yml
@@ -6964,6 +6964,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -6974,6 +6978,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - cvss_scores
       - delegated_resolution
@@ -7014,6 +7019,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7024,6 +7033,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - cvss_version
       - embargoed
@@ -7056,11 +7066,16 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
           readOnly: true
       required:
+      - alerts
       - created_dt
       - cvss_version
       - embargoed
@@ -7092,6 +7107,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7102,6 +7121,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - cvss_version
       - embargoed
@@ -7206,11 +7226,16 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
           readOnly: true
       required:
+      - alerts
       - created_dt
       - cvss_scores
       - delegated_resolution
@@ -7282,6 +7307,10 @@ components:
           additionalProperties:
             type: string
             nullable: true
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7292,6 +7321,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - updated_dt
       - uuid
@@ -7609,9 +7639,14 @@ components:
         team_id:
           type: string
           maxLength: 8
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
       required:
       - acknowledgments
       - affects
+      - alerts
       - classification
       - comments
       - created_dt
@@ -7652,6 +7687,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7663,6 +7702,7 @@ components:
             it is used to detect mit-air collisions.
       required:
       - affiliation
+      - alerts
       - created_dt
       - embargoed
       - flaw
@@ -7691,12 +7731,17 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
           readOnly: true
       required:
       - affiliation
+      - alerts
       - created_dt
       - embargoed
       - from_upstream
@@ -7723,6 +7768,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7734,6 +7783,7 @@ components:
             it is used to detect mit-air collisions.
       required:
       - affiliation
+      - alerts
       - created_dt
       - embargoed
       - from_upstream
@@ -7777,7 +7827,12 @@ components:
           format: date-time
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
       required:
+      - alerts
       - created_dt
       - cvss_version
       - embargoed
@@ -7814,7 +7869,12 @@ components:
           type: string
           format: date-time
           readOnly: true
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
       required:
+      - alerts
       - created_dt
       - cvss_version
       - embargoed
@@ -7855,7 +7915,12 @@ components:
           format: date-time
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
       required:
+      - alerts
       - created_dt
       - cvss_version
       - embargoed
@@ -7886,6 +7951,10 @@ components:
           maximum: 2147483647
           minimum: -2147483648
           nullable: true
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7901,6 +7970,7 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
       required:
+      - alerts
       - created_dt
       - embargoed
       - external_system_id
@@ -7925,6 +7995,10 @@ components:
           additionalProperties:
             type: string
             nullable: true
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -7935,6 +8009,7 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
       required:
+      - alerts
       - created_dt
       - embargoed
       - text
@@ -8297,9 +8372,14 @@ components:
         team_id:
           type: string
           maxLength: 8
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
       required:
       - acknowledgments
       - affects
+      - alerts
       - classification
       - comments
       - created_dt
@@ -8339,6 +8419,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -8349,6 +8433,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - embargoed
       - flaw
@@ -8376,11 +8461,16 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
           readOnly: true
       required:
+      - alerts
       - created_dt
       - embargoed
       - url
@@ -8406,6 +8496,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -8416,6 +8510,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - embargoed
       - updated_dt
@@ -8519,6 +8614,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -8529,6 +8628,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - embargoed
       - type
@@ -8576,7 +8676,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PackageVer'
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
       required:
+      - alerts
       - package
       - versions
     PackageVer:
@@ -9095,6 +9200,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -9105,6 +9214,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - embargoed
       - errata
@@ -9170,6 +9280,10 @@ components:
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
+        alerts:
+          type: object
+          additionalProperties: {}
+          readOnly: true
         created_dt:
           type: string
           format: date-time
@@ -9180,6 +9294,7 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
       required:
+      - alerts
       - created_dt
       - embargoed
       - errata


### PR DESCRIPTION
This PR exposes `alerts` field for every model which inherits from AlertMixin and thus supports alerts.
Namely:
* Flaw
* Affect
* Tracker
* FlawMeta
* FlawComment
* FlawCVSS
* AffectCVSS
* FlawAcknowledgment
* FlawReference
* Package

Closes OSIDB-2065