### PR TITLE
OSIDB-2734 refine stage jira http forwarder

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bulk PUT for Affects (OSIDB-2407)
 - Add Bugzilla token to promote API (OSIDB-2262)
 - Enable creation of Jira tasks for collector flaws (OSIDB-2649)
-- Add temporary JIRA stage http forwarder passing in headers/params (OSIDB-2734)
+- Add temporary JIRA stage http forwarder passing in params (OSIDB-2734)
 - Add link between trackers to flaws without CVE (OSIDB-2848)
 
 ### Changed


### PR DESCRIPTION
Require stage **jira-api-key** (via HTTP header) - which removes the need for using osidb-stage own jira token ... and will now throw HTTP 400 error if missing Jira-Api-Key header.