### PR TITLE
OSIDB-2585: fix read replica ATOMIC_REQUESTS setting

### DIFF
--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -102,6 +102,7 @@ DATABASES = {
         "HOST": get_env("OSIDB_DB_HOST_RO"),
         "PORT": get_env("OSIDB_DB_PORT", default="5432"),
         "ENGINE": "psqlextra.backend",
+        "ATOMIC_REQUESTS": True,  # perform HTTP requests as atomic transactions
         "OPTIONS": {
             "sslmode": "require",
             # prevent libpq from automatically trying to connect to the db via GSSAPI

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collect errata not linked to any flaws (OSIDB-1527)
 - Minor change to enable perf tests to run in CI (OSIDB-2447)
 - Allow editing flaws without affects in NEW state (OSIDB-2452)
+- Fixed read replica to perform HTTP requests as atomic transactions (OSIDB-2585)
 
 ## [3.7.0] - 2024-04-17
 ### Added

--- a/osidb/routers.py
+++ b/osidb/routers.py
@@ -1,14 +1,10 @@
-import random
-
-
 class WeightedReplicaRouter:
     def db_for_read(self, model, **hints):
         """
-        Distributes reads between the read-only replica (2/3) and default (1/3).
+        Reads always go to the read-replica-1 database.
         """
-        choices = ["default", "read-replica-1"]
-        weights = [0.3, 1]
-        return random.choices(choices, cum_weights=weights)[0]  # nosec
+        # TODO: make this dynamic when we have N+1 replicas
+        return "read-replica-1"
 
     def db_for_write(self, model, **hints):
         """


### PR DESCRIPTION
The read replica did not set ATOMIC_REQUESTS which messed about with tX in subtle and wondrous ways.