### PR TITLE
Fix flaw instance not being up to date after sync

### DIFF
--- a/apps/bbsync/save.py
+++ b/apps/bbsync/save.py
@@ -97,13 +97,13 @@ class BugzillaSaver(BugzillaQuerier):
         one last preventative check that Bugzilla last_change_time
         really corresponds to the stored one so there was no collision
         """
-        if self.actual_last_chante != self.stored_last_change:
+        if self.actual_last_change != self.stored_last_change:
             raise DataInconsistencyException(
                 "Save operation based on an outdated model instance"
             )
 
     @property
-    def actual_last_chante(self):
+    def actual_last_change(self):
         """
         retrieve the actual last change timestamp from Bugzilla
         """

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -444,7 +444,12 @@ class TestBBSyncIntegration:
         )
         ps_module1 = PsModuleFactory(
             bts_name="bugzilla",
-            bts_groups={"public": ["devel"]},
+            bts_groups={
+                "public": ["devel"],
+                "embargoed": [
+                    "private",
+                ],
+            },
             bts_key="Red Hat Certification Program",
             name="rhcertification-8",
             default_component="redhat-certification",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor change to enable perf tests to run in CI (OSIDB-2447)
 - Allow editing flaws without affects in NEW state (OSIDB-2452)
 - Fixed read replica to perform HTTP requests as atomic transactions (OSIDB-2585)
+- Fixed Bugzilla sync not working when Jira task sync is enabled (OSIDB-2628)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1518,6 +1518,8 @@ class Flaw(
         # fetch from Bugzilla
         fc = FlawCollector()
         fc.sync_flaw(self.bz_id)
+        # Make sure the flaw instance has the latest data
+        self.refresh_from_db()
 
     def tasksync(
         self,


### PR DESCRIPTION
After syncing a flaw with Bugzilla upon creating it from the API, the
flaw instance was not updated and if the Jira sync was enabled, a save
within its task sync would override the data and the Bugzilla data would
be lost. In particular, the `meta_attr` field would not be updated, even
if the Bugzilla bug is actually created. This caused errors when trying
to update the data from the API.

With this change, after the Bugzilla sync, the instance is updated so
that we are working with the latest data, and other mixins don't clash
with it.

Closes OSIDB-2628.