### PR TITLE
OSIDB-2734 refine /osidb/api/v1/jira_stage_forwarder?path= 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bulk PUT for Affects (OSIDB-2407)
 - Add Bugzilla token to promote API (OSIDB-2262)
 - Enable creation of Jira tasks for collector flaws (OSIDB-2649)
-- Add temporary JIRA stage http forwarder (OSIDB-2734)
+- Add temporary JIRA stage http forwarder passing in headers/params (OSIDB-2734)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -983,10 +983,14 @@ class JiraStageForwarderView(APIView):
         """perform JIRA stage HTTP GET"""
         path_value = request.GET.get("path")
         target_url = f"{JIRA_SERVER}{path_value}"
+        headers = dict(request.headers)
+        params = request.GET.copy()
+        params.pop("path")
         response = requests.get(
             target_url,
             proxies=self.proxies,
-            headers=self.headers,
+            params=params,
+            headers=headers.update(self.headers),
             timeout=30,
         )
         return Response(response.json(), status=response.status_code)
@@ -995,11 +999,15 @@ class JiraStageForwarderView(APIView):
         """perform JIRA stage HTTP POST"""
         path_value = request.GET.get("path")
         target_url = f"{JIRA_SERVER}{path_value}"
+        headers = dict(request.headers)
+        params = request.GET.copy()
+        params.pop("path")
         response = requests.post(
             target_url,
             data=request.POST,
             proxies=self.proxies,
-            headers=self.headers,
+            params=params,
+            headers=headers.update(self.headers),
             timeout=30,
         )
         return Response(response.json, status=response.status_code)

--- a/osidb/renderers.py
+++ b/osidb/renderers.py
@@ -24,10 +24,16 @@ class OsidbRenderer(JSONRenderer):
     def render(self, data, accepted_media_type=None, renderer_context=None):
         # this custom renderer will inject a couple of meta fields to every
         # response that is sent back for API requests
-        if data is None:
-            data = {}
-        data["dt"] = timezone.now()
-        data["revision"] = os.getenv("OPENSHIFT_BUILD_COMMIT") or "unknown"
-        data["version"] = osidb.__version__
-        data["env"] = calc_env(os.getenv("DJANGO_SETTINGS_MODULE"))
+        # TODO: remove this when we remove jira_stage_forwarder
+        if not (
+            renderer_context["request"].path.startswith(
+                "/osidb/api/v1/jira_stage_forwarder"
+            )
+        ):
+            if data is None:
+                data = {}
+            data["dt"] = timezone.now()
+            data["revision"] = os.getenv("OPENSHIFT_BUILD_COMMIT") or "unknown"
+            data["version"] = osidb.__version__
+            data["env"] = calc_env(os.getenv("DJANGO_SETTINGS_MODULE"))
         return super().render(data, accepted_media_type, renderer_context)


### PR DESCRIPTION
So we remove json boilerplate just for this endpoint - and pass thru headers/url params.