### PR TITLE
Fix not being able to set CVE to empty string through API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix workflow rejection endpoint (OSIDB-2456)
 - Fix FlawReference article count validation (OSIDB-2651)
 - Fix erratum-tracker linking (OSIDB-2752)
+- Fix not being able to set CVE ID to an empty string through the API (OSIDB-270)
 
 ### Removed
 - Remove "type" field from Affect (OSIDB-2743)

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1433,7 +1433,7 @@ class FlawSerializer(
         "task_owner",
     )
 
-    cve_id = serializers.CharField(required=False, allow_null=True)
+    cve_id = serializers.CharField(required=False, allow_null=True, allow_blank=True)
     trackers = FlawAffectsTrackersField(source="*", read_only=True)
     affects = serializers.SerializerMethodField()
     comments = CommentSerializer(many=True, read_only=True)

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -1452,6 +1452,7 @@ class TestEndpointsFlaws:
             (None, "CVE-2020-12345"),
             ("CVE-2020-12345", None),
             ("CVE-2020-12345", "CVE-2020-54321"),
+            ("CVE-2020-12345", ""),
         ],
     )
     def test_flaw_update_cve(


### PR DESCRIPTION
The `cve_id` field allows both empty and null values, but through the API it was rejecting an empty string with an error, because the serializer did not accept empty strings.

To make it consistent with the model, the serializer has been modified to allow empty strings as well.

Closes OSIDB-2702.