### PR TITLE
Add reported_dt to flaw drafts

### DIFF
--- a/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[NVD-CVE-2000-0048-CVE-2000-0048-OSIM-2470].yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[NVD-CVE-2000-0048-CVE-2000-0048-OSIM-2470].yaml
@@ -140,9 +140,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:01 GMT
+      - Tue, 28 May 2024 13:11:27 GMT
       Expires:
-      - Wed, 15 May 2024 11:27:01 GMT
+      - Tue, 28 May 2024 13:11:27 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -161,11 +161,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 687x44912x1
+      - 791x731744x1
       x-asessionid:
-      - r32u8
+      - f7b0tm
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -177,9 +177,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772421.1803c9cb
+      - 0.7df06e68.1716901887.2132e51
       x-rh-edge-request-id:
-      - 1803c9cb
+      - 2132e51
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -255,9 +255,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:01 GMT
+      - Tue, 28 May 2024 13:11:27 GMT
       Expires:
-      - Wed, 15 May 2024 11:27:01 GMT
+      - Tue, 28 May 2024 13:11:27 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -276,11 +276,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 687x44913x1
+      - 791x731745x1
       x-asessionid:
-      - 1utv3hc
+      - 1yar8jj
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -292,9 +292,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772421.1803ca2b
+      - 0.7df06e68.1716901887.2132f02
       x-rh-edge-request-id:
-      - 1803ca2b
+      - 2132f02
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -304,8 +304,9 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "From OSV collector", "description": "some description", "labels": ["flawuuid:338ee234-82bd-4767-9ebc-8020117ab512",
-      "impact:"], "priority": {"name": "Undefined"}}}'
+      "CVE-2000-0048 From NVD collector", "description": "some description", "labels":
+      ["flawuuid:1b190431-491e-4330-8b95-b1472af3e432", "impact:"], "priority": {"name":
+      "Undefined"}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -316,7 +317,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '245'
+      - '259'
       Content-Type:
       - application/json
       User-Agent:
@@ -327,18 +328,18 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "15885944", "key": "OSIM-1987", "self": "https://example.com/rest/api/2/issue/15885944"}'
+      string: '{"id": "15925606", "key": "OSIM-2470", "self": "https://example.com/rest/api/2/issue/15925606"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - close
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:03 GMT
+      - Tue, 28 May 2024 13:11:28 GMT
       Expires:
-      - Wed, 15 May 2024 11:27:03 GMT
+      - Tue, 28 May 2024 13:11:28 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -357,11 +358,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 687x44914x1
+      - 791x731746x1
       x-asessionid:
-      - puqwe6
+      - 1in4r81
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -373,9 +374,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772423.1803cac1
+      - 0.7df06e68.1716901888.2132fcd
       x-rh-edge-request-id:
