### PR TITLE
Show cvss_version as enum in API schema for CVSS

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix Jira tracker security level not being set based on embargo (OSIDB-2082)
 - Removed writing operations in workflows when READ_ONLY is enabled (OSIDB-2336)
 - Fix Flaw API allowing to sort by all fields (OSIDB-2367)
+- Fix FlawCVSS and AffectCVSS "cvss_version" on API to show version enum
 
 ## [3.6.2] - 2024-02-02
 ### Fixed

--- a/openapi.yml
+++ b/openapi.yml
@@ -7057,7 +7057,7 @@ components:
         comment:
           type: string
         cvss_version:
-          type: string
+          $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
           $ref: '#/components/schemas/IssuerEnum'
         score:
@@ -7106,7 +7106,7 @@ components:
         comment:
           type: string
         cvss_version:
-          type: string
+          $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
           $ref: '#/components/schemas/IssuerEnum'
         score:
@@ -7149,7 +7149,7 @@ components:
         comment:
           type: string
         cvss_version:
-          type: string
+          $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
           $ref: '#/components/schemas/IssuerEnum'
         score:
@@ -7387,6 +7387,12 @@ components:
       - created_dt
       - updated_dt
       - uuid
+    CvssVersionEnum:
+      enum:
+      - V2
+      - V3
+      - V4
+      type: string
     EPSS:
       type: object
       properties:
@@ -7864,7 +7870,7 @@ components:
         comment:
           type: string
         cvss_version:
-          type: string
+          $ref: '#/components/schemas/CvssVersionEnum'
         flaw:
           type: string
           format: uuid
@@ -7916,7 +7922,7 @@ components:
         comment:
           type: string
         cvss_version:
-          type: string
+          $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
           $ref: '#/components/schemas/IssuerEnum'
         score:
@@ -7959,7 +7965,7 @@ components:
         comment:
           type: string
         cvss_version:
-          type: string
+          $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
           $ref: '#/components/schemas/IssuerEnum'
         score:

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -771,7 +771,9 @@ class AffectCVSSSerializer(
 ):
     """AffectCVSS serializer"""
 
-    cvss_version = serializers.CharField(source="version")
+    cvss_version = serializers.ChoiceField(
+        choices=AffectCVSS.CVSSVersion, source="version"
+    )
     score = serializers.FloatField(read_only=True)
 
     class Meta:
@@ -1278,7 +1280,9 @@ class FlawCVSSSerializer(
 ):
     """FlawCVSS serializer"""
 
-    cvss_version = serializers.CharField(source="version")
+    cvss_version = serializers.ChoiceField(
+        choices=FlawCVSS.CVSSVersion, source="version"
+    )
     score = serializers.FloatField(read_only=True)
 
     class Meta:


### PR DESCRIPTION
This PR:
* changes `cvss_version` for FlawCVSS and AffectCVSS on API schema from string to enum