### PR TITLE
Ensure that snippet does not contain duplicate references

### DIFF
--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -126,7 +126,7 @@ class NVDQuerier:
                     "url": f"https://nvd.nist.gov/vuln/detail/{data.id}",
                 }
             ]
-            urls.extend(handle_urls([r.url for r in data.references]))
+            urls.extend(handle_urls([r.url for r in data.references], urls[0]["url"]))
 
             return urls
 

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -221,7 +221,11 @@ class OSVCollector(Collector):
                     "url": f"https://osv.dev/vulnerability/{osv_id}",
                 }
             ]
-            refs.extend(handle_urls([r["url"] for r in data.get("references", [])]))
+            refs.extend(
+                handle_urls(
+                    [r["url"] for r in data.get("references", [])], refs[0]["url"]
+                )
+            )
 
             return refs
 

--- a/collectors/tests/test_utils.py
+++ b/collectors/tests/test_utils.py
@@ -94,7 +94,13 @@ class TestParseUpdateStreamComponent:
 class TestHandleURLs:
     def test_handle_urls(self):
         result = handle_urls(
-            ["https://www.google1.com", "google2.com", "htt://www.google3.com"]
+            [
+                "https://www.google1.com",
+                "google2.com",
+                "htt://www.google3.com",
+                "https://www.source.com",
+            ],
+            "https://www.source.com",
         )
 
         assert len(result) == 2

--- a/collectors/utils.py
+++ b/collectors/utils.py
@@ -67,9 +67,11 @@ def tracker_summary2module_component(
     )
 
 
-def handle_urls(references: list) -> list:
+def handle_urls(references: list, source_ref: str) -> list:
     """
-    This function creates FlawReference objects and stores them in a list.
+    This function creates a list of external references matching FlawReference fields. References matching
+    "source_ref" are ignored because they would cause ValidationError in later validation.
+
     Also, it ensures that only valid URL strings are converted.
     The logic tries to fix a URL in a simple way. If the fix is not successful, a URL is ignored.
     """
@@ -83,12 +85,14 @@ def handle_urls(references: list) -> list:
 
             validate = URLValidator()
             validate(reference)
-            urls.append(
-                {
-                    "type": FlawReference.FlawReferenceType.EXTERNAL,
-                    "url": reference,
-                }
-            )
+
+            if reference != source_ref:
+                urls.append(
+                    {
+                        "type": FlawReference.FlawReferenceType.EXTERNAL,
+                        "url": reference,
+                    }
+                )
         except ValidationError:
             # Ignore the URL if it is invalid (e.g. due to a typo)
             pass


### PR DESCRIPTION
This PR ensures that snippet's external references never contain a URL that is also in a source reference. If this happens, `ValidationError` is raised when saving `FlawReference` with the same URL for the second time (for a given `Flaw`).

For example, see https://nvd.nist.gov/vuln/detail/CVE-2023-48733, where a source reference is already included in a list that we treat as a list of external references.