-      - 1803cac1
+      - 2132fcd
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -401,16 +402,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1987
+    uri: https://example.com/rest/api/2/issue/OSIM-2470
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15885944", "self": "https://example.com/rest/api/2/issue/15885944",
-        "key": "OSIM-1987", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15925606", "self": "https://example.com/rest/api/2/issue/15925606",
+        "key": "OSIM-2470", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12324461": [], "customfield_12318341": null, "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -419,28 +420,28 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@cbace3d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4d9a4c9b[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2c8e9628[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4ac04b4e[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f3e17fe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@205f7a16[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2390951f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@39176acb[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@76591bf0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2d8d50e7[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a120024[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@851629f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@36696efe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@71240abc[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@56e13f1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4dbcb229[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@60b85d7b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@72aec4c3[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@72ab0fc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2faf77ca[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@d5ea4c1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@952e175[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5b2d1df3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@f68307b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1987/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-05-15T11:27:02.092+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2470/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-28T13:11:27.868+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:338ee234-82bd-4767-9ebc-8020117ab512",
+        "Undefined", "id": "10300"}, "labels": ["flawuuid:1b190431-491e-4330-8b95-b1472af3e432",
         "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
-        null, "assignee": null, "updated": "2024-05-15T11:27:02.092+0000", "customfield_12313942":
+        null, "assignee": null, "updated": "2024-05-28T13:11:27.868+0000", "customfield_12313942":
         null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
@@ -452,10 +453,10 @@ interactions:
         [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
         null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "From OSV
-        collector", "customfield_12323640": null, "customfield_12323642": null, "creator":
-        {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
+        "9223372036854775807", "customfield_12316544": "None", "customfield_12323640":
+        null, "summary": "CVE-2000-0048 From NVD collector", "customfield_12323642":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
         "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
         "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
@@ -477,10 +478,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1987/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2470/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zeculc:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zejnww:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -489,9 +490,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:03 GMT
+      - Tue, 28 May 2024 13:11:29 GMT
       Expires:
-      - Wed, 15 May 2024 11:27:03 GMT
+      - Tue, 28 May 2024 13:11:29 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -504,17 +505,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8763'
+      - '8775'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 687x44915x1
+      - 791x731747x1
       x-asessionid:
-      - 1nxzzqd
+      - sh2o1g
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -526,9 +527,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772423.1c0887c
+      - 0.7df06e68.1716901889.2133367
       x-rh-edge-request-id:
-      - 1c0887c
+      - '2133367'
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -568,7 +569,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:03 GMT
+      - Tue, 28 May 2024 13:11:29 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -578,9 +579,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772423.1c088b0
+      - 0.64f06e68.1716901889.148cef19
       x-rh-edge-request-id:
-      - 1c088b0
+      - 148cef19
     status:
       code: 200
       message: OK
@@ -601,8 +602,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "id": 1, "real_name":
-        "Need Real Name", "email": "aander07@packetmaster.com", "can_login": true}]}'
+      string: '{"users": [{"real_name": "Need Real Name", "can_login": true, "id":
+        1, "name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -617,7 +618,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:04 GMT
+      - Tue, 28 May 2024 13:11:29 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -627,22 +628,23 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772424.1c088da
+      - 0.64f06e68.1716901889.148cefb8
       x-rh-edge-request-id:
-      - 1c088da
+      - 148cefb8
     status:
       code: 200
       message: OK
 - request:
     body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
       "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
-      "", "severity": "unspecified", "priority": "unspecified", "summary": "From OSV
-      collector", "description": "some description", "comment_is_private": false,
-      "alias": ["GHSA-0009"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
-      "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GHSA-0009\"], \"references\":
-      [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-0009\",
-      \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-      \"source\": \"osv\", \"cwe\": \"CWE-110\"}"}'
+      "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2000-0048
+      From NVD collector", "description": "some description", "comment_is_private":
+      false, "alias": ["CVE-2000-0048"], "keywords": ["Security"], "flags": [], "groups":
+      ["redhat"], "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-28T13:11:26Z\",
+      \"external_ids\": [\"CVE-2000-0048\"], \"references\": [{\"type\": \"source\",
+      \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2000-0048\", \"description\":
+      null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"source\":
+      \"nvd\", \"cwe\": \"CWE-110\"}"}'
     headers:
       Accept:
       - '*/*'
@@ -651,7 +653,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '683'
+      - '752'
       Content-Type:
       - application/json
       User-Agent:
@@ -660,7 +662,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2038326}'
+      string: '{"id": 2280633}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -675,7 +677,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:05 GMT
+      - Tue, 28 May 2024 13:11:31 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -685,9 +687,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772425.1c08907
+      - 0.64f06e68.1716901891.148cf116
       x-rh-edge-request-id:
-      - 1c08907
+      - 148cf116
     status:
       code: 200
       message: OK
@@ -723,7 +725,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:06 GMT
+      - Tue, 28 May 2024 13:11:31 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -733,9 +735,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772426.1c0896d
+      - 0.7df06e68.1716901891.2133f79
       x-rh-edge-request-id:
-      - 1c0896d
+      - 2133f79
     status:
       code: 200
       message: OK
@@ -756,8 +758,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "id": 1, "real_name":
-        "Need Real Name", "email": "aander07@packetmaster.com", "can_login": true}]}'
+      string: '{"users": [{"can_login": true, "real_name": "Need Real Name", "email":
+        "aander07@packetmaster.com", "name": "aander07@packetmaster.com", "id": 1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -772,7 +774,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:06 GMT
+      - Tue, 28 May 2024 13:11:32 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -782,9 +784,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772426.1c08989
+      - 0.7df06e68.1716901892.2134077
       x-rh-edge-request-id:
-      - 1c08989
+      - '2134077'
     status:
       code: 200
       message: OK
@@ -802,119 +804,41 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2038326
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280633
   response:
     body:
-      string: '{"limit": "20", "offset": 0, "total_matches": 1, "bugs": [{"cf_doc_type":
-        "If docs needed, set a value", "assigned_to": "nobody@redhat.com", "summary":
-        "From OSV collector", "cf_qa_whiteboard": "", "tags": [], "cf_conditional_nak":
-        [], "cc_detail": [], "is_cc_accessible": true, "comments": [{"tags": [], "creator":
-        "nobody@redhat.com", "time": "2024-05-15T11:27:05Z", "id": 15734115, "count":
-        0, "text": "some description", "is_private": false, "attachment_id": null,
-        "private_groups": [], "creation_time": "2024-05-15T11:27:05Z", "creator_id":
-        425662, "bug_id": 2038326}], "description": "some description", "cf_embargoed":
-        null, "assigned_to_detail": {"active": true, "name": "nobody@redhat.com",
-        "id": 29451, "email": "nobody@redhat.com", "partner": false, "real_name":
-        "Nobody", "insider": false}, "blocks": [], "cf_devel_whiteboard": "", "component":
-        ["vulnerability-draft"], "cf_qe_conditional_nak": [], "id": 2038326, "cf_last_closed":
-        null, "target_release": ["---"], "estimated_time": 0, "cf_environment": "",
-        "cf_build_id": "", "creation_time": "2024-05-15T11:27:05Z", "deadline": null,
-        "remaining_time": 0, "cf_release_notes": "", "data_category": "Red Hat", "is_confirmed":
-        true, "severity": "unspecified", "url": "", "platform": "All", "groups": ["redhat"],
-        "whiteboard": "", "cf_srtnotes": "{\"external_ids\": [\"GHSA-0009\"], \"references\":
-        [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0009\",
-        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "actual_time": 0, "creator":
-        "nobody@redhat.com", "cf_clone_of": null, "flags": [], "cf_pm_score": "0",
-        "depends_on": [], "creator_detail": {"real_name": "nobody", "insider":
-        true, "partner": false, "active": true, "name": "nobody@redhat.com", "email":
-        "nobody@redhat.com", "id": 425662}, "external_bugs": [], "cf_major_incident":
-        null, "target_milestone": "---", "classification": "Other", "cf_cust_facing":
-        "---", "alias": ["GHSA-0009"], "version": ["unspecified"], "priority": "unspecified",
-        "resolution": "", "product": "Security Response", "cc": [], "last_change_time":
-        "2024-05-15T11:27:05Z", "cf_fixed_in": "", "docs_contact": "", "cf_internal_whiteboard":
-        "", "sub_components": {}, "keywords": ["Security"], "op_sys": "Linux", "status":
-        "NEW", "cf_pgm_internal": "", "is_open": true, "qa_contact": "", "dupe_of":
-        null, "is_creator_accessible": true}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Wed, 15 May 2024 11:27:07 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2262'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.7df06e68.1715772427.1c089a9
-      x-rh-edge-request-id:
-      - 1c089a9
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2038326
-  response:
-    body:
-      string: '{"total_matches": 1, "offset": 0, "limit": "20", "bugs": [{"description":
-        "some description", "cf_embargoed": null, "assigned_to_detail": {"partner":
-        false, "id": 29451, "email": "nobody@redhat.com", "name": "nobody@redhat.com",
-        "active": true, "insider": false, "real_name": "Nobody"}, "blocks": [], "cf_doc_type":
-        "If docs needed, set a value", "assigned_to": "nobody@redhat.com", "cf_qa_whiteboard":
-        "", "summary": "From OSV collector", "tags": [], "cf_conditional_nak": [],
-        "cc_detail": [], "is_cc_accessible": true, "comments": [{"attachment_id":
-        null, "private_groups": [], "text": "some description", "is_private": false,
-        "bug_id": 2038326, "creation_time": "2024-05-15T11:27:05Z", "creator_id":
-        425662, "time": "2024-05-15T11:27:05Z", "id": 15734115, "tags": [], "creator":
-        "nobody@redhat.com", "count": 0}], "target_release": ["---"], "cf_environment":
-        "", "estimated_time": 0, "cf_build_id": "", "creation_time": "2024-05-15T11:27:05Z",
-        "remaining_time": 0, "deadline": null, "is_confirmed": true, "data_category":
-        "Red Hat", "cf_release_notes": "", "component": ["vulnerability-draft"], "cf_devel_whiteboard":
-        "", "cf_qe_conditional_nak": [], "id": 2038326, "cf_last_closed": null, "cf_major_incident":
-        null, "depends_on": [], "creator_detail": {"real_name": "nobody",
-        "insider": true, "partner": false, "active": true, "email": "nobody@redhat.com",
-        "name": "nobody@redhat.com", "id": 425662}, "external_bugs": [], "classification":
-        "Other", "target_milestone": "---", "cf_cust_facing": "---", "alias": ["GHSA-0009"],
-        "version": ["unspecified"], "priority": "unspecified", "severity": "unspecified",
-        "url": "", "platform": "All", "whiteboard": "", "groups": ["redhat"], "creator":
-        "nobody@redhat.com", "cf_clone_of": null, "actual_time": 0, "cf_srtnotes":
-        "{\"external_ids\": [\"GHSA-0009\"], \"references\": [{\"type\": \"source\",
-        \"url\": \"https://example.com/vulnerability/GHSA-0009\", \"description\":
+      string: '{"limit": "20", "offset": 0, "bugs": [{"description": "some description",
+        "dupe_of": null, "cf_srtnotes": "{\"reported\": \"2024-05-28T13:11:26Z\",
+        \"external_ids\": [\"CVE-2000-0048\"], \"references\": [{\"type\": \"source\",
+        \"url\": \"https://example.com/vuln/detail/CVE-2000-0048\", \"description\":
         null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"source\":
-        \"osv\", \"cwe\": \"CWE-110\"}", "cf_pm_score": "0", "flags": [], "cf_internal_whiteboard":
-        "", "sub_components": {}, "keywords": ["Security"], "op_sys": "Linux", "cf_pgm_internal":
-        "", "status": "NEW", "is_open": true, "dupe_of": null, "qa_contact": "", "is_creator_accessible":
-        true, "product": "Security Response", "resolution": "", "last_change_time":
-        "2024-05-15T11:27:05Z", "cc": [], "cf_fixed_in": "", "docs_contact": ""}]}'
+        \"nvd\", \"cwe\": \"CWE-110\"}", "id": 2280633, "keywords": ["Security"],
+        "depends_on": [], "cf_major_incident": null, "is_cc_accessible": true, "cc":
+        [], "cc_detail": [], "cf_internal_whiteboard": "", "cf_conditional_nak": [],
+        "cf_clone_of": null, "creator_detail": {"active": true, "name": "nobody@redhat.com",
+        "email": "nobody@redhat.com", "real_name": "nobody", "partner":
+        false, "id": 425662, "insider": true}, "cf_embargoed": null, "priority": "unspecified",
+        "remaining_time": 0, "docs_contact": "", "cf_qe_conditional_nak": [], "resolution":
+        "", "cf_environment": "", "whiteboard": "", "cf_last_closed": null, "product":
+        "Security Response", "data_category": "Red Hat", "component": ["vulnerability-draft"],
+        "op_sys": "Linux", "last_change_time": "2024-05-28T13:11:30Z", "cf_pm_score":
+        "0", "is_confirmed": true, "cf_cust_facing": "---", "is_creator_accessible":
+        true, "cf_doc_type": "If docs needed, set a value", "qa_contact": "", "severity":
+        "unspecified", "target_milestone": "---", "cf_fixed_in": "", "actual_time":
+        0, "is_open": true, "cf_devel_whiteboard": "", "groups": ["redhat"], "target_release":
+        ["---"], "alias": ["CVE-2000-0048"], "creator": "nobody@redhat.com", "cf_build_id":
+        "", "sub_components": {}, "assigned_to_detail": {"insider": true, "id": 377884,
+        "active": true, "name": "prodsec-dev@redhat.com", "real_name": "INVALID USER",
+        "email": "prodsec-dev@redhat.com", "partner": false}, "blocks": [], "assigned_to":
+        "prodsec-dev@redhat.com", "creation_time": "2024-05-28T13:11:30Z", "url":
+        "", "version": ["unspecified"], "comments": [{"id": 18006765, "text": "some
+        description", "creator_id": 425662, "creator": "nobody@redhat.com", "attachment_id":
+        null, "private_groups": [], "bug_id": 2280633, "time": "2024-05-28T13:11:30Z",
+        "tags": [], "count": 0, "creation_time": "2024-05-28T13:11:30Z", "is_private":
+        false}], "cf_qa_whiteboard": "", "external_bugs": [], "estimated_time": 0,
+        "flags": [], "summary": "CVE-2000-0048 From NVD collector", "tags": [], "platform":
+        "All", "deadline": null, "cf_release_notes": "", "classification": "Other",
+        "cf_pgm_internal": "", "status": "NEW"}], "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -927,7 +851,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:08 GMT
+      - Tue, 28 May 2024 13:11:33 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -937,13 +861,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2262'
+      - '2352'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772428.1c08a3b
+      - 0.7df06e68.1716901893.21342f1
       x-rh-edge-request-id:
-      - 1c08a3b
+      - 21342f1
     status:
       code: 200
       message: OK
@@ -961,14 +885,94 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2038326/comment
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280633
   response:
     body:
-      string: '{"comments": {}, "bugs": {"2038326": {"comments": [{"time": "2024-05-15T11:27:05Z",
-        "id": 15734115, "attachment_id": null, "is_private": false, "text": "some
-        description", "creator_id": 425662, "count": 0, "bug_id": 2038326, "creation_time":
-        "2024-05-15T11:27:05Z", "tags": [], "creator": "nobody@redhat.com", "private_groups":
-        []}]}}}'
+      string: '{"offset": 0, "limit": "20", "bugs": [{"cf_qa_whiteboard": "", "url":
+        "", "version": ["unspecified"], "comments": [{"time": "2024-05-28T13:11:30Z",
+        "bug_id": 2280633, "tags": [], "creation_time": "2024-05-28T13:11:30Z", "count":
+        0, "is_private": false, "id": 18006765, "text": "some description", "creator_id":
+        425662, "creator": "nobody@redhat.com", "private_groups": [], "attachment_id":
+        null}], "blocks": [], "assigned_to_detail": {"real_name": "INVALID USER",
+        "email": "prodsec-dev@redhat.com", "partner": false, "active": true, "name":
+        "prodsec-dev@redhat.com", "insider": true, "id": 377884}, "assigned_to": "prodsec-dev@redhat.com",
+        "creation_time": "2024-05-28T13:11:30Z", "status": "NEW", "cf_pgm_internal":
+        "", "cf_release_notes": "", "deadline": null, "classification": "Other", "tags":
+        [], "platform": "All", "estimated_time": 0, "external_bugs": [], "flags":
+        [], "summary": "CVE-2000-0048 From NVD collector", "qa_contact": "", "cf_doc_type":
+        "If docs needed, set a value", "severity": "unspecified", "target_milestone":
+        "---", "is_creator_accessible": true, "is_confirmed": true, "cf_cust_facing":
+        "---", "op_sys": "Linux", "last_change_time": "2024-05-28T13:11:30Z", "cf_pm_score":
+        "0", "cf_build_id": "", "sub_components": {}, "groups": ["redhat"], "target_release":
+        ["---"], "creator": "nobody@redhat.com", "alias": ["CVE-2000-0048"], "actual_time":
+        0, "is_open": true, "cf_devel_whiteboard": "", "cf_fixed_in": "", "cf_qe_conditional_nak":
+        [], "remaining_time": 0, "docs_contact": "", "cf_conditional_nak": [], "cf_clone_of":
+        null, "creator_detail": {"partner": false, "email": "nobody@redhat.com",
+        "real_name": "nobody", "name": "nobody@redhat.com", "active": true,
+        "id": 425662, "insider": true}, "cf_embargoed": null, "priority": "unspecified",
+        "cf_major_incident": null, "is_cc_accessible": true, "cc": [], "cc_detail":
+        [], "cf_internal_whiteboard": "", "product": "Security Response", "data_category":
+        "Red Hat", "component": ["vulnerability-draft"], "cf_last_closed": null, "resolution":
+        "", "whiteboard": "", "cf_environment": "", "cf_srtnotes": "{\"reported\":
+        \"2024-05-28T13:11:26Z\", \"external_ids\": [\"CVE-2000-0048\"], \"references\":
+        [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2000-0048\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"nvd\", \"cwe\": \"CWE-110\"}", "id": 2280633, "dupe_of": null,
+        "description": "some description", "depends_on": [], "keywords": ["Security"]}],
+        "total_matches": 1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Tue, 28 May 2024 13:11:34 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2352'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1716901894.21348ab
+      x-rh-edge-request-id:
+      - 21348ab
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2280633/comment
+  response:
+    body:
+      string: '{"comments": {}, "bugs": {"2280633": {"comments": [{"text": "some description",
+        "id": 18006765, "attachment_id": null, "private_groups": [], "creator": "nobody@redhat.com",
+        "creator_id": 425662, "tags": [], "bug_id": 2280633, "time": "2024-05-28T13:11:30Z",
+        "is_private": false, "count": 0, "creation_time": "2024-05-28T13:11:30Z"}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -983,7 +987,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:08 GMT
+      - Tue, 28 May 2024 13:11:34 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -993,9 +997,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772428.1c08ade
+      - 0.7df06e68.1716901894.2134d26
       x-rh-edge-request-id:
