### PR TITLE
Fix FlawReference article count validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)
 - Fix workflow rejection endpoint (OSIDB-2456)
+- Fix FlawReference article count validation (OSIDB-2651)
 
 ## [3.7.2] - 2024-05-17
 ### Fixed

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -3290,14 +3290,23 @@ class FlawReference(ACLMixin, BugzillaSyncMixin, TrackingMixin):
         """
         Checks that a flaw has maximally one article link.
         """
+        old_reference = FlawReference.objects.filter(uuid=self.uuid).first()
+        article_count = 0
+        if self.type == FlawReference.FlawReferenceType.ARTICLE:
+            if (
+                not old_reference
+                or old_reference.type != FlawReference.FlawReferenceType.ARTICLE
+            ):
+                article_count = 1
+
         article_links = self.flaw.references.filter(
             type=FlawReference.FlawReferenceType.ARTICLE
         )
+        article_count += article_links.count()
 
-        if article_links.count() > 1:
+        if article_count > 1:
             raise ValidationError(
-                f"A flaw has {article_links.count()} article links, "
-                f"but only 1 is allowed."
+                f"A flaw has {article_count} article links, but only 1 is allowed."
             )
 
     def bzsync(self, *args, bz_api_key, **kwargs):


### PR DESCRIPTION
This PR changes article validation to consider creation scenario.

This PR also remove `.save()` from the validation test, this would make the test pass since it saves the model twice.

Closes OSIDB-2651.