### PR TITLE
Allow filling trackers for flaws without bz_id

### DIFF
--- a/apps/trackers/save.py
+++ b/apps/trackers/save.py
@@ -21,7 +21,10 @@ class TrackerSaver:
         """
         # we do not support tracker filing for the old multi-CVE flaws
         for affect in tracker.affects.all():
-            if Flaw.objects.filter(meta_attr__bz_id=affect.flaw.bz_id).count() > 1:
+            if (
+                affect.flaw.bz_id
+                and Flaw.objects.filter(meta_attr__bz_id=affect.flaw.bz_id).count() > 1
+            ):
                 raise UnsupportedTrackerError(
                     "Creating trackers for flaws with multiple CVEs is not supported"
                 )

--- a/apps/trackers/tests/test_save.py
+++ b/apps/trackers/tests/test_save.py
@@ -173,6 +173,34 @@ class TestTrackerSaver:
         ):
             TrackerSaver(tracker)
 
+    def test_empty_bz_id(self):
+        """
+        test we can fill a tracker without bz_id
+        """
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        # need two empty bz_id flaws to test conflict
+        FlawFactory(bz_id=None)
+        flaw = FlawFactory(bz_id=None)
+
+        affect = AffectFactory(
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
+            ps_component="component",
+            flaw=flaw,
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.JIRA,
+        )
+
+        TrackerSaver(tracker, jira_token="SECRET")  # nosec
+
 
 class TestTrackerModelSave:
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Ignore SLA if update stream specifies it's not applicable (OSIDB-2612)
 - Allow filtering by empty or null CVE IDs (OSIDB-2625)
 - Redesign of flaw comments to make them independent of Bugzilla (OSIDB-2760)
+- Allow filling trackers for flaws without bz_id (OSIDB-2819)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)


### PR DESCRIPTION
This PR changes TrackerSaver in order to allow filling trackers for manually created flaws (without bz_id).

Closes OSIDB-2819.