### PR TITLE
Allow editing flaws in NEW workflow state

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)
 - Minor change to enable perf tests to run in CI (OSIDB-2447)
+- Allow editing flaws without affects in NEW state (OSIDB-2452)
 
 ## [3.7.0] - 2024-04-17
 ### Added

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1277,7 +1277,17 @@ class Flaw(
             return
 
         if not Affect.objects.filter(flaw=self).exists():
-            raise ValidationError("Flaw does not contain any affects.")
+            err = ValidationError("Flaw does not contain any affects.")
+            # When a flaw in a "new" workflow state is modified, allow saving
+            # with no affects but issue an alert
+            if self.workflow_state == WorkflowModel.WorkflowState.NEW:
+                self.alert(
+                    "_validate_flaw_without_affect",
+                    err.message,
+                    _type="error",
+                )
+            else:
+                raise err
 
     def _validate_nonempty_impact(self):
         """


### PR DESCRIPTION
There is a validation in flaws which enforces them to have at least one affect, which is only disabled when creating a flaw. This commit also disables this validation when editing 'draft' flaws, i.e. flaws which are in a NEW state, and instead issues an alert. The validation is still active in other states and when trying to move to the next state.

Closes OSIDB-2452.