-      - 1c08ade
+      - 2134d26
     status:
       code: 200
       message: OK

--- a/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-CVE-2000-0049-GHSA-0012-OSIM-2471].yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-CVE-2000-0049-GHSA-0012-OSIM-2471].yaml
@@ -140,9 +140,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:53 GMT
+      - Tue, 28 May 2024 13:11:36 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:53 GMT
+      - Tue, 28 May 2024 13:11:36 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -161,11 +161,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 686x44900x1
+      - 791x731749x1
       x-asessionid:
-      - 1hzpalj
+      - oi1iky
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -177,9 +177,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772413.1c081f1
+      - 0.64f06e68.1716901896.148d030c
       x-rh-edge-request-id:
-      - 1c081f1
+      - 148d030c
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -255,9 +255,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:53 GMT
+      - Tue, 28 May 2024 13:11:36 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:53 GMT
+      - Tue, 28 May 2024 13:11:36 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -276,11 +276,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 686x44901x1
+      - 791x731750x1
       x-asessionid:
-      - 1v96w7u
+      - 1nuwsiy
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -292,9 +292,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772413.1c0820b
+      - 0.64f06e68.1716901896.148d04fc
       x-rh-edge-request-id:
-      - 1c0820b
+      - 148d04fc
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -304,8 +304,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "CVE-2000-0044 From OSV collector", "description": "some description", "labels":
-      ["flawuuid:fb9632ef-884c-4a72-a3ed-576fbd121882", "impact:"], "priority": {"name":
+      "CVE-2000-0049 From OSV collector", "description": "some description", "labels":
+      ["flawuuid:a1f8ed1c-9f10-4407-b970-8c3b969f229a", "impact:"], "priority": {"name":
       "Undefined"}}}'
     headers:
       Accept:
@@ -328,7 +328,7 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "15885943", "key": "OSIM-1986", "self": "https://example.com/rest/api/2/issue/15885943"}'
+      string: '{"id": "15925607", "key": "OSIM-2471", "self": "https://example.com/rest/api/2/issue/15925607"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -338,9 +338,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:54 GMT
+      - Tue, 28 May 2024 13:11:38 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:54 GMT
+      - Tue, 28 May 2024 13:11:38 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -361,11 +361,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 686x44902x1
+      - 791x731751x1
       x-asessionid:
-      - 1pr7tjh
+      - sh8lgc
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -377,9 +377,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772414.1c08227
+      - 0.64f06e68.1716901898.148d0593
       x-rh-edge-request-id:
