### PR TITLE
OSIDB-2447: enable perf tests to run via gitlab CI

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -408,7 +408,7 @@
         "filename": "perf/main.py",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 19,
+        "line_number": 25,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-09T17:33:31Z"
+  "generated_at": "2024-04-19T06:24:30Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)
+- Minor change to enable perf tests to run in CI (OSIDB-2447)
 
 ## [3.7.0] - 2024-04-17
 ### Added

--- a/perf/README.md
+++ b/perf/README.md
@@ -1,0 +1,15 @@
+# Performance tests
+
+This directory contains a set of standalone [locust](https://docs.locust.io/en/stable/) locust perf tests.
+
+To independently run locust perf tests, first install locust and then run in headless mode:
+```shell
+> pip install locust
+> locust --headless -f ./perf --host https://$OSIDB_HOST --users 5 --spawn-rate 2 --csv=locust-result.csv --run-time 1m
+```
+
+To invoke locust web ux setting the target host and which tests to run (ex. _CoreUser_)
+```shell
+> pip install locust
+> locust --class-picker -f ./perf -H http://$OSIDB_HOST --web-host 0.0.0.0:9000  --modern-ui
+```

--- a/perf/main.py
+++ b/perf/main.py
@@ -1,9 +1,12 @@
-from locust import HttpUser, between, constant_pacing, task
+from locust import HttpUser, between, task
 
 
 class SFM2User(HttpUser):
     wait_time = between(1, 3)
     weight = 3
+
+    def on_start(self):
+        self.client.verify = False
 
     @task
     def get_nvd_cvss_scores(self):
@@ -13,6 +16,9 @@ class SFM2User(HttpUser):
 class SDEngineUser(HttpUser):
     wait_time = between(1, 3)
     weight = 3
+
+    def on_start(self):
+        self.client.verify = False
 
     @task(1)
     def get_status(self):
@@ -39,6 +45,9 @@ class SDEngineUser(HttpUser):
 class GriffonUser(HttpUser):
     wait_time = between(1, 3600)
     weight = 1
+
+    def on_start(self):
+        self.client.verify = False
 
     @task
     def get_affects_from_ps_product(self):


### PR DESCRIPTION
A minor tweak to perf tests to enable gitlab CI to be able to run these against UAT(as well as stage and prod).

**Note**: we had to address similar weirdness with locust for automating perf tests in CI for component registry