### PR TITLE
File trackers endpoint OpenAPI fix

### DIFF
--- a/apps/trackers/api.py
+++ b/apps/trackers/api.py
@@ -15,7 +15,7 @@ class TrackerFileSuggestionView(APIView):
     @extend_schema(
         request=FlawUUIDListSerializer,
         description="Given a list of flaws, generates a list of suggested trackers to file.",
-        responses=TrackerSuggestionSerializer(many=True),
+        responses=TrackerSuggestionSerializer,
     )
     def post(self, request, *args, **kwargs):
         """

--- a/apps/trackers/serializer.py
+++ b/apps/trackers/serializer.py
@@ -1,7 +1,6 @@
 """
 Taskman requests serializers
 """
-from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from osidb.serializer import AffectSerializer
@@ -21,39 +20,14 @@ class PsStreamSelectionSerializer(serializers.Serializer):
     aus = serializers.BooleanField()
 
 
-@extend_schema_field(AffectSerializer())
 class ModuleComponentSerializer(serializers.Serializer):
-    ps_module = serializers.UUIDField(format="hex_verbose")
-    ps_component = serializers.UUIDField(format="hex_verbose")
-    streams = serializers.ListField(child=PsStreamSelectionSerializer())
+    ps_module = serializers.CharField()
+    ps_component = serializers.CharField()
+    streams = PsStreamSelectionSerializer(many=True)
     selected = serializers.BooleanField()
-    affect = serializers.SerializerMethodField()
-
-    def get_affect(self, obj):
-        """affects serializer getter"""
-        context = {
-            "include_fields": [],
-            "exclude_fields": [],
-            "include_meta_attr": [],
-        }
-
-        serializer = AffectSerializer(instance=obj["affect"], context=context)
-        return serializer.data
+    affect = AffectSerializer()
 
 
-@extend_schema_field(AffectSerializer(many=True))
 class TrackerSuggestionSerializer(serializers.Serializer):
-    modules_components = serializers.ListField(child=ModuleComponentSerializer())
-    not_applicable = serializers.SerializerMethodField()
-
-    def get_not_applicable(self, obj):
-        """affects serializer getter"""
-        affects = obj["not_applicable"].all()
-        context = {
-            "include_fields": [],
-            "exclude_fields": [],
-            "include_meta_attr": [],
-        }
-
-        serializer = AffectSerializer(instance=affects, many=True, context=context)
-        return serializer.data
+    modules_components = ModuleComponentSerializer(many=True)
+    not_applicable = AffectSerializer(many=True)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tracker resolution is now readonly (OSIDB-2746)
 - Remove is_triage property from Tracker (OSIDB-2853)
 - Enable tracker suggestions for affects with new affectedness (OSIDB-2843)
+- Correct endpoint for tracker filing schema (OSIDB-2847)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)

--- a/openapi.yml
+++ b/openapi.yml
@@ -6415,19 +6415,19 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/TrackerSuggestion'
-                properties:
-                  dt:
-                    type: string
-                    format: date-time
-                  env:
-                    type: string
-                  revision:
-                    type: string
-                  version:
-                    type: string
+                allOf:
+                - $ref: '#/components/schemas/TrackerSuggestion'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
           description: ''
   /workflows/:
     get:
@@ -8211,10 +8211,8 @@ components:
       properties:
         ps_module:
           type: string
-          format: uuid
         ps_component:
           type: string
-          format: uuid
         streams:
           type: array
           items:
@@ -8222,8 +8220,7 @@ components:
         selected:
           type: boolean
         affect:
-          type: string
-          readOnly: true
+          $ref: '#/components/schemas/Affect'
       required:
       - affect
       - ps_component
@@ -8926,8 +8923,9 @@ components:
           items:
             $ref: '#/components/schemas/ModuleComponent'
         not_applicable:
-          type: string
-          readOnly: true
+          type: array
+          items:
+            $ref: '#/components/schemas/Affect'
       required:
       - modules_components
       - not_applicable

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -179,6 +179,9 @@ class IncludeMetaAttrMixin(serializers.ModelSerializer):
         # Instantiate the superclass normally
         super().__init__(*args, **kwargs)
 
+        self._include_meta_attr = []
+        self._next_level_include_meta_attr = {}
+
         request = self.context.get("request")
 
         # Get include meta attr from request


### PR DESCRIPTION
This PR:
* minor - allows Serializers which are subclassing `IncludeMetaAttrMixin` to be used as a standalone serializers without need to prepopulate the `include_meta_attr` in the context
* Fixes File trackers POST `/trackers/api/v1/file` endpoint to show a correct OpenAPI specification

Closes OSIDB-2847