### PR TITLE
Enable tracker suggestions for affects with new affectedness

### DIFF
--- a/apps/trackers/api.py
+++ b/apps/trackers/api.py
@@ -46,12 +46,18 @@ class TrackerFileSuggestionView(APIView):
 
             selected_affects = Affect.objects.filter(flaw__uuid__in=flaw_uuids)
             affects = selected_affects.filter(
-                affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution__in=[
-                    Affect.AffectResolution.FIX,
-                    Affect.AffectResolution.DELEGATED,
-                ],
-                ps_module__in=active_module_names,
+                Q(
+                    affectedness=Affect.AffectAffectedness.AFFECTED,
+                    resolution__in=[
+                        Affect.AffectResolution.FIX,
+                        Affect.AffectResolution.DELEGATED,
+                    ],
+                )
+                | Q(
+                    affectedness=Affect.AffectAffectedness.NEW,
+                    resolution=Affect.AffectResolution.NOVALUE,
+                ),
+                Q(ps_module__in=active_module_names),
             ).exclude(
                 (Q(flaw__acl_read=embargoed_acl) | Q(acl_read=embargoed_acl))
                 & Q(ps_module__in=exclude_private)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set "Target Release" field in Jira trackers (OSIDB-2727)
 - Tracker resolution is now readonly (OSIDB-2746)
 - Remove is_triage property from Tracker (OSIDB-2853)
+- Enable tracker suggestions for affects with new affectedness (OSIDB-2843)
 
 ### Fixed
 - Fix incorrect ACLs for flaw drafts (OSIDB-2263)


### PR DESCRIPTION
This PR enables suggesting trackers for affects with (NEW, None) as (Affectedness, Resolution) combination.

Closes OSIDB-2843.