### PR TITLE
OSIDB-2746: Set TrackerSerializer.resolution as read_only

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow filling trackers for flaws without bz_id (OSIDB-2819)
 - Split BBSync enablement switch into flaw and tracker ones (OSIDB-2820)
 - Set "Target Release" field in Jira trackers (OSIDB-2727)
+- Tracker resolution is now readonly (OSIDB-2746)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/openapi.yml
+++ b/openapi.yml
@@ -8855,7 +8855,7 @@ components:
           readOnly: true
         resolution:
           type: string
-          maxLength: 100
+          readOnly: true
         type:
           allOf:
           - $ref: '#/components/schemas/TrackerType'
@@ -8890,6 +8890,7 @@ components:
       - errata
       - external_system_id
       - meta_attr
+      - resolution
       - status
       - type
       - updated_dt
@@ -8936,7 +8937,7 @@ components:
           readOnly: true
         resolution:
           type: string
-          maxLength: 100
+          readOnly: true
         type:
           allOf:
           - $ref: '#/components/schemas/TrackerType'
@@ -8970,6 +8971,7 @@ components:
       - embargoed
       - errata
       - meta_attr
+      - resolution
       - status
       - type
       - updated_dt

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -526,6 +526,7 @@ class TrackerSerializer(
             "external_system_id",
             "status",
             "type",
+            "resolution",
         ]
 
     def create(self, validated_data):


### PR DESCRIPTION
`TrackerSerializer.resolution` should be set as read-only. We do not want to set either status or resolution for the trackers, that is still going to be left for the engineering.

This is part of the **4.0** release

Closes OSIDB-2746