### PR TITLE
support bz trackers for non bz flaws

### DIFF
--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -41,6 +41,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         self.generate_groups()
         self.generate_keywords()
         self.generate_summary()
+        self.generate_whiteboard()
 
     def generate_base(self):
         """
@@ -66,7 +67,13 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         that the tracker blocks the flaw so the flaw depends_on the tracker
         """
         # there may be multiple flaws in OSIDB with the same Bugzilla ID
-        flaw_ids = list(set(flaw.meta_attr["bz_id"] for flaw in self.flaws))
+        flaw_ids = list(
+            set(
+                flaw.meta_attr["bz_id"]
+                for flaw in self.flaws
+                if "bz_id" in flaw.meta_attr
+            )
+        )
 
         if self.old_tracker is None:
             self._query["blocks"] = flaw_ids
@@ -260,3 +267,11 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         generate query for tracker summary
         """
         self._query["summary"] = self.summary
+
+    def generate_whiteboard(self):
+        """
+        generate query for the tracker whiteboard
+        """
+        self._query["whiteboard"] = json.dumps(
+            {"flaws": [str(flaw.uuid) for flaw in self.flaws]}
+        )

--- a/collectors/bzimport/convertors.py
+++ b/collectors/bzimport/convertors.py
@@ -165,6 +165,7 @@ class BugzillaTrackerConvertor(BugzillaGroupsConvertorMixin, TrackerConvertor):
         returns the list of related affects
         """
         affects = []
+        # Bugzilla flaws
         for bz_id in self._raw["blocks"]:
             try:
                 flaw = Flaw.objects.get(meta_attr__bz_id=bz_id)
