### PR TITLE
Enable flaw draft creation in BZ

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,7 +162,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 70,
+        "line_number": 79,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-19T06:24:30Z"
+  "generated_at": "2024-04-26T08:10:33Z"
 }

--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -193,11 +193,16 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         """
         generate add or remove CVE alias query
         conditionally based on the changes and create|update
+
+        if a collector created a flaw, check the external ID, as CVE might not be present
         """
         if self.creation:
             if self.flaw.cve_id is not None:
                 # create query requires pure list
                 self._query["alias"] = [self.flaw.cve_id]
+
+            elif snippets := self.flaw.snippets.all():
+                self._query["alias"] = [s.external_id for s in snippets]
 
         elif self.flaw.cve_id != self.old_flaw.cve_id:
             self._query["alias"] = {}

--- a/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[NVD-CVE-2000-0025-CVE-2000-0025].yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[NVD-CVE-2000-0025-CVE-2000-0025].yaml
@@ -1,0 +1,466 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh94"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118682.1493360
+      x-rh-edge-request-id:
+      - '1493360'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "email": "aander07@packetmaster.com", "id": 1, "can_login": true}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:43 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118683.1493367
+      x-rh-edge-request-id:
+      - '1493367'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
+      "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2000-0025
+      From NVD collector", "description": "some description", "comment_is_private":
+      false, "alias": ["CVE-2000-0025"], "keywords": ["Security"], "flags": [], "groups":
+      ["redhat"], "cc": [], "cf_srtnotes": "{\"external_ids\": [\"CVE-2000-0025\"],
+      \"references\": [{\"type\": \"source\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2000-0025\",
+      \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+      \"source\": \"nvd\", \"cwe\": \"CWE-110\"}"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '712'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: POST
+    uri: https://example.com/rest/bug
+  response:
+    body:
+      string: '{"id": 2023529}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118684.1493383
+      x-rh-edge-request-id:
+      - '1493383'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh94"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:44 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118684.14933e7
+      x-rh-edge-request-id:
+      - 14933e7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"email": "aander07@packetmaster.com", "real_name": "Need
+        Real Name", "can_login": true, "name": "aander07@packetmaster.com", "id":
+        1}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118685.14933f0
+      x-rh-edge-request-id:
+      - 14933f0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023529
+  response:
+    body:
+      string: '{"bugs": [{"component": ["vulnerability-draft"], "cf_last_closed":
+        null, "actual_time": 0, "cf_srtnotes": "{\"external_ids\": [\"CVE-2000-0025\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2000-0025\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"nvd\", \"cwe\": \"CWE-110\"}", "cf_doc_type": "If docs needed,
+        set a value", "comments": [{"count": 0, "id": 15718601, "creation_time": "2024-04-26T08:04:44Z",
+        "is_private": false, "attachment_id": null, "private_groups": [], "creator_id":
+        425662, "text": "some description", "bug_id": 2023529, "time": "2024-04-26T08:04:44Z",
+        "creator": "nobody@redhat.com", "tags": []}], "version": ["unspecified"],
+        "remaining_time": 0, "sub_components": {}, "cf_pm_score": "0", "cf_build_id":
+        "", "depends_on": [], "cf_qa_whiteboard": "", "resolution": "", "classification":
+        "Other", "cf_release_notes": "", "cf_qe_conditional_nak": [], "assigned_to":
+        "nobody@redhat.com", "cf_pgm_internal": "", "docs_contact": "", "is_confirmed":
+        true, "op_sys": "Linux", "creation_time": "2024-04-26T08:04:44Z", "flags":
+        [], "cf_devel_whiteboard": "", "platform": "All", "product": "Security Response",
+        "priority": "unspecified", "description": "some description", "is_cc_accessible":
+        true, "target_milestone": "---", "qa_contact": "", "cf_internal_whiteboard":
+        "", "cf_cust_facing": "---", "url": "", "alias": ["CVE-2000-0025"], "target_release":
+        ["---"], "is_open": true, "whiteboard": "", "assigned_to_detail": {"active":
+        true, "id": 29451, "name": "nobody@redhat.com", "insider": false, "email":
+        "nobody@redhat.com", "real_name": "Nobody", "partner": false}, "cf_embargoed":
+        null, "estimated_time": 0, "cc_detail": [], "keywords": ["Security"], "creator_detail":
+        {"name": "nobody@redhat.com", "id": 425662, "active": true, "partner": false,
+        "email": "nobody@redhat.com", "real_name": "nobody", "insider":
+        true}, "dupe_of": null, "cf_conditional_nak": [], "id": 2023529, "data_category":
+        "Red Hat", "groups": ["redhat"], "cc": [], "cf_environment": "", "summary":
+        "CVE-2000-0025 From NVD collector", "is_creator_accessible": true, "cf_major_incident":
+        null, "last_change_time": "2024-04-26T08:04:44Z", "blocks": [], "external_bugs":
+        [], "status": "NEW", "creator": "nobody@redhat.com", "cf_fixed_in": "",
+        "severity": "unspecified", "cf_clone_of": null, "tags": [], "deadline": null}],
+        "limit": "20", "offset": 0, "total_matches": 1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:45 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2291'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118685.149340a
+      x-rh-edge-request-id:
+      - 149340a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023529
+  response:
+    body:
+      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"blocks":
+        [], "external_bugs": [], "status": "NEW", "creator": "nobody@redhat.com",
+        "cf_fixed_in": "", "severity": "unspecified", "cf_clone_of": null, "tags":
+        [], "deadline": null, "target_release": ["---"], "whiteboard": "", "is_open":
+        true, "assigned_to_detail": {"email": "nobody@redhat.com", "real_name": "Nobody",
+        "partner": false, "insider": false, "id": 29451, "name": "nobody@redhat.com",
+        "active": true}, "cf_embargoed": null, "cc_detail": [], "keywords": ["Security"],
+        "estimated_time": 0, "dupe_of": null, "creator_detail": {"insider": true,
+        "partner": false, "email": "nobody@redhat.com", "real_name": "nobody",
+        "active": true, "name": "nobody@redhat.com", "id": 425662}, "data_category":
+        "Red Hat", "id": 2023529, "cf_conditional_nak": [], "groups": ["redhat"],
+        "cf_environment": "", "cc": [], "is_creator_accessible": true, "summary":
+        "CVE-2000-0025 From NVD collector", "last_change_time": "2024-04-26T08:04:44Z",
+        "cf_major_incident": null, "is_confirmed": true, "docs_contact": "", "creation_time":
+        "2024-04-26T08:04:44Z", "op_sys": "Linux", "cf_devel_whiteboard": "", "flags":
+        [], "product": "Security Response", "platform": "All", "description": "some
+        description", "priority": "unspecified", "target_milestone": "---", "is_cc_accessible":
+        true, "qa_contact": "", "cf_internal_whiteboard": "", "cf_cust_facing": "---",
+        "alias": ["CVE-2000-0025"], "url": "", "actual_time": 0, "cf_srtnotes": "{\"external_ids\":
+        [\"CVE-2000-0025\"], \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2000-0025\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"nvd\", \"cwe\": \"CWE-110\"}", "cf_last_closed": null, "component":
+        ["vulnerability-draft"], "cf_doc_type": "If docs needed, set a value", "comments":
+        [{"private_groups": [], "is_private": false, "attachment_id": null, "creator_id":
+        425662, "count": 0, "creation_time": "2024-04-26T08:04:44Z", "id": 15718601,
+        "bug_id": 2023529, "time": "2024-04-26T08:04:44Z", "creator": "nobody@redhat.com",
+        "tags": [], "text": "some description"}], "version": ["unspecified"], "remaining_time":
+        0, "sub_components": {}, "cf_pm_score": "0", "cf_build_id": "", "cf_qa_whiteboard":
+        "", "depends_on": [], "classification": "Other", "resolution": "", "cf_qe_conditional_nak":
+        [], "cf_release_notes": "", "cf_pgm_internal": "", "assigned_to": "nobody@redhat.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:46 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2291'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118686.1493461
+      x-rh-edge-request-id:
+      - '1493461'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2023529/comment
+  response:
+    body:
+      string: '{"bugs": {"2023529": {"comments": [{"text": "some description", "bug_id":
+        2023529, "tags": [], "time": "2024-04-26T08:04:44Z", "creator": "nobody@redhat.com",
+        "id": 15718601, "creation_time": "2024-04-26T08:04:44Z", "count": 0, "is_private":
+        false, "private_groups": [], "attachment_id": null, "creator_id": 425662}]}},
+        "comments": {}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '309'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:47 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118687.14934e2
+      x-rh-edge-request-id:
+      - 14934e2
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-CVE-2000-0026-GHSA-0006].yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-CVE-2000-0026-GHSA-0006].yaml
@@ -1,0 +1,466 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh94"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:48 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1714118688.1d71ed47
+      x-rh-edge-request-id:
+      - 1d71ed47
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"id": 1, "name": "aander07@packetmaster.com", "email":
+        "aander07@packetmaster.com", "real_name": "Need Real Name", "can_login": true}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:48 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1714118688.1d71ed90
+      x-rh-edge-request-id:
+      - 1d71ed90
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
+      "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2000-0026
+      From OSV collector", "description": "some description", "comment_is_private":
+      false, "alias": ["CVE-2000-0026"], "keywords": ["Security"], "flags": [], "groups":
+      ["redhat"], "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GHSA-0006/CVE-2000-0026\"],
+      \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-0006\",
+      \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+      \"source\": \"osv\", \"cwe\": \"CWE-110\"}"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '715'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: POST
+    uri: https://example.com/rest/bug
+  response:
+    body:
+      string: '{"id": 2023530}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1714118689.1d71ee20
+      x-rh-edge-request-id:
+      - 1d71ee20
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh94"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118689.14935f0
+      x-rh-edge-request-id:
+      - 14935f0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "email": "aander07@packetmaster.com",
+        "name": "aander07@packetmaster.com", "id": 1, "can_login": true}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:50 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118690.14935fc
+      x-rh-edge-request-id:
+      - 14935fc
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023530
+  response:
+    body:
+      string: '{"total_matches": 1, "limit": "20", "offset": 0, "bugs": [{"cf_internal_whiteboard":
+        "", "cf_pm_score": "0", "actual_time": 0, "cf_doc_type": "If docs needed,
+        set a value", "data_category": "Red Hat", "qa_contact": "", "docs_contact":
+        "", "target_milestone": "---", "keywords": ["Security"], "is_creator_accessible":
+        true, "estimated_time": 0, "cf_qe_conditional_nak": [], "cf_embargoed": null,
+        "cf_build_id": "", "cf_fixed_in": "", "target_release": ["---"], "id": 2023530,
+        "whiteboard": "", "last_change_time": "2024-04-26T08:04:49Z", "alias": ["CVE-2000-0026"],
+        "severity": "unspecified", "cf_srtnotes": "{\"external_ids\": [\"GHSA-0006/CVE-2000-0026\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0006\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "url": "", "is_open": true, "product":
+        "Security Response", "classification": "Other", "cf_major_incident": null,
+        "remaining_time": 0, "cf_environment": "", "priority": "unspecified", "summary":
+        "CVE-2000-0026 From OSV collector", "op_sys": "Linux", "blocks": [], "cc":
+        [], "assigned_to": "nobody@redhat.com", "cf_pgm_internal": "", "creator":
+        "nobody@redhat.com", "tags": [], "groups": ["redhat"], "is_confirmed": true,
+        "cf_release_notes": "", "cf_clone_of": null, "creation_time": "2024-04-26T08:04:49Z",
+        "external_bugs": [], "comments": [{"creator_id": 425662, "bug_id": 2023530,
+        "is_private": false, "text": "some description", "count": 0, "creation_time":
+        "2024-04-26T08:04:49Z", "tags": [], "creator": "nobody@redhat.com", "private_groups":
+        [], "time": "2024-04-26T08:04:49Z", "id": 15718602, "attachment_id": null}],
+        "assigned_to_detail": {"active": true, "id": 29451, "insider": false, "real_name":
+        "Nobody", "email": "nobody@redhat.com", "name": "nobody@redhat.com", "partner":
+        false}, "dupe_of": null, "cf_qa_whiteboard": "", "cf_last_closed": null, "creator_detail":
+        {"email": "nobody@redhat.com", "name": "nobody@redhat.com", "partner":
+        false, "real_name": "nobody", "insider": true, "active": true, "id":
+        425662}, "flags": [], "platform": "All", "cc_detail": [], "cf_cust_facing":
+        "---", "cf_conditional_nak": [], "depends_on": [], "status": "NEW", "deadline":
+        null, "sub_components": {}, "cf_devel_whiteboard": "", "component": ["vulnerability-draft"],
+        "is_cc_accessible": true, "description": "some description", "version": ["unspecified"],
+        "resolution": ""}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:51 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2294'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118691.1493626
+      x-rh-edge-request-id:
+      - '1493626'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023530
+  response:
+    body:
+      string: '{"total_matches": 1, "limit": "20", "offset": 0, "bugs": [{"cf_doc_type":
+        "If docs needed, set a value", "cf_last_closed": null, "component": ["vulnerability-draft"],
+        "cf_srtnotes": "{\"external_ids\": [\"GHSA-0006/CVE-2000-0026\"], \"references\":
+        [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0006\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "actual_time": 0, "version":
+        ["unspecified"], "comments": [{"creation_time": "2024-04-26T08:04:49Z", "id":
+        15718602, "count": 0, "private_groups": [], "attachment_id": null, "is_private":
+        false, "creator_id": 425662, "text": "some description", "bug_id": 2023530,
+        "tags": [], "time": "2024-04-26T08:04:49Z", "creator": "nobody@redhat.com"}],
+        "cf_pm_score": "0", "remaining_time": 0, "sub_components": {}, "depends_on":
+        [], "cf_qa_whiteboard": "", "cf_build_id": "", "resolution": "", "classification":
+        "Other", "cf_release_notes": "", "cf_qe_conditional_nak": [], "assigned_to":
+        "nobody@redhat.com", "cf_pgm_internal": "", "op_sys": "Linux", "creation_time":
+        "2024-04-26T08:04:49Z", "is_confirmed": true, "docs_contact": "", "flags":
+        [], "cf_devel_whiteboard": "", "platform": "All", "product": "Security Response",
+        "is_cc_accessible": true, "target_milestone": "---", "priority": "unspecified",
+        "description": "some description", "qa_contact": "", "cf_cust_facing": "---",
+        "cf_internal_whiteboard": "", "url": "", "alias": ["CVE-2000-0026"], "target_release":
+        ["---"], "is_open": true, "whiteboard": "", "cf_embargoed": null, "assigned_to_detail":
+        {"id": 29451, "name": "nobody@redhat.com", "active": true, "email": "nobody@redhat.com",
+        "real_name": "Nobody", "partner": false, "insider": false}, "estimated_time":
+        0, "keywords": ["Security"], "cc_detail": [], "cf_conditional_nak": [], "data_category":
+        "Red Hat", "id": 2023530, "creator_detail": {"insider": true, "partner": false,
+        "real_name": "nobody", "email": "nobody@redhat.com", "active":
+        true, "name": "nobody@redhat.com", "id": 425662}, "dupe_of": null, "groups":
+        ["redhat"], "summary": "CVE-2000-0026 From OSV collector", "is_creator_accessible":
+        true, "cc": [], "cf_environment": "", "cf_major_incident": null, "last_change_time":
+        "2024-04-26T08:04:49Z", "blocks": [], "status": "NEW", "external_bugs": [],
+        "creator": "nobody@redhat.com", "cf_fixed_in": "", "cf_clone_of": null,
+        "severity": "unspecified", "tags": [], "deadline": null}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2294'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118692.1493681
+      x-rh-edge-request-id:
+      - '1493681'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2023530/comment
+  response:
+    body:
+      string: '{"bugs": {"2023530": {"comments": [{"attachment_id": null, "id": 15718602,
+        "time": "2024-04-26T08:04:49Z", "creator": "nobody@redhat.com", "private_groups":
+        [], "tags": [], "creation_time": "2024-04-26T08:04:49Z", "count": 0, "text":
+        "some description", "is_private": false, "bug_id": 2023530, "creator_id":
+        425662}]}}, "comments": {}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '309'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:52 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118692.1493723
+      x-rh-edge-request-id:
+      - '1493723'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-None-GHSA-0007].yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-None-GHSA-0007].yaml
@@ -1,0 +1,464 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh94"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1714118693.1d71f7e4
+      x-rh-edge-request-id:
+      - 1d71f7e4
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"id": 1, "name": "aander07@packetmaster.com", "real_name":
+        "Need Real Name", "email": "aander07@packetmaster.com", "can_login": true}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1714118693.1d71f820
+      x-rh-edge-request-id:
+      - 1d71f820
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
+      "", "severity": "unspecified", "priority": "unspecified", "summary": "From OSV
+      collector", "description": "some description", "comment_is_private": false,
+      "alias": ["GHSA-0007"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
+      "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GHSA-0007\"], \"references\":
+      [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-0007\",
+      \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+      \"source\": \"osv\", \"cwe\": \"CWE-110\"}"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '683'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: POST
+    uri: https://example.com/rest/bug
+  response:
+    body:
+      string: '{"id": 2023531}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:54 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.64f06e68.1714118694.1d71f8c2
+      x-rh-edge-request-id:
+      - 1d71f8c2
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh94"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:54 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118694.14938a9
+      x-rh-edge-request-id:
+      - 14938a9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"id": 1, "name": "aander07@packetmaster.com", "can_login":
+        true, "email": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118695.14938af
+      x-rh-edge-request-id:
+      - 14938af
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023531
+  response:
+    body:
+      string: '{"bugs": [{"keywords": ["Security"], "target_milestone": "---", "is_creator_accessible":
+        true, "cf_qe_conditional_nak": [], "cf_embargoed": null, "estimated_time":
+        0, "cf_fixed_in": "", "cf_build_id": "", "target_release": ["---"], "whiteboard":
+        "", "id": 2023531, "cf_internal_whiteboard": "", "cf_pm_score": "0", "actual_time":
+        0, "cf_doc_type": "If docs needed, set a value", "data_category": "Red Hat",
+        "docs_contact": "", "qa_contact": "", "remaining_time": 0, "cf_environment":
+        "", "priority": "unspecified", "summary": "From OSV collector", "blocks":
+        [], "cc": [], "op_sys": "Linux", "alias": ["GHSA-0007"], "last_change_time":
+        "2024-04-26T08:04:54Z", "cf_srtnotes": "{\"external_ids\": [\"GHSA-0007\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0007\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "severity": "unspecified", "url":
+        "", "is_open": true, "product": "Security Response", "classification": "Other",
+        "cf_major_incident": null, "cf_release_notes": "", "cf_clone_of": null, "creation_time":
+        "2024-04-26T08:04:54Z", "comments": [{"attachment_id": null, "id": 15718603,
+        "time": "2024-04-26T08:04:54Z", "private_groups": [], "creator": "nobody@redhat.com",
+        "tags": [], "creation_time": "2024-04-26T08:04:54Z", "count": 0, "text": "some
+        description", "is_private": false, "bug_id": 2023531, "creator_id": 425662}],
+        "external_bugs": [], "dupe_of": null, "assigned_to_detail": {"name": "nobody@redhat.com",
+        "partner": false, "email": "nobody@redhat.com", "real_name": "Nobody", "insider":
+        false, "id": 29451, "active": true}, "cf_qa_whiteboard": "", "creator_detail":
+        {"insider": true, "id": 425662, "active": true, "name": "nobody@redhat.com",
+        "partner": false, "email": "nobody@redhat.com", "real_name": "nobody"},
+        "cf_last_closed": null, "assigned_to": "nobody@redhat.com", "cf_pgm_internal":
+        "", "tags": [], "creator": "nobody@redhat.com", "groups": ["redhat"], "is_confirmed":
+        true, "cf_devel_whiteboard": "", "component": ["vulnerability-draft"], "is_cc_accessible":
+        true, "description": "some description", "resolution": "", "version": ["unspecified"],
+        "platform": "All", "flags": [], "cc_detail": [], "cf_cust_facing": "---",
+        "cf_conditional_nak": [], "depends_on": [], "sub_components": {}, "deadline":
+        null, "status": "NEW"}], "total_matches": 1, "offset": 0, "limit": "20"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:56 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2262'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118696.14938c3
+      x-rh-edge-request-id:
+      - 14938c3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023531
+  response:
+    body:
+      string: '{"limit": "20", "total_matches": 1, "offset": 0, "bugs": [{"target_milestone":
+        "---", "keywords": ["Security"], "estimated_time": 0, "cf_embargoed": null,
+        "cf_qe_conditional_nak": [], "is_creator_accessible": true, "target_release":
+        ["---"], "cf_build_id": "", "cf_fixed_in": "", "id": 2023531, "whiteboard":
+        "", "cf_pm_score": "0", "cf_internal_whiteboard": "", "actual_time": 0, "qa_contact":
+        "", "docs_contact": "", "cf_doc_type": "If docs needed, set a value", "data_category":
+        "Red Hat", "cf_environment": "", "remaining_time": 0, "priority": "unspecified",
+        "summary": "From OSV collector", "cc": [], "op_sys": "Linux", "blocks": [],
+        "severity": "unspecified", "cf_srtnotes": "{\"external_ids\": [\"GHSA-0007\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0007\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "last_change_time": "2024-04-26T08:04:54Z",
+        "alias": ["GHSA-0007"], "is_open": true, "url": "", "product": "Security Response",
+        "cf_major_incident": null, "classification": "Other", "cf_release_notes":
+        "", "creation_time": "2024-04-26T08:04:54Z", "cf_clone_of": null, "assigned_to_detail":
+        {"insider": false, "active": true, "id": 29451, "email": "nobody@redhat.com",
+        "partner": false, "name": "nobody@redhat.com", "real_name": "Nobody"}, "dupe_of":
+        null, "external_bugs": [], "comments": [{"creation_time": "2024-04-26T08:04:54Z",
+        "count": 0, "is_private": false, "text": "some description", "bug_id": 2023531,
+        "creator_id": 425662, "attachment_id": null, "id": 15718603, "time": "2024-04-26T08:04:54Z",
+        "creator": "nobody@redhat.com", "private_groups": [], "tags": []}], "creator_detail":
+        {"insider": true, "active": true, "id": 425662, "email": "nobody@redhat.com",
+        "name": "nobody@redhat.com", "partner": false, "real_name": "nobody"},
+        "cf_last_closed": null, "cf_qa_whiteboard": "", "assigned_to": "nobody@redhat.com",
+        "cf_pgm_internal": "", "creator": "nobody@redhat.com", "tags": [], "is_confirmed":
+        true, "groups": ["redhat"], "component": ["vulnerability-draft"], "cf_devel_whiteboard":
+        "", "description": "some description", "is_cc_accessible": true, "version":
+        ["unspecified"], "resolution": "", "cc_detail": [], "flags": [], "platform":
+        "All", "cf_cust_facing": "---", "depends_on": [], "cf_conditional_nak": [],
+        "status": "NEW", "deadline": null, "sub_components": {}}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:56 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2262'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118696.149390b
+      x-rh-edge-request-id:
+      - 149390b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2023531/comment
+  response:
+    body:
+      string: '{"bugs": {"2023531": {"comments": [{"creation_time": "2024-04-26T08:04:54Z",
+        "count": 0, "is_private": false, "text": "some description", "bug_id": 2023531,
+        "creator_id": 425662, "id": 15718603, "attachment_id": null, "time": "2024-04-26T08:04:54Z",
+        "creator": "nobody@redhat.com", "private_groups": [], "tags": []}]}}, "comments":
+        {}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '309'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 26 Apr 2024 08:04:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1714118697.1493968
+      x-rh-edge-request-id:
+      - '1493968'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -208,6 +208,29 @@ class TestGenerateBasics:
         bbq = FlawBugzillaQueryBuilder(flaw)
         assert bbq.query["component"] == result
 
