### PR TITLE
Allow trackers for non CVE flaws

### DIFF
--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -163,6 +163,12 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
                         "flaw__cve_id", flat=True
                     )
                 ),
+                *[  # add all linked flaw UUIDs
+                    f"flawuuid:{uuid}"
+                    for uuid in self.tracker.affects.filter(
+                        flaw__isnull=False
+                    ).values_list("flaw__uuid", flat=True)
+                ],
                 *[  # add all linked non-empty BZ IDs
                     "flaw:bz#" + meta_attr["bz_id"]
                     for meta_attr in self.tracker.affects.filter(

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -148,6 +148,9 @@ class TestTrackerJiraQueryBuilder:
                     "SecurityTracking",
                     "flaw:bz#42",
                     "flaw:bz#72",
+                    "flawuuid:b46a4c34-3c29-4fbd-8543-95d460bb3ceb",
+                    "flawuuid:7f30f723-317d-4eff-97ed-65fc844e7c69",
+                    "flawuuid:f3979e01-47ca-48e0-830c-ebe6fc02b259",
                     "pscomponent:component",
                 ],
             ),
@@ -164,6 +167,9 @@ class TestTrackerJiraQueryBuilder:
                     "custom_label",
                     "flaw:bz#42",
                     "flaw:bz#72",
+                    "flawuuid:b46a4c34-3c29-4fbd-8543-95d460bb3ceb",
+                    "flawuuid:7f30f723-317d-4eff-97ed-65fc844e7c69",
+                    "flawuuid:f3979e01-47ca-48e0-830c-ebe6fc02b259",
                     "pscomponent:component",
                 ],
             ),
@@ -176,6 +182,9 @@ class TestTrackerJiraQueryBuilder:
                     "SecurityTracking",
                     "flaw:bz#42",
                     "flaw:bz#72",
+                    "flawuuid:b46a4c34-3c29-4fbd-8543-95d460bb3ceb",
+                    "flawuuid:7f30f723-317d-4eff-97ed-65fc844e7c69",
+                    "flawuuid:f3979e01-47ca-48e0-830c-ebe6fc02b259",
                     "pscomponent:component",
                 ],
             ),
@@ -205,6 +214,9 @@ class TestTrackerJiraQueryBuilder:
                     "SecurityTracking",
                     "flaw:bz#42",
                     "flaw:bz#72",
+                    "flawuuid:b46a4c34-3c29-4fbd-8543-95d460bb3ceb",
+                    "flawuuid:7f30f723-317d-4eff-97ed-65fc844e7c69",
+                    "flawuuid:f3979e01-47ca-48e0-830c-ebe6fc02b259",
                     "foobaa",
                     "foobar",
                     "foobaz",
@@ -221,10 +233,22 @@ class TestTrackerJiraQueryBuilder:
             # Do what jiraffe/convertors.py::JiraTrackerConvertor._normalize normally does
             # when saving meta_attr (improve readability of pytest parameters).
             meta["labels"] = json.dumps(meta["labels"])