@@ -184,7 +185,7 @@ class BugzillaTrackerConvertor(BugzillaGroupsConvertorMixin, TrackerConvertor):
                     {
                         "name": "tracker_no_affect",
                         "description": (
-                            f"Bugzilla tracker {bz_id} is associated with flaw "
+                            f"Bugzilla tracker {self.bz_id} is associated with flaw "
                             f"{flaw.cve_id or flaw.bz_id} but there is no associated affect "
                             f"({self.ps_module}:{self.ps_component})"
                         ),
@@ -194,7 +195,48 @@ class BugzillaTrackerConvertor(BugzillaGroupsConvertorMixin, TrackerConvertor):
                 continue
 
             affects.append(affect)
-        return affects
+
+        try:
+            whiteboard = json.loads(self._raw["whiteboard"])
+        except json.JSONDecodeError:
+            return affects
+
+        if not isinstance(whiteboard, dict) or "flaws" not in whiteboard:
+            return affects
+
+        # non-Bugzilla flaws
+        for flaw_uuid in whiteboard["flaws"]:
+            try:
+                flaw = Flaw.objects.get(uuid=flaw_uuid)
+            except Flaw.DoesNotExist:
+                # no such flaw
+                continue
+
+            try:
+                affect = flaw.affects.get(
+                    ps_module=self.ps_module,
+                    ps_component=self.ps_component,
+                )
+            except Affect.DoesNotExist:
+                # tracker created against
+                # non-existing affect
+                self.alert(
+                    {
+                        "name": "tracker_no_affect",
+                        "description": (
+                            f"Bugzilla tracker {self.bz_id} is associated with flaw "
+                            f"{flaw.uuid} but there is no associated affect "
+                            f"({self.ps_module}:{self.ps_component})"
+                        ),
+                        "alert_type": Alert.AlertType.ERROR,
+                    }
+                )
+                continue
+
+            affects.append(affect)
+
+        # prevent eventual duplicates
+        return list(set(affects))
 
     def _normalize(self) -> dict:
         """
@@ -222,6 +264,7 @@ class BugzillaTrackerConvertor(BugzillaGroupsConvertorMixin, TrackerConvertor):
             "updated_dt": self._raw["last_change_time"],
             "blocks": json.dumps(self._raw["blocks"]),
             "groups": json.dumps(self._raw["groups"]),
+            "whiteboard": self._raw["whiteboard"],
         }
 
 

--- a/collectors/bzimport/tests/cassettes/test_collectors/TestBugzillaTrackerCollector.test_sync_with_non_bz_flaws.yaml
+++ b/collectors/bzimport/tests/cassettes/test_collectors/TestBugzillaTrackerCollector.test_sync_with_non_bz_flaws.yaml
@@ -1,0 +1,188 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh95"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '24'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 05 Jun 2024 14:48:18 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.692645f.1717598898.fe094510
+      x-rh-edge-request-id:
+      - fe094510
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com",
+        "id": 1, "can_login": true, "real_name": "Need Real Name"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 05 Jun 2024 14:48:18 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.692645f.1717598898.fe094a1e
+      x-rh-edge-request-id:
+      - fe094a1e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&id=2280681
+  response:
+    body:
+      string: '{"offset": 0, "limit": "20", "bugs": [{"target_milestone": "---", "actual_time":
+        0, "status": "NEW", "cf_fixed_in": "", "severity": "low", "data_category":
+        "Engineering", "deadline": "2004-03-28", "cf_clone_of": null, "creator_detail":
+        {"id": 412888, "real_name": "Ondrej Soukup", "email": "osoukup@redhat.com",
+        "insider": true, "name": "osoukup@redhat.com", "partner": false, "active":
+        true}, "platform": "Unspecified", "is_creator_accessible": true, "version":
+        ["1.0"], "dupe_of": null, "is_cc_accessible": true, "cf_last_closed": null,
+        "alias": [], "comments": [{"text": "rhcertification-9 tracking bug for ssh:
+        see the bugs linked in the \"Blocks\" field of this bug for full details of
+        the security issue(s).\n\nThis bug is never intended to be made public, please
+        put any public notes in the blocked bugs.", "count": 0, "time": "2024-06-05T11:24:13Z",
+        "creation_time": "2024-06-05T11:24:13Z", "attachment_id": null, "creator":
+        "osoukup@redhat.com", "private_groups": [], "id": 18007119, "creator_id":
+        412888, "is_private": false, "tags": [], "bug_id": 2280681}], "cf_cust_facing":
+        "---", "is_confirmed": true, "cf_embargoed": null, "cf_partner": [], "target_release":
+        ["---"], "cf_qe_conditional_nak": [], "keywords": ["Security", "SecurityTracking"],
+        "cf_pgm_internal": "", "sub_components": {}, "description": "rhcertification-9
+        tracking bug for ssh: see the bugs linked in the \"Blocks\" field of this
+        bug for full details of the security issue(s).\n\nThis bug is never intended
+        to be made public, please put any public notes in the blocked bugs.", "cf_environment":
+        "", "docs_contact": "", "qa_contact_detail": {"active": false, "partner":
+        false, "email": "rhcert-qe@redhat.com", "insider": false, "name": "rhcert-qe@redhat.com",
+        "real_name": "rhcert qe", "id": 408554}, "cf_pm_score": "0", "cc": [], "assigned_to_detail":
+        {"email": "jweng@redhat.com", "insider": true, "name": "jweng@redhat.com",
+        "real_name": "Jianwei Weng", "id": 283338, "active": true, "partner": false},
+        "whiteboard": "{\"flaws\": [\"12472365-87e0-4376-be09-c1d4b4cbc6b0\", \"8ea223a7-7805-4d55-9a12-46d8b49b70a3\"]}",
+        "estimated_time": 0, "priority": "low", "url": "", "remaining_time": 0, "cf_release_notes":
+        "", "product": "Red Hat Certification Program", "component": ["redhat-certification"],
+        "qa_contact": "rhcert-qe@redhat.com", "summary": "ssh: various flaws [rhcertification-9]",
+        "cf_qa_whiteboard": "", "tags": [], "creator": "osoukup@redhat.com", "cf_devel_whiteboard":
+        "", "cf_doc_type": "No Doc Update", "cf_conditional_nak": [], "id": 2280681,
+        "flags": [{"id": 6115805, "is_active": 1, "setter": "bugzilla@redhat.com",
+        "name": "requires_doc_text", "status": "-", "type_id": 415, "creation_date":
+        "2024-06-05T11:24:13Z", "modification_date": "2024-06-05T11:24:13Z"}], "assigned_to":
+        "jweng@redhat.com", "classification": "Red Hat", "cf_target_upstream_version":
+        "", "resolution": "", "external_bugs": [], "blocks": [], "cc_detail": [],
+        "groups": ["devel"], "cf_verified": [], "cf_build_id": "", "creation_time":
+        "2024-06-05T11:24:13Z", "last_change_time": "2024-06-05T11:24:13Z", "cf_internal_whiteboard":
+        "", "cf_major_incident": null, "is_open": true, "depends_on": [], "op_sys":
+        "Unspecified"}], "total_matches": 1}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 05 Jun 2024 14:48:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '2993'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.692645f.1717598899.fe095310
+      x-rh-edge-request-id:
+      - fe095310
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable creation of Jira tasks for collector flaws (OSIDB-2649)
 - Add temporary JIRA stage http forwarder passing in params (OSIDB-2734)
 - Add link between trackers to flaws without CVE (OSIDB-2848)
+- Support Bugzilla tracker creation/linking for non-Bugzilla flaws (OSIDB-2845)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2330,7 +2330,7 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             # sync to Bugzilla
             self = TrackerSaver(self, bz_api_key=bz_api_key).save()
             # save in case a new Bugzilla ID was obtained
-            # so the flaw is later matched in BZ import
+            # so the tracker is later matched in BZ import
             kwargs[
                 "auto_timestamps"
             ] = False  # the timestamps will be get from Bugzilla


### PR DESCRIPTION
This PR enhances the tracker creation and linking logic to work with non-Bugzilla flaws. To keep the links in the tracker data the `whiteboard` field originally used by ProdSec (but no more) was chosen. It is then used as another/fallback linking option during the sync from Bugzilla.

Closes OSIDB-2845