-      - 1c08227
+      - 148d0593
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -405,16 +405,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1986
+    uri: https://example.com/rest/api/2/issue/OSIM-2471
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15885943", "self": "https://example.com/rest/api/2/issue/15885943",
-        "key": "OSIM-1986", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15925607", "self": "https://example.com/rest/api/2/issue/15925607",
+        "key": "OSIM-2471", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12324461": [], "customfield_12318341": null, "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -423,28 +423,28 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@491eb477[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f0ba755[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@13c15925[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2dfb6c4b[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@53a73e77[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@71341a59[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@69b20a08[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@32d86404[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5866a0ae[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@9519f29[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@704a2641[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1c39408[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ccd274e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@69605529[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@14219df8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@624e2203[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4cd15716[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@46436323[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e15f84e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4d5887b5[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@bf710ef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@56f030c9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@275665d1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2e3a2ba1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1986/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-05-15T11:26:53.395+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2471/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-28T13:11:36.491+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:fb9632ef-884c-4a72-a3ed-576fbd121882",
+        "Undefined", "id": "10300"}, "labels": ["flawuuid:a1f8ed1c-9f10-4407-b970-8c3b969f229a",
         "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
-        null, "assignee": null, "updated": "2024-05-15T11:26:53.395+0000", "customfield_12313942":
+        null, "assignee": null, "updated": "2024-05-28T13:11:36.491+0000", "customfield_12313942":
         null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
@@ -456,9 +456,9 @@ interactions:
         [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
         null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2000-0044
-        From OSV collector", "customfield_12323640": null, "customfield_12323642":
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
+        "9223372036854775807", "customfield_12316544": "None", "customfield_12323640":
+        null, "summary": "CVE-2000-0049 From OSV collector", "customfield_12323642":
         null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
         "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
@@ -470,7 +470,7 @@ interactions:
         "reporter": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
         "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=v&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
         "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
         "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
         "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
@@ -481,10 +481,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1986/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2471/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecul4:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zejnx4:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -493,9 +493,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:55 GMT
+      - Tue, 28 May 2024 13:11:38 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:55 GMT
+      - Tue, 28 May 2024 13:11:38 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -508,17 +508,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8778'
+      - '8779'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 686x44904x1
+      - 791x731753x1
       x-asessionid:
-      - sq5cwb
+      - cs31v0
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -530,9 +530,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772415.1c08349
+      - 0.64f06e68.1716901898.148d0b57
       x-rh-edge-request-id:
-      - 1c08349
+      - 148d0b57
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -572,7 +572,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:55 GMT
+      - Tue, 28 May 2024 13:11:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -582,9 +582,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772415.1803bd02
+      - 0.7df06e68.1716901898.213635f
       x-rh-edge-request-id:
-      - 1803bd02
+      - 213635f
     status:
       code: 200
       message: OK
@@ -605,8 +605,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"id": 1, "email": "aander07@packetmaster.com", "name":
-        "aander07@packetmaster.com", "can_login": true, "real_name": "Need Real Name"}]}'
+      string: '{"users": [{"name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com",
+        "real_name": "Need Real Name", "can_login": true, "id": 1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -621,7 +621,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:56 GMT
+      - Tue, 28 May 2024 13:11:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -631,22 +631,23 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772416.1803bd47
+      - 0.7df06e68.1716901899.213640a
       x-rh-edge-request-id:
-      - 1803bd47
+      - 213640a
     status:
       code: 200
       message: OK
 - request:
     body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
       "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
-      "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2000-0044
+      "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2000-0049
       From OSV collector", "description": "some description", "comment_is_private":
-      false, "alias": ["CVE-2000-0044"], "keywords": ["Security"], "flags": [], "groups":
-      ["redhat"], "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GHSA-0008/CVE-2000-0044\"],
-      \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-0008\",
-      \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-      \"source\": \"osv\", \"cwe\": \"CWE-110\"}"}'
+      false, "alias": ["CVE-2000-0049"], "keywords": ["Security"], "flags": [], "groups":
+      ["redhat"], "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-28T13:11:35Z\",
+      \"external_ids\": [\"GHSA-0012/CVE-2000-0049\"], \"references\": [{\"type\":
+      \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-0012\", \"description\":
+      null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"source\":
+      \"osv\", \"cwe\": \"CWE-110\"}"}'
     headers:
       Accept:
       - '*/*'
@@ -655,7 +656,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '715'
+      - '755'
       Content-Type:
       - application/json
       User-Agent:
@@ -664,7 +665,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2038325}'
+      string: '{"id": 2280634}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -679,7 +680,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:57 GMT
+      - Tue, 28 May 2024 13:11:40 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -689,9 +690,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772417.1803be41
+      - 0.7df06e68.1716901900.21366b8
       x-rh-edge-request-id:
-      - 1803be41
+      - 21366b8
     status:
       code: 200
       message: OK
@@ -727,7 +728,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:58 GMT
+      - Tue, 28 May 2024 13:11:41 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -737,9 +738,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772418.1c084d3
+      - 0.7df06e68.1716901901.2136d87
       x-rh-edge-request-id:
-      - 1c084d3
+      - 2136d87
     status:
       code: 200
       message: OK
@@ -760,8 +761,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"real_name": "Need Real Name", "id": 1, "email": "aander07@packetmaster.com",
-        "name": "aander07@packetmaster.com", "can_login": true}]}'
+      string: '{"users": [{"id": 1, "name": "aander07@packetmaster.com", "can_login":
+        true, "real_name": "Need Real Name", "email": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -776,7 +777,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:58 GMT
+      - Tue, 28 May 2024 13:11:41 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -786,9 +787,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772418.1c08504
+      - 0.7df06e68.1716901901.2136e46
       x-rh-edge-request-id:
-      - 1c08504
+      - 2136e46
     status:
       code: 200
       message: OK
@@ -806,40 +807,41 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2038325
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280634
   response:
     body:
-      string: '{"offset": 0, "bugs": [{"classification": "Other", "deadline": null,
-        "external_bugs": [], "groups": ["redhat"], "target_milestone": "---", "severity":
-        "unspecified", "version": ["unspecified"], "op_sys": "Linux", "alias": ["CVE-2000-0044"],
-        "creator": "nobody@redhat.com", "cc": [], "url": "", "cf_devel_whiteboard":
-        "", "cf_internal_whiteboard": "", "sub_components": {}, "is_confirmed": true,
-        "cf_major_incident": null, "dupe_of": null, "remaining_time": 0, "summary":
-        "CVE-2000-0044 From OSV collector", "depends_on": [], "docs_contact": "",
-        "cf_conditional_nak": [], "description": "some description", "cf_release_notes":
-        "", "actual_time": 0, "cf_srtnotes": "{\"external_ids\": [\"GHSA-0008/CVE-2000-0044\"],
-        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0008\",
+      string: '{"bugs": [{"is_confirmed": true, "cf_cust_facing": "---", "op_sys":
+        "Linux", "last_change_time": "2024-05-28T13:11:40Z", "cf_pm_score": "0", "qa_contact":
+        "", "cf_doc_type": "If docs needed, set a value", "severity": "unspecified",
+        "target_milestone": "---", "is_creator_accessible": true, "actual_time": 0,
+        "is_open": true, "cf_devel_whiteboard": "", "cf_fixed_in": "", "sub_components":
+        {}, "cf_build_id": "", "groups": ["redhat"], "target_release": ["---"], "alias":
+        ["CVE-2000-0049"], "creator": "nobody@redhat.com", "blocks": [], "assigned_to_detail":
+        {"id": 377884, "insider": true, "name": "prodsec-dev@redhat.com", "active":
+        true, "partner": false, "email": "prodsec-dev@redhat.com", "real_name": "INVALID
+        USER"}, "assigned_to": "prodsec-dev@redhat.com", "creation_time": "2024-05-28T13:11:40Z",
+        "cf_qa_whiteboard": "", "url": "", "version": ["unspecified"], "comments":
+        [{"creator_id": 425662, "creator": "nobody@redhat.com", "private_groups":
+        [], "attachment_id": null, "id": 18006766, "text": "some description", "creation_time":
+        "2024-05-28T13:11:40Z", "count": 0, "is_private": false, "time": "2024-05-28T13:11:40Z",
+        "bug_id": 2280634, "tags": []}], "tags": [], "platform": "All", "estimated_time":
+        0, "external_bugs": [], "flags": [], "summary": "CVE-2000-0049 From OSV collector",
+        "status": "NEW", "cf_pgm_internal": "", "deadline": null, "cf_release_notes":
+        "", "classification": "Other", "description": "some description", "cf_srtnotes":
+        "{\"reported\": \"2024-05-28T13:11:35Z\", \"external_ids\": [\"GHSA-0012/CVE-2000-0049\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0012\",
         \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "cf_pgm_internal": "", "is_open":
-        true, "cf_qa_whiteboard": "", "blocks": [], "creation_time": "2024-05-15T11:26:56Z",
-        "whiteboard": "", "tags": [], "cf_cust_facing": "---", "component": ["vulnerability-draft"],
-        "cf_last_closed": null, "estimated_time": 0, "creator_detail": {"id": 425662,
-        "partner": false, "name": "nobody@redhat.com", "insider": true, "active":
-        true, "email": "nobody@redhat.com", "real_name": "nobody"}, "product":
-        "Security Response", "flags": [], "qa_contact": "", "cf_environment": "",
-        "priority": "unspecified", "cf_embargoed": null, "target_release": ["---"],
-        "status": "NEW", "last_change_time": "2024-05-15T11:26:56Z", "comments": [{"time":
-        "2024-05-15T11:26:56Z", "id": 15734114, "attachment_id": null, "text": "some
-        description", "is_private": false, "creator_id": 425662, "bug_id": 2038325,
-        "count": 0, "tags": [], "creation_time": "2024-05-15T11:26:56Z", "creator":
-        "nobody@redhat.com", "private_groups": []}], "is_creator_accessible": true,
-        "cf_clone_of": null, "assigned_to": "nobody@redhat.com", "cf_pm_score": "0",
-        "keywords": ["Security"], "cf_qe_conditional_nak": [], "cf_doc_type": "If
-        docs needed, set a value", "assigned_to_detail": {"email": "nobody@redhat.com",
-        "real_name": "Nobody", "active": true, "name": "nobody@redhat.com", "insider":
-        false, "id": 29451, "partner": false}, "data_category": "Red Hat", "platform":
-        "All", "cf_fixed_in": "", "cf_build_id": "", "is_cc_accessible": true, "cc_detail":
-        [], "id": 2038325, "resolution": ""}], "limit": "20", "total_matches": 1}'
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "id": 2280634, "dupe_of": null,
+        "keywords": ["Security"], "depends_on": [], "cf_conditional_nak": [], "cf_clone_of":
+        null, "creator_detail": {"name": "nobody@redhat.com", "active": true, "partner":
+        false, "email": "nobody@redhat.com", "real_name": "nobody", "id":
+        425662, "insider": true}, "cf_embargoed": null, "priority": "unspecified",
+        "cf_major_incident": null, "cc": [], "is_cc_accessible": true, "cc_detail":
+        [], "cf_internal_whiteboard": "", "cf_qe_conditional_nak": [], "remaining_time":
+        0, "docs_contact": "", "cf_last_closed": null, "resolution": "", "whiteboard":
+        "", "cf_environment": "", "data_category": "Red Hat", "product": "Security
+        Response", "component": ["vulnerability-draft"]}], "total_matches": 1, "offset":
+        0, "limit": "20"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -852,7 +854,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:59 GMT
+      - Tue, 28 May 2024 13:11:42 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -862,13 +864,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2294'
+      - '2355'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772419.1c08524
+      - 0.7df06e68.1716901902.2136fa1
       x-rh-edge-request-id:
-      - 1c08524
+      - 2136fa1
     status:
       code: 200
       message: OK
@@ -886,40 +888,41 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2038325
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280634
   response:
     body:
-      string: '{"bugs": [{"cf_internal_whiteboard": "", "sub_components": {}, "op_sys":
-        "Linux", "keywords": ["Security"], "cf_pgm_internal": "", "status": "NEW",
-        "is_open": true, "qa_contact": "", "dupe_of": null, "is_creator_accessible":
-        true, "product": "Security Response", "resolution": "", "last_change_time":
-        "2024-05-15T11:26:56Z", "cc": [], "cf_fixed_in": "", "docs_contact": "", "cf_major_incident":
-        null, "creator_detail": {"insider": true, "real_name": "nobody",
-        "partner": false, "email": "nobody@redhat.com", "id": 425662, "name": "nobody@redhat.com",
-        "active": true}, "external_bugs": [], "depends_on": [], "target_milestone":
-        "---", "classification": "Other", "cf_cust_facing": "---", "alias": ["CVE-2000-0044"],
-        "version": ["unspecified"], "priority": "unspecified", "severity": "unspecified",
-        "url": "", "platform": "All", "whiteboard": "", "groups": ["redhat"], "cf_clone_of":
-        null, "creator": "nobody@redhat.com", "cf_srtnotes": "{\"external_ids\":
-        [\"GHSA-0008/CVE-2000-0044\"], \"references\": [{\"type\": \"source\", \"url\":
-        \"https://example.com/vulnerability/GHSA-0008\", \"description\": null}],
-        \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\", \"source\":
-        \"osv\", \"cwe\": \"CWE-110\"}", "actual_time": 0, "cf_pm_score": "0", "flags":
-        [], "target_release": ["---"], "estimated_time": 0, "cf_environment": "",
-        "cf_build_id": "", "creation_time": "2024-05-15T11:26:56Z", "remaining_time":
-        0, "deadline": null, "is_confirmed": true, "cf_release_notes": "", "data_category":
-        "Red Hat", "component": ["vulnerability-draft"], "cf_devel_whiteboard": "",
-        "cf_qe_conditional_nak": [], "id": 2038325, "cf_last_closed": null, "description":
-        "some description", "cf_embargoed": null, "assigned_to_detail": {"insider":
-        false, "real_name": "Nobody", "partner": false, "id": 29451, "name": "nobody@redhat.com",
-        "email": "nobody@redhat.com", "active": true}, "blocks": [], "cf_doc_type":
-        "If docs needed, set a value", "assigned_to": "nobody@redhat.com", "cf_qa_whiteboard":
-        "", "summary": "CVE-2000-0044 From OSV collector", "tags": [], "cf_conditional_nak":
-        [], "cc_detail": [], "is_cc_accessible": true, "comments": [{"bug_id": 2038325,
-        "creation_time": "2024-05-15T11:26:56Z", "creator_id": 425662, "attachment_id":
-        null, "private_groups": [], "text": "some description", "is_private": false,
-        "count": 0, "time": "2024-05-15T11:26:56Z", "id": 15734114, "tags": [], "creator":
-        "nobody@redhat.com"}]}], "offset": 0, "limit": "20", "total_matches": 1}'
+      string: '{"limit": "20", "offset": 0, "bugs": [{"cf_srtnotes": "{\"reported\":
+        \"2024-05-28T13:11:35Z\", \"external_ids\": [\"GHSA-0012/CVE-2000-0049\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0012\",
+        \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "id": 2280634, "dupe_of": null,
+        "description": "some description", "depends_on": [], "keywords": ["Security"],
+        "cf_qe_conditional_nak": [], "docs_contact": "", "remaining_time": 0, "priority":
+        "unspecified", "creator_detail": {"name": "nobody@redhat.com", "active":
+        true, "partner": false, "real_name": "nobody", "email": "nobody@redhat.com",
+        "insider": true, "id": 425662}, "cf_embargoed": null, "cf_clone_of": null,
+        "cf_conditional_nak": [], "cf_internal_whiteboard": "", "cc_detail": [], "is_cc_accessible":
+        true, "cc": [], "cf_major_incident": null, "component": ["vulnerability-draft"],
+        "data_category": "Red Hat", "product": "Security Response", "cf_last_closed":
+        null, "cf_environment": "", "whiteboard": "", "resolution": "", "target_milestone":
+        "---", "severity": "unspecified", "qa_contact": "", "cf_doc_type": "If docs
+        needed, set a value", "is_creator_accessible": true, "cf_cust_facing": "---",
+        "is_confirmed": true, "cf_pm_score": "0", "last_change_time": "2024-05-28T13:11:40Z",
+        "op_sys": "Linux", "cf_build_id": "", "sub_components": {}, "alias": ["CVE-2000-0049"],
+        "creator": "nobody@redhat.com", "target_release": ["---"], "groups": ["redhat"],
+        "cf_devel_whiteboard": "", "is_open": true, "actual_time": 0, "cf_fixed_in":
+        "", "cf_qa_whiteboard": "", "comments": [{"bug_id": 2280634, "time": "2024-05-28T13:11:40Z",
+        "tags": [], "count": 0, "creation_time": "2024-05-28T13:11:40Z", "is_private":
+        false, "id": 18006766, "text": "some description", "creator_id": 425662, "creator":
+        "nobody@redhat.com", "attachment_id": null, "private_groups": []}], "version":
+        ["unspecified"], "url": "", "creation_time": "2024-05-28T13:11:40Z", "assigned_to":
+        "prodsec-dev@redhat.com", "assigned_to_detail": {"id": 377884, "insider":
+        true, "name": "prodsec-dev@redhat.com", "active": true, "partner": false,
+        "email": "prodsec-dev@redhat.com", "real_name": "INVALID USER"}, "blocks":
+        [], "status": "NEW", "cf_pgm_internal": "", "classification": "Other", "cf_release_notes":
+        "", "deadline": null, "platform": "All", "tags": [], "summary": "CVE-2000-0049
+        From OSV collector", "flags": [], "estimated_time": 0, "external_bugs": []}],
+        "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -932,7 +935,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:00 GMT
+      - Tue, 28 May 2024 13:11:43 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -942,13 +945,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2294'
+      - '2355'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772420.1c08581
+      - 0.7df06e68.1716901903.213731c
       x-rh-edge-request-id:
-      - 1c08581
+      - 213731c
     status:
       code: 200
       message: OK
@@ -966,14 +969,14 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2038325/comment
+    uri: https://example.com/rest/bug/2280634/comment
   response:
     body:
-      string: '{"comments": {}, "bugs": {"2038325": {"comments": [{"creator_id": 425662,
-        "creation_time": "2024-05-15T11:26:56Z", "bug_id": 2038325, "is_private":
-        false, "text": "some description", "private_groups": [], "attachment_id":
-        null, "count": 0, "creator": "nobody@redhat.com", "tags": [], "id": 15734114,
-        "time": "2024-05-15T11:26:56Z"}]}}}'
+      string: '{"comments": {}, "bugs": {"2280634": {"comments": [{"bug_id": 2280634,
+        "id": 18006766, "creator_id": 425662, "is_private": false, "tags": [], "attachment_id":
+        null, "creator": "nobody@redhat.com", "private_groups": [], "text": "some
+        description", "count": 0, "time": "2024-05-28T13:11:40Z", "creation_time":
+        "2024-05-28T13:11:40Z"}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -988,7 +991,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:27:01 GMT
+      - Tue, 28 May 2024 13:11:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -998,9 +1001,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772421.1c08648
+      - 0.7df06e68.1716901904.2137670
       x-rh-edge-request-id:
