### PR TITLE
OSIDB-2585: backing out db routing until we deprecate BZ sync

### DIFF
--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import
 
+import os
+
 import django
 
 # This will make sure the app is always imported when
@@ -10,3 +12,8 @@ from .celery import app as celery_app  # noqa: F401
 
 django.setup()
 __all__ = ["osidb"]
+
+
+def get_env() -> str:
+    # return "config.settings.env" -> ["config", "settings", "env"] -> "env"
+    return os.getenv("DJANGO_SETTINGS_MODULE", "").split("_")[-1]

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -95,26 +95,7 @@ DATABASES = {
         },
         "CONN_MAX_AGE": 120,
     },
-    "read-replica-1": {
-        "NAME": get_env("OSIDB_DB_NAME", default="osidb"),
-        "USER": get_env("OSIDB_DB_USER"),
-        "PASSWORD": get_env("OSIDB_DB_PASSWORD"),
-        "HOST": get_env("OSIDB_DB_HOST_RO"),
-        "PORT": get_env("OSIDB_DB_PORT", default="5432"),
-        "ENGINE": "psqlextra.backend",
-        "OPTIONS": {
-            "sslmode": "require",
-            # prevent libpq from automatically trying to connect to the db via GSSAPI
-            "gssencmode": "disable",
-            # this is a hack due to our inability to set a custom parameter either at
-            # the database or role level in managed databases such as AWS RDS
-            "options": "-c osidb.acl=00000000-0000-0000-0000-000000000000",
-        },
-    },
 }
-
-# use a custom database router to effectively serve as a load balancer
-DATABASE_ROUTERS = ("osidb.routers.WeightedReplicaRouter",)
 
 STATIC_ROOT = "/opt/app-root/static/"
 STATIC_URL = "/static/"

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -95,28 +95,7 @@ DATABASES = {
         },
         "CONN_MAX_AGE": 120,
     },
-    "read-replica-1": {
-        "NAME": get_env("OSIDB_DB_NAME", default="osidb"),
-        "USER": get_env("OSIDB_DB_USER"),
-        "PASSWORD": get_env("OSIDB_DB_PASSWORD"),
-        "HOST": get_env("OSIDB_DB_HOST_RO"),
-        "PORT": get_env("OSIDB_DB_PORT", default="5432"),
-        "ENGINE": "psqlextra.backend",
-        "ATOMIC_REQUESTS": True,  # perform HTTP requests as atomic transactions
-        "OPTIONS": {
-            "sslmode": "require",
-            # prevent libpq from automatically trying to connect to the db via GSSAPI
-            "gssencmode": "disable",
-            # this is a hack due to our inability to set a custom parameter either at
-            # the database or role level in managed databases such as AWS RDS
-            "options": "-c osidb.acl=00000000-0000-0000-0000-000000000000",
-        },
-        "CONN_MAX_AGE": 120,
-    },
 }
-
-# use a custom database router to effectively serve as a load balancer
-DATABASE_ROUTERS = ("osidb.routers.WeightedReplicaRouter",)
 
 STATIC_ROOT = "/opt/app-root/static/"
 STATIC_URL = "/static/"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mainly Flaw, Affect, Tracker (OSIDB-2065)
 - Add support for additional_fields in Jira BTS (OSIDB-696)
 - Add scripts/restore_pg.sh script for restoring sql dump
-- Add db routing taking advantage of write and read pg replicas
 
 ### Changed
 - Ignore hosts on VCR recording (OSIDB-1678)

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,13 +1,25 @@
+from config import get_env
+
 bind = "0.0.0.0:8000"
 worker_class = "gthread"
 workers = 3
 threads = 10
 proc_name = "osidb"
 timeout = 300
-graceful_timeout = 800
 reuse_port = True
-preload_app = True
 
 errorlog = "-"
 # Make sure wsgi.url_scheme gets set to HTTPS, by trusting the X_FORWARDED_PROTO header set by the proxy
 forwarded_allow_ips = "*"
+
+# the gunicorn default for worker_tmp_dir is /tmp which may not reliably
+# exist in deployment environments, setting to shm filesystem avoids this
+worker_tmp_dir = "/dev/shm"
+
+if get_env() in ["stage", "prod", "ci"]:
+    preload_app = True
+    graceful_timeout = 800  # if a restart must happen then let it be graceful
+    keepalive = 60  # specifically this should be a value larger then nginx setting
+else:
+    # Support hot-reloading of Gunicorn / Django when files change in dev/local/shell
+    reload = True

--- a/osidb/core.py
+++ b/osidb/core.py
@@ -5,7 +5,7 @@ core
 
 import uuid
 
-from django.db import connections
+from django.db import connection
 
 from osidb.exceptions import OSIDBException
 
@@ -32,17 +32,10 @@ def set_user_acls(groups) -> None:
     try:
         acls = generate_acls(groups)
         if acls:
-            # we must set osidb.acl for every replica at the connection level
-            # otherwise we'd set it only in one and then potentially read
-            # from another replica without osidb.acl set, resulting in an
-            # empty result set.
-            for db_alias in ("default", "read-replica-1"):
-                if db_alias in connections:
-                    with connections[db_alias].cursor() as cursor:
-                        # in theory psycopg2 should support list conversion but
-                        # it seems to be broken, to pass into postgres we need
-                        # to convert UUID[] into STRING[] doing some old
-                        # fashioned string munging TBD-INVESTIGATE psycopg2
-                        cursor.execute("SET osidb.acl = %s", [",".join(acls)])
+            # in theory psycopg2 should support list conversion but it seems to be broken,
+            # to pass into postgres we need to convert UUID[] into STRING[]
+            # doing some old fashioned string munging TBD-INVESTIGATE psycopg2
+            with connection.cursor() as cursor:
+                cursor.execute("SET osidb.acl = %s", [",".join(acls)])
     except Exception:
         raise OSIDBException("Cannot set user acl")


### PR DESCRIPTION
Backed out using db routing which seems unstable with usage of BZsync ... also added the ability for gunicorn to reload on changes when using local dev environment.