### PR TITLE
Implement is_triage in trackers and use it in SLA policies

### DIFF
--- a/apps/sla/sla.yml
+++ b/apps/sla/sla.yml
@@ -32,6 +32,8 @@ conditions:
   flaw:
     - is major incident
     - is not embargoed
+  tracker:
+    - is not triage
 sla:
   duration: 5
   start:
@@ -53,6 +55,7 @@ conditions:
     - is not embargoed
   tracker:
     - is compliance priority
+    - is not triage
 sla:
   duration: 7
   start:
@@ -70,6 +73,8 @@ conditions:
     - is not community
   flaw:
     - is not embargoed
+  tracker:
+    - is not triage
 sla:
   duration: 30
   start:
@@ -91,6 +96,7 @@ conditions:
     - is not embargoed
   tracker:
     - is compliance priority
+    - is not triage
 sla:
   duration: 21
   start:
@@ -108,6 +114,8 @@ conditions:
     - is not community
   flaw:
     - is not embargoed
+  tracker:
+    - is not triage
 sla:
   duration: 60
   start:
@@ -129,6 +137,7 @@ conditions:
     - is not embargoed
   tracker:
     - is compliance priority
+    - is not triage
 sla:
   duration: 50
   start:
@@ -146,6 +155,8 @@ conditions:
     - is not community
   flaw:
     - is not embargoed
+  tracker:
+    - is not triage
 sla:
   duration: 90
   start:
@@ -163,6 +174,8 @@ conditions:
     - is not community
   flaw:
     - is not embargoed
+  tracker:
+    - is not triage
 sla:
   duration: 180
   start:

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -358,11 +358,7 @@ class TrackerQueryBuilder:
         if not self.ps_module.private_trackers_allowed:
             header += "Public "
 
-        header += (
-            "Security Issue Notification"
-            if self.tracker.is_triage
-            else "Security Tracking Issue"
-        )
+        header += "Security Tracking Issue"
         description_parts.append(header)
 
         if self.ps_module.private_trackers_allowed:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split BBSync enablement switch into flaw and tracker ones (OSIDB-2820)
 - Set "Target Release" field in Jira trackers (OSIDB-2727)
 - Tracker resolution is now readonly (OSIDB-2746)
+- Implement is_triage in trackers and use it in SLA policies (OSIDB-2729)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2604,11 +2604,11 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
     @property
     def is_triage(self):
         """
-        triage tracker has a non-published flaw state attached
+        A tracker is in triage if all the affects linked to it are in NEW state of affectedness.
         """
-        # TODO this is only a placeholder for now
-        # it is to be determined and implemented
-        return False
+        return not self.affects.exclude(
+            affectedness=Affect.AffectAffectedness.NEW
+        ).exists()
 
     @property
     def is_compliance_priority(self) -> bool:

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -100,6 +100,36 @@ class TestTracker:
         assert acked_tracker.is_acked and not acked_tracker.is_unacked
         assert not unacked_tracker.is_acked and unacked_tracker.is_unacked
 
+    @pytest.mark.parametrize(
+        "affectedness_list, is_triage",
+        [
+            ([Affect.AffectAffectedness.NEW], True),
+            ([Affect.AffectAffectedness.AFFECTED], False),
+            ([Affect.AffectAffectedness.NEW, Affect.AffectAffectedness.NEW], True),
+            (
+                [Affect.AffectAffectedness.NEW, Affect.AffectAffectedness.AFFECTED],
+                False,
+            ),
+        ],
+    )
+    def test_is_triage(self, affectedness_list, is_triage):
+        """
+        Test that a tracker is considered on triage if all of its affects are in NEW
+        affectedness state.
+        """
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        affects = [
+            AffectFactory(
+                ps_module=ps_module.name,
+                affectedness=affectedness,
+                ps_component="component",
+                flaw=FlawFactory(embargoed=False),
+            )
+            for affectedness in affectedness_list
+        ]
+        tracker = TrackerFactory(affects=affects, type=Tracker.TrackerType.BUGZILLA)
+        assert tracker.is_triage == is_triage
+
 
 class TestTrackerValidators:
     def test_validate_good(self):


### PR DESCRIPTION
This commit implements the `is_triage` property in trackers. A tracker is considered in triage when all the linked affects have a NEW affectedness state. This property is now used in all SLA policies, which will not be accepted if the tracker is in triage.

Closes OSIDB-2729.