### PR TITLE
Clearly raise non-skippable Jira errors instead of crashing elsewhere.

### DIFF
--- a/apps/taskman/exceptions.py
+++ b/apps/taskman/exceptions.py
@@ -9,3 +9,7 @@ class TaskmanException(Exception):
 
 class MissingJiraTokenException(TaskmanException):
     """exception for performing user action without providing token"""
+
+
+class JiraTaskErrorException(TaskmanException):
+    """exception for getting an error from Jira"""


### PR DESCRIPTION
Clearly raise non-skippable Jira errors instead of crashing elsewhere.
Log skippable Jira errors for easier debugging.
Closes OSIDB-2707
Related to OSIDB-2643