### PR TITLE
Set target release in Jira trackers

### DIFF
--- a/apps/trackers/exceptions.py
+++ b/apps/trackers/exceptions.py
@@ -15,6 +15,12 @@ class NoSecurityLevelAvailableError(BTSException):
     """exception class for missing correct Security Level in the particular project"""
 
 
+class NoTargetReleaseVersionAvailableError(BTSException):
+    """
+    Exception class for missing target release (or its fallback target version) value in the project.
+    """
+
+
 class TrackerCreationError(BTSException):
     """
     exception class for the cases of unsuccessful tracker creation

--- a/apps/trackers/jira/constants.py
+++ b/apps/trackers/jira/constants.py
@@ -11,8 +11,10 @@ JIRA_INTERNAL_SECURITY_LEVEL_NAME = get_env(
     "JIRA_INTERNAL_SECURITY_LEVEL_NAME", default="Red Hat Employee"
 )
 
-# Translate additional fields as defined in product definitions to the actual Jira field
+# Translate fields as defined in product definitions to the actual Jira field
 PS_ADDITIONAL_FIELD_TO_JIRA = {
     "fixVersions": "fixVersions",
     "release_blocker": "customfield_12319743",
+    "target_release": "customfield_12311240",
+    "target_version": "customfield_12319940",
 }

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -10,6 +10,7 @@ from apps.trackers.common import TrackerQueryBuilder
 from apps.trackers.exceptions import (
     NoPriorityAvailableError,
     NoSecurityLevelAvailableError,
+    NoTargetReleaseVersionAvailableError,
     TrackerCreationError,
 )
 from apps.trackers.models import JiraProjectFields
@@ -96,6 +97,7 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
         self.generate_additional_fields()
         self.generate_security()
         self.generate_cc()
+        self.generate_target_release()
 
     def generate_base(self):
         self._query = {
@@ -332,6 +334,43 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
                     f"Jira project {self.ps_module.bts_key} does not have available field Contributors or "
                     f"Involved. This is a regression on the part of the administration of that Jira project."
                 )
+
+    def generate_target_release(self):
+        """
+        Generate target release field from the PsUpdateStream's data.
+        """
+        value = self.ps_update_stream.target_release
+        if value is None:
+            return
+
+        # Try to use Jira field "Target Release"
+        field_name = "Target Release"
+        field_id = PS_ADDITIONAL_FIELD_TO_JIRA["target_release"]
+        field_obj = JiraProjectFields.objects.filter(
+            project_key=self.ps_module.bts_key, field_id=field_id
+        ).first()
+        if field_obj is None:
+            # Use field "Target Version" as fallback option
+            field_name = "Target Version"
+            field_id = PS_ADDITIONAL_FIELD_TO_JIRA["target_version"]
+            field_obj = JiraProjectFields.objects.filter(
+                project_key=self.ps_module.bts_key, field_id=field_id
+            ).first()
+        if field_obj is None:
+            # The fields are not available for this project
+            return
+
+        allowed_values = field_obj.allowed_values
+        if allowed_values and value in allowed_values:
+            query_value = (
+                {"name": value} if field_name == "Target Release" else [{"name": value}]
+            )
+            self._query["fields"][field_id] = query_value
+        else:
+            raise NoTargetReleaseVersionAvailableError(
+                f"Jira project {self.ps_module.bts_key} does not have {field_name} with value "
+                f"{value} available; allowed values values are: {', '.join(allowed_values)}"
+            )
 
     @property
     def query_comment(self):

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -1,6 +1,7 @@
 """
 Bugzilla specific tracker test cases
 """
+
 import json
 from typing import Any, Dict
 from unittest.mock import mock_open, patch
@@ -8,7 +9,10 @@ from unittest.mock import mock_open, patch
 import pytest
 from django.utils.timezone import datetime, make_aware
 
-from apps.trackers.exceptions import NoSecurityLevelAvailableError
+from apps.trackers.exceptions import (
+    NoSecurityLevelAvailableError,
+    NoTargetReleaseVersionAvailableError,
+)
 from apps.trackers.jira.constants import PS_ADDITIONAL_FIELD_TO_JIRA
 from apps.trackers.jira.query import JiraPriority, TrackerJiraQueryBuilder
 from apps.trackers.models import JiraProjectFields
@@ -752,6 +756,79 @@ sla:
 
             assert query_builder.query["fields"] == expected_fields
             assert query_builder.query_comment == expected_comment
+
+    @pytest.mark.parametrize(
+        "target_release, target_version, valid_jira_field, available_field",
+        [
+            ("4.1.0", None, True, True),
+            (None, "One-off release", True, True),
+            ("4.1.0", None, True, False),
+            (None, None, False, False),
+            ("42.17", None, False, True),
+            (None, "20.77", False, True),
+        ],
+    )
+    def test_generate_target_release(
+        self, target_release, target_version, valid_jira_field, available_field
+    ):
+        """
+        Test generation of Target Release/Target Version fields from PsUpdateStream.
+        """
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(
+            ps_module=ps_module,
+            target_release=(
+                target_release if target_release is not None else target_version
+            ),
+        )
+        flaw = FlawFactory()
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            type=Tracker.TrackerType.JIRA,
+            ps_update_stream=ps_update_stream.name,
+            embargoed=flaw.embargoed,
+        )
+
+        # Create mock field
+        if available_field:
+            if target_release is not None:
+                field_id = "customfield_12311240"
+                field_name = "Target Release"
+            else:
+                field_id = "customfield_12319940"
+                field_name = "Target Version"
+            JiraProjectFieldsFactory(
+                project_key=ps_module.bts_key,
+                field_id=field_id,
+                field_name=field_name,
+                allowed_values=[
+                    "4.1.0",
+                    "One-off release",
+                ],
+            )
+
+        query_builder = TrackerJiraQueryBuilder(tracker)
+        query_builder._query = {"fields": {}}
+        if not available_field:
+            # If the field is not available in the project, nothing is generated
+            query_builder.generate_target_release()
+            assert "customfield_12311240" not in query_builder.query["fields"]
+            assert "customfield_12319940" not in query_builder.query["fields"]
+        elif valid_jira_field:
+            query_builder.generate_target_release()
+            query_value = query_builder.query["fields"].get(field_id)
+            if target_release is not None:
+                assert query_value == {"name": target_release}
+            elif target_version is not None:
+                assert query_value == [{"name": target_version}]
+        else:
+            with pytest.raises(NoTargetReleaseVersionAvailableError):
+                query_builder.generate_target_release()
 
 
 def validate_minimum_key_value(minimum: Dict[str, Any], evaluated: Dict[str, Any]):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Redesign of flaw comments to make them independent of Bugzilla (OSIDB-2760)
 - Allow filling trackers for flaws without bz_id (OSIDB-2819)
 - Split BBSync enablement switch into flaw and tracker ones (OSIDB-2820)
+- Set "Target Release" field in Jira trackers (OSIDB-2727)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)


### PR DESCRIPTION
Using the data from the PsUpdateStream, set the Target Release field (or if not available, use the Target Version field as fallback) when creating/updating Jira trackers. This info is available in the `target_release` field in PsUpdateStream.

Closes OSIDB-2727.