-      - 1c08648
+      - '2137670'
     status:
       code: 200
       message: OK

--- a/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-None-GHSA-0013-OSIM-2472].yaml
+++ b/apps/bbsync/tests/cassettes/test_integration/TestFlawDraftBBSyncIntegration.test_flaw_draft_create[OSV-None-GHSA-0013-OSIM-2472].yaml
@@ -140,9 +140,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:45 GMT
+      - Tue, 28 May 2024 13:11:45 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:45 GMT
+      - Tue, 28 May 2024 13:11:45 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -161,11 +161,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 686x52968x1
+      - 791x720197x1
       x-asessionid:
-      - 1q7wnzi
+      - l69v4l
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -177,9 +177,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772405.1c07da0
+      - 0.7df06e68.1716901905.2137bec
       x-rh-edge-request-id:
-      - 1c07da0
+      - 2137bec
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -255,9 +255,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:45 GMT
+      - Tue, 28 May 2024 13:11:45 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:45 GMT
+      - Tue, 28 May 2024 13:11:45 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -276,11 +276,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 686x52969x1
+      - 791x720199x1
       x-asessionid:
-      - 1oqu0p4
+      - 1ovo31b
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -292,9 +292,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772405.1c07db3
+      - 0.7df06e68.1716901905.2137ca4
       x-rh-edge-request-id:
-      - 1c07db3
+      - 2137ca4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -304,9 +304,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "CVE-2000-0043 From NVD collector", "description": "some description", "labels":
-      ["flawuuid:d2184587-cd0c-4bf6-b264-9bd4b1cb29db", "impact:"], "priority": {"name":
-      "Undefined"}}}'
+      "From OSV collector", "description": "some description", "labels": ["flawuuid:dd5394ca-f495-4a04-a79d-a575fb94cd1f",
+      "impact:"], "priority": {"name": "Undefined"}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -317,7 +316,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '259'
+      - '245'
       Content-Type:
       - application/json
       User-Agent:
@@ -328,18 +327,18 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "15885883", "key": "OSIM-1985", "self": "https://example.com/rest/api/2/issue/15885883"}'
+      string: '{"id": "15925665", "key": "OSIM-2472", "self": "https://example.com/rest/api/2/issue/15925665"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - close
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:46 GMT
+      - Tue, 28 May 2024 13:11:47 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:46 GMT
+      - Tue, 28 May 2024 13:11:47 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -358,11 +357,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 686x52970x1
+      - 791x720200x1
       x-asessionid:
-      - 1687kw5
+      - c8vo89
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -374,9 +373,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772406.1c07dcb
+      - 0.7df06e68.1716901907.2137dd2
       x-rh-edge-request-id:
-      - 1c07dcb
+      - 2137dd2
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -402,16 +401,16 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-1985
+    uri: https://example.com/rest/api/2/issue/OSIM-2472
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15885883", "self": "https://example.com/rest/api/2/issue/15885883",
-        "key": "OSIM-1985", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "15925665", "self": "https://example.com/rest/api/2/issue/15925665",
+        "key": "OSIM-2472", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0.0", "customfield_12318341": null, "customfield_12324461": [], "timespent":
+        "0.0", "customfield_12324461": [], "customfield_12318341": null, "timespent":
         null, "customfield_12320940": null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
         "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
         "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
