### PR TITLE
Remove team prereq and add bzsync to promote remove endpoint

### DIFF
--- a/apps/workflows/api.py
+++ b/apps/workflows/api.py
@@ -94,7 +94,14 @@ class promote(APIView):
                 type=str,
                 location=OpenApiParameter.HEADER,
                 description="User generated api key for Jira authentication.",
-            )
+            ),
+            OpenApiParameter(
+                name="Bugzilla-Api-Key",
+                required=True,
+                type=str,
+                location=OpenApiParameter.HEADER,
+                description="User generated api key for Bugzilla authentication.",
+            ),
         ]
     )
     def post(self, request, flaw_id):
@@ -108,11 +115,12 @@ class promote(APIView):
         flaw = get_flaw_or_404(flaw_id)
         try:
             jira_token = request.META.get("HTTP_JIRA_API_KEY")
+            bz_token = request.META.get("HTTP_BUGZILLA_API_KEY")
             if not jira_token:
                 raise serializers.ValidationError(
                     {"Jira-Api-Key": "This HTTP header is required."}
                 )
-            flaw.promote(jira_token=jira_token)
+            flaw.promote(jira_token=jira_token, bz_api_key=bz_token)
             return Response(
                 {
                     "flaw": flaw.pk,
@@ -136,7 +144,14 @@ class reject(APIView):
                 type=str,
                 location=OpenApiParameter.HEADER,
                 description="User generated api key for Jira authentication.",
-            )
+            ),
+            OpenApiParameter(
+                name="Bugzilla-Api-Key",
+                required=True,
+                type=str,
+                location=OpenApiParameter.HEADER,
+                description="User generated api key for Bugzilla authentication.",
+            ),
         ],
         request=RejectSerializer,
     )
@@ -153,11 +168,12 @@ class reject(APIView):
         flaw = get_flaw_or_404(flaw_id)
         try:
             jira_token = request.META.get("HTTP_JIRA_API_KEY")
+            bz_token = request.META.get("HTTP_BUGZILLA_API_KEY")
             if not jira_token:
                 raise serializers.ValidationError(
                     {"Jira-Api-Key": "This HTTP header is required."}
                 )