-        flaw1 = FlawFactory(bz_id="42", cve_id="CVE-2000-2000")
-        flaw2 = FlawFactory(bz_id="72", embargoed=flaw1.embargoed, cve_id=None)
+        flaw1 = FlawFactory(
+            uuid="b46a4c34-3c29-4fbd-8543-95d460bb3ceb",
+            bz_id="42",
+            cve_id="CVE-2000-2000",
+        )
+        flaw2 = FlawFactory(
+            uuid="7f30f723-317d-4eff-97ed-65fc844e7c69",
+            bz_id="72",
+            embargoed=flaw1.embargoed,
+            cve_id=None,
+        )
         flaw3 = FlawFactory(
-            bz_id=None, embargoed=flaw1.embargoed, cve_id="CVE-2000-2001"
+            uuid="f3979e01-47ca-48e0-830c-ebe6fc02b259",
+            bz_id=None,
+            embargoed=flaw1.embargoed,
+            cve_id="CVE-2000-2001",
         )
         ps_module = PsModuleFactory(bts_name="jboss")
         affect1 = AffectFactory(
@@ -262,6 +286,9 @@ class TestTrackerJiraQueryBuilder:
         query_builder.generate_labels()
 
         labels = query_builder.query["fields"]["labels"]
+        assert f"flawuuid:{flaw1.uuid}" in labels
+        assert f"flawuuid:{flaw2.uuid}" in labels
+        assert f"flawuuid:{flaw3.uuid}" in labels
         assert "SecurityTracking" in labels
         assert "Security" in labels
         assert "pscomponent:component" in labels
@@ -270,7 +297,7 @@ class TestTrackerJiraQueryBuilder:
         assert "flaw:bz#72" in labels
         assert "flaw:bz#" not in labels
         assert len(labels) == len(expected_labels)
-        assert labels == expected_labels
+        assert sorted(labels) == sorted(expected_labels)
 
     def test_generate_label_contract_priority(self):
         """
@@ -305,7 +332,8 @@ class TestTrackerJiraQueryBuilder:
         assert "pscomponent:component" in labels
         assert "CVE-2000-2000" in labels
         assert "flaw:bz#42" in labels
-        assert len(labels) == 6
+        assert f"flawuuid:{flaw1}" in labels
+        assert len(labels) == 7
 
     @pytest.mark.parametrize(
         "impact,yml_components",
@@ -356,12 +384,13 @@ class TestTrackerJiraQueryBuilder:
         assert "pscomponent:component" in labels
         assert "CVE-2000-2000" in labels
         assert "flaw:bz#42" in labels
+        assert f"flawuuid:{flaw1}" in labels
         if impact == "LOW" or "foobar" in yml_components:
             assert "compliance-priority" not in labels
-            assert len(labels) == 6
+            assert len(labels) == 7
         else:
             assert "compliance-priority" in labels
-            assert len(labels) == 7
+            assert len(labels) == 8
 
     @pytest.mark.parametrize(
         "external_system_id, affectedness, preexisting_val_req_lbl, result_val_req_lbl",
@@ -457,12 +486,14 @@ class TestTrackerJiraQueryBuilder:
         assert "CVE-2000-2000" in labels
         assert "flaw:bz#1" in labels
         assert "flaw:bz#2" in labels
+        assert f"flawuuid:{flaw1}" in labels
+        assert f"flawuuid:{flaw2}" in labels
         if result_val_req_lbl:
             assert "validation-requested" in labels
-            assert len(labels) == 7
+            assert len(labels) == 9
         else:
             assert "validation-requested" not in labels
-            assert len(labels) == 6
+            assert len(labels) == 8
 
         # NOTE: In real usage, this query is sent to Jira and it overwrites the list of
         # labels stored in Jira, so if the label is not generated anymore, it effectively

--- a/collectors/jiraffe/tests/cassettes/test_convertors/TestJiraTrackerConvertor.test_convert_linked_from_tracker_side_flawuuid.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_convertors/TestJiraTrackerConvertor.test_convert_linked_from_tracker_side_flawuuid.yaml
@@ -1,0 +1,234 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.31.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/ENTMQ-755
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "12548499", "self": "https://example.com/rest/api/2/issue/12548499",
+        "key": "ENTMQ-755", "fields": {"customfield_12324544": "0.0", "fixVersions":
+        [{"self": "https://example.com/rest/api/2/version/12323365", "id": "12323365",
+        "description": "7.1 release", "name": "7.1.0.fuse-046", "archived": false,
+        "released": true, "releaseDate": "2012-12-21"}], "resolution": {"self": "https://example.com/rest/api/2/resolution/1",
+        "id": "1", "description": "This issue is closed, and complete.", "name": "Done"},
+        "customfield_12312840": null, "customfield_12312442": null, "customfield_12314740":
+        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5452e287[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7d6b28ec[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6e7141fb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4af93891[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@ec4b62a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5fb0b72[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61e1ecaf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@625f6db2[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4901e235[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@147cc0fc[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a96d248[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@63bd1255[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12312848": null, "customfield_12315950": null, "customfield_12310940":
+        null, "lastViewed": null, "customfield_12313140": null, "priority": {"self":
+        "https://example.com/rest/api/2/priority/3", "iconUrl": "https://example.com/images/icons/priorities/major.svg",
+        "name": "Major", "id": "3"}, "labels": ["Security", "SecurityTracking", "component:elasticsearch",
+        "flawuuid:56f06643-6eb9-4fd0-aef7-38ddcbfab65d", "pscomponent:elasticsearch"],
+        "customfield_12311640": null, "customfield_12311244": null, "customfield_12311245":
+        null, "customfield_12311641": null, "customfield_12311242": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [{"self": "https://example.com/rest/api/2/version/12323365",
+        "id": "12323365", "description": "7.1 release", "name": "7.1.0.fuse-046",
+        "archived": false, "released": true, "releaseDate": "2012-12-21"}], "customfield_12311241":
+        null, "customfield_12310031": null, "issuelinks": [], "customfield_12325240":
+        null, "assignee": {"self": "https://example.com/rest/api/2/user?username=acunning%40redhat.com",
+        "name": "acunning@redhat.com", "key": "aileenc", "emailAddress": "acunning@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c1d56f16088f3b6e97589cd0cff6de3a?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c1d56f16088f3b6e97589cd0cff6de3a?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c1d56f16088f3b6e97589cd0cff6de3a?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c1d56f16088f3b6e97589cd0cff6de3a?d=mm&s=32"},
+        "displayName": "Aileen Cunningham", "active": true, "timeZone": "UTC"}, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        "description": "The issue is closed. See the resolution for context regarding
+        why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
+        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
+        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}, "components":
+        [], "customfield_12310080": null, "customfield_12314040": null, "customfield_12320844":
+        null, "archiveddate": null, "customfield_12320842": null, "customfield_12310120":
+        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12317313":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=chess.hazlett",
+        "name": "chess.hazlett", "key": "chazlett", "emailAddress": "chazlett@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=48",
+        "24x24": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=24",
+        "16x16": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=16",
+        "32x32": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=32"},
+        "displayName": "Chess Hazlett", "active": false, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12310091": null, "customfield_12310090":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=chess.hazlett",
+        "name": "chess.hazlett", "key": "chazlett", "emailAddress": "chazlett@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=48",
+        "24x24": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=24",
+        "16x16": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=16",
+        "32x32": "https://example.com/avatar/850d3ad61d93c0925018db52d1c9f6ba?d=mm&s=32"},
+        "displayName": "Chess Hazlett", "active": false, "timeZone": "UTC"}, "customfield_12320850":
+        null, "customfield_12310092": null, "aggregateprogress": {"progress": 0, "total":
+        0}, "customfield_12310010": null, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/ENTMQ-755/votes",
+        "votes": 0, "hasVoted": false}, "worklog": {"startAt": 0, "maxResults": 20,
+        "total": 0, "worklogs": []}, "customfield_12319743": null, "archivedby": null,
+        "issuetype": {"self": "https://example.com/rest/api/2/issuetype/1", "id":
+        "1", "description": "A problem that impairs or prevents the functions of the
+        product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12314575", "id": "12314575", "key":
+        "ENTMQ", "name": "JBoss A-MQ", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12314575&avatarId=10011",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12314575&avatarId=10011",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12314575&avatarId=10011",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12314575&avatarId=10011"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10130",
+        "id": "10130", "description": "Active projects migrated from Fusesource issue
+        tracker", "name": "Fuse"}}, "customfield_12320944": null, "aggregatetimespent":
+        null, "customfield_12310220": null, "customfield_12310183": null, "resolutiondate":
+        "2014-09-10T01:43:37.000+0000", "workratio": -1, "customfield_12317379": null,
+        "customfield_12316840": null, "customfield_12316841": null, "customfield_12319040":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/ENTMQ-755/watchers",
+        "watchCount": 3, "isWatching": false}, "created": "2014-08-04T15:07:19.000+0000",
+        "customfield_12321240": null, "customfield_12320947": null, "customfield_12320946":
+        null, "updated": "2024-06-04T14:36:30.745+0000", "customfield_12311840": null,
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
+        "https://example.com/show_bug.cgi?id=1124252", "timetracking": {}, "customfield_12310440":
+        null, "security": {"self": "https://example.com/rest/api/2/securitylevel/11697",
+        "id": "11697", "description": "Red Hat Employee and Contractors only", "name":
+        "Red Hat Employee"}, "customfield_12312340": null, "attachment": [], "customfield_12316542":
+        null, "customfield_12316543": null, "customfield_12310840": "9223372036854775807",
+        "customfield_12316544": null, "summary": "CVE-2014-3120 elasticsearch: remote
+        code execution flaw via dynamic scripting [amq-7.1]", "customfield_12323640":
+        null, "customfield_12323642": null, "customfield_12323641": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "customfield_12313441": "", "customfield_12315740": null, "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "comment": {"comments":
+        [{"self": "https://example.com/rest/api/2/issue/12548499/comment/12999689",
+        "id": "12999689", "author": {"self": "https://example.com/rest/api/2/user?username=dfj_jira",
+        "name": "dfj_jira", "key": "dfj", "emailAddress": "djorm@redhat.com", "avatarUrls":
+        {"48x48": "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=48",
+        "24x24": "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=24",
+        "16x16": "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=16",
+        "32x32": "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=32"},
+        "displayName": "David Jorm", "active": false, "timeZone": "UTC"}, "body":
+        "It has been reported that CVE-2014-3120 is being actively exploited in the
+        wild to spread a botnet. For more information, please see the following knowledge
+        solution:\n\nhttps://example.com/solutions/1189133\n\nWe need to ship patches
+        across all affected products as a critical priority. I have tested and confirmed
+        that this issue is exploitable on Fuse products.", "updateAuthor": {"self":
+        "https://example.com/rest/api/2/user?username=dfj_jira", "name": "dfj_jira",
+        "key": "dfj", "emailAddress": "djorm@redhat.com", "avatarUrls": {"48x48":
+        "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=48", "24x24":
+        "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=24", "16x16":
+        "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=16", "32x32":
+        "https://example.com/avatar/57a50b7afda86587ff149bde634f232d?d=mm&s=32"},
+        "displayName": "David Jorm", "active": false, "timeZone": "UTC"}, "created":
+        "2014-09-08T00:49:03.000+0000", "updated": "2014-09-08T00:49:03.000+0000"},
+        {"self": "https://example.com/rest/api/2/issue/12548499/comment/13000639",
+        "id": "13000639", "author": {"self": "https://example.com/rest/api/2/user?username=e-tool",
+        "name": "e-tool", "key": "e-tool", "emailAddress": "errata-owner+e-tool+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=e-tool&avatarId=33138",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=e-tool&avatarId=33138",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=e-tool&avatarId=33138",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=e-tool&avatarId=33138"},
+        "displayName": "Errata Tool", "active": true, "timeZone": "UTC"}, "body":
+        "This issue has been added to advisory RHSA-2014:18746 by David Jorm (djorm@redhat.com)",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=e-tool",
+        "name": "e-tool", "key": "e-tool", "emailAddress": "errata-owner+e-tool+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=e-tool&avatarId=33138",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=e-tool&avatarId=33138",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=e-tool&avatarId=33138",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=e-tool&avatarId=33138"},
+        "displayName": "Errata Tool", "active": true, "timeZone": "UTC"}, "created":
+        "2014-09-10T01:18:58.000+0000", "updated": "2014-09-10T01:18:58.000+0000",
+        "visibility": {"type": "group", "value": "JBoss Employee"}}, {"self": "https://example.com/rest/api/2/issue/12548499/comment/13000647",
+        "id": "13000647", "author": {"self": "https://example.com/rest/api/2/user?username=e-tool",
+        "name": "e-tool", "key": "e-tool", "emailAddress": "errata-owner+e-tool+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=e-tool&avatarId=33138",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=e-tool&avatarId=33138",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=e-tool&avatarId=33138",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=e-tool&avatarId=33138"},
+        "displayName": "Errata Tool", "active": true, "timeZone": "UTC"}, "body":
+        "Since the problem described in this issue should be resolved in a recent
+        advisory, it has been closed.\n\nFor information on the advisory, and where
+        to find the updated files, follow the link below.\n\nIf the solution does
+        not work for you, open a new bug report.\nhttps://example.com/errata/RHSA-2014-1171.html",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=e-tool",
+        "name": "e-tool", "key": "e-tool", "emailAddress": "errata-owner+e-tool+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=e-tool&avatarId=33138",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=e-tool&avatarId=33138",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=e-tool&avatarId=33138",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=e-tool&avatarId=33138"},
+        "displayName": "Errata Tool", "active": true, "timeZone": "UTC"}, "created":
+        "2014-09-10T01:43:37.000+0000", "updated": "2014-09-10T01:43:37.000+0000"}],
+        "maxResults": 3, "total": 3, "startAt": 0}, "customfield_12310213": null,
+        "customfield_12311940": "1|hz4zfj:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 04 Jun 2024 14:41:54 GMT
+      Expires:
+      - Tue, 04 Jun 2024 14:41:54 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '-1'
+      X-RateLimit-Remaining:
+      - '9223372036854775807'
+      content-length:
+      - '15380'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 881x1165819x1
+      x-asessionid:
+      - mmbnu2
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '-1'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.b685d817.1717512114.1bea3bfb
+      x-rh-edge-request-id:
+      - 1bea3bfb
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Bugzilla token to promote API (OSIDB-2262)
 - Enable creation of Jira tasks for collector flaws (OSIDB-2649)
 - Add temporary JIRA stage http forwarder passing in headers/params (OSIDB-2734)
+- Add link between trackers to flaws without CVE (OSIDB-2848)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)


### PR DESCRIPTION
This PR enable linking a tracker to a flaw through UUID.
This PR add `flawuuid` as a label in jira trackers so non-CVE flaws can have trackers.

Closes OSIDB-2848.