### PR TITLE
OSIDB-2347: Readonly CVSS score

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make workflows API RESTful (OSIDB-1716)
 - SLA for compliance priority brought to parity with SFM2 (OSIDB-2257)
 - Migrate data with outdated workflow_state values to the current ones (OSIDB-1718)
+- Flaw CVSS score and Affect CVSS score are now readonly (OSIDB-2347)
 
 ### Fixed
 - Fix Jira sync when bugzilla token is present (OSIDB-2171)

--- a/openapi.yml
+++ b/openapi.yml
@@ -1995,7 +1995,7 @@ paths:
       security:
       - OsidbTokenAuthentication: []
       responses:
-        '204':
+        '200':
           content:
             application/json:
               schema:
@@ -7007,6 +7007,7 @@ components:
         score:
           type: number
           format: float
+          readOnly: true
         uuid:
           type: string
           format: uuid
@@ -7038,6 +7039,7 @@ components:
       - cvss_version
       - embargoed
       - issuer
+      - score
       - updated_dt
       - uuid
       - vector
@@ -7054,6 +7056,7 @@ components:
         score:
           type: number
           format: float
+          readOnly: true
         uuid:
           type: string
           format: uuid
@@ -7080,6 +7083,7 @@ components:
       - cvss_version
       - embargoed
       - issuer
+      - score
       - uuid
       - vector
     AffectCVSSPut:
@@ -7095,6 +7099,7 @@ components:
         score:
           type: number
           format: float
+          readOnly: true
         uuid:
           type: string
           format: uuid
@@ -7126,6 +7131,7 @@ components:
       - cvss_version
       - embargoed
       - issuer
+      - score
       - updated_dt
       - uuid
       - vector
@@ -7806,6 +7812,7 @@ components:
         score:
           type: number
           format: float
+          readOnly: true
         uuid:
           type: string
           format: uuid
@@ -7837,6 +7844,7 @@ components:
       - cvss_version
       - embargoed
       - issuer
+      - score
       - updated_dt
       - uuid
       - vector
@@ -7853,6 +7861,7 @@ components:
         score:
           type: number
           format: float
+          readOnly: true
         uuid:
           type: string
           format: uuid
@@ -7879,6 +7888,7 @@ components:
       - cvss_version
       - embargoed
       - issuer
+      - score
       - uuid
       - vector
     FlawCVSSPut:
@@ -7894,6 +7904,7 @@ components:
         score:
           type: number
           format: float
+          readOnly: true
         uuid:
           type: string
           format: uuid
@@ -7925,6 +7936,7 @@ components:
       - cvss_version
       - embargoed
       - issuer
+      - score
       - updated_dt
       - uuid
       - vector

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -783,6 +783,11 @@ class AffectCVSSView(ModelViewSet):
             kwargs["data"] = data
         return super().get_serializer(*args, **kwargs)
 
+    @extend_schema(
+        responses={
+            200: {},
+        }
+    )
     def destroy(self, request, *args, **kwargs):
         """
         Destroy the instance and proxy the delete to Bugzilla.

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -772,6 +772,7 @@ class AffectCVSSSerializer(
     """AffectCVSS serializer"""
 
     cvss_version = serializers.CharField(source="version")
+    score = serializers.FloatField(read_only=True)
 
     class Meta:
         """filter fields"""
@@ -1278,6 +1279,7 @@ class FlawCVSSSerializer(
     """FlawCVSS serializer"""
 
     cvss_version = serializers.CharField(source="version")
+    score = serializers.FloatField(read_only=True)
 
     class Meta:
         """filter fields"""


### PR DESCRIPTION
This PR:
* makes AffectCVSS and FlawCVSS scores readonly
* minor - changes AffectCVSS DELETE response code from 204 to 200 (just a schema adjustment, in really we are already sending 200)

Closes OSIDB-2347