### PR TITLE
Comments not properly updating when syncing from Bugzilla

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix workflow rejection endpoint (OSIDB-2456)
 - Fix FlawReference article count validation (OSIDB-2651)
 - Fix not being able to set CVE ID to an empty string through the API (OSIDB-270)
+- Comments not properly updating when syncing from Bugzilla (OSIDB-1385)
 
 ### Removed
 - Remove "type" field from Affect (OSIDB-2743)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2716,6 +2716,8 @@ class FlawCommentManager(ACLMixinManager, TrackingMixinManager):
                 external_system_id=external_system_id,
             )
             flawcomment.meta_attr = comment
+            for attr, value in extra_fields.items():
+                setattr(flawcomment, attr, value)
             return flawcomment
         except MultipleObjectsReturned:
             # When sync is run multiple times concurrently, each thread may


### PR DESCRIPTION
Existing comment data was not being properly updated when re-syncing from Bugzilla, as only some of the fields would get updated.

Closes OSIDB-1385.