-            flaw.reject(jira_token=jira_token)
+            flaw.reject(jira_token=jira_token, bz_api_key=bz_token)
             JiraTaskmanQuerier(token=jira_token).create_comment(
                 issue_key=flaw.task_key,
                 body=request.data["reason"],

--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -238,7 +238,7 @@ class WorkflowModel(models.Model):
         """
         WorkflowFramework().validate_classification(self, target_workflow, target_state)
 
-    def promote(self, save=True, jira_token=None):
+    def promote(self, save=True, jira_token=None, **kwargs):
         """
         this is the cannonical way of changing classification
 
@@ -283,9 +283,9 @@ class WorkflowModel(models.Model):
         if not save:
             return
 
-        self.save(jira_token=jira_token, raise_validation_error=False)
+        self.save(jira_token=jira_token, raise_validation_error=False, **kwargs)
 
-    def reject(self, save=True, jira_token=None):
+    def reject(self, save=True, jira_token=None, **kwargs):
         """
         this is the cannonical way of rejecting a flaw / task
 
@@ -304,7 +304,7 @@ class WorkflowModel(models.Model):
         if not save:
             return
 
-        self.save(jira_token=jira_token, raise_validation_error=False)
+        self.save(jira_token=jira_token, raise_validation_error=False, **kwargs)
 
     def jira_status(self):
         return WorkflowFramework().jira_status(self)

--- a/apps/workflows/workflows/default.yml
+++ b/apps/workflows/workflows/default.yml
@@ -25,14 +25,13 @@ states:
   - name: PRE_SECONDARY_ASSESSMENT
     description: >
       Task qualified for further work and has initial data filled, triage
-      trackers have been filled and product team has been identified.
+      trackers have been filled.
     jira_state: To Do
     jira_resolution: null
     requirements:
       - has affects
       - has impact
       - has source
-      - has team
       - has title
       - has trackers
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for UAT (OSIDB-2447)
 - Added API for Alerts (OSIDB-325)
 - Add bulk PUT for Affects (OSIDB-2407)
+- Add Bugzilla token to promote API (OSIDB-2262)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/openapi.yml
+++ b/openapi.yml
@@ -5092,6 +5092,12 @@ paths:
         return its workflow:state classification or errors if not possible to promote
       parameters:
       - in: header
+        name: Bugzilla-Api-Key
+        schema:
+          type: string
+        description: User generated api key for Bugzilla authentication.
+        required: true
+      - in: header
         name: Jira-Api-Key
         schema:
           type: string
@@ -5506,6 +5512,12 @@ paths:
 
         try to reject a flaw / task
       parameters:
+      - in: header
+        name: Bugzilla-Api-Key
+        schema:
+          type: string
+        description: User generated api key for Bugzilla authentication.
+        required: true
       - in: header
         name: Jira-Api-Key
         schema:

--- a/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinInteration.test_api_changes.yaml
+++ b/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinInteration.test_api_changes.yaml
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:14 GMT
+      - Tue, 21 May 2024 12:29:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -41,9 +41,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398794.124bfea5
+      - 0.96292117.1716294584.424c9704
       x-rh-edge-request-id:
-      - 124bfea5
+      - 424c9704
     status:
       code: 200
       message: OK
@@ -79,7 +79,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:15 GMT
+      - Tue, 21 May 2024 12:29:45 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -89,9 +89,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398795.124bfec9
+      - 0.96292117.1716294585.424c9abe
       x-rh-edge-request-id:
-      - 124bfec9
+      - 424c9abe
     status:
       code: 200
       message: OK
@@ -125,9 +125,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:15 GMT
+      - Tue, 21 May 2024 12:29:45 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:15 GMT
+      - Tue, 21 May 2024 12:29:45 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -148,9 +148,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509208x1
+      - 749x308177x1
       x-asessionid:
-      - k6iw8q
+      - wuilow
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -162,9 +162,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398795.17d3db2e
+      - 0.96292117.1716294585.424ca52d
       x-rh-edge-request-id:
-      - 17d3db2e
+      - 424ca52d
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -204,7 +204,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:16 GMT
+      - Tue, 21 May 2024 12:29:45 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -214,9 +214,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398796.124c0243
+      - 0.96292117.1716294585.424cab76
       x-rh-edge-request-id:
-      - 124c0243
+      - 424cab76
     status:
       code: 200
       message: OK
@@ -237,8 +237,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "id": 1, "real_name":
-        "Need Real Name", "can_login": true, "email": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com",
+        "can_login": true, "id": 1, "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:16 GMT
+      - Tue, 21 May 2024 12:29:46 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -263,9 +263,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398796.124c026c
+      - 0.96292117.1716294586.424cb0d3
       x-rh-edge-request-id:
-      - 124c026c
+      - 424cb0d3
     status:
       code: 200
       message: OK
@@ -294,7 +294,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2024014}'
+      string: '{"id": 2279556}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -309,7 +309,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:17 GMT
+      - Tue, 21 May 2024 12:29:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -319,9 +319,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398797.124c0317
+      - 0.96292117.1716294587.424cb6cd
       x-rh-edge-request-id:
-      - 124c0317
+      - 424cb6cd
     status:
       code: 200
       message: OK
@@ -357,7 +357,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:17 GMT
+      - Tue, 21 May 2024 12:29:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -367,9 +367,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398797.124c07dc
+      - 0.96292117.1716294587.424cd518
       x-rh-edge-request-id:
-      - 124c07dc
+      - 424cd518
     status:
       code: 200
       message: OK
@@ -390,8 +390,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"real_name": "Need Real Name", "can_login": true, "name":
-        "aander07@packetmaster.com", "email": "aander07@packetmaster.com", "id": 1}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com",
+        "real_name": "Need Real Name", "can_login": true, "id": 1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -406,7 +406,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:18 GMT
+      - Tue, 21 May 2024 12:29:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -416,9 +416,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398798.124c07ff
+      - 0.96292117.1716294588.424cd7c8
       x-rh-edge-request-id:
-      - 124c07ff
+      - 424cd7c8
     status:
       code: 200
       message: OK
@@ -436,37 +436,38 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2024014
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556
   response:
     body:
-      string: '{"bugs": [{"platform": "All", "cf_major_incident": null, "blocks":
-        [], "whiteboard": "", "cf_qa_whiteboard": "", "tags": [], "remaining_time":
-        0, "cf_internal_whiteboard": "", "target_release": ["---"], "cf_build_id":
-        "", "classification": "Other", "dupe_of": null, "severity": "low", "description":
-        "test", "cf_cust_facing": "---", "deadline": null, "cf_doc_type": "If docs
-        needed, set a value", "url": "", "qa_contact": "", "cf_pgm_internal": "",
-        "cf_pm_score": "0", "comments": [{"tags": [], "count": 0, "id": 15719452,
-        "private_groups": [], "text": "test", "creation_time": "2024-04-29T13:53:17Z",
-        "bug_id": 2024014, "is_private": false, "attachment_id": null, "time": "2024-04-29T13:53:17Z",
-        "creator": "concosta@redhat.com", "creator_id": 464818}], "alias": [], "component":
-        ["vulnerability-draft"], "estimated_time": 0, "docs_contact": "", "id": 2024014,
-        "product": "Security Response", "creator": "concosta@redhat.com", "cf_conditional_nak":
-        [], "depends_on": [], "is_creator_accessible": true, "assigned_to_detail":
-        {"real_name": "Nobody", "active": true, "partner": false, "id": 29451, "email":
-        "nobody@redhat.com", "insider": false, "name": "nobody@redhat.com"}, "flags":
-        [], "cf_qe_conditional_nak": [], "cf_release_notes": "", "assigned_to": "nobody@redhat.com",
-        "data_category": "Public", "last_change_time": "2024-04-29T13:53:17Z", "target_milestone":
-        "---", "groups": [], "cc_detail": [], "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-        \"mitigation\": \"mitigation\"}", "cf_fixed_in": "", "cc": [], "cf_clone_of":
-        null, "cf_last_closed": null, "op_sys": "Linux", "external_bugs": [], "creator_detail":
-        {"insider": true, "name": "concosta@redhat.com", "email": "concosta@redhat.com",
-        "id": 464818, "partner": false, "active": true, "real_name": ""}, "keywords":
-        ["Security"], "is_cc_accessible": true, "version": ["unspecified"], "sub_components":
-        {}, "status": "NEW", "is_open": true, "creation_time": "2024-04-29T13:53:17Z",
-        "cf_embargoed": null, "cf_environment": "", "summary": "curl: Foo", "actual_time":
-        0, "priority": "low", "cf_devel_whiteboard": "", "resolution": "", "is_confirmed":
-        true}], "total_matches": 1, "offset": 0, "limit": "20"}'
+      string: '{"bugs": [{"dupe_of": null, "cf_build_id": "", "cf_embargoed": null,
+        "assigned_to": "prodsec-dev@redhat.com", "last_change_time": "2024-05-21T12:29:47Z",
+        "estimated_time": 0, "keywords": ["Security"], "actual_time": 0, "cf_cust_facing":
+        "---", "severity": "low", "version": ["unspecified"], "cf_release_notes":
+        "", "creator_detail": {"email": "conrado@redhat.com", "insider": true, "name":
+        "conrado@redhat.com", "partner": false, "id": 482384, "active": true, "real_name":
+        "Conrado Costa"}, "depends_on": [], "is_creator_accessible": true, "component":
+        ["vulnerability-draft"], "docs_contact": "", "cf_doc_type": "If docs needed,
+        set a value", "remaining_time": 0, "cf_devel_whiteboard": "", "cf_fixed_in":
+        "", "data_category": "Public", "comments": [{"attachment_id": null, "tags":
+        [], "creator_id": 482384, "bug_id": 2279556, "count": 0, "creator": "conrado@redhat.com",
+        "creation_time": "2024-05-21T12:29:47Z", "is_private": false, "private_groups":
+        [], "time": "2024-05-21T12:29:47Z", "id": 18005633, "text": "test"}], "cf_pm_score":
+        "0", "summary": "curl: Foo", "priority": "low", "cc": [], "classification":
+        "Other", "creation_time": "2024-05-21T12:29:47Z", "cf_environment": "", "is_confirmed":
+        true, "flags": [], "cf_major_incident": null, "cf_clone_of": null, "cf_qe_conditional_nak":
+        [], "cf_last_closed": null, "id": 2279556, "external_bugs": [], "qa_contact":
+        "", "cf_pgm_internal": "", "groups": [], "assigned_to_detail": {"email": "prodsec-dev@redhat.com",
+        "insider": true, "name": "prodsec-dev@redhat.com", "id": 377884, "partner":
+        false, "active": true, "real_name": "INVALID USER"}, "op_sys": "Linux", "sub_components":
+        {}, "alias": [], "cf_conditional_nak": [], "product": "Security Response",
+        "target_release": ["---"], "description": "test", "cc_detail": [], "cf_srtnotes":
+        "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\": \"2022-11-22T15:55:22Z\",
+        \"impact\": \"low\", \"source\": \"debian\", \"mitigation\": \"mitigation\"}",
+        "url": "", "deadline": null, "creator": "conrado@redhat.com", "whiteboard":
+        "", "status": "NEW", "cf_internal_whiteboard": "", "blocks": [], "resolution":
+        "", "tags": [], "is_open": true, "cf_qa_whiteboard": "", "target_milestone":
+        "---", "is_cc_accessible": true, "platform": "All"}], "limit": "20", "offset":
+        0, "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -479,7 +480,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:18 GMT
+      - Tue, 21 May 2024 12:29:49 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -489,13 +490,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2071'
+      - '2101'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398798.124c08f2
+      - 0.96292117.1716294589.424cde38
       x-rh-edge-request-id:
-      - 124c08f2
+      - 424cde38
     status:
       code: 200
       message: OK
@@ -513,38 +514,37 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2024014
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556
   response:
     body:
-      string: '{"bugs": [{"platform": "All", "comments": [{"time": "2024-04-29T13:53:17Z",
-        "creator": "concosta@redhat.com", "attachment_id": null, "creator_id": 464818,
-        "bug_id": 2024014, "private_groups": [], "tags": [], "is_private": false,
-        "count": 0, "creation_time": "2024-04-29T13:53:17Z", "id": 15719452, "text":
-        "test"}], "cf_last_closed": null, "severity": "low", "whiteboard": "", "url":
-        "", "assigned_to": "nobody@redhat.com", "resolution": "", "component": ["vulnerability-draft"],
-        "cf_embargoed": null, "sub_components": {}, "dupe_of": null, "creator_detail":
-        {"email": "concosta@redhat.com", "insider": true, "id": 464818, "real_name":
-        "", "active": true, "partner": false, "name": "concosta@redhat.com"}, "cf_pm_score":
-        "0", "cf_qa_whiteboard": "", "cf_build_id": "", "tags": [], "target_release":
-        ["---"], "cf_cust_facing": "---", "summary": "curl: Foo", "cf_clone_of": null,
-        "cf_release_notes": "", "product": "Security Response", "cf_fixed_in": "",
-        "depends_on": [], "alias": [], "status": "NEW", "external_bugs": [], "last_change_time":
-        "2024-04-29T13:53:17Z", "cf_environment": "", "creator": "concosta@redhat.com",
-        "version": ["unspecified"], "is_creator_accessible": true, "remaining_time":
-        0, "cc": [], "qa_contact": "", "priority": "low", "estimated_time": 0, "cf_conditional_nak":
-        [], "classification": "Other", "groups": [], "actual_time": 0, "creation_time":
-        "2024-04-29T13:53:17Z", "target_milestone": "---", "op_sys": "Linux", "is_open":
-        true, "keywords": ["Security"], "cf_devel_whiteboard": "", "deadline": null,
-        "cf_internal_whiteboard": "", "cf_major_incident": null, "is_confirmed": true,
-        "cf_qe_conditional_nak": [], "is_cc_accessible": true, "blocks": [], "flags":
-        [], "assigned_to_detail": {"insider": false, "email": "nobody@redhat.com",
-        "name": "nobody@redhat.com", "partner": false, "id": 29451, "active": true,
-        "real_name": "Nobody"}, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-        \"mitigation\": \"mitigation\"}", "docs_contact": "", "id": 2024014, "data_category":
-        "Public", "cf_doc_type": "If docs needed, set a value", "cc_detail": [], "description":
-        "test", "cf_pgm_internal": ""}], "offset": 0, "total_matches": 1, "limit":
-        "20"}'
+      string: '{"bugs": [{"is_open": true, "cf_qa_whiteboard": "", "target_milestone":
+        "---", "is_cc_accessible": true, "platform": "All", "status": "NEW", "blocks":
+        [], "cf_internal_whiteboard": "", "resolution": "", "tags": [], "whiteboard":
+        "", "creator": "conrado@redhat.com", "target_release": ["---"], "cc_detail":
+        [], "description": "test", "deadline": null, "url": "", "cf_srtnotes": "{\"public\":
+        \"2000-01-01T22:03:26Z\", \"reported\": \"2022-11-22T15:55:22Z\", \"impact\":
+        \"low\", \"source\": \"debian\", \"mitigation\": \"mitigation\"}", "alias":
+        [], "op_sys": "Linux", "sub_components": {}, "product": "Security Response",
+        "cf_conditional_nak": [], "groups": [], "assigned_to_detail": {"email": "prodsec-dev@redhat.com",
+        "insider": true, "id": 377884, "name": "prodsec-dev@redhat.com", "partner":
+        false, "active": true, "real_name": "INVALID USER"}, "qa_contact": "", "external_bugs":
+        [], "cf_pgm_internal": "", "cf_clone_of": null, "cf_major_incident": null,
+        "cf_qe_conditional_nak": [], "id": 2279556, "cf_last_closed": null, "creation_time":
+        "2024-05-21T12:29:47Z", "is_confirmed": true, "cf_environment": "", "flags":
+        [], "priority": "low", "summary": "curl: Foo", "cf_pm_score": "0", "cc": [],
+        "classification": "Other", "remaining_time": 0, "cf_fixed_in": "", "cf_devel_whiteboard":
+        "", "comments": [{"text": "test", "private_groups": [], "time": "2024-05-21T12:29:47Z",
+        "id": 18005633, "creation_time": "2024-05-21T12:29:47Z", "is_private": false,
+        "count": 0, "creator": "conrado@redhat.com", "creator_id": 482384, "bug_id":
+        2279556, "attachment_id": null, "tags": []}], "data_category": "Public", "component":
+        ["vulnerability-draft"], "cf_doc_type": "If docs needed, set a value", "docs_contact":
+        "", "depends_on": [], "cf_release_notes": "", "creator_detail": {"real_name":
+        "Conrado Costa", "active": true, "id": 482384, "name": "conrado@redhat.com",
+        "partner": false, "insider": true, "email": "conrado@redhat.com"}, "is_creator_accessible":
+        true, "actual_time": 0, "version": ["unspecified"], "severity": "low", "cf_cust_facing":
+        "---", "dupe_of": null, "cf_embargoed": null, "cf_build_id": "", "keywords":
+        ["Security"], "last_change_time": "2024-05-21T12:29:47Z", "assigned_to": "prodsec-dev@redhat.com",
+        "estimated_time": 0}], "total_matches": 1, "limit": "20", "offset": 0}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -557,7 +557,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:19 GMT
+      - Tue, 21 May 2024 12:29:50 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -567,13 +567,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2071'
+      - '2101'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398799.124c0b42
+      - 0.96292117.1716294590.424cedc5
       x-rh-edge-request-id:
-      - 124c0b42
+      - 424cedc5
     status:
       code: 200
       message: OK
@@ -591,13 +591,14 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2024014/comment
+    uri: https://example.com/rest/bug/2279556/comment
   response:
     body:
-      string: '{"comments": {}, "bugs": {"2024014": {"comments": [{"text": "test",
-        "count": 0, "is_private": false, "tags": [], "creation_time": "2024-04-29T13:53:17Z",
-        "id": 15719452, "private_groups": [], "bug_id": 2024014, "creator_id": 464818,
-        "attachment_id": null, "time": "2024-04-29T13:53:17Z", "creator": "concosta@redhat.com"}]}}}'
+      string: '{"comments": {}, "bugs": {"2279556": {"comments": [{"private_groups":
+        [], "id": 18005633, "attachment_id": null, "count": 0, "is_private": false,
+        "creator": "conrado@redhat.com", "tags": [], "text": "test", "bug_id": 2279556,
+        "time": "2024-05-21T12:29:47Z", "creation_time": "2024-05-21T12:29:47Z", "creator_id":
+        482384}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -608,11 +609,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '297'
+      - '296'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:20 GMT
+      - Tue, 21 May 2024 12:29:50 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -622,9 +623,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398800.124c0df8
+      - 0.96292117.1716294590.424cfead
       x-rh-edge-request-id:
-      - 124c0df8
+      - 424cfead
     status:
       code: 200
       message: OK
@@ -769,9 +770,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:20 GMT
+      - Tue, 21 May 2024 12:29:51 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:20 GMT
+      - Tue, 21 May 2024 12:29:51 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -790,11 +791,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x509210x1
+      - 749x296616x1
       x-asessionid:
-      - gd6lob
+      - 9wg8bz
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -806,9 +807,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398800.17d3e7e0
+      - 0.96292117.1716294591.424d11bd
       x-rh-edge-request-id:
-      - 17d3e7e0
+      - 424d11bd
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -884,9 +885,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:20 GMT
+      - Tue, 21 May 2024 12:29:51 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:20 GMT
+      - Tue, 21 May 2024 12:29:51 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -905,11 +906,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x509211x1
+      - 749x296617x1
       x-asessionid:
-      - k9pcj8
+      - dmodos
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -921,9 +922,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398800.17d3e80a
+      - 0.96292117.1716294591.424d1542
       x-rh-edge-request-id:
-      - 17d3e80a
+      - 424d1542
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -933,7 +934,7 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "Foo", "description": "test", "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
+      "Foo", "description": "test", "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
       "impact:LOW"], "priority": {"name": "Minor"}}}'
     headers:
       Accept:
@@ -956,18 +957,18 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "15883217", "key": "OSIM-1870", "self": "https://example.com/rest/api/2/issue/15883217"}'
+      string: '{"id": "15890120", "key": "OSIM-2044", "self": "https://example.com/rest/api/2/issue/15890120"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - keep-alive
+      - close
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:21 GMT
+      - Tue, 21 May 2024 12:29:52 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:21 GMT
+      - Tue, 21 May 2024 12:29:52 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -986,11 +987,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x509212x1
+      - 749x296618x1
       x-asessionid:
-      - at18uz
+      - jc89z3
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1002,9 +1003,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398801.17d3e83b
+      - 0.96292117.1716294592.424d17c0
       x-rh-edge-request-id:
-      - 17d3e83b
+      - 424d17c0
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1030,16 +1031,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -1048,29 +1049,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@38d0bbb5[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@19182cba[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@441be5dd[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d4a51a8[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3c1009bd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@64359f79[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61345902[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@60aca3e4[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5ccd13ad[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@144b811a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@57f436d8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@52420c41[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66262ddf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2e2d3350[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6b48ab30[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@24c060e0[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49c3407e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@d8e2dc7[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2331066d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@451a58b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5742c5cf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2b5e3af5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@f7439d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@983c3f5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1870/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2044/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
+        "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
         "impact:LOW"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:20.838+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:29:51.619+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -1105,10 +1106,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1117,9 +1118,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:21 GMT
+      - Tue, 21 May 2024 12:29:57 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:21 GMT
+      - Tue, 21 May 2024 12:29:57 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1132,17 +1133,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8760'
+      - '8785'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x509213x1
+      - 749x296622x1
       x-asessionid:
-      - 7357eb
+      - 1ompoyg
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1154,9 +1155,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398801.17d3eb34
+      - 0.96292117.1716294597.424d8322
       x-rh-edge-request-id:
-      - 17d3eb34
+      - 424d8322
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1305,9 +1306,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:22 GMT
+      - Tue, 21 May 2024 12:29:58 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:22 GMT
+      - Tue, 21 May 2024 12:29:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1326,11 +1327,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338355x1
+      - 749x308182x1
       x-asessionid:
-      - 1gp4wbv
+      - hw6bro
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1342,9 +1343,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398802.17d3ec99
+      - 0.96292117.1716294598.424d9457
       x-rh-edge-request-id:
-      - 17d3ec99
+      - 424d9457
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1420,9 +1421,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:22 GMT
+      - Tue, 21 May 2024 12:29:59 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:22 GMT
+      - Tue, 21 May 2024 12:29:59 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1441,11 +1442,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338356x1
+      - 749x308183x1
       x-asessionid:
-      - 1oq0cq9
+      - 1ew903q
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1457,9 +1458,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398802.17d3ecd0
+      - 0.96292117.1716294599.424d997e
       x-rh-edge-request-id:
-      - 17d3ecd0
+      - 424d997e
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1469,8 +1470,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "Foo", "description": "test", "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-      "impact:LOW", "team:oil"], "priority": {"name": "Minor"}}}'
+      "Foo", "description": "test", "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+      "impact:LOW", "team:strong"], "priority": {"name": "Minor"}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1481,7 +1482,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '229'
+      - '232'
       Content-Type:
       - application/json
       User-Agent:
@@ -1489,7 +1490,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: ''
@@ -1501,9 +1502,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:23 GMT
+      - Tue, 21 May 2024 12:30:00 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:23 GMT
+      - Tue, 21 May 2024 12:30:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1517,11 +1518,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338357x1
+      - 749x308184x1
       x-asessionid:
-      - ghusxq
+      - x4ppaa
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1533,9 +1534,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398803.17d3ed0e
+      - 0.96292117.1716294600.424d9d7b
       x-rh-edge-request-id:
-      - 17d3ed0e
+      - 424d9d7b
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1561,16 +1562,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -1579,29 +1580,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@232320a6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3d7edc1f[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6ac083e5[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@44d39a51[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@39f069af[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7225d4aa[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d145873[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3c623bca[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66590f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5ab9841a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@259188fe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@8005bed[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2248e845[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@34c73142[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3523e95d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6dfafcba[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@ce2f26[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4f2080c0[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6563e178[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5f46de42[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2e007d93[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@656dce13[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1f7f9be7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@76a2f284[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1870/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2044/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-        "impact:LOW", "team:oil"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+        "impact:LOW", "team:strong"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:22.635+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:29:59.312+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -1636,10 +1637,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1648,9 +1649,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:23 GMT
+      - Tue, 21 May 2024 12:30:00 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:23 GMT
+      - Tue, 21 May 2024 12:30:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1663,17 +1664,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8769'
+      - '8802'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338358x1
+      - 750x308185x1
       x-asessionid:
-      - 1na69c2
+      - fpz2cv
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1685,9 +1686,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398803.17d3efd8
+      - 0.96292117.1716294600.424dadc4
       x-rh-edge-request-id:
-      - 17d3efd8
+      - 424dadc4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1713,7 +1714,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2044/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -1758,9 +1759,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:23 GMT
+      - Tue, 21 May 2024 12:30:00 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:23 GMT
+      - Tue, 21 May 2024 12:30:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1779,11 +1780,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338359x1
+      - 750x308186x1
       x-asessionid:
-      - 11wuhva
+      - 1y9s6be
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1795,9 +1796,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398803.17d3f09d
+      - 0.96292117.1716294600.424db211
       x-rh-edge-request-id:
-      - 17d3f09d
+      - 424db211
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1825,7 +1826,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-1870/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2044/transitions
   response:
     body:
       string: ''
@@ -1837,9 +1838,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:24 GMT
+      - Tue, 21 May 2024 12:30:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:24 GMT
+      - Tue, 21 May 2024 12:30:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1853,11 +1854,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338360x1
+      - 750x308187x1
       x-asessionid:
-      - 3n1ue
+      - j5c860
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1869,9 +1870,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398804.17d3f11b
+      - 0.96292117.1716294601.424db3ce
       x-rh-edge-request-id:
-      - 17d3f11b
+      - 424db3ce
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1897,16 +1898,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -1915,29 +1916,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@25e9dab0[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9ececee[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4c5bb6ab[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@30c61eae[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d712a8f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@43142853[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@63e0a912[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1717fa13[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@33169f2c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@51a26fad[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@37ecf4b2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1f03473e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@18eb440d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5a768fba[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b05b5d3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@bb6e973[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5dc449a8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1247f027[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@34ca6491[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@80bfe0a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@77fd6faa[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5a967fba[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3d9f7695[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6ab33482[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1870/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2044/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-        "impact:LOW", "team:oil"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+        "impact:LOW", "team:strong"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:23.959+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:30:00.559+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -1972,10 +1973,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1984,9 +1985,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:24 GMT
+      - Tue, 21 May 2024 12:30:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:24 GMT
+      - Tue, 21 May 2024 12:30:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1999,17 +2000,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8744'
+      - '8775'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x338363x1
+      - 750x308190x2
       x-asessionid:
-      - chz3uo
+      - ksg51c
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2021,13 +2022,537 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.ba85d817.1714398804.17d3f28c
+      - 0.96292117.1716294601.424dbf82
       x-rh-edge-request-id:
-      - 17d3f28c
+      - 424dbf82
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:01 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294601.424dc895
+      x-rh-edge-request-id:
+      - 424dc895
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "id": 1, "can_login": true, "email": "aander07@packetmaster.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294602.424dcb96
+      x-rh-edge-request-id:
+      - 424dcb96
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556&include_fields=id&include_fields=last_change_time
+  response:
+    body:
+      string: '{"total_matches": 1, "offset": 0, "limit": "20", "bugs": [{"data_category":
+        "Public", "last_change_time": "2024-05-21T12:29:47Z", "id": 2279556}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294603.424dd208
+      x-rh-edge-request-id:
+      - 424dd208
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
+      "", "severity": "low", "priority": "low", "summary": "curl: Foo", "keywords":
+      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
+      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
+      \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
+      \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
+      \"ps_component\": \"ps-component-1\", \"affectedness\": \"new\", \"resolution\":
+      null, \"impact\": \"moderate\", \"cvss2\": null, \"cvss3\": null, \"cvss4\":
+      null}]}", "cf_fixed_in": "", "ids": ["2279556"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '756'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: PUT
+    uri: https://example.com/rest/bug/2279556
+  response:
+    body:
+      string: '{"bugs": [{"changes": {"component": {"added": "vulnerability", "removed":
+        "vulnerability-draft"}, "cf_srtnotes": {"added": "{\"public\": \"2000-01-01T22:03:26Z\",
+        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
+        \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
+        \"ps_component\": \"ps-component-1\", \"affectedness\": \"new\", \"resolution\":
+        null, \"impact\": \"moderate\", \"cvss2\": null, \"cvss3\": null, \"cvss4\":
+        null}]}", "removed": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\":
+        \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\", \"mitigation\":
+        \"mitigation\"}"}}, "alias": [], "last_change_time": "2024-05-21T12:30:04Z",
+        "id": 2279556}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '723'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294604.424deafa
+      x-rh-edge-request-id:
+      - 424deafa
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294604.424e095e
+      x-rh-edge-request-id:
+      - 424e095e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"email": "aander07@packetmaster.com", "can_login": true,
+        "name": "aander07@packetmaster.com", "id": 1, "real_name": "Need Real Name"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294605.424e0b86
+      x-rh-edge-request-id:
+      - 424e0b86
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556
+  response:
+    body:
+      string: '{"offset": 0, "total_matches": 1, "limit": "20", "bugs": [{"op_sys":
+        "Linux", "target_release": ["---"], "blocks": [], "product": "Security Response",
+        "description": "test", "classification": "Other", "last_change_time": "2024-05-21T12:30:04Z",
+        "resolution": "", "cf_clone_of": null, "actual_time": 0, "is_creator_accessible":
+        true, "url": "", "groups": [], "alias": [], "cc": [], "is_confirmed": true,
+        "remaining_time": 0, "cf_internal_whiteboard": "", "status": "NEW", "cf_doc_type":
+        "If docs needed, set a value", "assigned_to": "prodsec-dev@redhat.com", "cf_last_closed":
+        null, "cf_major_incident": null, "component": ["vulnerability"], "cf_release_notes":
+        "", "cf_cust_facing": "---", "cf_qe_conditional_nak": [], "creation_time":
+        "2024-05-21T12:29:47Z", "target_milestone": "---", "cc_detail": [], "qa_contact":
+        "", "cf_embargoed": null, "platform": "All", "comments": [{"creator_id": 482384,
+        "creation_time": "2024-05-21T12:29:47Z", "time": "2024-05-21T12:29:47Z", "bug_id":
+        2279556, "tags": [], "creator": "conrado@redhat.com", "text": "test", "id":
+        18005633, "private_groups": [], "is_private": false, "attachment_id": null,
+        "count": 0}], "whiteboard": "", "cf_fixed_in": "", "cf_pgm_internal": "",
+        "version": ["unspecified"], "sub_components": {}, "cf_build_id": "", "creator":
+        "conrado@redhat.com", "cf_qa_whiteboard": "", "creator_detail": {"active":
+        true, "email": "conrado@redhat.com", "name": "conrado@redhat.com", "insider":
+        true, "real_name": "Conrado Costa", "partner": false, "id": 482384}, "dupe_of":
+        null, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\":
+        \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\", \"mitigation\":
+        \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+        \"ps-component-1\", \"affectedness\": \"new\", \"resolution\": null, \"impact\":
+        \"moderate\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}", "docs_contact":
+        "", "deadline": null, "cf_devel_whiteboard": "", "flags": [], "id": 2279556,
+        "summary": "curl: Foo", "external_bugs": [], "depends_on": [], "is_open":
+        true, "tags": [], "severity": "low", "is_cc_accessible": true, "cf_conditional_nak":
+        [], "priority": "low", "assigned_to_detail": {"name": "prodsec-dev@redhat.com",
+        "active": true, "email": "prodsec-dev@redhat.com", "partner": false, "id":
+        377884, "insider": true, "real_name": "INVALID USER"}, "cf_pm_score": "0",
+        "data_category": "Public", "estimated_time": 0, "cf_environment": "", "keywords":
+        ["Security"]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:06 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2308'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294606.424e1279
+      x-rh-edge-request-id:
+      - 424e1279
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556
+  response:
+    body:
+      string: '{"bugs": [{"cf_last_closed": null, "id": 2279556, "cf_qe_conditional_nak":
+        [], "cf_major_incident": null, "cf_clone_of": null, "flags": [], "cf_environment":
+        "", "is_confirmed": true, "creation_time": "2024-05-21T12:29:47Z", "classification":
+        "Other", "cc": [], "cf_pm_score": "0", "summary": "curl: Foo", "priority":
+        "low", "data_category": "Public", "comments": [{"bug_id": 2279556, "creator_id":
+        482384, "tags": [], "attachment_id": null, "creation_time": "2024-05-21T12:29:47Z",
+        "is_private": false, "creator": "conrado@redhat.com", "count": 0, "time":
+        "2024-05-21T12:29:47Z", "id": 18005633, "private_groups": [], "text": "test"}],
+        "cf_fixed_in": "", "cf_devel_whiteboard": "", "remaining_time": 0, "cf_doc_type":
+        "If docs needed, set a value", "docs_contact": "", "component": ["vulnerability"],
+        "is_creator_accessible": true, "creator_detail": {"insider": true, "email":
+        "conrado@redhat.com", "id": 482384, "partner": false, "name": "conrado@redhat.com",
+        "real_name": "Conrado Costa", "active": true}, "depends_on": [], "cf_release_notes":
+        "", "severity": "low", "cf_cust_facing": "---", "version": ["unspecified"],
+        "actual_time": 0, "assigned_to": "prodsec-dev@redhat.com", "estimated_time":
+        0, "last_change_time": "2024-05-21T12:30:04Z", "keywords": ["Security"], "cf_build_id":
+        "", "cf_embargoed": null, "dupe_of": null, "platform": "All", "is_cc_accessible":
+        true, "cf_qa_whiteboard": "", "target_milestone": "---", "is_open": true,
+        "tags": [], "resolution": "", "cf_internal_whiteboard": "", "blocks": [],
+        "status": "NEW", "whiteboard": "", "creator": "conrado@redhat.com", "url":
+        "", "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\": \"2022-11-22T15:55:22Z\",
+        \"impact\": \"low\", \"source\": \"debian\", \"mitigation\": \"mitigation\",
+        \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\": \"ps-component-1\",
+        \"affectedness\": \"new\", \"resolution\": null, \"impact\": \"moderate\",
+        \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}", "deadline": null, "description":
+        "test", "cc_detail": [], "target_release": ["---"], "product": "Security Response",
+        "cf_conditional_nak": [], "sub_components": {}, "op_sys": "Linux", "alias":
+        [], "assigned_to_detail": {"name": "prodsec-dev@redhat.com", "id": 377884,
+        "partner": false, "active": true, "real_name": "INVALID USER", "email": "prodsec-dev@redhat.com",
+        "insider": true}, "groups": [], "cf_pgm_internal": "", "external_bugs": [],
+        "qa_contact": ""}], "limit": "20", "offset": 0, "total_matches": 1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2308'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294607.424e28a3
+      x-rh-edge-request-id:
+      - 424e28a3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2279556/comment
+  response:
+    body:
+      string: '{"comments": {}, "bugs": {"2279556": {"comments": [{"creator_id": 482384,
+        "bug_id": 2279556, "attachment_id": null, "tags": [], "is_private": false,
+        "creation_time": "2024-05-21T12:29:47Z", "count": 0, "creator": "conrado@redhat.com",
+        "private_groups": [], "time": "2024-05-21T12:29:47Z", "id": 18005633, "text":
+        "test"}]}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '296'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:08 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294608.424e3e59
+      x-rh-edge-request-id:
+      - 424e3e59
     status:
       code: 200
       message: OK
@@ -2049,16 +2574,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -2067,29 +2592,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@29847b74[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@73da2afe[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@67c92042[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@900b6e[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4ef36541[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6c5c2bbb[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@71d8d811[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2469279[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@57ca361d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5ac6deac[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6d698db5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5b0a0f3b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5df6b099[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@31293635[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@76becf85[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@76757147[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@53fe4a2c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@525babf0[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@521984d9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@f3b2894[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2e35ac75[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@21be9668[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f9fe1ca[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@69361125[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1870/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2044/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-        "impact:LOW", "team:oil"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+        "impact:LOW", "team:strong"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:23.959+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:30:00.559+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -2124,10 +2649,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2136,9 +2661,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:09 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:09 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2151,17 +2676,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8744'
+      - '8775'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x509214x1
+      - 750x296631x1
       x-asessionid:
-      - 1tmq1ox
+      - 6oo54a
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2173,9 +2698,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398805.124c1ed4
+      - 0.96292117.1716294609.424e5c0c
       x-rh-edge-request-id:
-      - 124c1ed4
+      - 424e5c0c
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2324,9 +2849,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:09 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:09 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2347,9 +2872,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509215x1
+      - 750x308194x1
       x-asessionid:
-      - 1l61287
+      - txlbzh
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2361,9 +2886,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398805.124c1fd9
+      - 0.96292117.1716294609.424e6458
       x-rh-edge-request-id:
-      - 124c1fd9
+      - 424e6458
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2439,9 +2964,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:09 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:09 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2462,9 +2987,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509216x1
+      - 750x308195x1
       x-asessionid:
-      - 1pr25lw
+      - owc91d
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2476,9 +3001,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398805.124c20f9
+      - 0.96292117.1716294609.424e6674
       x-rh-edge-request-id:
-      - 124c20f9
+      - 424e6674
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2488,8 +3013,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "Foo", "description": "test", "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-      "impact:LOW", "team:oil"], "priority": {"name": "Minor"}}}'
+      "Foo", "description": "test", "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+      "impact:LOW", "team:strong"], "priority": {"name": "Minor"}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -2500,7 +3025,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '229'
+      - '232'
       Content-Type:
       - application/json
       User-Agent:
@@ -2508,7 +3033,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: ''
@@ -2520,9 +3045,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:10 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:25 GMT
+      - Tue, 21 May 2024 12:30:10 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2538,9 +3063,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509217x1
+      - 750x308196x1
       x-asessionid:
-      - 7alybj
+      - xebn5r
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2552,9 +3077,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398805.124c2153
+      - 0.96292117.1716294610.424e6982
       x-rh-edge-request-id:
-      - 124c2153
+      - 424e6982
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2580,16 +3105,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -2598,29 +3123,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7aa07e2d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f89e6b0[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5f041043[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b243514[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@35edc4d7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@355108bc[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@19571139[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@79a13e5d[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@22b196c2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1f986ec0[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3ee76ad3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4e44f884[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@60ed7008[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3cdfecbb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3b0e9057[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@11288eb7[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4216a3e0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3e296ea6[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@71eadd1c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2462a8a0[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@531c066f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@26b50ef4[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1102503[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3006aa29[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1870/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2044/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-        "impact:LOW", "team:oil"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+        "impact:LOW", "team:strong"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:23.959+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:30:00.559+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -2655,10 +3180,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2667,9 +3192,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:26 GMT
+      - Tue, 21 May 2024 12:30:10 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:26 GMT
+      - Tue, 21 May 2024 12:30:10 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2682,7 +3207,7 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8745'
+      - '8776'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2690,9 +3215,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509218x1
+      - 750x308197x1
       x-asessionid:
-      - 1ymjkiu
+      - fhu0uq
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2704,9 +3229,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398806.124c21c4
+      - 0.96292117.1716294610.424e6ede
       x-rh-edge-request-id:
-      - 124c21c4
+      - 424e6ede
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2732,7 +3257,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2044/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -2777,9 +3302,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:26 GMT
+      - Tue, 21 May 2024 12:30:10 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:26 GMT
+      - Tue, 21 May 2024 12:30:10 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2800,9 +3325,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509219x1
+      - 750x308198x1
       x-asessionid:
-      - 1yy9h72
+      - n9a8k1
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2814,9 +3339,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398806.124c229b
+      - 0.96292117.1716294610.424e747c
       x-rh-edge-request-id:
-      - 124c229b
+      - 424e747c
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2845,7 +3370,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-1870/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2044/transitions
   response:
     body:
       string: ''
@@ -2857,9 +3382,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:27 GMT
+      - Tue, 21 May 2024 12:30:11 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:27 GMT
+      - Tue, 21 May 2024 12:30:11 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2875,9 +3400,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509220x1
+      - 750x308199x1
       x-asessionid:
-      - kdc7qd
+      - 16w6l3e
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2889,9 +3414,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398807.124c2373
+      - 0.96292117.1716294611.424e7750
       x-rh-edge-request-id:
-      - 124c2373
+      - 424e7750
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2917,16 +3442,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -2936,29 +3461,29 @@ interactions:
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
         "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@68b98960[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@dc0cdcc[overall=PullRequestOverallBean{stateCount=0,
+        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@13080741[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61f70b6a[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@77b082a9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7c958f3e[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@56b645e4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@322d238d[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@417b4aab[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@11c7c1c5[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@75ba2f7c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2ed05b0d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@35e5626e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1a8344fe[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@42e9dc69[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1b1c2305[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2523665e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7365213f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f63b1ae[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@59db14c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3b322637[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@610494b7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@388b7f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6bf77114[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-04-29T13:53:26.502+0000", "workratio": -1, "customfield_12316840":
+        "resolutiondate": "2024-05-21T12:30:10.583+0000", "workratio": -1, "customfield_12316840":
         null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
         null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-1870/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000",
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-2044/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000",
         "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
         "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-        "impact:LOW", "team:oil"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "name": "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+        "impact:LOW", "team:strong"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:26.515+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:30:10.597+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
         "description": "The issue is closed. See the resolution for context regarding
         why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
         "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
@@ -2993,10 +3518,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -3005,9 +3530,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:27 GMT
+      - Tue, 21 May 2024 12:30:11 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:27 GMT
+      - Tue, 21 May 2024 12:30:11 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3020,7 +3545,7 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8932'
+      - '8964'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -3028,9 +3553,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 833x509222x1
+      - 750x308200x1
       x-asessionid:
-      - 1yq7g57
+      - zjx7vu
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3042,13 +3567,530 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398807.124c26cd
+      - 0.96292117.1716294611.424e84fe
       x-rh-edge-request-id:
-      - 124c26cd
+      - 424e84fe
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:11 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294611.424e9086
+      x-rh-edge-request-id:
+      - 424e9086
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "can_login": true, "id": 1, "email": "aander07@packetmaster.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:12 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294612.424e9432
+      x-rh-edge-request-id:
+      - 424e9432
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556&include_fields=id&include_fields=last_change_time
+  response:
+    body:
+      string: '{"bugs": [{"data_category": "Public", "id": 2279556, "last_change_time":
+        "2024-05-21T12:30:04Z"}], "total_matches": 1, "offset": 0, "limit": "20"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:12 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294612.424e9b81
+      x-rh-edge-request-id:
+      - 424e9b81
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
+      "", "severity": "low", "priority": "low", "summary": "curl: Foo", "keywords":
+      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
+      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
+      \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
+      \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
+      \"ps_component\": \"ps-component-1\", \"affectedness\": \"new\", \"resolution\":
+      null, \"impact\": \"moderate\", \"cvss2\": null, \"cvss3\": null, \"cvss4\":
+      null}]}", "cf_fixed_in": "", "ids": ["2279556"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '756'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: PUT
+    uri: https://example.com/rest/bug/2279556
+  response:
+    body:
+      string: '{"bugs": [{"last_change_time": "2024-05-21T12:30:04Z", "alias": [],
+        "changes": {}, "id": 2279556}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:13 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294613.424eabce
+      x-rh-edge-request-id:
+      - 424eabce
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:13 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294613.424ec28d
+      x-rh-edge-request-id:
+      - 424ec28d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com",
+        "id": 1, "can_login": true, "real_name": "Need Real Name"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:14 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294614.424ec59c
+      x-rh-edge-request-id:
+      - 424ec59c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556
+  response:
+    body:
+      string: '{"bugs": [{"groups": [], "assigned_to_detail": {"name": "prodsec-dev@redhat.com",
+        "id": 377884, "partner": false, "real_name": "INVALID USER", "active": true,
+        "insider": true, "email": "prodsec-dev@redhat.com"}, "external_bugs": [],
+        "qa_contact": "", "cf_pgm_internal": "", "target_release": ["---"], "description":
+        "test", "cc_detail": [], "url": "", "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
+        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
+        \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
+        \"ps_component\": \"ps-component-1\", \"affectedness\": \"new\", \"resolution\":
+        null, \"impact\": \"moderate\", \"cvss2\": null, \"cvss3\": null, \"cvss4\":
+        null}]}", "deadline": null, "op_sys": "Linux", "sub_components": {}, "alias":
+        [], "cf_conditional_nak": [], "product": "Security Response", "whiteboard":
+        "", "creator": "conrado@redhat.com", "is_open": true, "cf_qa_whiteboard":
+        "", "target_milestone": "---", "is_cc_accessible": true, "platform": "All",
+        "status": "NEW", "cf_internal_whiteboard": "", "blocks": [], "resolution":
+        "", "tags": [], "actual_time": 0, "cf_cust_facing": "---", "severity": "low",
+        "version": ["unspecified"], "dupe_of": null, "cf_embargoed": null, "cf_build_id":
+        "", "keywords": ["Security"], "last_change_time": "2024-05-21T12:30:04Z",
+        "estimated_time": 0, "assigned_to": "prodsec-dev@redhat.com", "component":
+        ["vulnerability"], "docs_contact": "", "cf_doc_type": "If docs needed, set
+        a value", "depends_on": [], "creator_detail": {"email": "conrado@redhat.com",
+        "insider": true, "active": true, "real_name": "Conrado Costa", "partner":
+        false, "name": "conrado@redhat.com", "id": 482384}, "cf_release_notes": "",
+        "is_creator_accessible": true, "cf_pm_score": "0", "summary": "curl: Foo",
+        "priority": "low", "cc": [], "classification": "Other", "remaining_time":
+        0, "cf_devel_whiteboard": "", "cf_fixed_in": "", "data_category": "Public",
+        "comments": [{"private_groups": [], "time": "2024-05-21T12:29:47Z", "id":
+        18005633, "text": "test", "attachment_id": null, "tags": [], "creator_id":
+        482384, "bug_id": 2279556, "count": 0, "creator": "conrado@redhat.com", "is_private":
+        false, "creation_time": "2024-05-21T12:29:47Z"}], "cf_major_incident": null,
+        "cf_clone_of": null, "cf_qe_conditional_nak": [], "cf_last_closed": null,
+        "id": 2279556, "creation_time": "2024-05-21T12:29:47Z", "cf_environment":
+        "", "is_confirmed": true, "flags": []}], "limit": "20", "offset": 0, "total_matches":
+        1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:15 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2308'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294615.424ecc93
+      x-rh-edge-request-id:
+      - 424ecc93
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279556
+  response:
+    body:
+      string: '{"total_matches": 1, "limit": "20", "offset": 0, "bugs": [{"classification":
+        "Other", "cf_pm_score": "0", "summary": "curl: Foo", "priority": "low", "cc":
+        [], "data_category": "Public", "comments": [{"creator": "conrado@redhat.com",
+        "count": 0, "is_private": false, "creation_time": "2024-05-21T12:29:47Z",
+        "tags": [], "attachment_id": null, "bug_id": 2279556, "creator_id": 482384,
+        "text": "test", "id": 18005633, "time": "2024-05-21T12:29:47Z", "private_groups":
+        []}], "remaining_time": 0, "cf_fixed_in": "", "cf_devel_whiteboard": "", "cf_last_closed":
+        null, "id": 2279556, "cf_major_incident": null, "cf_clone_of": null, "cf_qe_conditional_nak":
+        [], "cf_environment": "", "is_confirmed": true, "flags": [], "creation_time":
+        "2024-05-21T12:29:47Z", "cf_cust_facing": "---", "severity": "low", "version":
+        ["unspecified"], "actual_time": 0, "cf_embargoed": null, "cf_build_id": "",
+        "last_change_time": "2024-05-21T12:30:04Z", "assigned_to": "prodsec-dev@redhat.com",
+        "estimated_time": 0, "keywords": ["Security"], "dupe_of": null, "component":
+        ["vulnerability"], "cf_doc_type": "If docs needed, set a value", "docs_contact":
+        "", "is_creator_accessible": true, "cf_release_notes": "", "creator_detail":
+        {"insider": true, "email": "conrado@redhat.com", "real_name": "Conrado Costa",
+        "active": true, "id": 482384, "name": "conrado@redhat.com", "partner": false},
+        "depends_on": [], "whiteboard": "", "creator": "conrado@redhat.com", "is_cc_accessible":
+        true, "platform": "All", "is_open": true, "target_milestone": "---", "cf_qa_whiteboard":
+        "", "resolution": "", "tags": [], "status": "NEW", "cf_internal_whiteboard":
+        "", "blocks": [], "assigned_to_detail": {"insider": true, "email": "prodsec-dev@redhat.com",
+        "name": "prodsec-dev@redhat.com", "partner": false, "id": 377884, "real_name":
+        "INVALID USER", "active": true}, "groups": [], "cf_pgm_internal": "", "external_bugs":
+        [], "qa_contact": "", "url": "", "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
+        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
+        \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
+        \"ps_component\": \"ps-component-1\", \"affectedness\": \"new\", \"resolution\":
+        null, \"impact\": \"moderate\", \"cvss2\": null, \"cvss3\": null, \"cvss4\":
+        null}]}", "deadline": null, "target_release": ["---"], "description": "test",
+        "cc_detail": [], "cf_conditional_nak": [], "product": "Security Response",
+        "sub_components": {}, "op_sys": "Linux", "alias": []}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:16 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2308'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294616.424edf5d
+      x-rh-edge-request-id:
+      - 424edf5d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2279556/comment
+  response:
+    body:
+      string: '{"bugs": {"2279556": {"comments": [{"creation_time": "2024-05-21T12:29:47Z",
+        "time": "2024-05-21T12:29:47Z", "bug_id": 2279556, "creator_id": 482384, "id":
+        18005633, "private_groups": [], "is_private": false, "count": 0, "attachment_id":
+        null, "tags": [], "creator": "conrado@redhat.com", "text": "test"}]}}, "comments":
+        {}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '296'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:30:16 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716294616.424ef3d8
+      x-rh-edge-request-id:
+      - 424ef3d8
     status:
       code: 200
       message: OK
@@ -3072,11 +4114,11 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-1870/comment
+    uri: https://example.com/rest/api/2/issue/OSIM-2044/comment
   response:
     body:
-      string: '{"self": "https://example.com/rest/api/2/issue/15883217/comment/24181685",
-        "id": "24181685", "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+      string: '{"self": "https://example.com/rest/api/2/issue/15890120/comment/24183010",
+        "id": "24183010", "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -3090,24 +4132,27 @@ interactions:
         "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
         "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
         "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "created": "2024-04-29T13:53:27.865+0000", "updated": "2024-04-29T13:53:27.865+0000"}'
+        "created": "2024-05-21T12:30:17.389+0000", "updated": "2024-05-21T12:30:17.389+0000"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - close
+      - keep-alive
+      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:29 GMT
+      - Tue, 21 May 2024 12:30:18 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:29 GMT
+      - Tue, 21 May 2024 12:30:18 GMT
       Location:
-      - https://example.com/rest/api/2/issue/15883217/comment/24181685
+      - https://example.com/rest/api/2/issue/15890120/comment/24183010
       Pragma:
       - no-cache
       Retry-After:
       - '0'
+      Transfer-Encoding:
+      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
@@ -3124,9 +4169,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x338366x1
+      - 750x296634x1
       x-asessionid:
-      - ryyz9x
+      - 1tq1g2f
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3138,9 +4183,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398809.124c28a2
+      - 0.96292117.1716294618.424f0e97
       x-rh-edge-request-id:
-      - 124c28a2
+      - 424f0e97
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3166,16 +4211,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1870
+    uri: https://example.com/rest/api/2/issue/OSIM-2044
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883217", "self": "https://example.com/rest/api/2/issue/15883217",
-        "key": "OSIM-1870", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890120", "self": "https://example.com/rest/api/2/issue/15890120",
+        "key": "OSIM-2044", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -3185,29 +4230,29 @@ interactions:
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
         "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@12e2c565[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@35d505a7[overall=PullRequestOverallBean{stateCount=0,
+        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@52836191[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@26a06124[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3996651e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@24f3a7b6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@413c6fd5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@26b1a361[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c859c3c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1572400d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3792c7b1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1c13d089[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1c77db4b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1b8292e0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@54d02ede[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@71dccc21[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12b794db[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3d56a3e2[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6825dc48[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7f8fb8a9[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@51b0facf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@59711aa8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1f704a52[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1db8e3e5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-04-29T13:53:26.502+0000", "workratio": -1, "customfield_12316840":
+        "resolutiondate": "2024-05-21T12:30:10.583+0000", "workratio": -1, "customfield_12316840":
         null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
         null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-1870/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-04-29T13:53:20.838+0000",
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-2044/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2024-05-21T12:29:51.619+0000",
         "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
         "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:cacd59ed-6ffe-4f5c-aa47-6ba2ba12e398",
-        "impact:LOW", "team:oil"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "name": "Minor", "id": "4"}, "labels": ["flawuuid:0576927b-06a0-4176-8e1b-e07fb4eed664",
+        "impact:LOW", "team:strong"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:53:27.865+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:30:17.389+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
         "description": "The issue is closed. See the resolution for context regarding
         why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
         "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
@@ -3241,8 +4286,8 @@ interactions:
         null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "comment": {"comments": [{"self": "https://example.com/rest/api/2/issue/15883217/comment/24181685",
-        "id": "24181685", "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "comment": {"comments": [{"self": "https://example.com/rest/api/2/issue/15890120/comment/24183010",
+        "id": "24183010", "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
         "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
         "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
@@ -3256,11 +4301,11 @@ interactions:
         "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
         "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
         "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "created": "2024-04-29T13:53:27.865+0000", "updated": "2024-04-29T13:53:27.865+0000"}],
-        "maxResults": 1, "total": 1, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-1870/votes",
+        "created": "2024-05-21T12:30:17.389+0000", "updated": "2024-05-21T12:30:17.389+0000"}],
+        "maxResults": 1, "total": 1, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-2044/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg48:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk00:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -3269,9 +4314,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:53:29 GMT
+      - Tue, 21 May 2024 12:30:18 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:53:29 GMT
+      - Tue, 21 May 2024 12:30:18 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3284,17 +4329,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '10570'
+      - '10603'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 833x509226x1
+      - 750x296635x1
       x-asessionid:
-      - 1bpz97p
+      - 1w8q5ge
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3306,9 +4351,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714398809.124c1f18
+      - 0.96292117.1716294618.424e5f09
       x-rh-edge-request-id:
-      - 124c1f18
+      - 424e5f09
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinInteration.test_manual_changes.yaml
+++ b/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinInteration.test_manual_changes.yaml
@@ -140,9 +140,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:55 GMT
+      - Tue, 21 May 2024 12:43:41 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:28:55 GMT
+      - Tue, 21 May 2024 12:43:41 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -163,9 +163,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 808x337326x1
+      - 763x297053x1
       x-asessionid:
-      - 11pbyrw
+      - 1k9ccue
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -177,9 +177,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.bb85d817.1714397335.14587974
+      - 0.88292117.1716295421.48de96bd
       x-rh-edge-request-id:
-      - '14587974'
+      - 48de96bd
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -255,9 +255,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:55 GMT
+      - Tue, 21 May 2024 12:43:41 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:28:55 GMT
+      - Tue, 21 May 2024 12:43:41 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -278,9 +278,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 808x337327x1
+      - 763x297054x1
       x-asessionid:
-      - 1rsqui1
+      - qe2bt1
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -292,9 +292,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.bb85d817.1714397335.145879b5
+      - 0.88292117.1716295421.48de981b
       x-rh-edge-request-id:
-      - 145879b5
+      - 48de981b
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -304,7 +304,7 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "title", "description": "description", "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
+      "title", "description": "description", "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
       "impact:LOW"], "priority": {"name": "Minor"}}}'
     headers:
       Accept:
@@ -327,7 +327,7 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "15883169", "key": "OSIM-1856", "self": "https://example.com/rest/api/2/issue/15883169"}'
+      string: '{"id": "15890122", "key": "OSIM-2046", "self": "https://example.com/rest/api/2/issue/15890122"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -336,9 +336,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:56 GMT
+      - Tue, 21 May 2024 12:43:42 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:28:56 GMT
+      - Tue, 21 May 2024 12:43:42 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -359,9 +359,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 808x337328x1
+      - 763x297055x1
       x-asessionid:
-      - 1iltkzr
+      - 1ghm1tk
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -373,9 +373,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.bb85d817.1714397336.14587a44
+      - 0.88292117.1716295422.48de99ba
       x-rh-edge-request-id:
-      - 14587a44
+      - 48de99ba
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -401,16 +401,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -419,29 +419,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5d511242[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@17f384b1[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3dbc70d7[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6a5989aa[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f4e7309[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3493be5d[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@25740316[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@a7b0815[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4661f468[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6f29cbaf[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ac019ef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@38a99f02[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7122fecb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@507727f3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1b29f525[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3d9b2b33[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e8478c8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@33985d0c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67cc0687[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3ea6bfe[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3e151173[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4f944b80[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48eb84cb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@180eb3b3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1856/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2046/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
+        "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
         "impact:LOW"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:28:55.633+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:43:41.909+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -477,10 +477,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -489,9 +489,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:56 GMT
+      - Tue, 21 May 2024 12:43:43 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:28:56 GMT
+      - Tue, 21 May 2024 12:43:43 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -504,7 +504,7 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8768'
+      - '8798'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -512,9 +512,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 808x337329x1
+      - 763x297056x1
       x-asessionid:
-      - gdhd3c
+      - 10kdjhv
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -526,9 +526,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.bb85d817.1714397336.14587f19
+      - 0.88292117.1716295423.48dea6c4
       x-rh-edge-request-id:
-      - 14587f19
+      - 48dea6c4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -568,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:57 GMT
+      - Tue, 21 May 2024 12:43:43 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -578,9 +578,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397337.b9e853a
+      - 0.96292117.1716295423.427e531b
       x-rh-edge-request-id:
-      - b9e853a
+      - 427e531b
     status:
       code: 200
       message: OK
@@ -601,8 +601,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"email": "aander07@packetmaster.com", "can_login": true,
-        "id": 1, "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "real_name": "Need
+        Real Name", "id": 1, "can_login": true, "name": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -617,7 +617,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:57 GMT
+      - Tue, 21 May 2024 12:43:43 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -627,9 +627,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397337.b9e858d
+      - 0.96292117.1716295423.427e5559
       x-rh-edge-request-id:
-      - b9e858d
+      - 427e5559
     status:
       code: 200
       message: OK
@@ -639,7 +639,7 @@ interactions:
       "", "severity": "low", "priority": "low", "summary": "curl: title", "description":
       "description", "comment_is_private": false, "keywords": ["Security"], "flags":
       [], "groups": [], "cc": [], "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
-      \"reported\": \"2024-04-29T13:28:55Z\", \"impact\": \"low\", \"source\": \"internet\",
+      \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
       \"cwe\": \"CWE-1\"}"}'
     headers:
       Accept:
@@ -658,7 +658,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2023942}'
+      string: '{"id": 2279558}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -673,7 +673,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:58 GMT
+      - Tue, 21 May 2024 12:43:45 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -683,9 +683,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397338.b9e8693
+      - 0.96292117.1716295425.427e587a
       x-rh-edge-request-id:
-      - b9e8693
+      - 427e587a
     status:
       code: 200
       message: OK
@@ -721,7 +721,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:59 GMT
+      - Tue, 21 May 2024 12:43:45 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -731,9 +731,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397339.b9e8b63
+      - 0.96292117.1716295425.427e6fb7
       x-rh-edge-request-id:
-      - b9e8b63
+      - 427e6fb7
     status:
       code: 200
       message: OK
@@ -754,8 +754,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"can_login": true, "id": 1, "real_name": "Need Real Name",
-        "name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "can_login": true,
+        "id": 1, "name": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -770,7 +770,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:59 GMT
+      - Tue, 21 May 2024 12:43:46 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -780,9 +780,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397339.b9e8b9a
+      - 0.96292117.1716295426.427e7220
       x-rh-edge-request-id:
-      - b9e8b9a
+      - 427e7220
     status:
       code: 200
       message: OK
@@ -800,38 +800,38 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023942
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558
   response:
     body:
-      string: '{"total_matches": 1, "bugs": [{"cf_release_notes": "", "cf_qe_conditional_nak":
-        [], "assigned_to": "nobody@redhat.com", "data_category": "Public", "last_change_time":
-        "2024-04-29T13:28:58Z", "target_milestone": "---", "groups": [], "cf_srtnotes":
-        "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-04-29T13:28:55Z\",
-        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\"}", "cc_detail":
-        [], "cc": [], "cf_fixed_in": "", "cf_last_closed": null, "cf_clone_of": null,
-        "sub_components": {}, "version": ["unspecified"], "is_cc_accessible": true,
-        "keywords": ["Security"], "external_bugs": [], "creator_detail": {"partner":
-        false, "email": "concosta@redhat.com", "name": "concosta@redhat.com", "insider":
-        true, "id": 464818, "active": true, "real_name": ""}, "op_sys": "Linux", "is_open":
-        true, "status": "NEW", "creation_time": "2024-04-29T13:28:58Z", "summary":
-        "curl: title", "cf_environment": "", "cf_embargoed": null, "actual_time":
-        0, "cf_devel_whiteboard": "", "resolution": "", "priority": "low", "is_confirmed":
-        true, "platform": "All", "cf_major_incident": null, "cf_qa_whiteboard": "",
-        "whiteboard": "", "blocks": [], "cf_internal_whiteboard": "", "remaining_time":
-        0, "tags": [], "classification": "Other", "dupe_of": null, "cf_build_id":
-        "", "target_release": ["---"], "severity": "low", "description": "description",
-        "cf_cust_facing": "---", "url": "", "cf_doc_type": "If docs needed, set a
-        value", "deadline": null, "cf_pm_score": "0", "qa_contact": "", "cf_pgm_internal":
-        "", "alias": [], "comments": [{"creation_time": "2024-04-29T13:28:58Z", "bug_id":
-        2023942, "tags": [], "count": 0, "id": 15719380, "private_groups": [], "text":
-        "description", "time": "2024-04-29T13:28:58Z", "creator": "concosta@redhat.com",
-        "creator_id": 464818, "is_private": false, "attachment_id": null}], "estimated_time":
-        0, "docs_contact": "", "id": 2023942, "component": ["vulnerability-draft"],
-        "creator": "concosta@redhat.com", "product": "Security Response", "assigned_to_detail":
-        {"email": "nobody@redhat.com", "name": "nobody@redhat.com", "insider": false,
-        "id": 29451, "partner": false, "active": true, "real_name": "Nobody"}, "is_creator_accessible":
-        true, "depends_on": [], "cf_conditional_nak": [], "flags": []}], "offset":
-        0, "limit": "20"}'
+      string: '{"total_matches": 1, "limit": "20", "offset": 0, "bugs": [{"cf_srtnotes":
+        "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-05-21T12:43:41Z\",
+        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\"}", "url":
+        "", "deadline": null, "target_release": ["---"], "description": "description",
+        "cc_detail": [], "cf_conditional_nak": [], "product": "Security Response",
+        "op_sys": "Linux", "sub_components": {}, "alias": [], "assigned_to_detail":
+        {"partner": false, "name": "prodsec-dev@redhat.com", "id": 377884, "active":
+        true, "real_name": "INVALID USER", "email": "prodsec-dev@redhat.com", "insider":
+        true}, "groups": [], "cf_pgm_internal": "", "external_bugs": [], "qa_contact":
+        "", "is_cc_accessible": true, "platform": "All", "is_open": true, "cf_qa_whiteboard":
+        "", "target_milestone": "---", "resolution": "", "tags": [], "status": "NEW",
+        "cf_internal_whiteboard": "", "blocks": [], "whiteboard": "", "creator": "conrado@redhat.com",
+        "component": ["vulnerability-draft"], "cf_doc_type": "If docs needed, set
+        a value", "docs_contact": "", "is_creator_accessible": true, "creator_detail":
+        {"insider": true, "email": "conrado@redhat.com", "real_name": "Conrado Costa",
+        "active": true, "name": "conrado@redhat.com", "id": 482384, "partner": false},
+        "depends_on": [], "cf_release_notes": "", "severity": "low", "cf_cust_facing":
+        "---", "version": ["unspecified"], "actual_time": 0, "cf_build_id": "", "cf_embargoed":
+        null, "estimated_time": 0, "keywords": ["Security"], "last_change_time": "2024-05-21T12:43:44Z",
+        "assigned_to": "prodsec-dev@redhat.com", "dupe_of": null, "cf_last_closed":
+        null, "id": 2279558, "cf_major_incident": null, "cf_clone_of": null, "cf_qe_conditional_nak":
+        [], "cf_environment": "", "is_confirmed": true, "flags": [], "creation_time":
+        "2024-05-21T12:43:44Z", "classification": "Other", "cf_pm_score": "0", "summary":
+        "curl: title", "priority": "low", "cc": [], "data_category": "Public", "comments":
+        [{"text": "description", "private_groups": [], "id": 18005635, "time": "2024-05-21T12:43:44Z",
+        "count": 0, "creator": "conrado@redhat.com", "is_private": false, "creation_time":
+        "2024-05-21T12:43:44Z", "attachment_id": null, "tags": [], "creator_id": 482384,
+        "bug_id": 2279558}], "remaining_time": 0, "cf_fixed_in": "", "cf_devel_whiteboard":
+        ""}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -844,7 +844,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:28:59 GMT
+      - Tue, 21 May 2024 12:43:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -854,13 +854,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2077'
+      - '2107'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397339.b9e8c52
+      - 0.96292117.1716295427.427e798e
       x-rh-edge-request-id:
-      - b9e8c52
+      - 427e798e
     status:
       code: 200
       message: OK
@@ -878,38 +878,38 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2023942
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558
   response:
     body:
-      string: '{"limit": "20", "total_matches": 1, "offset": 0, "bugs": [{"severity":
-        "low", "comments": [{"text": "description", "count": 0, "tags": [], "is_private":
-        false, "creation_time": "2024-04-29T13:28:58Z", "id": 15719380, "private_groups":
-        [], "creator_id": 464818, "bug_id": 2023942, "attachment_id": null, "time":
-        "2024-04-29T13:28:58Z", "creator": "concosta@redhat.com"}], "cf_last_closed":
-        null, "platform": "All", "component": ["vulnerability-draft"], "cf_embargoed":
-        null, "resolution": "", "whiteboard": "", "url": "", "assigned_to": "nobody@redhat.com",
-        "dupe_of": null, "sub_components": {}, "cf_pm_score": "0", "creator_detail":
-        {"partner": false, "name": "concosta@redhat.com", "real_name": "", "id": 464818,
-        "active": true, "insider": true, "email": "concosta@redhat.com"}, "target_release":
-        ["---"], "cf_cust_facing": "---", "tags": [], "cf_build_id": "", "cf_qa_whiteboard":
-        "", "cf_release_notes": "", "cf_clone_of": null, "summary": "curl: title",
-        "external_bugs": [], "last_change_time": "2024-04-29T13:28:58Z", "cf_environment":
-        "", "depends_on": [], "status": "NEW", "alias": [], "product": "Security Response",
-        "cf_fixed_in": "", "cc": [], "qa_contact": "", "is_creator_accessible": true,
-        "version": ["unspecified"], "remaining_time": 0, "creator": "concosta@redhat.com",
-        "priority": "low", "estimated_time": 0, "cf_conditional_nak": [], "creation_time":
-        "2024-04-29T13:28:58Z", "groups": [], "actual_time": 0, "classification":
-        "Other", "deadline": null, "keywords": ["Security"], "is_open": true, "cf_devel_whiteboard":
-        "", "target_milestone": "---", "op_sys": "Linux", "cf_qe_conditional_nak":
-        [], "is_confirmed": true, "cf_major_incident": null, "cf_internal_whiteboard":
-        "", "assigned_to_detail": {"real_name": "Nobody", "id": 29451, "active": true,
-        "name": "nobody@redhat.com", "partner": false, "email": "nobody@redhat.com",
-        "insider": false}, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
-        \"reported\": \"2024-04-29T13:28:55Z\", \"impact\": \"low\", \"source\": \"internet\",
-        \"cwe\": \"CWE-1\"}", "blocks": [], "is_cc_accessible": true, "flags": [],
-        "data_category": "Public", "id": 2023942, "docs_contact": "", "cf_pgm_internal":
-        "", "cf_doc_type": "If docs needed, set a value", "description": "description",
-        "cc_detail": []}]}'
+      string: '{"limit": "20", "total_matches": 1, "bugs": [{"platform": "All", "comments":
+        [{"id": 18005635, "private_groups": [], "is_private": false, "attachment_id":
+        null, "count": 0, "tags": [], "creator": "conrado@redhat.com", "text": "description",
+        "creation_time": "2024-05-21T12:43:44Z", "time": "2024-05-21T12:43:44Z", "bug_id":
+        2279558, "creator_id": 482384}], "cf_embargoed": null, "cc_detail": [], "qa_contact":
+        "", "cf_qe_conditional_nak": [], "cf_cust_facing": "---", "creation_time":
+        "2024-05-21T12:43:44Z", "target_milestone": "---", "cf_doc_type": "If docs
+        needed, set a value", "assigned_to": "prodsec-dev@redhat.com", "cf_major_incident":
+        null, "component": ["vulnerability-draft"], "cf_last_closed": null, "cf_release_notes":
+        "", "alias": [], "cc": [], "is_confirmed": true, "cf_internal_whiteboard":
+        "", "remaining_time": 0, "status": "NEW", "cf_clone_of": null, "actual_time":
+        0, "is_creator_accessible": true, "url": "", "groups": [], "op_sys": "Linux",
+        "target_release": ["---"], "blocks": [], "product": "Security Response", "description":
+        "description", "classification": "Other", "resolution": "", "last_change_time":
+        "2024-05-21T12:43:44Z", "cf_environment": "", "keywords": ["Security"], "priority":
+        "low", "assigned_to_detail": {"email": "prodsec-dev@redhat.com", "active":
+        true, "name": "prodsec-dev@redhat.com", "id": 377884, "partner": false, "real_name":
+        "INVALID USER", "insider": true}, "cf_pm_score": "0", "data_category": "Public",
+        "estimated_time": 0, "is_open": true, "tags": [], "severity": "low", "is_cc_accessible":
+        true, "cf_conditional_nak": [], "depends_on": [], "id": 2279558, "flags":
+        [], "cf_devel_whiteboard": "", "summary": "curl: title", "external_bugs":
+        [], "deadline": null, "version": ["unspecified"], "sub_components": {}, "cf_build_id":
+        "", "creator": "conrado@redhat.com", "cf_qa_whiteboard": "", "dupe_of": null,
+        "creator_detail": {"real_name": "Conrado Costa", "insider": true, "id": 482384,
+        "partner": false, "email": "conrado@redhat.com", "name": "conrado@redhat.com",
+        "active": true}, "docs_contact": "", "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
+        \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
+        \"cwe\": \"CWE-1\"}", "whiteboard": "", "cf_fixed_in": "", "cf_pgm_internal":
+        ""}], "offset": 0}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -922,7 +922,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:01 GMT
+      - Tue, 21 May 2024 12:43:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -932,13 +932,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2077'
+      - '2107'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397340.b9e8e3e
+      - 0.96292117.1716295428.427e86da
       x-rh-edge-request-id:
-      - b9e8e3e
+      - 427e86da
     status:
       code: 200
       message: OK
@@ -956,14 +956,14 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2023942/comment
+    uri: https://example.com/rest/bug/2279558/comment
   response:
     body:
-      string: '{"bugs": {"2023942": {"comments": [{"text": "description", "private_groups":
-        [], "id": 15719380, "count": 0, "tags": [], "bug_id": 2023942, "creation_time":
-        "2024-04-29T13:28:58Z", "attachment_id": null, "is_private": false, "creator":
-        "concosta@redhat.com", "creator_id": 464818, "time": "2024-04-29T13:28:58Z"}]}},
-        "comments": {}}'
+      string: '{"comments": {}, "bugs": {"2279558": {"comments": [{"attachment_id":
+        null, "tags": [], "creator_id": 482384, "bug_id": 2279558, "count": 0, "creator":
+        "conrado@redhat.com", "is_private": false, "creation_time": "2024-05-21T12:43:44Z",
+        "private_groups": [], "time": "2024-05-21T12:43:44Z", "id": 18005635, "text":
+        "description"}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -974,11 +974,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '304'
+      - '303'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:01 GMT
+      - Tue, 21 May 2024 12:43:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -988,9 +988,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397341.b9e90af
+      - 0.96292117.1716295428.427e93eb
       x-rh-edge-request-id:
-      - b9e90af
+      - 427e93eb
     status:
       code: 200
       message: OK
@@ -1135,9 +1135,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:02 GMT
+      - Tue, 21 May 2024 12:43:49 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:02 GMT
+      - Tue, 21 May 2024 12:43:49 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1156,11 +1156,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337333x1
+      - 763x308688x1
       x-asessionid:
-      - 1pqdith
+      - doymc7
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1172,9 +1172,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397342.b9e93a4
+      - 0.88292117.1716295429.48defbd4
       x-rh-edge-request-id:
-      - b9e93a4
+      - 48defbd4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1250,9 +1250,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:02 GMT
+      - Tue, 21 May 2024 12:43:49 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:02 GMT
+      - Tue, 21 May 2024 12:43:49 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1271,11 +1271,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337335x2
+      - 763x308689x1
       x-asessionid:
-      - dvxpe5
+      - v5rhss
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1287,9 +1287,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397342.b9e93bd
+      - 0.88292117.1716295429.48defcf3
       x-rh-edge-request-id:
-      - b9e93bd
+      - 48defcf3
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1299,8 +1299,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "title", "description": "description", "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-      "impact:LOW", "team:yard"], "priority": {"name": "Minor"}}}'
+      "title", "description": "description", "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+      "impact:LOW", "team:memory"], "priority": {"name": "Minor"}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1311,7 +1311,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '239'
+      - '241'
       Content-Type:
       - application/json
       User-Agent:
@@ -1319,7 +1319,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: ''
@@ -1331,9 +1331,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:03 GMT
+      - Tue, 21 May 2024 12:43:51 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:03 GMT
+      - Tue, 21 May 2024 12:43:51 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1347,11 +1347,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337336x2
+      - 763x308690x1
       x-asessionid:
-      - 9y7265
+      - bh3ca8
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1363,9 +1363,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397343.b9e93e9
+      - 0.88292117.1716295431.48defee0
       x-rh-edge-request-id:
-      - b9e93e9
+      - 48defee0
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1391,16 +1391,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -1409,29 +1409,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7ea6616a[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@638a5bfc[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6a6d0a02[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70c7ea63[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@35b0f9a0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4540151[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a89765e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@21f5988c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13ba08eb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3740cd44[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@266a7674[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2b56bbcd[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@68e8131c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@59f3d9a8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13b52c01[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@5cee58e6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d3fa50d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1cbdb4db[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@26525669[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@855032d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28e2c8e7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5988ba4c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6d5d4e0a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@4d3164e7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1856/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2046/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-        "impact:LOW", "team:yard"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+        "impact:LOW", "team:memory"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:29:02.564+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:43:49.973+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -1467,10 +1467,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1479,9 +1479,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:03 GMT
+      - Tue, 21 May 2024 12:43:51 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:03 GMT
+      - Tue, 21 May 2024 12:43:51 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1494,17 +1494,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8780'
+      - '8812'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337338x1
+      - 763x308691x1
       x-asessionid:
-      - 15eu6xa
+      - 1h9le9h
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1516,9 +1516,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397343.b9e95a3
+      - 0.88292117.1716295431.48df0d20
       x-rh-edge-request-id:
-      - b9e95a3
+      - 48df0d20
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1544,7 +1544,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2046/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -1589,9 +1589,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:03 GMT
+      - Tue, 21 May 2024 12:43:51 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:03 GMT
+      - Tue, 21 May 2024 12:43:51 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1610,11 +1610,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337341x2
+      - 763x308692x1
       x-asessionid:
-      - 197rbrs
+      - 55qp8g
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1626,9 +1626,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397343.b9e9635
+      - 0.88292117.1716295431.48df0f45
       x-rh-edge-request-id:
-      - b9e9635
+      - 48df0f45
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1656,7 +1656,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-1856/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2046/transitions
   response:
     body:
       string: ''
@@ -1668,9 +1668,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:04 GMT
+      - Tue, 21 May 2024 12:43:52 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:04 GMT
+      - Tue, 21 May 2024 12:43:52 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1684,11 +1684,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337343x1
+      - 763x308693x1
       x-asessionid:
-      - j9099k
+      - 5zdgro
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1700,9 +1700,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397344.b9e968f
+      - 0.88292117.1716295432.48df108d
       x-rh-edge-request-id:
-      - b9e968f
+      - 48df108d
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1728,16 +1728,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -1746,29 +1746,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@601854d6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5eda460a[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@d4a8a38[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@f464a77[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@f55fea8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@333035e[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61756c6a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1d509de[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21d507f2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3ae7d965[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70bbf46f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5909985f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@506aee1b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@54422982[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@34329ea5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@91a6fa6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2cef6ec1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@47e702bf[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67006b50[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3d3d4f49[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6af3a749[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@15feb252[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@71400156[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@26505f30[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1856/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2046/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-        "impact:LOW", "team:yard"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+        "impact:LOW", "team:memory"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:29:03.986+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:43:51.404+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -1804,10 +1804,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1816,9 +1816,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:04 GMT
+      - Tue, 21 May 2024 12:43:52 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:04 GMT
+      - Tue, 21 May 2024 12:43:52 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1831,17 +1831,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8752'
+      - '8784'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x337345x1
+      - 763x308694x1
       x-asessionid:
-      - 1xffzx8
+      - 1m5vzxd
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1853,13 +1853,536 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.b685d817.1714397344.b9e9813
+      - 0.88292117.1716295432.48df19b0
       x-rh-edge-request-id:
-      - b9e9813
+      - 48df19b0
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295433.427ecc61
+      x-rh-edge-request-id:
+      - 427ecc61
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"id": 1, "can_login": true, "real_name": "Need Real Name",
+        "name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295433.427ed164
+      x-rh-edge-request-id:
+      - 427ed164
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558&include_fields=id&include_fields=last_change_time
+  response:
+    body:
+      string: '{"bugs": [{"data_category": "Public", "id": 2279558, "last_change_time":
+        "2024-05-21T12:43:44Z"}], "total_matches": 1, "limit": "20", "offset": 0}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:54 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295434.427ed9f6
+      x-rh-edge-request-id:
+      - 427ed9f6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
+      "", "severity": "low", "priority": "low", "summary": "curl: title", "keywords":
+      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
+      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
+      \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
+      \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+      \"ps-component-0\", \"affectedness\": \"notaffected\", \"resolution\": null,
+      \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
+      "cf_fixed_in": "", "ids": ["2279558"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '751'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: PUT
+    uri: https://example.com/rest/bug/2279558
+  response:
+    body:
+      string: '{"bugs": [{"id": 2279558, "last_change_time": "2024-05-21T12:43:55Z",
+        "changes": {"component": {"added": "vulnerability", "removed": "vulnerability-draft"},
+        "cf_srtnotes": {"added": "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\":
+        \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\", \"cwe\":
+        \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+        \"ps-component-0\", \"affectedness\": \"notaffected\", \"resolution\": null,
+        \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
+        "removed": "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-05-21T12:43:41Z\",
+        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\"}"}}, "alias":
+        []}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '706'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:55 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295435.427ee712
+      x-rh-edge-request-id:
+      - 427ee712
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295437.427efec7
+      x-rh-edge-request-id:
+      - 427efec7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
+        "can_login": true, "id": 1, "email": "aander07@packetmaster.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:57 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295437.427f0aec
+      x-rh-edge-request-id:
+      - 427f0aec
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558
+  response:
+    body:
+      string: '{"bugs": [{"cf_pgm_internal": "", "qa_contact": "", "external_bugs":
+        [], "assigned_to_detail": {"name": "prodsec-dev@redhat.com", "id": 377884,
+        "partner": false, "real_name": "INVALID USER", "active": true, "insider":
+        true, "email": "prodsec-dev@redhat.com"}, "groups": [], "cf_conditional_nak":
+        [], "product": "Security Response", "alias": [], "op_sys": "Linux", "sub_components":
+        {}, "deadline": null, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
+        \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
+        \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+        \"ps-component-0\", \"affectedness\": \"notaffected\", \"resolution\": null,
+        \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
+        "url": "", "target_release": ["---"], "cc_detail": [], "description": "description",
+        "creator": "conrado@redhat.com", "whiteboard": "", "resolution": "", "tags":
+        [], "status": "NEW", "blocks": [], "cf_internal_whiteboard": "", "is_cc_accessible":
+        true, "platform": "All", "is_open": true, "cf_qa_whiteboard": "", "target_milestone":
+        "---", "cf_embargoed": null, "cf_build_id": "", "estimated_time": 0, "assigned_to":
+        "prodsec-dev@redhat.com", "keywords": ["Security"], "last_change_time": "2024-05-21T12:43:55Z",
+        "dupe_of": null, "version": ["unspecified"], "severity": "low", "cf_cust_facing":
+        "---", "actual_time": 0, "is_creator_accessible": true, "cf_release_notes":
+        "", "depends_on": [], "creator_detail": {"real_name": "Conrado Costa", "active":
+        true, "id": 482384, "name": "conrado@redhat.com", "partner": false, "insider":
+        true, "email": "conrado@redhat.com"}, "component": ["vulnerability"], "docs_contact":
+        "", "cf_doc_type": "If docs needed, set a value", "comments": [{"text": "description",
+        "private_groups": [], "time": "2024-05-21T12:43:44Z", "id": 18005635, "count":
+        0, "creator": "conrado@redhat.com", "is_private": false, "creation_time":
+        "2024-05-21T12:43:44Z", "attachment_id": null, "tags": [], "creator_id": 482384,
+        "bug_id": 2279558}], "data_category": "Public", "remaining_time": 0, "cf_devel_whiteboard":
+        "", "cf_fixed_in": "", "classification": "Other", "priority": "low", "summary":
+        "curl: title", "cf_pm_score": "0", "cc": [], "is_confirmed": true, "cf_environment":
+        "", "flags": [], "creation_time": "2024-05-21T12:43:44Z", "id": 2279558, "cf_last_closed":
+        null, "cf_clone_of": null, "cf_major_incident": null, "cf_qe_conditional_nak":
+        []}], "limit": "20", "offset": 0, "total_matches": 1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:58 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2317'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295438.427f0fc3
+      x-rh-edge-request-id:
+      - 427f0fc3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558
+  response:
+    body:
+      string: '{"total_matches": 1, "limit": "20", "bugs": [{"product": "Security
+        Response", "blocks": [], "target_release": ["---"], "op_sys": "Linux", "last_change_time":
+        "2024-05-21T12:43:55Z", "resolution": "", "classification": "Other", "description":
+        "description", "is_creator_accessible": true, "actual_time": 0, "cf_clone_of":
+        null, "groups": [], "url": "", "alias": [], "cc": [], "status": "NEW", "is_confirmed":
+        true, "cf_internal_whiteboard": "", "remaining_time": 0, "cf_doc_type": "If
+        docs needed, set a value", "cf_release_notes": "", "cf_last_closed": null,
+        "component": ["vulnerability"], "cf_major_incident": null, "assigned_to":
+        "prodsec-dev@redhat.com", "creation_time": "2024-05-21T12:43:44Z", "cf_qe_conditional_nak":
+        [], "cf_cust_facing": "---", "target_milestone": "---", "cc_detail": [], "qa_contact":
+        "", "cf_embargoed": null, "comments": [{"is_private": false, "count": 0, "attachment_id":
+        null, "id": 18005635, "private_groups": [], "text": "description", "tags":
+        [], "creator": "conrado@redhat.com", "time": "2024-05-21T12:43:44Z", "creation_time":
+        "2024-05-21T12:43:44Z", "bug_id": 2279558, "creator_id": 482384}], "platform":
+        "All", "cf_pgm_internal": "", "cf_fixed_in": "", "whiteboard": "", "version":
+        ["unspecified"], "cf_build_id": "", "sub_components": {}, "dupe_of": null,
+        "docs_contact": "", "creator_detail": {"active": true, "email": "conrado@redhat.com",
+        "name": "conrado@redhat.com", "real_name": "Conrado Costa", "insider": true,
+        "id": 482384, "partner": false}, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
+        \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
+        \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+        \"ps-component-0\", \"affectedness\": \"notaffected\", \"resolution\": null,
+        \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
+        "cf_qa_whiteboard": "", "creator": "conrado@redhat.com", "deadline": null,
+        "cf_devel_whiteboard": "", "id": 2279558, "flags": [], "external_bugs": [],
+        "summary": "curl: title", "depends_on": [], "is_open": true, "cf_conditional_nak":
+        [], "is_cc_accessible": true, "severity": "low", "tags": [], "assigned_to_detail":
+        {"active": true, "email": "prodsec-dev@redhat.com", "name": "prodsec-dev@redhat.com",
+        "real_name": "INVALID USER", "insider": true, "id": 377884, "partner": false},
+        "priority": "low", "estimated_time": 0, "data_category": "Public", "cf_pm_score":
+        "0", "cf_environment": "", "keywords": ["Security"]}], "offset": 0}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2317'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295439.427f1d99
+      x-rh-edge-request-id:
+      - 427f1d99
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2279558/comment
+  response:
+    body:
+      string: '{"comments": {}, "bugs": {"2279558": {"comments": [{"attachment_id":
+        null, "tags": [], "creator_id": 482384, "bug_id": 2279558, "count": 0, "creator":
+        "conrado@redhat.com", "is_private": false, "creation_time": "2024-05-21T12:43:44Z",
+        "private_groups": [], "time": "2024-05-21T12:43:44Z", "id": 18005635, "text":
+        "description"}]}}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '303'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:43:59 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295439.427f299f
+      x-rh-edge-request-id:
+      - 427f299f
     status:
       code: 200
       message: OK
@@ -1881,16 +2404,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -1899,29 +2422,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1439b1d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@42455c9d[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@37083aa4[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@36811b5e[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7eb6e73d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@167ffdc2[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28550f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@63e2c794[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2aa44bda[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@43dc22a1[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@19e87f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@74352e38[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7c4751ff[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5e2cbdfc[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@46cd38f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@78a89094[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@17a07651[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@108b61d6[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f2e81c7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3be9a86[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1738665e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5c7630be[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@171db24e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@60006081[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1856/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2046/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-        "impact:LOW", "team:yard"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+        "impact:LOW", "team:memory"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:29:03.986+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:43:51.404+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -1957,10 +2480,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1969,9 +2492,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:00 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1984,17 +2507,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8751'
+      - '8786'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 809x508178x1
+      - 764x297063x1
       x-asessionid:
-      - 14w5rg4
+      - 13049k9
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2006,9 +2529,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397345.12318eb2
+      - 0.96292117.1716295440.427f3750
       x-rh-edge-request-id:
-      - 12318eb2
+      - 427f3750
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2157,9 +2680,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2180,9 +2703,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508179x1
+      - 764x308701x3
       x-asessionid:
-      - 6al412
+      - yuwvf9
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2194,9 +2717,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397345.123191d2
+      - 0.96292117.1716295441.427f3b72
       x-rh-edge-request-id:
-      - 123191d2
+      - 427f3b72
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2272,9 +2795,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2295,9 +2818,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508180x1
+      - 764x308702x1
       x-asessionid:
-      - 1t8lu91
+      - zivy7n
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2309,9 +2832,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397345.123192b7
+      - 0.96292117.1716295441.427f3c5d
       x-rh-edge-request-id:
-      - 123192b7
+      - 427f3c5d
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2321,8 +2844,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "title", "description": "description", "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-      "impact:LOW", "team:yard"], "priority": {"name": "Minor"}}}'
+      "title", "description": "description", "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+      "impact:LOW", "team:memory"], "priority": {"name": "Minor"}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -2333,7 +2856,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '239'
+      - '241'
       Content-Type:
       - application/json
       User-Agent:
@@ -2341,7 +2864,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: ''
@@ -2353,9 +2876,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:05 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2371,9 +2894,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508181x1
+      - 764x308703x1
       x-asessionid:
-      - 1j1yj90
+      - 1y29cuv
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2385,9 +2908,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397345.12319337
+      - 0.96292117.1716295441.427f3d69
       x-rh-edge-request-id:
-      - '12319337'
+      - 427f3d69
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2413,16 +2936,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -2431,29 +2954,29 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7e7f9ab6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49ce2b60[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2ee10ee[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@730050ca[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2bacabd5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@138110eb[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@547992e6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5c8609e6[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@123af3a0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@9a7bf44[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1151e234[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7df400c1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38964b2c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@c7f8ee5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7d7f8145[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@c880820[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2ed9d97e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@55fc0b3[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4ab1cf4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@482ecd49[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@285cef1b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@53fdf8fb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@f6d02cc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3197d2ed[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1856/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2046/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-        "impact:LOW", "team:yard"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+        "impact:LOW", "team:memory"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:29:03.986+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:43:51.404+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
@@ -2489,10 +3012,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2501,9 +3024,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:06 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:06 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2516,7 +3039,7 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8753'
+      - '8782'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2524,9 +3047,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508182x1
+      - 764x308704x1
       x-asessionid:
-      - qvsfzl
+      - 1m1sz2d
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2538,9 +3061,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397346.12319414
+      - 0.96292117.1716295441.427f3e83
       x-rh-edge-request-id:
-      - '12319414'
+      - 427f3e83
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2566,7 +3089,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2046/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -2611,9 +3134,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:06 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:06 GMT
+      - Tue, 21 May 2024 12:44:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2634,9 +3157,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508183x1
+      - 764x308705x1
       x-asessionid:
-      - 1c6wrxb
+      - 10sz8f2
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2648,9 +3171,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397346.12319730
+      - 0.96292117.1716295441.427f4075
       x-rh-edge-request-id:
-      - '12319730'
+      - 427f4075
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2679,7 +3202,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-1856/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-2046/transitions
   response:
     body:
       string: ''
@@ -2691,9 +3214,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:06 GMT
+      - Tue, 21 May 2024 12:44:02 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:06 GMT
+      - Tue, 21 May 2024 12:44:02 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2709,9 +3232,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508185x1
+      - 764x308706x1
       x-asessionid:
-      - 1qpejgx
+      - 15qrmd4
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2723,9 +3246,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397346.1231980f
+      - 0.96292117.1716295442.427f42a1
       x-rh-edge-request-id:
-      - 1231980f
+      - 427f42a1
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2751,16 +3274,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -2770,29 +3293,29 @@ interactions:
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
         "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@520800ef[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d36099f[overall=PullRequestOverallBean{stateCount=0,
+        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7f9aca52[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4c6deb4b[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@17c014a2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7ad78d34[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1dad7abc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@73822b84[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64705452[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2288cbc5[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@54062db2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@363ae2bd[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@500ef2ec[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@34bcddcb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ca24e16[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@5f36d57a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c71b0db[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@674c3515[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9700514[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@60049c45[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@41d21ff6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@47b07e44[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4e618b03[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@a43c03e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-04-29T13:29:06.344+0000", "workratio": -1, "customfield_12316840":
+        "resolutiondate": "2024-05-21T12:44:01.785+0000", "workratio": -1, "customfield_12316840":
         null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
         null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-1856/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000",
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-2046/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000",
         "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
         "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-        "impact:LOW", "team:yard"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "name": "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+        "impact:LOW", "team:memory"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:29:06.357+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:44:01.797+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
         "description": "The issue is closed. See the resolution for context regarding
         why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
         "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
@@ -2828,10 +3351,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2840,9 +3363,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:07 GMT
+      - Tue, 21 May 2024 12:44:02 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:07 GMT
+      - Tue, 21 May 2024 12:44:02 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2855,7 +3378,7 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8943'
+      - '8973'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2863,9 +3386,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 809x508186x1
+      - 764x308707x1
       x-asessionid:
-      - 68cna6
+      - 9yz53d
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2877,13 +3400,527 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397347.12319c22
+      - 0.96292117.1716295442.427f47ef
       x-rh-edge-request-id:
-      - 12319c22
+      - 427f47ef
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:02 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295442.427f4da3
+      x-rh-edge-request-id:
+      - 427f4da3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"real_name": "Need Real Name", "can_login": true, "name":
+        "aander07@packetmaster.com", "id": 1, "email": "aander07@packetmaster.com"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295443.427f4ed5
+      x-rh-edge-request-id:
+      - 427f4ed5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558&include_fields=id&include_fields=last_change_time
+  response:
+    body:
+      string: '{"bugs": [{"last_change_time": "2024-05-21T12:43:55Z", "id": 2279558,
+        "data_category": "Public"}], "total_matches": 1, "offset": 0, "limit": "20"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '134'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:03 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295443.427f518a
+      x-rh-edge-request-id:
+      - 427f518a
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
+      "", "severity": "low", "priority": "low", "summary": "curl: title", "keywords":
+      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
+      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
+      \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
+      \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+      \"ps-component-0\", \"affectedness\": \"notaffected\", \"resolution\": null,
+      \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
+      "cf_fixed_in": "", "ids": ["2279558"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '751'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: PUT
+    uri: https://example.com/rest/bug/2279558
+  response:
+    body:
+      string: '{"bugs": [{"alias": [], "changes": {}, "last_change_time": "2024-05-21T12:43:55Z",
+        "id": 2279558}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295444.427f57f8
+      x-rh-edge-request-id:
+      - 427f57f8
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:04 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295444.427f5f5c
+      x-rh-edge-request-id:
+      - 427f5f5c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com",
+        "can_login": true, "id": 1, "real_name": "Need Real Name"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:05 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295445.427f6029
+      x-rh-edge-request-id:
+      - 427f6029
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558
+  response:
+    body:
+      string: '{"offset": 0, "total_matches": 1, "limit": "20", "bugs": [{"cf_fixed_in":
+        "", "whiteboard": "", "cf_pgm_internal": "", "creator": "conrado@redhat.com",
+        "cf_qa_whiteboard": "", "dupe_of": null, "creator_detail": {"real_name": "Conrado
+        Costa", "insider": true, "id": 482384, "partner": false, "email": "conrado@redhat.com",
+        "name": "conrado@redhat.com", "active": true}, "docs_contact": "", "cf_srtnotes":
+        "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-05-21T12:43:41Z\",
+        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\", \"affects\":
+        [{\"ps_module\": \"ps-module-0\", \"ps_component\": \"ps-component-0\", \"affectedness\":
+        \"notaffected\", \"resolution\": null, \"impact\": \"low\", \"cvss2\": null,
+        \"cvss3\": null, \"cvss4\": null}]}", "cf_build_id": "", "sub_components":
+        {}, "version": ["unspecified"], "deadline": null, "summary": "curl: title",
+        "external_bugs": [], "id": 2279558, "cf_devel_whiteboard": "", "flags": [],
+        "depends_on": [], "tags": [], "is_cc_accessible": true, "severity": "low",
+        "cf_conditional_nak": [], "is_open": true, "cf_pm_score": "0", "data_category":
+        "Public", "estimated_time": 0, "priority": "low", "assigned_to_detail": {"email":
+        "prodsec-dev@redhat.com", "active": true, "name": "prodsec-dev@redhat.com",
+        "insider": true, "real_name": "INVALID USER", "partner": false, "id": 377884},
+        "keywords": ["Security"], "cf_environment": "", "description": "description",
+        "classification": "Other", "resolution": "", "last_change_time": "2024-05-21T12:43:55Z",
+        "op_sys": "Linux", "target_release": ["---"], "blocks": [], "product": "Security
+        Response", "url": "", "groups": [], "cf_clone_of": null, "actual_time": 0,
+        "is_creator_accessible": true, "cf_internal_whiteboard": "", "remaining_time":
+        0, "is_confirmed": true, "status": "NEW", "alias": [], "cc": [], "assigned_to":
+        "prodsec-dev@redhat.com", "cf_major_incident": null, "component": ["vulnerability"],
+        "cf_last_closed": null, "cf_release_notes": "", "cf_doc_type": "If docs needed,
+        set a value", "target_milestone": "---", "cf_cust_facing": "---", "cf_qe_conditional_nak":
+        [], "creation_time": "2024-05-21T12:43:44Z", "qa_contact": "", "cc_detail":
+        [], "cf_embargoed": null, "platform": "All", "comments": [{"creator_id": 482384,
+        "bug_id": 2279558, "time": "2024-05-21T12:43:44Z", "creation_time": "2024-05-21T12:43:44Z",
+        "creator": "conrado@redhat.com", "tags": [], "text": "description", "private_groups":
+        [], "id": 18005635, "attachment_id": null, "count": 0, "is_private": false}]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:06 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2317'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295446.427f61fd
+      x-rh-edge-request-id:
+      - 427f61fd
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2279558
+  response:
+    body:
+      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"classification":
+        "Other", "summary": "curl: title", "priority": "low", "cf_pm_score": "0",
+        "cc": [], "comments": [{"text": "description", "id": 18005635, "time": "2024-05-21T12:43:44Z",
+        "private_groups": [], "creator": "conrado@redhat.com", "count": 0, "creation_time":
+        "2024-05-21T12:43:44Z", "is_private": false, "tags": [], "attachment_id":
+        null, "bug_id": 2279558, "creator_id": 482384}], "data_category": "Public",
+        "remaining_time": 0, "cf_fixed_in": "", "cf_devel_whiteboard": "", "id": 2279558,
+        "cf_last_closed": null, "cf_clone_of": null, "cf_major_incident": null, "cf_qe_conditional_nak":
+        [], "is_confirmed": true, "cf_environment": "", "flags": [], "creation_time":
+        "2024-05-21T12:43:44Z", "version": ["unspecified"], "severity": "low", "cf_cust_facing":
+        "---", "actual_time": 0, "cf_build_id": "", "cf_embargoed": null, "keywords":
+        ["Security"], "estimated_time": 0, "assigned_to": "prodsec-dev@redhat.com",
+        "last_change_time": "2024-05-21T12:43:55Z", "dupe_of": null, "component":
+        ["vulnerability"], "docs_contact": "", "cf_doc_type": "If docs needed, set
+        a value", "is_creator_accessible": true, "depends_on": [], "cf_release_notes":
+        "", "creator_detail": {"partner": false, "id": 482384, "name": "conrado@redhat.com",
+        "active": true, "real_name": "Conrado Costa", "email": "conrado@redhat.com",
+        "insider": true}, "whiteboard": "", "creator": "conrado@redhat.com", "is_cc_accessible":
+        true, "platform": "All", "is_open": true, "target_milestone": "---", "cf_qa_whiteboard":
+        "", "resolution": "", "tags": [], "status": "NEW", "blocks": [], "cf_internal_whiteboard":
+        "", "assigned_to_detail": {"email": "prodsec-dev@redhat.com", "insider": true,
+        "active": true, "real_name": "INVALID USER", "partner": false, "id": 377884,
+        "name": "prodsec-dev@redhat.com"}, "groups": [], "cf_pgm_internal": "", "qa_contact":
+        "", "external_bugs": [], "deadline": null, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
+        \"reported\": \"2024-05-21T12:43:41Z\", \"impact\": \"low\", \"source\": \"internet\",
+        \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
+        \"ps-component-0\", \"affectedness\": \"notaffected\", \"resolution\": null,
+        \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
+        "url": "", "target_release": ["---"], "cc_detail": [], "description": "description",
+        "cf_conditional_nak": [], "product": "Security Response", "alias": [], "op_sys":
+        "Linux", "sub_components": {}}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2317'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295447.427f6ba7
+      x-rh-edge-request-id:
+      - 427f6ba7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2279558/comment
+  response:
+    body:
+      string: '{"bugs": {"2279558": {"comments": [{"private_groups": [], "id": 18005635,
+        "count": 0, "attachment_id": null, "is_private": false, "creator": "conrado@redhat.com",
+        "tags": [], "text": "description", "bug_id": 2279558, "creation_time": "2024-05-21T12:43:44Z",
+        "time": "2024-05-21T12:43:44Z", "creator_id": 482384}]}}, "comments": {}}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '303'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 21 May 2024 12:44:07 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.96292117.1716295447.427f72b4
+      x-rh-edge-request-id:
+      - 427f72b4
     status:
       code: 200
       message: OK
@@ -2905,16 +3942,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1856
+    uri: https://example.com/rest/api/2/issue/OSIM-2046
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15883169", "self": "https://example.com/rest/api/2/issue/15883169",
-        "key": "OSIM-1856", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15890122", "self": "https://example.com/rest/api/2/issue/15890122",
+        "key": "OSIM-2046", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -2924,29 +3961,29 @@ interactions:
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
         "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@610188a5[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7bb8b592[overall=PullRequestOverallBean{stateCount=0,
+        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1eada635[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9ae7091[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2f1b8b0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3c5b9959[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@257da6dd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@882410d[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7b94c95[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@67c88c6a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2f4b9500[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@35db33cd[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@78cb0c07[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5bc364a8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67dbc705[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1d0b1997[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f08ecdb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@69b76995[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@50ed6849[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@15ef1462[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@d994c30[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5fb077d7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64a4e348[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@985a7ba[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-04-29T13:29:06.344+0000", "workratio": -1, "customfield_12316840":
+        "resolutiondate": "2024-05-21T12:44:01.785+0000", "workratio": -1, "customfield_12316840":
         null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
         null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-1856/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-04-29T13:28:55.633+0000",
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-2046/watchers",
+        "watchCount": 1, "isWatching": true}, "created": "2024-05-21T12:43:41.909+0000",
         "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
         "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:47452024-7dbe-44da-9fc3-39befef0fa0a",
-        "impact:LOW", "team:yard"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
+        "name": "Minor", "id": "4"}, "labels": ["flawuuid:f3e95168-2d39-4cd1-acc9-fc163658fc41",
+        "impact:LOW", "team:memory"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-04-29T13:29:06.357+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "updated": "2024-05-21T12:44:01.797+0000", "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
         "description": "The issue is closed. See the resolution for context regarding
         why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
         "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
@@ -2982,10 +4019,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1856/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2046/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecg0w:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zedk0g:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2994,9 +4031,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 29 Apr 2024 13:29:07 GMT
+      - Tue, 21 May 2024 12:44:08 GMT
       Expires:
-      - Mon, 29 Apr 2024 13:29:07 GMT
+      - Tue, 21 May 2024 12:44:08 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3009,17 +4046,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8940'
+      - '8972'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 809x508188x1
+      - 764x297070x1
       x-asessionid:
-      - optagl
+      - 19oippr
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3031,9 +4068,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.c585d817.1714397347.12318fe8
+      - 0.96292117.1716295448.427f395e
       x-rh-edge-request-id:
-      - 12318fe8
+      - 427f395e
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -589,19 +589,20 @@ class TestBugzillaJiraMixinInteration:
         PsModuleFactory(name="ps-module-0")
         assert flaw.bz_id
         assert flaw.task_key
+        assert flaw.meta_attr["bz_component"] == "vulnerability-draft"
 
         AffectFactory(flaw=flaw, ps_module="ps-module-0")
         flaw = Flaw.objects.get(pk=flaw.uuid)
 
-        flaw.promote(jira_token=jira_token)
+        flaw.promote(jira_token=jira_token, bz_api_key=bz_token)
         assert flaw.workflow_state == WorkflowModel.WorkflowState.TRIAGE
+        assert flaw.meta_attr["bz_component"] == "vulnerability"
 
         jtq = JiraTaskmanQuerier(jira_token)
 
         issue = jtq.jira_conn.issue(flaw.task_key).raw
         assert issue["fields"]["status"]["name"] == "Refinement"
-
-        flaw.reject(jira_token=jira_token)
+        flaw.reject(jira_token=jira_token, bz_api_key=bz_token)
         assert flaw.workflow_state == WorkflowModel.WorkflowState.REJECTED
 
         issue = jtq.jira_conn.issue(flaw.task_key).raw
@@ -646,6 +647,7 @@ class TestBugzillaJiraMixinInteration:
         PsModuleFactory(name="ps-module-0")
         assert flaw.bz_id
         assert flaw.task_key
+        assert flaw.meta_attr["bz_component"] == "vulnerability-draft"
 
         AffectFactory(flaw=flaw, ps_module="ps-module-0")
 
@@ -658,6 +660,7 @@ class TestBugzillaJiraMixinInteration:
 
         flaw = Flaw.objects.get(pk=created_uuid)
         assert flaw.workflow_state == WorkflowModel.WorkflowState.TRIAGE
+        assert flaw.meta_attr["bz_component"] == "vulnerability"
 
         jtq = JiraTaskmanQuerier(jira_token)
 


### PR DESCRIPTION
This PR removes team as prerequisite for  PRE_SECONDARY_ASSESSMENT state.
This PR also make Bugzilla token a mandatory header for promoting / rejecting a Flaw since it need to be synchronized to Bugzilla.

Closes OSIDB-2262.