### PR TITLE
Create API for Alerts

### DIFF
--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -88,7 +88,7 @@ class TestTrackerSaver:
         assert not loaded_tracker.resolution
         assert loaded_tracker.affects.count() == 1
         assert loaded_tracker.affects.first() == affect
-        assert not loaded_tracker._alerts
+        assert not loaded_tracker.alerts.exists()
 
     @pytest.mark.vcr
     def test_tracker_update_bugzilla(self):
@@ -159,7 +159,7 @@ class TestTrackerSaver:
         assert not loaded_tracker.resolution
         assert loaded_tracker.affects.count() == 1
         assert loaded_tracker.affects.first() == affect
-        assert not loaded_tracker._alerts
+        assert not loaded_tracker.alerts.exists()
 
         # 7) check that the update actually happened
         assert "updated_dt" in loaded_tracker.meta_attr
@@ -232,7 +232,7 @@ class TestTrackerAPI:
         assert not tracker.resolution
         assert tracker.affects.count() == 1
         assert tracker.affects.first() == affect
-        assert not tracker._alerts
+        assert not tracker.alerts.exists()
 
     @pytest.mark.vcr
     def test_tracker_update_bugzilla(
@@ -316,7 +316,7 @@ class TestTrackerAPI:
         assert not tracker.resolution
         assert tracker.affects.count() == 1
         assert tracker.affects.first() == affect
-        assert not tracker._alerts
+        assert not tracker.alerts.exists()
 
         # 6) check that the update actually happened
         assert "updated_dt" in tracker.meta_attr
@@ -408,7 +408,7 @@ class TestTrackerAPI:
         assert not tracker.resolution
         assert tracker.affects.count() == 1
         assert tracker.affects.first() == affect
-        assert not tracker._alerts
+        assert not tracker.alerts.exists()
 
         # 5) reload the flaw and check that the tracker still links
         #    to make sure that the SRT notes were properly updated
@@ -561,7 +561,7 @@ class TestTrackerAPI:
         assert tracker.affects.count() == 2
         assert affect1 in tracker.affects.all()
         assert affect3 in tracker.affects.all()
-        assert not tracker._alerts
+        assert not tracker.alerts.exists()
 
         # 6) check that the update actually happened
         assert updated_dt != tracker.updated_dt

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add CC lists to Jira trackers and to Bugzilla trackers (OSIDB-2191)
 - Enable flaw draft creation in BZ (OSIDB-2261)
 - Add support for UAT (OSIDB-2447)
+- Added API for Alerts (OSIDB-325)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2192,6 +2192,160 @@ paths:
                   version:
                     type: string
           description: ''
+  /osidb/api/v1/alerts:
+    get:
+      operationId: osidb_api_v1_alerts_list
+      description: List existing alerts for all models.
+      parameters:
+      - in: query
+        name: alert_type
+        schema:
+          type: string
+          enum:
+          - ERROR
+          - WARNING
+      - in: query
+        name: exclude_fields
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Exclude specified fields from the response. Multiple values
+          may be separated by commas. Dot notation can be used to filter on related
+          model fields. Example: `exclude_fields=field,related_model_field.field`'
+      - in: query
+        name: include_fields
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Include only specified fields in the response. Multiple values
+          may be separated by commas. Dot notation can be used to filter on related
+          model fields. Example: `include_fields=field,related_model_field.field`'
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: name
+        schema:
+          type: string
+        description: Retrieve only Alerts with the specified name, which is given
+          by the model's validation process.
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      - in: query
+        name: parent_model
+        schema:
+          type: string
+          enum:
+          - affect
+          - affectcvss
+          - flaw
+          - flawacknowledgment
+          - flawcomment
+          - flawcvss
+          - flawmeta
+          - flawreference
+          - package
+          - snippet
+          - tracker
+        description: Retrieve only Alerts related to the specified model, e.g. flaw
+          or affect.
+      - in: query
+        name: parent_uuid
+        schema:
+          type: string
+          format: uuid
+        description: Retrieve only Alerts related to a model with the given UUID.
+      - in: query
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+      tags:
+      - osidb
+      security:
+      - OsidbTokenAuthentication: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/PaginatedAlertList'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+  /osidb/api/v1/alerts/{uuid}:
+    get:
+      operationId: osidb_api_v1_alerts_retrieve
+      parameters:
+      - in: query
+        name: exclude_fields
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Exclude specified fields from the response. Multiple values
+          may be separated by commas. Dot notation can be used to filter on related
+          model fields. Example: `exclude_fields=field,related_model_field.field`'
+      - in: query
+        name: include_fields
+        schema:
+          type: array
+          items:
+            type: string
+        description: 'Include only specified fields in the response. Multiple values
+          may be separated by commas. Dot notation can be used to filter on related
+          model fields. Example: `include_fields=field,related_model_field.field`'
+      - in: path
+        name: uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this alert.
+        required: true
+      tags:
+      - osidb
+      security:
+      - OsidbTokenAuthentication: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/Alert'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
   /osidb/api/v1/flaws:
     get:
       operationId: osidb_api_v1_flaws_list
@@ -7377,8 +7531,8 @@ components:
       type: string
     Alert:
       type: object
-      description: Alert serializer to expose alerts stored in models that inherit
-        from AlertMixin.
+      description: Alerts indicate some inconsistency in a linked flaw, affect, tracker
+        or other models.
       properties:
         uuid:
           type: string
@@ -7393,14 +7547,22 @@ components:
           $ref: '#/components/schemas/AlertTypeEnum'
         resolution_steps:
           type: string
+        parent_uuid:
+          type: string
+          readOnly: true
+        parent_model:
+          type: string
+          readOnly: true
       required:
       - description
       - name
+      - parent_model
+      - parent_uuid
       - uuid
     AlertTypeEnum:
       enum:
-      - warning
-      - error
+      - WARNING
+      - ERROR
       type: string
     BlankEnum:
       enum:
@@ -8900,6 +9062,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Affect'
+    PaginatedAlertList:
+      type: object
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
     PaginatedEPSSList:
       type: object
       properties:

--- a/openapi.yml
+++ b/openapi.yml
@@ -7048,8 +7048,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7104,8 +7105,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7153,8 +7155,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7196,8 +7199,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7316,8 +7320,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7370,6 +7375,33 @@ components:
       - AFFECTED
       - NOTAFFECTED
       type: string
+    Alert:
+      type: object
+      description: Alert serializer to expose alerts stored in models that inherit
+        from AlertMixin.
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        name:
+          type: string
+          maxLength: 255
+        description:
+          type: string
+        alert_type:
+          $ref: '#/components/schemas/AlertTypeEnum'
+        resolution_steps:
+          type: string
+      required:
+      - description
+      - name
+      - uuid
+    AlertTypeEnum:
+      enum:
+      - warning
+      - error
+      type: string
     BlankEnum:
       enum:
       - ''
@@ -7397,8 +7429,9 @@ components:
             type: string
             nullable: true
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7740,8 +7773,9 @@ components:
           type: string
           maxLength: 8
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
       required:
       - acknowledgments
@@ -7788,8 +7822,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7832,8 +7867,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7869,8 +7905,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -7929,8 +7966,9 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
       required:
       - alerts
@@ -7973,8 +8011,9 @@ components:
           format: date-time
           readOnly: true
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
       required:
       - alerts
@@ -8021,8 +8060,9 @@ components:
           description: The updated_dt timestamp attribute is mandatory on update as
             it is used to detect mit-air collisions.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
       required:
       - alerts
@@ -8058,8 +8098,9 @@ components:
           minimum: -2147483648
           nullable: true
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -8102,8 +8143,9 @@ components:
             type: string
             nullable: true
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -8484,8 +8526,9 @@ components:
           type: string
           maxLength: 8
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
       required:
       - acknowledgments
@@ -8531,8 +8574,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -8573,8 +8617,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -8608,8 +8653,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -8726,8 +8772,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -8788,8 +8835,9 @@ components:
           items:
             $ref: '#/components/schemas/PackageVer'
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
       required:
       - alerts
@@ -9313,8 +9361,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string
@@ -9393,8 +9442,9 @@ components:
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
         alerts:
-          type: object
-          additionalProperties: {}
+          type: array
+          items:
+            $ref: '#/components/schemas/Alert'
           readOnly: true
         created_dt:
           type: string

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -16,6 +16,7 @@ from django_filters.rest_framework import (
 
 from apps.workflows.workflow import WorkflowModel
 
+from .mixins import Alert
 from .models import (
     Affect,
     AffectCVSS,
@@ -794,4 +795,17 @@ class FlawPackageVersionFilter(IncludeFieldsFilterSet, ExcludeFieldsFilterSet):
             + DATE_LOOKUP_EXPRS,
             # versions fields
             "versions__version": ["exact"],
+        }
+
+
+class AlertFilter(IncludeFieldsFilterSet, ExcludeFieldsFilterSet):
+    parent_uuid = CharFilter(field_name="object_id")
+    parent_model = CharFilter(field_name="content_type__model")
+
+    class Meta:
+        model = Alert
+        fields = {
+            "uuid": ["exact"],
+            "name": ["exact"],
+            "alert_type": ["exact"],
         }

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -106,6 +106,17 @@ def get_model_fields(model: Type[models.Model]) -> List[str]:
     return [field.name for field in model._meta.get_fields()]
 
 
+def get_mixin_subclases(mixin):
+    """Gets all non-abstract models that inherit from a mixin."""
+    result = []
+    for subclass in mixin.__subclasses__():
+        if subclass._meta.abstract:
+            result.extend(get_mixin_subclases(subclass))
+        else:
+            result.append(subclass.__name__)
+    return result
+
+
 class TaskFormatter(logging.Formatter):
     """
     Custom formatter based on celery 'celery.utils.log.TaskFormatter'

--- a/osidb/migrations/0127_alert_refactor.py
+++ b/osidb/migrations/0127_alert_refactor.py
@@ -1,0 +1,203 @@
+"""
+Written manually on 2024-03-26
+
+Create new Alert model, convert alerts stored in a JSON field to Alert records,
+and remove the JSON field.
+"""
+
+from django.conf import settings
+from django.db import migrations, models
+import django.db.models.deletion
+from itertools import islice
+import uuid
+
+from osidb.core import set_user_acls
+
+
+BATCH_SIZE = 1000
+
+# From a migration we cannot get the models that implement the ALertMixin programmatically so
+# these need to be declared explicitly.
+ALERTABLE_MODELS = [
+    "Flaw",
+    "Affect",
+    "Snippet",
+    "FlawCVSS",
+    "AffectCVSS",
+    "Tracker",
+    "FlawMeta",
+    "FlawComment",
+    "FlawAcknowledgment",
+    "FlawReference",
+    "Package",
+]
+
+
+def generate_alertmixins(apps, model):
+    Alert = apps.get_model("osidb", "Alert")
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    # Convert alerts in JSON format to Alert records.
+    # At this point in the migration we have both the old _alerts field and the
+    # new alerts relation.
+    for instance in (
+        model.objects.exclude(_alerts={}).exclude(_alerts__isnull=True).iterator()
+    ):
+        for key, values in instance._alerts.items():
+            yield Alert(
+                name=key,
+                description=values.get("description", ""),
+                alert_type=values.get("type", "WARNING").upper(),
+                resolution_steps=values.get("resolution_steps", ""),
+                content_type=ContentType.objects.get_for_model(instance),
+                object_id=instance.uuid,
+            )
+
+
+def forwards_func(apps, schema_editor):
+    set_user_acls(settings.ALL_GROUPS)
+    Alert = apps.get_model("osidb", "Alert")
+
+    for model_name in ALERTABLE_MODELS:
+        model = apps.get_model("osidb", model_name)
+        generator = generate_alertmixins(apps, model)
+        while batch := list(islice(generator, BATCH_SIZE)):
+            Alert.objects.bulk_create(batch, BATCH_SIZE)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("contenttypes", "0002_remove_content_type_name"),
+        ("osidb", "0126_flaw_default_workflow_state"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Alert",
+            fields=[
+                (
+                    "uuid",
+                    models.UUIDField(
+                        default=uuid.uuid4,
+                        editable=False,
+                        primary_key=True,
+                        serialize=False,
+                    ),
+                ),
+                ("name", models.CharField(max_length=255)),
+                ("description", models.TextField()),
+                (
+                    "alert_type",
+                    models.CharField(
+                        choices=[("WARNING", "Warning"), ("ERROR", "Error")],
+                        default="WARNING",
+                        max_length=10,
+                    ),
+                ),
+                ("resolution_steps", models.TextField(blank=True)),
+                ("object_id", models.CharField(max_length=36)),
+                (
+                    "content_type",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        to="contenttypes.contenttype",
+                    ),
+                ),
+                (
+                    "acl_read",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.UUIDField(), default=list, size=None
+                    ),
+                ),
+                (
+                    "acl_write",
+                    django.contrib.postgres.fields.ArrayField(
+                        base_field=models.UUIDField(), default=list, size=None
+                    ),
+                ),
+            ],
+            options={
+                "abstract": False,
+            },
+        ),
+        migrations.RunPython(forwards_func, migrations.RunPython.noop, atomic=True),
+        migrations.RemoveField(
+            model_name="affect",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="affectcvss",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="flaw",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="flawacknowledgment",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="flawcomment",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="flawcvss",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="flawmeta",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="flawreference",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="package",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="snippet",
+            name="_alerts",
+        ),
+        migrations.RemoveField(
+            model_name="tracker",
+            name="_alerts",
+        ),
+        # Add row level security to the alert model
+        migrations.RunSQL(
+            reverse_sql=migrations.RunSQL.noop,
+            sql="""
+ALTER TABLE osidb_alert ENABLE ROW LEVEL SECURITY;
+ALTER TABLE osidb_alert FORCE ROW LEVEL SECURITY;
+--following policies define fine grained read/write control on osidb_alert entity
+--policy for entity insert (eg. create)
+DROP policy if exists acl_policy_alert_create on osidb_alert;
+create policy acl_policy_alert_create
+on osidb_alert
+for INSERT
+WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+     AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+--policy for entity select
+DROP policy if exists acl_policy_alert_select on osidb_alert;
+create policy acl_policy_alert_select
+on osidb_alert
+for select
+USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+--policy for entity update
+DROP policy if exists acl_policy_alert_update on osidb_alert;
+create policy acl_policy_alert_update
+on osidb_alert
+for update
+USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+     AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+--policy for entity delete
+DROP policy if exists acl_policy_alert_delete on osidb_alert;
+create policy acl_policy_alert_delete
+on osidb_alert
+for delete
+USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+""",
+        ),
+    ]

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -45,6 +45,7 @@ from .helpers import ps_update_stream_natural_keys
 from .mixins import (
     ACLMixin,
     ACLMixinManager,
+    Alert,
     AlertMixin,
     NullStrFieldsMixin,
     TrackingMixin,
@@ -1284,7 +1285,7 @@ class Flaw(
                 self.alert(
                     "_validate_flaw_without_affect",
                     err.message,
-                    _type="error",
+                    alert_type=Alert.AlertType.ERROR,
                 )
             else:
                 raise err

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -390,11 +390,28 @@ class JiraAPIKeyMixin:
 
 
 class AlertSerializer(serializers.ModelSerializer):
-    """Alert serializer to expose alerts stored in models that inherit from AlertMixin."""
+    """Alerts indicate some inconsistency in a linked flaw, affect, tracker or other models."""
+
+    parent_uuid = serializers.SerializerMethodField()
+    parent_model = serializers.SerializerMethodField()
 
     class Meta:
         model = Alert
-        fields = ["uuid", "name", "description", "alert_type", "resolution_steps"]
+        fields = [
+            "uuid",
+            "name",
+            "description",
+            "alert_type",
+            "resolution_steps",
+            "parent_uuid",
+            "parent_model",
+        ]
+
+    def get_parent_uuid(self, obj):
+        return obj.object_id
+
+    def get_parent_model(self, obj):
+        return obj.content_type.model
 
 
 class AlertMixinSerializer(serializers.ModelSerializer):

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -23,7 +23,7 @@ from apps.workflows.serializers import WorkflowModelSerializer
 from .core import generate_acls
 from .exceptions import DataInconsistencyException
 from .helpers import differ, ensure_list
-from .mixins import ACLMixin, AlertMixin, TrackingMixin
+from .mixins import ACLMixin, Alert, AlertMixin, TrackingMixin
 from .models import (
     Affect,
     AffectCVSS,
@@ -389,14 +389,20 @@ class JiraAPIKeyMixin:
         return jira_token
 
 
-class AlertMixinSerializer(serializers.ModelSerializer):
-    """Alert mixin serializer to expose alerts stored via AlertMixin"""
-
-    alerts = serializers.JSONField(read_only=True, source="_alerts")
+class AlertSerializer(serializers.ModelSerializer):
+    """Alert serializer to expose alerts stored in models that inherit from AlertMixin."""
 
     class Meta:
-        """filter fields"""
+        model = Alert
+        fields = ["uuid", "name", "description", "alert_type", "resolution_steps"]
 
+
+class AlertMixinSerializer(serializers.ModelSerializer):
+    """Serializes the alerts in models that implement AlertMixin."""
+
+    alerts = AlertSerializer(many=True, read_only=True)
+
+    class Meta:
         model = AlertMixin
         abstract = True
         fields = ["alerts"]

--- a/osidb/tests/models.py
+++ b/osidb/tests/models.py
@@ -1,12 +1,18 @@
+import uuid
+
+from django.db import models
+
 from osidb.mixins import AlertMixin
 from osidb.models import ComparableTextChoices
 
 
-class AlertModelBasic(AlertMixin):
-    pass
+class AlertableModelBasic(AlertMixin):
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
 
 
-class AlertModel(AlertMixin):
+class AlertableModel(AlertMixin):
+    uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
     def _validate_test(self):
         """
         Creates a new alert when validate() method runs.

--- a/osidb/tests/test_rls.py
+++ b/osidb/tests/test_rls.py
@@ -4,8 +4,8 @@ from django.db import transaction
 from django.db.utils import ProgrammingError
 
 from osidb.core import set_user_acls
-from osidb.models import Flaw
-from osidb.tests.factories import FlawFactory
+from osidb.models import CVSS, Flaw
+from osidb.tests.factories import FlawCVSSFactory, FlawFactory
 
 pytestmark = pytest.mark.enable_rls
 
@@ -81,6 +81,10 @@ class TestRLS:
         set_user_acls(settings.ALL_GROUPS)
         f1 = FlawFactory(title="foo", embargoed=False)
         f2 = FlawFactory(title="bar", embargoed=True)
+        # Avoid issuing alerts for f2 so that the error is not due to the RLS in the alert table
+        FlawCVSSFactory(
+            flaw=f2, version=CVSS.CVSSVersion.VERSION3, issuer=CVSS.CVSSIssuer.REDHAT
+        )
 
         set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
         f1.title = "baz"

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -10,6 +10,7 @@ from apps.workflows.api import promote, reject
 from .api_views import (
     AffectCVSSView,
     AffectView,
+    AlertView,
     FlawAcknowledgmentView,
     FlawCommentView,
     FlawCVSSView,
@@ -52,6 +53,7 @@ router.register(
     r"affects/(?P<affect_id>[^/.]+)/cvss_scores", AffectCVSSView, basename="affectcvss"
 )
 router.register(r"trackers", TrackerView)
+router.register(r"alerts", AlertView)
 
 urlpatterns = [
     path("healthy", healthy),


### PR DESCRIPTION
Alerts have been refactored into their own model instead of being stored in a JSON field, and an API endpoint to retrieve alerts for all models has been created.

Closes OSIDB-325.