### PR TITLE
Add support for additional_fields for Jira BTS

### DIFF
--- a/apps/trackers/jira/constants.py
+++ b/apps/trackers/jira/constants.py
@@ -7,3 +7,9 @@ JIRA_SERVER = get_env("JIRA_URL", default="https://issues.redhat.com")
 JIRA_EMBARGO_SECURITY_LEVEL_NAME = get_env(
     "JIRA_EMBARGO_SECURITY_LEVEL_NAME", default="Embargoed Security Issue"
 )
+
+# Translate additional fields as defined in product definitions to the actual Jira field
+PS_ADDITIONAL_FIELD_TO_JIRA = {
+    "fixVersions": "fixVersions",
+    "release_blocker": "customfield_12319743",
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add label compliance-priority to jira trackers based on ps-constants compliance_priority.yml (OSIDB-2062)
 - Expose alerts on API for every model alert supported model,
   mainly Flaw, Affect, Tracker (OSIDB-2065)
+- Add support for additional_fields in Jira BTS (OSIDB-696)
 
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)


### PR DESCRIPTION
In product definitions, there can be optional additional fields for Jira, which at the time of this commit are `fixVersions` or `release_blocker`. This commit translates these fields to fields that the Jira tracker understands, and adds them to the query when creating/updating a tracker.

Closes OSIDB-696