### PR TITLE
Make flaw comments independent of Bugzilla

### DIFF
--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -843,6 +843,8 @@ class FlawConvertor(BugzillaGroupsConvertorMixin):
                 ),
                 order=comment["count"],
                 text=comment["text"],
+                creator=comment["creator"],
+                is_private=comment.get("is_private", False),
                 type=FlawComment.FlawCommentType.BUGZILLA,
                 acl_read=self.acl_read,
                 acl_write=self.acl_write,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Bugzilla sync not working when Jira task sync is enabled (OSIDB-2628)
 - Ignore SLA if update stream specifies it's not applicable (OSIDB-2612)
 - Allow filtering by empty or null CVE IDs (OSIDB-2625)
+- Redesign of flaw comments to make them independent of Bugzilla (OSIDB-2760)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/openapi.yml
+++ b/openapi.yml
@@ -4135,6 +4135,10 @@ paths:
         comments are created simultaneously.
       parameters:
       - in: query
+        name: creator
+        schema:
+          type: string
+      - in: query
         name: exclude_fields
         schema:
           type: array
@@ -7586,6 +7590,8 @@ components:
           type: string
           format: uuid
           readOnly: true
+        text:
+          type: string
         type:
           $ref: '#/components/schemas/FlawCommentType'
         external_system_id:
@@ -7596,6 +7602,11 @@ components:
           maximum: 2147483647
           minimum: -2147483648
           nullable: true
+        creator:
+          type: string
+          maxLength: 100
+        is_private:
+          type: boolean
         meta_attr:
           type: object
           additionalProperties:
@@ -7618,6 +7629,7 @@ components:
       required:
       - alerts
       - created_dt
+      - text
       - updated_dt
       - uuid
     CvssVersionEnum:
@@ -8261,6 +8273,11 @@ components:
           maximum: 2147483647
           minimum: -2147483648
           nullable: true
+        creator:
+          type: string
+          maxLength: 100
+        is_private:
+          type: boolean
         alerts:
           type: array
           items:
@@ -8301,6 +8318,11 @@ components:
           readOnly: true
         type:
           $ref: '#/components/schemas/FlawCommentType'
+        creator:
+          type: string
+          maxLength: 100
+        is_private:
+          type: boolean
         meta_attr:
           type: object
           additionalProperties:

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -728,6 +728,7 @@ class FlawCommentFilter(IncludeFieldsFilterSet, ExcludeFieldsFilterSet):
             "uuid": ["exact"],
             "order": ["exact"],
             "external_system_id": ["exact"],
+            "creator": ["exact"],
         }
 
 

--- a/osidb/migrations/0133_flawcomment_redesign.py
+++ b/osidb/migrations/0133_flawcomment_redesign.py
@@ -1,0 +1,55 @@
+from django.db import migrations, models
+from django.conf import settings
+
+from osidb.core import set_user_acls
+
+
+BATCH_SIZE = 1000
+
+
+def forwards_func(apps, schema_editor):
+    set_user_acls(settings.ALL_GROUPS)
+    FlawComment = apps.get_model("osidb", "FlawComment")
+
+    # Move existing comment data from meta_attr to the model
+    comments = FlawComment.objects.all().iterator(chunk_size=BATCH_SIZE)
+
+    batch = []
+    for i, comment in enumerate(comments, 1):
+        comment.creator = comment.meta_attr.get("creator", "")
+        # is_private seems to be stored as either a string ("True", "False") or
+        # as a bool in old data, so check both cases
+        is_private = comment.meta_attr.get("is_private", False)
+        if isinstance(is_private, str):
+            is_private = is_private == "True"
+        elif not isinstance(is_private, bool):
+            # Just in case we have something else...
+            is_private = False
+        comment.is_private = is_private
+        batch.append(comment)
+        if i % BATCH_SIZE == 0:
+            FlawComment.objects.bulk_update(batch, ["creator", "is_private"])
+            batch = []
+    if batch:
+        FlawComment.objects.bulk_update(batch, ["creator", "is_private"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("osidb", "0132_remove_flaw_state"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="flawcomment",
+            name="creator",
+            field=models.CharField(blank=True, max_length=100),
+        ),
+        migrations.AddField(
+            model_name="flawcomment",
+            name="is_private",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(forwards_func, migrations.RunPython.noop, atomic=True),
+    ]

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2943,6 +2943,14 @@ class FlawComment(
     # text of the comment
     text = models.TextField()
 
+    # creator of the comment, which can be passed as an argument when creating it,
+    # similar to the flaw's owner field, or if BZ sync is enabled, then it will be
+    # implied from the BZ API key owner during sync
+    creator = models.CharField(max_length=100, blank=True)
+
+    # whether the comment is internal or not
+    is_private = models.BooleanField(default=False)
+
     # comment meta data
     meta_attr = HStoreField(default=dict)
 

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -691,9 +691,12 @@ class CommentSerializer(AlertMixinSerializer, TrackingMixinSerializer):
         fields = (
             [
                 "uuid",
+                "text",
                 "type",
                 "external_system_id",
                 "order",
+                "creator",
+                "is_private",
                 "meta_attr",
             ]
             + AlertMixinSerializer.Meta.fields


### PR DESCRIPTION
This commit redesigns the FlawComment model as well as the API to make them independent of Bugzilla sync. Before this commit, the comment info was being stored in meta_attr, which is filled during the sync with Bugzilla. Some info was also shared in the base model (text) but wasn't being sent through the API, while other info was completely lost (creator, is_private, time).

With this commit, the info is stored in the model, and during sync it is updated. The info in the model is also serialized and sent via the API.

Closes OSIDB-2760.