+    def test_generate_alias_cve_id(self):
+        """
+        test generating of CVE ID alias on creation
+        """
+        flaw = FlawFactory(cve_id="CVE-2000-1001")
+
+        bbq = FlawBugzillaQueryBuilder(flaw)
+        assert bbq.query["alias"] == ["CVE-2000-1001"]
+
+    def test_generate_alias_external_id(self):
+        """
+        test generating of external ID alias on creation
+        """
+        snippet = SnippetFactory(
+            source=Snippet.Source.OSV, ext_id="GHSA-0001", cve_id=None
+        )
+        flaw = FlawFactory(cve_id=None, meta_attr={"external_ids": ["GHSA-0001"]})
+        snippet.flaw = flaw
+        snippet.save()
+
+        bbq = FlawBugzillaQueryBuilder(flaw)
+        assert bbq.query["alias"] == ["GHSA-0001"]
+
 
 class TestGenerateSRTNotes:
     @freeze_time(timezone.datetime(2022, 11, 25))

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -155,7 +155,7 @@ class NVDQuerier:
                     "description": get_description(vulnerability.descriptions),
                     "references": get_references(vulnerability),
                     "source": Snippet.Source.NVD,
-                    "title": "from NVD collector",
+                    "title": "From NVD collector",
                     # required for ignoring historical data
                     "published_in_nvd": f"{vulnerability.published}Z",
                 }

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -268,7 +268,7 @@ class TestNVDCollector:
                 },
             ],
             "source": Snippet.Source.NVD,