@@ -420,28 +419,28 @@ interactions:
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
         "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
         "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@22d993be[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a992880[overall=PullRequestOverallBean{stateCount=0,
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6076d90b[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@42c88d96[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f05619c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4c4b9fd4[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@176de70e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5c0ab9e7[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28772a7b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3852b59e[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@40ff700d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@49b32c74[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5886f3cb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@75d54300[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@f059757[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@9270f1c[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@71cc164e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@458ad9b4[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6616517d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@57f8fd4c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4697ef9b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5543d984[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@18ae7e8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@11087808[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
         null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
         null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-1985/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-05-15T11:26:45.617+0000", "customfield_12321240":
+        "https://example.com/rest/api/2/issue/OSIM-2472/watchers", "watchCount": 1,
+        "isWatching": true}, "created": "2024-05-28T13:11:46.090+0000", "customfield_12321240":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:d2184587-cd0c-4bf6-b264-9bd4b1cb29db",
+        "Undefined", "id": "10300"}, "labels": ["flawuuid:dd5394ca-f495-4a04-a79d-a575fb94cd1f",
         "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
         "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
         "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
         null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
-        null, "assignee": null, "updated": "2024-05-15T11:26:45.617+0000", "customfield_12313942":
+        null, "assignee": null, "updated": "2024-05-28T13:11:46.090+0000", "customfield_12313942":
         null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
@@ -453,10 +452,10 @@ interactions:
         [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
         null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2000-0043
-        From NVD collector", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
+        "9223372036854775807", "customfield_12316544": "None", "customfield_12323640":
+        null, "summary": "From OSV collector", "customfield_12323642": null, "creator":
+        {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
         "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
         "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
@@ -478,10 +477,10 @@ interactions:
         "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
         "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-1985/votes", "votes":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-2472/votes", "votes":
         0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
         0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zecukw:"}}'
+        null, "archivedby": null, "customfield_12311940": "1|zejnxc:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -490,9 +489,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:46 GMT
+      - Tue, 28 May 2024 13:11:47 GMT
       Expires:
-      - Wed, 15 May 2024 11:26:46 GMT
+      - Tue, 28 May 2024 13:11:47 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -505,17 +504,17 @@ interactions:
       X-RateLimit-Remaining:
       - '9223372036854775807'
       content-length:
-      - '8780'
+      - '8763'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 686x52971x1
+      - 791x720202x2
       x-asessionid:
-      - 1md3qar
+      - 14ca15p
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -527,9 +526,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772406.1c07e88
+      - 0.7df06e68.1716901907.21383c7
       x-rh-edge-request-id:
-      - 1c07e88
+      - 21383c7
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -569,7 +568,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:47 GMT
+      - Tue, 28 May 2024 13:11:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -579,9 +578,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772407.1803ac29
+      - 0.64f06e68.1716901907.148d291d
       x-rh-edge-request-id:
-      - 1803ac29
+      - 148d291d
     status:
       code: 200
       message: OK
@@ -602,8 +601,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"id": 1, "name": "aander07@packetmaster.com", "can_login":
-        true, "real_name": "Need Real Name", "email": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"id": 1, "can_login": true, "real_name": "Need Real Name",
+        "name": "aander07@packetmaster.com", "email": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -618,7 +617,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:47 GMT
+      - Tue, 28 May 2024 13:11:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -628,22 +627,22 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772407.1803ac6b
+      - 0.64f06e68.1716901908.148d29b6
       x-rh-edge-request-id:
-      - 1803ac6b
+      - 148d29b6
     status:
       code: 200
       message: OK
 - request:
     body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
       "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
-      "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2000-0043
-      From NVD collector", "description": "some description", "comment_is_private":
-      false, "alias": ["CVE-2000-0043"], "keywords": ["Security"], "flags": [], "groups":
-      ["redhat"], "cc": [], "cf_srtnotes": "{\"external_ids\": [\"CVE-2000-0043\"],
-      \"references\": [{\"type\": \"source\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2000-0043\",
+      "", "severity": "unspecified", "priority": "unspecified", "summary": "From OSV
+      collector", "description": "some description", "comment_is_private": false,
+      "alias": ["GHSA-0013"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
+      "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-28T13:11:44Z\", \"external_ids\":
+      [\"GHSA-0013\"], \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-0013\",
       \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-      \"source\": \"nvd\", \"cwe\": \"CWE-110\"}"}'
+      \"source\": \"osv\", \"cwe\": \"CWE-110\"}"}'
     headers:
       Accept:
       - '*/*'
@@ -652,7 +651,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '712'
+      - '723'
       Content-Type:
       - application/json
       User-Agent:
@@ -661,7 +660,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2038324}'
+      string: '{"id": 2280635}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -676,7 +675,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:48 GMT
+      - Tue, 28 May 2024 13:11:49 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -686,9 +685,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1715772408.1803ad35
+      - 0.64f06e68.1716901909.148d2b34
       x-rh-edge-request-id:
-      - 1803ad35
+      - 148d2b34
     status:
       code: 200
       message: OK
@@ -724,7 +723,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:49 GMT
+      - Tue, 28 May 2024 13:11:49 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -734,9 +733,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772409.1c0802f
+      - 0.7df06e68.1716901909.2138e96
       x-rh-edge-request-id:
-      - 1c0802f
+      - 2138e96
     status:
       code: 200
       message: OK
@@ -757,8 +756,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"real_name": "Need Real Name", "id": 1, "email": "aander07@packetmaster.com",
-        "name": "aander07@packetmaster.com", "can_login": true}]}'
+      string: '{"users": [{"can_login": true, "real_name": "Need Real Name", "email":
+        "aander07@packetmaster.com", "name": "aander07@packetmaster.com", "id": 1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -773,7 +772,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:49 GMT
+      - Tue, 28 May 2024 13:11:50 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -783,9 +782,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772409.1c0806b
+      - 0.7df06e68.1716901910.2138f28
       x-rh-edge-request-id:
-      - 1c0806b
+      - 2138f28
     status:
       code: 200
       message: OK
@@ -803,41 +802,40 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2038324
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280635
   response:
     body:
-      string: '{"limit": "20", "bugs": [{"cf_pm_score": "0", "assigned_to": "nobody@redhat.com",
-        "cf_qe_conditional_nak": [], "keywords": ["Security"], "is_cc_accessible":
-        true, "cf_build_id": "", "cf_fixed_in": "", "platform": "All", "data_category":
-        "Red Hat", "assigned_to_detail": {"id": 29451, "partner": false, "name": "nobody@redhat.com",
-        "insider": false, "active": true, "email": "nobody@redhat.com", "real_name":
-        "Nobody"}, "cf_doc_type": "If docs needed, set a value", "resolution": "",
-        "id": 2038324, "cc_detail": [], "estimated_time": 0, "cf_last_closed": null,
-        "cf_cust_facing": "---", "component": ["vulnerability-draft"], "tags": [],
-        "creation_time": "2024-05-15T11:26:48Z", "whiteboard": "", "product": "Security
-        Response", "creator_detail": {"name": "nobody@redhat.com", "insider": true,
-        "id": 425662, "partner": false, "email": "nobody@redhat.com", "real_name":
-        "nobody", "active": true}, "priority": "unspecified", "cf_embargoed":
-        null, "cf_environment": "", "qa_contact": "", "flags": [], "cf_clone_of":
-        null, "is_creator_accessible": true, "comments": [{"attachment_id": null,
-        "id": 15734113, "time": "2024-05-15T11:26:48Z", "is_private": false, "text":
-        "some description", "bug_id": 2038324, "count": 0, "creator_id": 425662, "private_groups":
-        [], "creator": "nobody@redhat.com", "tags": [], "creation_time": "2024-05-15T11:26:48Z"}],
-        "last_change_time": "2024-05-15T11:26:48Z", "status": "NEW", "target_release":
-        ["---"], "summary": "CVE-2000-0043 From NVD collector", "remaining_time":
-        0, "dupe_of": null, "description": "some description", "cf_conditional_nak":
-        [], "docs_contact": "", "depends_on": [], "cf_pgm_internal": "", "is_open":
-        true, "cf_srtnotes": "{\"external_ids\": [\"CVE-2000-0043\"], \"references\":
-        [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2000-0043\",
+      string: '{"limit": "20", "offset": 0, "bugs": [{"url": "", "version": ["unspecified"],
+        "comments": [{"creation_time": "2024-05-28T13:11:49Z", "count": 0, "is_private":
+        false, "time": "2024-05-28T13:11:49Z", "bug_id": 2280635, "tags": [], "creator_id":
+        425662, "creator": "nobody@redhat.com", "private_groups": [], "attachment_id":
+        null, "id": 18006767, "text": "some description"}], "cf_qa_whiteboard": "",
+        "assigned_to_detail": {"partner": false, "real_name": "INVALID USER", "email":
+        "prodsec-dev@redhat.com", "name": "prodsec-dev@redhat.com", "active": true,
+        "id": 377884, "insider": true}, "blocks": [], "assigned_to": "prodsec-dev@redhat.com",
+        "creation_time": "2024-05-28T13:11:49Z", "deadline": null, "cf_release_notes":
+        "", "classification": "Other", "status": "NEW", "cf_pgm_internal": "", "estimated_time":
+        0, "external_bugs": [], "flags": [], "summary": "From OSV collector", "tags":
+        [], "platform": "All", "is_creator_accessible": true, "cf_doc_type": "If docs
+        needed, set a value", "qa_contact": "", "severity": "unspecified", "target_milestone":
+        "---", "op_sys": "Linux", "last_change_time": "2024-05-28T13:11:49Z", "cf_pm_score":
+        "0", "is_confirmed": true, "cf_cust_facing": "---", "groups": ["redhat"],
+        "target_release": ["---"], "alias": ["GHSA-0013"], "creator": "nobody@redhat.com",
+        "sub_components": {}, "cf_build_id": "", "cf_fixed_in": "", "actual_time":
+        0, "is_open": true, "cf_devel_whiteboard": "", "remaining_time": 0, "docs_contact":
+        "", "cf_qe_conditional_nak": [], "cf_major_incident": null, "is_cc_accessible":
+        true, "cc": [], "cc_detail": [], "cf_internal_whiteboard": "", "cf_clone_of":
+        null, "cf_conditional_nak": [], "creator_detail": {"name": "nobody@redhat.com",
+        "active": true, "partner": false, "real_name": "nobody", "email":
+        "nobody@redhat.com", "insider": true, "id": 425662}, "cf_embargoed": null,
+        "priority": "unspecified", "product": "Security Response", "data_category":
+        "Red Hat", "component": ["vulnerability-draft"], "resolution": "", "whiteboard":
+        "", "cf_environment": "", "cf_last_closed": null, "dupe_of": null, "id": 2280635,
+        "cf_srtnotes": "{\"reported\": \"2024-05-28T13:11:44Z\", \"external_ids\":
+        [\"GHSA-0013\"], \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0013\",
         \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-        \"source\": \"nvd\", \"cwe\": \"CWE-110\"}", "actual_time": 0, "cf_release_notes":
-        "", "blocks": [], "cf_qa_whiteboard": "", "groups": ["redhat"], "external_bugs":
-        [], "classification": "Other", "deadline": null, "op_sys": "Linux", "version":
-        ["unspecified"], "severity": "unspecified", "target_milestone": "---", "url":
-        "", "cc": [], "creator": "nobody@redhat.com", "alias": ["CVE-2000-0043"],
-        "cf_major_incident": null, "is_confirmed": true, "cf_internal_whiteboard":
-        "", "sub_components": {}, "cf_devel_whiteboard": ""}], "total_matches": 1,
-        "offset": 0}'
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "description": "some description",
+        "depends_on": [], "keywords": ["Security"]}], "total_matches": 1}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -850,7 +848,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:50 GMT
+      - Tue, 28 May 2024 13:11:51 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -860,13 +858,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2291'
+      - '2323'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772410.1c080a5
+      - 0.7df06e68.1716901911.2139073
       x-rh-edge-request-id:
-      - 1c080a5
+      - '2139073'
     status:
       code: 200
       message: OK
@@ -884,40 +882,41 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2038324
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280635
   response:
     body:
-      string: '{"offset": 0, "total_matches": 1, "bugs": [{"product": "Security Response",
-        "creator_detail": {"partner": false, "id": 425662, "insider": true, "name":
-        "nobody@redhat.com", "active": true, "real_name": "nobody", "email":
-        "nobody@redhat.com"}, "estimated_time": 0, "cf_last_closed": null, "cf_cust_facing":
-        "---", "component": ["vulnerability-draft"], "tags": [], "creation_time":
-        "2024-05-15T11:26:48Z", "whiteboard": "", "cf_clone_of": null, "comments":
-        [{"text": "some description", "is_private": false, "attachment_id": null,
-        "time": "2024-05-15T11:26:48Z", "id": 15734113, "private_groups": [], "creator":
-        "nobody@redhat.com", "tags": [], "creation_time": "2024-05-15T11:26:48Z",
-        "creator_id": 425662, "bug_id": 2038324, "count": 0}], "is_creator_accessible":
-        true, "last_change_time": "2024-05-15T11:26:48Z", "target_release": ["---"],
-        "status": "NEW", "cf_environment": "", "priority": "unspecified", "cf_embargoed":
-        null, "flags": [], "qa_contact": "", "cf_qe_conditional_nak": [], "keywords":
-        ["Security"], "cf_pm_score": "0", "assigned_to": "nobody@redhat.com", "id":
-        2038324, "resolution": "", "cc_detail": [], "is_cc_accessible": true, "cf_build_id":
-        "", "cf_fixed_in": "", "platform": "All", "data_category": "Red Hat", "cf_doc_type":
-        "If docs needed, set a value", "assigned_to_detail": {"name": "nobody@redhat.com",
-        "insider": false, "id": 29451, "partner": false, "email": "nobody@redhat.com",
-        "real_name": "Nobody", "active": true}, "op_sys": "Linux", "version": ["unspecified"],
-        "severity": "unspecified", "target_milestone": "---", "groups": ["redhat"],
-        "external_bugs": [], "classification": "Other", "deadline": null, "cf_major_incident":
-        null, "is_confirmed": true, "cf_internal_whiteboard": "", "sub_components":
-        {}, "cf_devel_whiteboard": "", "url": "", "cc": [], "creator": "nobody@redhat.com",
-        "alias": ["CVE-2000-0043"], "cf_conditional_nak": [], "description": "some
-        description", "depends_on": [], "docs_contact": "", "summary": "CVE-2000-0043
-        From NVD collector", "remaining_time": 0, "dupe_of": null, "blocks": [], "cf_qa_whiteboard":
-        "", "is_open": true, "cf_pgm_internal": "", "cf_srtnotes": "{\"external_ids\":
-        [\"CVE-2000-0043\"], \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2000-0043\",
+      string: '{"offset": 0, "limit": "20", "total_matches": 1, "bugs": [{"target_milestone":
+        "---", "status": "NEW", "actual_time": 0, "cf_fixed_in": "", "data_category":
+        "Red Hat", "severity": "unspecified", "creator_detail": {"partner": false,
+        "active": true, "id": 425662, "real_name": "nobody", "insider": true,
+        "name": "nobody@redhat.com", "email": "nobody@redhat.com"}, "cf_clone_of":
+        null, "deadline": null, "platform": "All", "is_creator_accessible": true,
+        "version": ["unspecified"], "cf_last_closed": null, "is_cc_accessible": true,
+        "dupe_of": null, "comments": [{"id": 18006767, "tags": [], "is_private": false,
+        "creator_id": 425662, "bug_id": 2280635, "time": "2024-05-28T13:11:49Z", "text":
+        "some description", "count": 0, "creation_time": "2024-05-28T13:11:49Z", "creator":
+        "nobody@redhat.com", "attachment_id": null, "private_groups": []}], "alias":
+        ["GHSA-0013"], "is_confirmed": true, "cf_cust_facing": "---", "target_release":
+        ["---"], "cf_embargoed": null, "description": "some description", "sub_components":
+        {}, "cf_pgm_internal": "", "keywords": ["Security"], "cf_qe_conditional_nak":
+        [], "docs_contact": "", "cf_environment": "", "whiteboard": "", "assigned_to_detail":
+        {"id": 377884, "real_name": "INVALID USER", "email": "prodsec-dev@redhat.com",
+        "insider": true, "name": "prodsec-dev@redhat.com", "partner": false, "active":
+        true}, "cc": [], "cf_pm_score": "0", "priority": "unspecified", "estimated_time":
+        0, "component": ["vulnerability-draft"], "product": "Security Response", "cf_release_notes":
+        "", "remaining_time": 0, "url": "", "tags": [], "summary": "From OSV collector",
+        "cf_qa_whiteboard": "", "qa_contact": "", "creator": "nobody@redhat.com",
+        "cf_doc_type": "If docs needed, set a value", "cf_devel_whiteboard": "", "id":
+        2280635, "cf_conditional_nak": [], "flags": [], "classification": "Other",
+        "assigned_to": "prodsec-dev@redhat.com", "blocks": [], "external_bugs": [],
+        "resolution": "", "cc_detail": [], "cf_build_id": "", "groups": ["redhat"],
+        "creation_time": "2024-05-28T13:11:49Z", "last_change_time": "2024-05-28T13:11:49Z",
+        "cf_srtnotes": "{\"reported\": \"2024-05-28T13:11:44Z\", \"external_ids\":
+        [\"GHSA-0013\"], \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-0013\",
         \"description\": null}], \"cvss3\": \"8.1/CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H\",
-        \"source\": \"nvd\", \"cwe\": \"CWE-110\"}", "actual_time": 0, "cf_release_notes":
-        ""}], "limit": "20"}'
+        \"source\": \"osv\", \"cwe\": \"CWE-110\"}", "cf_internal_whiteboard": "",
+        "is_open": true, "cf_major_incident": null, "op_sys": "Linux", "depends_on":
+        []}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -930,7 +929,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:51 GMT
+      - Tue, 28 May 2024 13:11:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -940,13 +939,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2291'
+      - '2323'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772411.1c08113
+      - 0.7df06e68.1716901912.21393a1
       x-rh-edge-request-id:
-      - 1c08113
+      - 21393a1
     status:
       code: 200
       message: OK
@@ -964,14 +963,14 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2038324/comment
+    uri: https://example.com/rest/bug/2280635/comment
   response:
     body:
-      string: '{"bugs": {"2038324": {"comments": [{"private_groups": [], "creation_time":
-        "2024-05-15T11:26:48Z", "creator": "nobody@redhat.com", "tags": [], "creator_id":
-        425662, "count": 0, "bug_id": 2038324, "text": "some description", "is_private":
-        false, "attachment_id": null, "time": "2024-05-15T11:26:48Z", "id": 15734113}]}},
-        "comments": {}}'
+      string: '{"comments": {}, "bugs": {"2280635": {"comments": [{"id": 18006767,
+        "is_private": false, "tags": [], "creator_id": 425662, "bug_id": 2280635,
+        "time": "2024-05-28T13:11:49Z", "text": "some description", "count": 0, "creation_time":
+        "2024-05-28T13:11:49Z", "creator": "nobody@redhat.com", "attachment_id":
+        null, "private_groups": []}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -986,7 +985,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Wed, 15 May 2024 11:26:52 GMT
+      - Tue, 28 May 2024 13:11:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -996,9 +995,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1715772412.1c0816c
+      - 0.7df06e68.1716901912.213976a
       x-rh-edge-request-id:
