### PR TITLE
Remove is_triage property from Tracker

### DIFF
--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -358,11 +358,7 @@ class TrackerQueryBuilder:
         if not self.ps_module.private_trackers_allowed:
             header += "Public "
 
-        header += (
-            "Security Issue Notification"
-            if self.tracker.is_triage
-            else "Security Tracking Issue"
-        )
+        header += "Security Tracking Issue"
         description_parts.append(header)
 
         if self.ps_module.private_trackers_allowed:

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -3,7 +3,6 @@ import pytest
 import apps.trackers.common as common
 from apps.sla.framework import SLAFramework
 from apps.trackers.constants import TRACKERS_API_VERSION
-from osidb.models import Tracker
 
 
 @pytest.fixture(autouse=True)
@@ -61,18 +60,6 @@ def api_version() -> str:
 @pytest.fixture
 def test_app_api_uri(test_app_scheme_host, api_version) -> str:
     return f"{test_app_scheme_host}/api/{api_version}"
-
-
-@pytest.fixture
-def fake_triage() -> None:
-    """
-    fake triage tracker property to be always True
-    """
-    is_triage = getattr(Tracker, "is_triage")
-    setattr(Tracker, "is_triage", property(lambda self: True))
-    yield
-    # cleanup after the test run
-    setattr(Tracker, "is_triage", is_triage)
 
 
 @pytest.fixture()

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -688,7 +688,7 @@ until the embargo has lifted. Please post the patch only to the \
             "Reproducers, if any, will remain confidential and never be made public, unless done so by the security team."
         )
 
-    def test_triage(self, fake_triage):
+    def test_triage(self):
         """
         test triage tracker description generation
         """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split BBSync enablement switch into flaw and tracker ones (OSIDB-2820)
 - Set "Target Release" field in Jira trackers (OSIDB-2727)
 - Tracker resolution is now readonly (OSIDB-2746)
+- Remove is_triage property from Tracker (OSIDB-2853)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2602,15 +2602,6 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         )
 
     @property
-    def is_triage(self):
-        """
-        triage tracker has a non-published flaw state attached
-        """
-        # TODO this is only a placeholder for now
-        # it is to be determined and implemented
-        return False
-
-    @property
     def is_compliance_priority(self) -> bool:
         """
         Check and return whether this affect module, component and update stream combination is


### PR DESCRIPTION
This property will not be needed anymore, and it was never properly implemented, so it can be safely removed.

Closes OSIDB-2853.