-            "title": "from NVD collector",
+            "title": "From NVD collector",
             "published_in_nvd": "2024-01-21T16:29:00.393Z",
         }
         cve_id = snippet_content["cve_id"]

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -231,7 +231,7 @@ class OSVCollector(Collector):
 
         def get_title(data: dict) -> str:
             #  https://ossf.github.io/osv-schema/#summary-details-fields
-            return data.get("summary", "from OSV collector")
+            return data.get("summary", "From OSV collector")
 
         def get_cvss(data: dict) -> list:
             # https://ossf.github.io/osv-schema/#severity-field

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new OSV option into FlawSource
 - Allow searching by CVE similarity (OSIDB-2482)
 - Add CC lists to Jira trackers and to Bugzilla trackers (OSIDB-2191)
+- Enable flaw draft creation in BZ (OSIDB-2261)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -38,7 +38,7 @@ from apps.taskman.constants import JIRA_TASKMAN_AUTO_SYNC_FLAW, SYNC_REQUIRED_FI
 from apps.taskman.mixins import JiraTaskSyncMixin
 from apps.trackers.constants import SYNC_TO_JIRA
 from apps.workflows.workflow import WorkflowModel
-from collectors.bzimport.constants import FLAW_PLACEHOLDER_KEYWORD
+from collectors.bzimport.constants import BZ_API_KEY, FLAW_PLACEHOLDER_KEYWORD
 
 from .helpers import deprecate_field as deprecate_field_custom
 from .helpers import ps_update_stream_natural_keys
