### PR TITLE
Fix component backward compatibility

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1323,11 +1323,13 @@ paths:
             - -cvss3_score
             - -cvss_scores__comment
             - -cvss_scores__created_dt
+            - -cvss_scores__cvss_version
             - -cvss_scores__issuer
             - -cvss_scores__score
             - -cvss_scores__updated_dt
             - -cvss_scores__uuid
             - -cvss_scores__vector
+            - -embargoed
             - -flaw__component
             - -flaw__components
             - -flaw__created_dt
@@ -1337,7 +1339,9 @@ paths:
             - -flaw__cvss3
             - -flaw__cvss3_score
             - -flaw__cwe_id
+            - -flaw__embargoed
             - -flaw__impact
+            - -flaw__is_major_incident
             - -flaw__nvd_cvss2
             - -flaw__nvd_cvss3
             - -flaw__reported_dt
@@ -1351,6 +1355,7 @@ paths:
             - -ps_module
             - -resolution
             - -trackers__created_dt
+            - -trackers__embargoed
             - -trackers__external_system_id
             - -trackers__ps_update_stream
             - -trackers__resolution
@@ -1369,11 +1374,13 @@ paths:
             - cvss3_score
             - cvss_scores__comment
             - cvss_scores__created_dt
+            - cvss_scores__cvss_version
             - cvss_scores__issuer
             - cvss_scores__score
             - cvss_scores__updated_dt
             - cvss_scores__uuid
             - cvss_scores__vector
+            - embargoed
             - flaw__component
             - flaw__components
             - flaw__created_dt
@@ -1383,7 +1390,9 @@ paths:
             - flaw__cvss3
             - flaw__cvss3_score
             - flaw__cwe_id
+            - flaw__embargoed
             - flaw__impact
+            - flaw__is_major_incident
             - flaw__nvd_cvss2
             - flaw__nvd_cvss3
             - flaw__reported_dt
@@ -1397,6 +1406,7 @@ paths:
             - ps_module
             - resolution
             - trackers__created_dt
+            - trackers__embargoed
             - trackers__external_system_id
             - trackers__ps_update_stream
             - trackers__resolution
@@ -6326,6 +6336,7 @@ paths:
             - -affects__cvss2_score
             - -affects__cvss3
             - -affects__cvss3_score
+            - -affects__embargoed
             - -affects__flaw__component
             - -affects__flaw__components
             - -affects__flaw__created_dt
@@ -6335,7 +6346,9 @@ paths:
             - -affects__flaw__cvss3
             - -affects__flaw__cvss3_score
             - -affects__flaw__cwe_id
+            - -affects__flaw__embargoed
             - -affects__flaw__impact
+            - -affects__flaw__is_major_incident
             - -affects__flaw__nvd_cvss2
             - -affects__flaw__nvd_cvss3
             - -affects__flaw__reported_dt
@@ -6352,6 +6365,7 @@ paths:
             - -affects__updated_dt
             - -affects__uuid
             - -created_dt
+            - -embargoed
             - -external_system_id
             - -ps_update_stream
             - -resolution
@@ -6365,6 +6379,7 @@ paths:
             - affects__cvss2_score
             - affects__cvss3
             - affects__cvss3_score
+            - affects__embargoed
             - affects__flaw__component
             - affects__flaw__components
             - affects__flaw__created_dt
@@ -6374,7 +6389,9 @@ paths:
             - affects__flaw__cvss3
             - affects__flaw__cvss3_score
             - affects__flaw__cwe_id
+            - affects__flaw__embargoed
             - affects__flaw__impact
+            - affects__flaw__is_major_incident
             - affects__flaw__nvd_cvss2
             - affects__flaw__nvd_cvss3
             - affects__flaw__reported_dt
@@ -6391,6 +6408,7 @@ paths:
             - affects__updated_dt
             - affects__uuid
             - created_dt
+            - embargoed
             - external_system_id
             - ps_update_stream
             - resolution

