### PR TITLE
Update ubi8 base image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi:8.7
+FROM registry.redhat.io/ubi8/ubi:8.9
 
 LABEL summary="OSIDB" \
       maintainer="Product Security DevOps <prodsec-dev@redhat.com>"

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.7
+FROM registry.access.redhat.com/ubi8/ubi:8.9
 
 LABEL summary="OSIDB testrunner" \
       maintainer="Product Security DevOps <prodsec-dev@redhat.com>"


### PR DESCRIPTION
There have been reports of vulnerabilities in UBI version 8.7. This commit updates it to the latest major version, 8.9, where the vulnerabilities should have been patched, in the Dockerfile.