@@ -1686,7 +1686,9 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
         self.flaw = flaw
         self.save()
 
-        return flaw
+        flaw.save(bz_api_key=BZ_API_KEY, raise_validation_error=False)
+
+        return Flaw.objects.get(uuid=flaw.uuid)
 
     def _validate_acl_identical_to_parent_flaw(self) -> None:
         """

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -56,7 +56,7 @@ class TestSnippet:
 
         flaw_ref = flaw.references.all().first()
         assert flaw_ref.type == FlawReference.FlawReferenceType.SOURCE
-        assert flaw_ref.url == "https://nvd.nist.gov/vuln/detail/CVE-2023-0001"
+        assert flaw_ref.url == "https://nvd.nist.gov/vuln/detail/CVE-2024-0001"
 
         flaw_snippet = flaw.snippets.all().first()
         assert flaw_snippet == snippet
@@ -65,22 +65,9 @@ class TestSnippet:
         assert flaw_snippet.source == snippet.source
 
         # check ACLs
-        assert (
-            internal_read_groups
-            == snippet.acl_read
-            == flaw.acl_read
-            == flaw_cvss.acl_read
-            == flaw_ref.acl_read
-            == flaw_snippet.acl_read
-        )
-        assert (
-            internal_write_groups
-            == snippet.acl_write
-            == flaw.acl_write
-            == flaw_cvss.acl_write
-            == flaw_ref.acl_write
-            == flaw_snippet.acl_write
-        )
+        for i in [snippet, flaw, flaw_cvss, flaw_ref, flaw_snippet]:
+            assert internal_read_groups == i.acl_read
+            assert internal_write_groups == i.acl_write
 
     @pytest.mark.parametrize(
         "flaw_present,identifier,source",
@@ -99,9 +86,13 @@ class TestSnippet:
         """
         Tests the conversion of a snippet into a flaw (if a flaw does not exist) and their linking.
         """
-        snippet = SnippetFactory(source=source)
+        if source == Snippet.Source.OSV and identifier == "external_id":
+            snippet = SnippetFactory(source=source, cve_id=None)
+        else:
+            snippet = SnippetFactory(source=source)
+
         cve_id = snippet.content["cve_id"]
-        ext_id = f"{snippet.external_id}/{cve_id}"
+        ext_id = snippet.external_id
 
         if flaw_present:
             if identifier == "cve_id":


### PR DESCRIPTION
This PR enables collectors to create flaw drafts in BZ. A collector can only create a flaw draft, updating is not possible. The `alias` field prevents duplicate creation.

Flaw drafts created by NVD:
- A source flaw always contains only one cve_id, which is also used in `alias` and `external_ids`.

Flaw drafts created by OSV:
- If a source flaw does not contain cve_id, osv_id is used in both `alias` and `external_ids`.
- If a source flaw contains cve_id, cve_id is used in `alias` and osv_id/cve_id in `external_ids`.
- If a source flaw contains more cve_ids, a new flaw draft is created for each.

Closes OSIDB-2261