-      - 1c0816c
+      - 213976a
     status:
       code: 200
       message: OK

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -889,9 +889,9 @@ class TestFlawDraftBBSyncIntegration:
     @pytest.mark.parametrize(
         "source,cve_id,ext_id,jira_id",
         [
-            (Snippet.Source.NVD, "CVE-2000-0043", "CVE-2000-0043", "OSIM-1985"),
-            (Snippet.Source.OSV, "CVE-2000-0044", "GHSA-0008", "OSIM-1986"),
-            (Snippet.Source.OSV, None, "GHSA-0009", "OSIM-1987"),
+            (Snippet.Source.NVD, "CVE-2000-0048", "CVE-2000-0048", "OSIM-2470"),
+            (Snippet.Source.OSV, "CVE-2000-0049", "GHSA-0012", "OSIM-2471"),
+            (Snippet.Source.OSV, None, "GHSA-0013", "OSIM-2472"),
         ],
     )
     def test_flaw_draft_create(
@@ -950,6 +950,7 @@ class TestFlawDraftBBSyncIntegration:
         assert flaw.cwe_id == content["cwe_id"]
         assert flaw.description == content["description"]
         assert flaw.references.all().count() == 1
+        assert flaw.reported_dt
         assert flaw.source == source
         assert flaw.title == f"From {source} collector"
 

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
@@ -709,7 +709,7 @@ interactions:
       "", "severity": "unspecified", "priority": "unspecified", "summary": "CVE-2017-7542
       From NVD collector", "description": "The ip6_find_1stfragopt function allows local users to cause
       a denial of service.", "comment_is_private": false, "alias": ["CVE-2017-7542"], "keywords":
-      ["Security"], "flags": [], "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"external_ids\":
+      ["Security"], "flags": [], "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-15T07:36:59Z\", \"external_ids\":
       [\"CVE-2017-7542\"], \"references\": [{\"type\": \"source\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2017-7542\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"http://www.debian.org/security/2017/dsa-3927\",
       \"description\": null}], \"source\": \"nvd\", \"cwe\": \"(CWE-190|CWE-835)\"}"}'
@@ -882,7 +882,7 @@ interactions:
         "---", "alias": ["CVE-2017-7542"], "version": ["unspecified"], "priority":
         "unspecified", "severity": "unspecified", "url": "", "platform": "All", "whiteboard":
         "", "groups": ["redhat"], "cf_clone_of": null, "creator": "nobody@redhat.com",
-        "cf_srtnotes": "{\"external_ids\": [\"CVE-2017-7542\"], \"references\": [{\"type\":
+        "cf_srtnotes": "{\"reported\": \"2024-05-15T07:36:59Z\", \"external_ids\": [\"CVE-2017-7542\"], \"references\": [{\"type\":
         \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2017-7542\", \"description\":
         null}, {\"type\": \"external\", \"url\": \"https://example.com/security/2017/dsa-3927\",
         \"description\": null}], \"source\": \"nvd\", \"cwe\": \"(CWE-190|CWE-835)\"}",
@@ -983,7 +983,7 @@ interactions:
         allows local users to cause a denial of service.", "cf_conditional_nak": [], "depends_on":
         [], "docs_contact": "", "summary": "CVE-2017-7542 From NVD collector", "dupe_of":
         null, "remaining_time": 0, "cf_qa_whiteboard": "", "blocks": [], "is_open":
-        true, "cf_pgm_internal": "", "actual_time": 0, "cf_srtnotes": "{\"external_ids\":
+        true, "cf_pgm_internal": "", "actual_time": 0, "cf_srtnotes": "{\"reported\": \"2024-05-15T07:36:59Z\", \"external_ids\":
         [\"CVE-2017-7542\"], \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2017-7542\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"http://www.example.com/security/2017/dsa-3927\",
         \"description\": null}], \"source\": \"nvd\", \"cwe\": \"(CWE-190|CWE-835)\"}",

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -329,6 +329,7 @@ class TestNVDCollector:
         assert flaw.cve_id == cve_id
         assert flaw.cwe_id == snippet_content["cwe_id"]
         assert flaw.description == snippet_content["description"]
+        assert flaw.reported_dt
         assert flaw.source == snippet_content["source"]
         assert flaw.task_key == "OSIM-1982"
         assert flaw.title == snippet_content["title"]

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_multi_cve_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_multi_cve_osv_record.yaml
@@ -716,7 +716,7 @@ interactions:
       API, which will not create vulnerable files. Old files will remain vulnerable
       until re-encrypted with the new client.", "comment_is_private": false, "alias":
       ["CVE-2020-8911"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
-      "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
+      "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-14T14:25:01Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
       \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2022-0646\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://aws.amazon.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/aws/aws-sdk-go/pull/3403\",
@@ -903,7 +903,7 @@ interactions:
         "dupe_of": null, "op_sys": "Linux", "depends_on": [], "cf_major_incident":
         null, "keywords": ["Security"], "cf_clone_of": null, "sub_components": {},
         "data_category": "Red Hat", "target_milestone": "---", "cf_release_notes":
-        "", "creator": "nobody@redhat.com", "cf_srtnotes": "{\"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
+        "", "creator": "nobody@redhat.com", "cf_srtnotes": "{\"reported\": \"2024-05-14T14:25:01Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
         \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
@@ -999,7 +999,7 @@ interactions:
         [], "is_private": false, "bug_id": 2037692, "creation_time": "2024-05-14T14:25:01Z",
         "creator_id": 425662, "private_groups": [], "attachment_id": null}], "id":
         2037692, "cf_qa_whiteboard": "", "tags": [], "assigned_to": "nobody@redhat.com",
-        "cf_devel_whiteboard": "", "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
+        "cf_devel_whiteboard": "", "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-14T14:25:01Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
         \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
@@ -1770,7 +1770,7 @@ interactions:
       API, which will not create vulnerable files. Old files will remain vulnerable
       until re-encrypted with the new client.", "comment_is_private": false, "alias":
       ["CVE-2020-8912"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
-      "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"],
+      "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-14T14:25:14Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"],
       \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2022-0646\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://aws.amazon.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/aws/aws-sdk-go/pull/3403\",
