### PR TITLE
Fix changelog for is_triage removal

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,7 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Split BBSync enablement switch into flaw and tracker ones (OSIDB-2820)
 - Set "Target Release" field in Jira trackers (OSIDB-2727)
 - Tracker resolution is now readonly (OSIDB-2746)
-- Remove is_triage property from Tracker (OSIDB-2853)
 - Enable tracker suggestions for affects with new affectedness (OSIDB-2843)
 
 ### Fixed


### PR DESCRIPTION
With PR #564, the `is_triage` property was removed. This change was added in the 'Changed' section of the changelog.

However, after further consideration, this change should have been considered technical since this property was never even properly implemented or visible in the API, so it's not even going into the 'Removed' section and just outright removed from the changelog to keep things tidy.