### PR TITLE
Preserve existing JiraProjectField models when fetching from Jira breaks

### DIFF
--- a/collectors/jiraffe/exceptions.py
+++ b/collectors/jiraffe/exceptions.py
@@ -14,3 +14,12 @@ class NonRecoverableJiraffeException(JiraffeException):
     permanent exceptions consistent between runs
     may be malformed data or permission issues
     """
+
+
+class MetadataCollectorInsufficientDataJiraffeException(JiraffeException):
+    """
+    Unable to download jira project metadata. Either unable to download any,
+    or more than 20%, indicating breakage rather than slight administrative
+    changes and transient errors. Using such data would make it impossible
+    to work with Trackers.
+    """


### PR DESCRIPTION
Preserve existing JiraProjectField models when fetching from Jira breaks
Related to OSIDB-2576
Closes OSIDB-2583