### PR TITLE
split flaw tracker bbsync

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,7 +162,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 84,
         "is_secret": false
       }
     ],
@@ -258,7 +258,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 113,
+        "line_number": 115,
         "is_secret": false
       }
     ],
@@ -268,7 +268,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 85,
+        "line_number": 89,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-05-30T17:18:05Z"
+  "generated_at": "2024-05-31T12:29:53Z"
 }

--- a/apps/bbsync/constants.py
+++ b/apps/bbsync/constants.py
@@ -14,8 +14,12 @@ RHSCL_BTS_KEY = "Red Hat Software Collections"
 # JSON schema for SRT notes flaw metadata
 SRTNOTES_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "./srtnotes-schema.json")
 
-# switch to enable or disable BBSync
+# switches to enable or disable BBSync
 SYNC_TO_BZ = get_env("BBSYNC_SYNC_TO_BZ", default="False", is_bool=True)
+SYNC_FLAWS_TO_BZ = get_env("BBSYNC_SYNC_FLAWS_TO_BZ", default="False", is_bool=True)
+SYNC_TRACKERS_TO_BZ = get_env(
+    "BBSYNC_SYNC_TRACKERS_TO_BZ", default="False", is_bool=True
+)
 
 # in SFM2 there are Bugzilla bot accounts and invalid users being filtered out from the CC lists
 # however the list of the corresponding emails is being pulled from VDB by the old vdbqb library

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -34,8 +34,11 @@ pytestmark = pytest.mark.integration
 @pytest.fixture(autouse=True)
 def enable_bbsync_env_var(monkeypatch) -> None:
     import apps.bbsync.mixins as mixins
+    import osidb.models as models
 
     monkeypatch.setattr(mixins, "SYNC_TO_BZ", True)
+    monkeypatch.setattr(models, "SYNC_FLAWS_TO_BZ", True)
+    monkeypatch.setattr(models, "SYNC_TRACKERS_TO_BZ", True)
 
 
 class TestBBSyncIntegration:

--- a/collectors/nvd/tests/conftest.py
+++ b/collectors/nvd/tests/conftest.py
@@ -21,6 +21,8 @@ def enable_env_vars(monkeypatch) -> None:
     monkeypatch.setattr(bbsync_mixins, "SYNC_TO_BZ", True)
     monkeypatch.setattr(taskman_mixins, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
     monkeypatch.setattr(models, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
+    monkeypatch.setattr(models, "SYNC_FLAWS_TO_BZ", True)
+    monkeypatch.setattr(models, "SYNC_TRACKERS_TO_BZ", True)
     monkeypatch.setattr(collectors, "JIRA_AUTH_TOKEN", "SECRET")
 
 

--- a/collectors/osv/tests/conftest.py
+++ b/collectors/osv/tests/conftest.py
@@ -16,4 +16,6 @@ def enable_env_vars(monkeypatch) -> None:
     monkeypatch.setattr(bbsync_mixins, "SYNC_TO_BZ", True)
     monkeypatch.setattr(taskman_mixins, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
     monkeypatch.setattr(models, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
+    monkeypatch.setattr(models, "SYNC_FLAWS_TO_BZ", True)
+    monkeypatch.setattr(models, "SYNC_TRACKERS_TO_BZ", True)
     monkeypatch.setattr(collectors, "JIRA_AUTH_TOKEN", "SECRET")

--- a/conftest.py
+++ b/conftest.py
@@ -217,7 +217,8 @@ def enable_bugzilla_sync(monkeypatch) -> None:
     import osidb.models as models
 
     monkeypatch.setattr(mixins, "SYNC_TO_BZ", True)
-    monkeypatch.setattr(models, "SYNC_TO_BZ", True)
+    monkeypatch.setattr(models, "SYNC_FLAWS_TO_BZ", True)
+    monkeypatch.setattr(models, "SYNC_TRACKERS_TO_BZ", True)
 
 
 @pytest.fixture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
         - "8000:8000"
       environment:
         BBSYNC_SYNC_TO_BZ: ${BBSYNC_SYNC_TO_BZ}
+        BBSYNC_SYNC_FLAWS_TO_BZ: ${BBSYNC_SYNC_FLAWS_TO_BZ}
+        BBSYNC_SYNC_TRACKERS_TO_BZ: ${BBSYNC_SYNC_TRACKERS_TO_BZ}
         BZIMPORT_BZ_API_KEY: ${BZIMPORT_BZ_API_KEY:?Variable BZIMPORT_BZ_API_KEY must be set.}
         BZIMPORT_BZ_URL: ${BZIMPORT_BZ_URL}
         DJANGO_SETTINGS_MODULE: "config.settings_local"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow filtering by empty or null CVE IDs (OSIDB-2625)
 - Redesign of flaw comments to make them independent of Bugzilla (OSIDB-2760)
 - Allow filling trackers for flaws without bz_id (OSIDB-2819)
+- Split BBSync enablement switch into flaw and tracker ones (OSIDB-2820)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -57,6 +57,10 @@ RH_CERT_URL="https://foo.bar"
 # enable Bugzilla backwards sync to propagate writes to Bugzilla
 # otherwise all the writes are performed only locally in OSIDB
 BBSYNC_SYNC_TO_BZ=1
+# enable Bugzilla backwards sync of the flaws
+BBSYNC_SYNC_FLAWS_TO_BZ=1
+# enable Bugzilla backwards sync of the trackers
+BBSYNC_SYNC_TRACKERS_TO_BZ=1
 
 # enable Jira tracker sync to propagate writes to Jira
 # otherwise all the writes are performed only locally in OSIDB

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -140,5 +140,6 @@ def disable_sync(monkeypatch) -> None:
 
     monkeypatch.setattr(mixins, "SYNC_TO_BZ", False)
     monkeypatch.setattr(models, "JIRA_TASKMAN_AUTO_SYNC_FLAW", False)
-    monkeypatch.setattr(models, "SYNC_TO_BZ", False)
+    monkeypatch.setattr(models, "SYNC_FLAWS_TO_BZ", False)
+    monkeypatch.setattr(models, "SYNC_TRACKERS_TO_BZ", False)
     monkeypatch.setattr(models, "SYNC_TO_JIRA", False)

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -507,7 +507,8 @@ class TestBugzillaJiraMixinInteration:
         monkeypatch.setattr(models, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
         monkeypatch.setattr(serializer, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
         monkeypatch.setattr(bz_mixins, "SYNC_TO_BZ", True)
-        monkeypatch.setattr(models, "SYNC_TO_BZ", True)
+        monkeypatch.setattr(models, "SYNC_FLAWS_TO_BZ", True)
+        monkeypatch.setattr(models, "SYNC_TRACKERS_TO_BZ", True)
         monkeypatch.setattr(models, "SYNC_TO_JIRA", True)
 
         monkeypatch.setenv("HTTPS_PROXY", "http://squid.corp.redhat.com:3128")


### PR DESCRIPTION
This PR splits the enablement switch for the BBSync to flaw and tracker switches. It also adds them to the compose and the docs and fixes some related test environments.

The OPS part is in https://gitlab.corp.redhat.com/product-security/dev/osidb-ops/-/merge_requests/83

Closes OSIDB-2820