--- a/openapi.yml
+++ b/openapi.yml
@@ -1328,6 +1328,7 @@ paths:
             - -cvss_scores__updated_dt
             - -cvss_scores__uuid
             - -cvss_scores__vector
+            - -flaw__component
             - -flaw__components
             - -flaw__created_dt
             - -flaw__cve_id
@@ -1373,6 +1374,7 @@ paths:
             - cvss_scores__updated_dt
             - cvss_scores__uuid
             - cvss_scores__vector
+            - flaw__component
             - flaw__components
             - flaw__created_dt
             - flaw__cve_id
@@ -3030,6 +3032,7 @@ paths:
             - -affects__updated_dt
             - -affects__uuid
             - -bz_id
+            - -component
             - -components
             - -created_dt
             - -cve_id
@@ -3103,6 +3106,7 @@ paths:
             - affects__updated_dt
             - affects__uuid
             - bz_id
+            - component
             - components
             - created_dt
             - cve_id
@@ -6322,6 +6326,7 @@ paths:
             - -affects__cvss2_score
             - -affects__cvss3
             - -affects__cvss3_score
+            - -affects__flaw__component
             - -affects__flaw__components
             - -affects__flaw__created_dt
             - -affects__flaw__cve_id
@@ -6360,6 +6365,7 @@ paths:
             - affects__cvss2_score
             - affects__cvss3
             - affects__cvss3_score
+            - affects__flaw__component
             - affects__flaw__components
             - affects__flaw__created_dt
             - affects__flaw__cve_id

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -559,7 +559,12 @@ class AffectFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilte
         }
 
     order_fields = [
+        "cvss_scores__cvss_version",
+        "embargoed",
         "flaw__component",
+        "flaw__embargoed",
+        "flaw__is_major_incident",
+        "trackers__embargoed",
     ] + list(Meta.fields.keys())
     order = OrderingFilter(fields=order_fields)
 
@@ -672,6 +677,10 @@ class TrackerFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilt
         }
 
     order_fields = [
+        "embargoed",
+        "affects__embargoed",
+        "affects__flaw__embargoed",
+        "affects__flaw__is_major_incident",
         "affects__flaw__component",
     ] + list(Meta.fields.keys())
     order = OrderingFilter(fields=order_fields)

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -425,6 +425,7 @@ class FlawFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilterS
     order_fields = [
         "bz_id",
         "cve_id",
+        "component",
         "embargoed",
         "description",
         "is_major_incident",
@@ -557,7 +558,10 @@ class AffectFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilte
             "cvss_scores__vector": ["exact"],
         }
 
-    order = OrderingFilter(fields=Meta.fields.keys())
+    order_fields = [
+        "flaw__component",
+    ] + list(Meta.fields.keys())
+    order = OrderingFilter(fields=order_fields)
 
 
 class TrackerFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilterSet):
@@ -667,7 +671,10 @@ class TrackerFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilt
             "affects__flaw__components": ["exact"],
         }
 
-    order = OrderingFilter(fields=Meta.fields.keys())
+    order_fields = [
+        "affects__flaw__component",
+    ] + list(Meta.fields.keys())
+    order = OrderingFilter(fields=order_fields)
 
 
 class FlawAcknowledgmentFilter(IncludeFieldsFilterSet, ExcludeFieldsFilterSet):


### PR DESCRIPTION
This PR fix the retro compatibility for sorting API.

This PR also adds non-model fields in the sorting mechanism.


Context: during the creation of release 3.7.0 I noticed I've introduced a break on the backwards compatibility of sorting by component [here](https://github.com/RedHatProductSecurity/osidb/commit/358be8a41399a12bcb500477171a1f3007925032#diff-5016bdc926b6c0f649f363739d09159a1db664aae19a08fa6b38b03406f040dcL6269)
I also noticed other models had the same issue of non-model fields being missing in the sorting API.