### PR TITLE
Filter by null or empty CVE IDs in the API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -328,7 +328,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1325,
+        "line_number": 1354,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-03T16:26:18Z"
+  "generated_at": "2024-05-16T11:19:05Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed read replica to perform HTTP requests as atomic transactions (OSIDB-2585)
 - Fixed Bugzilla sync not working when Jira task sync is enabled (OSIDB-2628)
 - Ignore SLA if update stream specifies it's not applicable (OSIDB-2612)
+- Allow filtering by empty or null CVE IDs (OSIDB-2625)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2926,6 +2926,10 @@ paths:
         explode: false
         style: form
       - in: query
+        name: cve_id__isempty
+        schema:
+          type: boolean
+      - in: query
         name: cvss2
         schema:
           type: string


### PR DESCRIPTION
With this commit, there is now the possibility to filter, at the API level, for null or empty CVE IDs.

To do this, one may use the query parameter cve_id__isempty and set it to 1 (show only flaws with null or empty CVE IDs) or 0 (show flaws with CVE IDs that are neither null nor empty).

The change has been done in a way that it could be reused by other nullable string fields in the future, if needed.

Closes OSIDB-2625.