@@ -1975,7 +1975,7 @@ interactions:
         "", "creator_detail": {"insider": true, "email": "nobody@redhat.com", "real_name":
         "nobody", "active": true, "partner": false, "name": "nobody@redhat.com",
         "id": 425662}, "cf_internal_whiteboard": "", "cf_conditional_nak": [], "cc":
-        [], "cf_srtnotes": "{\"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"], \"references\":
+        [], "cf_srtnotes": "{\"reported\": \"2024-05-14T14:25:14Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"], \"references\":
         [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
@@ -2056,7 +2056,7 @@ interactions:
         "nobody@redhat.com", "partner": false, "id": 29451, "insider": false}, "classification":
         "Other", "actual_time": 0, "url": "", "target_milestone": "---", "data_category":
         "Red Hat", "cf_release_notes": "", "creator": "nobody@redhat.com", "cf_srtnotes":
-        "{\"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"], \"references\": [{\"type\":
+        "{\"reported\": \"2024-05-14T14:25:14Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"], \"references\": [{\"type\":
         \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\", \"description\":
         null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record.yaml
@@ -695,7 +695,7 @@ interactions:
       SQL injection in github.com/elgs/gosqljson", "description": "There is a potential
       for SQL injection through manipulation of the sqlStatement argument.", "comment_is_private":
       false, "alias": ["CVE-2014-125064"], "keywords": ["Security"], "flags": [],
-      "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
+      "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-14T13:57:55Z\", \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
       \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2023-1494\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
       \"description\": null}], \"source\": \"osv\"}"}'
@@ -873,7 +873,7 @@ interactions:
         "nobody", "insider": true, "email": "nobody@redhat.com", "partner":
         false, "name": "nobody@redhat.com", "id": 425662}, "resolution": "", "url":
         "", "op_sys": "Linux", "cf_devel_whiteboard": "", "assigned_to": "nobody@redhat.com",
-        "cc": [], "cf_srtnotes": "{\"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
+        "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-14T13:57:55Z\", \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
         \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2023-1494\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
         \"description\": null}], \"source\": \"osv\"}", "data_category": "Red Hat",
@@ -953,7 +953,7 @@ interactions:
         "NEW", "cf_pm_score": "0", "last_change_time": "2024-05-14T13:57:55Z", "is_creator_accessible":
         true, "is_cc_accessible": true, "target_milestone": "---", "data_category":
         "Red Hat", "product": "Security Response", "creator": "nobody@redhat.com",
-        "cf_srtnotes": "{\"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"], \"references\":
+        "cf_srtnotes": "{\"reported\": \"2024-05-14T13:57:55Z\", \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"], \"references\":
         [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2023-1494\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
         \"description\": null}], \"source\": \"osv\"}", "cf_release_notes": "", "sub_components":

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record_without_cve.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record_without_cve.yaml
@@ -718,7 +718,7 @@ interactions:
       to cause a denial of service (DoS) attack on the s42.app API, resulting in unavailability
       of the API for legitimate users.", "comment_is_private": false, "alias": ["GHSA-3hwm-922r-47hw"],
       "keywords": ["Security"], "flags": [], "groups": ["redhat"], "cc": [], "cf_srtnotes":
-      "{\"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\": [{\"type\": \"source\",
+      "{\"reported\": \"2024-05-14T14:06:42Z\", \"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\": [{\"type\": \"source\",
       \"url\": \"https://osv.dev/vulnerability/GHSA-3hwm-922r-47hw\", \"description\":
       null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42/issues/412\",
@@ -914,7 +914,7 @@ interactions:
         "nobody@redhat.com", "active": true, "name": "nobody@redhat.com", "real_name":
         "Nobody"}, "resolution": "", "cf_doc_type": "If docs needed, set a value",
         "sub_components": {}, "cf_clone_of": null, "product": "Security Response",
-        "cf_srtnotes": "{\"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\":
+        "cf_srtnotes": "{\"reported\": \"2024-05-14T14:06:42Z\", \"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\":
         [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-3hwm-922r-47hw\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/issues/412\",
@@ -989,7 +989,7 @@ interactions:
         "Linux", "url": "", "resolution": "", "creator_detail": {"insider": true,
         "email": "nobody@redhat.com", "active": true, "real_name": "nobody",
         "id": 425662, "name": "nobody@redhat.com", "partner": false}, "cf_internal_whiteboard":
-        "", "cf_conditional_nak": [], "cc": [], "cf_srtnotes": "{\"external_ids\":
+        "", "cf_conditional_nak": [], "cc": [], "cf_srtnotes": "{\"reported\": \"2024-05-14T14:06:42Z\", \"external_ids\":
         [\"GHSA-3hwm-922r-47hw\"], \"references\": [{\"type\": \"source\", \"url\":
         \"https://example.com/vulnerability/GHSA-3hwm-922r-47hw\", \"description\":
         null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -37,6 +37,7 @@ class TestOSVCollector:
         assert flaw.task_key == "OSIM-1975"
         assert json.loads(flaw.meta_attr["alias"]) == [cve_id]
         assert json.loads(flaw.meta_attr["external_ids"]) == [f"{osv_id}/{cve_id}"]
+        assert flaw.reported_dt
 
     @pytest.mark.vcr
     @pytest.mark.default_cassette("TestOSVCollector.test_collect_osv_record.yaml")

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1593,6 +1593,8 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
         model, data = [i for i in main_model.items()][0]
         flaw = model(**data, **shared_acl)
         flaw.save(raise_validation_error=False)
+        # reported_dt is set according to created_dt, which is set after flaw.save()
+        flaw.reported_dt = flaw.created_dt
 
         # creates related models (e.g. FlawCVSS)
         for model, list_of_data in related_models.items():

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -42,6 +42,7 @@ class TestSnippet:
         assert flaw.description == content["description"]
         assert flaw.meta_attr == {}
         assert flaw.references.count() == 1
+        assert flaw.reported_dt
         assert flaw.snippets.count() == 1
         assert flaw.source == snippet.source
         assert flaw.title == content["title"]


### PR DESCRIPTION
This PR adds the `reported_dt` field to flaws created by collectors. `reported_dt` is set according to `created_dt`.

Fixes OSIDB-2771