### PR TITLE
Fix incorrect ACLs for flaw drafts

### DIFF
--- a/apps/bbsync/tests/conftest.py
+++ b/apps/bbsync/tests/conftest.py
@@ -1,5 +1,9 @@
-import pytest
+import uuid
 
+import pytest
+from django.conf import settings
+
+from osidb.core import generate_acls
 from osidb.tests.factories import FlawFactory
 
 
@@ -16,3 +20,13 @@ def test_flaw():
 @pytest.fixture
 def sentinel_err_message():
     return "400 Client Error: Bad Request"
+
+
+@pytest.fixture
+def internal_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
+
+
+@pytest.fixture
+def internal_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -854,7 +854,9 @@ class TestFlawDraftBBSyncIntegration:
             (Snippet.Source.OSV, None, "GHSA-0007"),
         ],
     )
-    def test_flaw_draft_create(self, source, cve_id, ext_id):
+    def test_flaw_draft_create(
+        self, internal_read_groups, internal_write_groups, source, cve_id, ext_id
+    ):
         """
         test creating a flaw draft with Bugzilla two-way sync
         """
@@ -912,3 +914,14 @@ class TestFlawDraftBBSyncIntegration:
             assert flaw.meta_attr["alias"] == f"['{ext_id}']"
             assert flaw.meta_attr["bz_summary"] == f"From {source} collector"
             assert flaw.meta_attr["external_ids"] == f"['{ext_id}']"
+
+        # check that all ACLs are internal after Bugzilla two-way sync
+        for i in [
+            snippet,
+            flaw,
+            flaw.cvss_scores.first(),
+            flaw.references.first(),
+            flaw.snippets.first(),
+        ]:
+            assert internal_read_groups == i.acl_read
+            assert internal_write_groups == i.acl_write

--- a/collectors/bzimport/tests/conftest.py
+++ b/collectors/bzimport/tests/conftest.py
@@ -1,6 +1,10 @@
+import uuid
+
 import pytest
+from django.conf import settings
 
 from collectors.bzimport.collectors import BugzillaTrackerCollector, FlawCollector
+from osidb.core import generate_acls
 
 
 @pytest.fixture(autouse=True)
@@ -60,3 +64,33 @@ def bz_tracker_collector():
 @pytest.fixture
 def bz_bug_requires_summary():
     return "2086753"
+
+
+@pytest.fixture
+def public_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)]
+
+
+@pytest.fixture
+def embargoed_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])]
+
+
+@pytest.fixture
+def internal_read_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
+
+
+@pytest.fixture
+def public_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])]
+
+
+@pytest.fixture
+def embargoed_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])]
+
+
+@pytest.fixture
+def internal_write_groups():
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow editing flaws without affects in NEW state (OSIDB-2452)
 - Fixed read replica to perform HTTP requests as atomic transactions (OSIDB-2585)
 
+### Fixed
+- Fix incorrect ACLs for flaw drafts (OSIDB-2263)
+
 ## [3.7.0] - 2024-04-17
 ### Added
 - Implement flaw unembargo mechanism (OSIDB-1177)


### PR DESCRIPTION
This PR fixes group settings when reading data from BZ, so flaw drafts always have internal ACLs.

Fixes OSIDB-2263