### PR TITLE
Implement search on emptiness for several fields

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -328,7 +328,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1261,
+        "line_number": 1323,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-12T03:17:54Z"
+  "generated_at": "2024-06-13T10:28:42Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add bulk-enabling parameter "sync_to_bz" to POST for Trackers (OSIDB-2609)
 - Add bulk POST, DELETE for Affects (OSIDB-2722)
 - Add audit history to Flaws and Affects (OSIDB-2269)
+- Implement search on emptiness for several fields (OSIDB-2815)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2874,6 +2874,10 @@ paths:
         schema:
           type: string
       - in: query
+        name: cve_description__isempty
+        schema:
+          type: boolean
+      - in: query
         name: cve_id
         schema:
           type: array
@@ -2884,6 +2888,30 @@ paths:
         style: form
       - in: query
         name: cve_id__isempty
+        schema:
+          type: boolean
+      - in: query
+        name: cvss2_nist__isempty
+        schema:
+          type: boolean
+      - in: query
+        name: cvss2_rh__isempty
+        schema:
+          type: boolean
+      - in: query
+        name: cvss3_nist__isempty
+        schema:
+          type: boolean
+      - in: query
+        name: cvss3_rh__isempty
+        schema:
+          type: boolean
+      - in: query
+        name: cvss4_nist__isempty
+        schema:
+          type: boolean
+      - in: query
+        name: cvss4_rh__isempty
         schema:
           type: boolean
       - in: query
@@ -3001,6 +3029,10 @@ paths:
         schema:
           type: string
       - in: query
+        name: cwe_id__isempty
+        schema:
+          type: boolean
+      - in: query
         name: embargoed
         schema:
           type: boolean
@@ -3061,6 +3093,10 @@ paths:
           - INVALID
           - REJECTED
           - REQUESTED
+      - in: query
+        name: mitigation__isempty
+        schema:
+          type: boolean
       - in: query
         name: nist_cvss_validation
         schema:
@@ -3210,6 +3246,10 @@ paths:
         name: owner
         schema:
           type: string
+      - in: query
+        name: owner__isempty
+        schema:
+          type: boolean
       - in: query
         name: references__created_dt
         schema:
@@ -3462,6 +3502,10 @@ paths:
         name: statement
         schema:
           type: string
+      - in: query
+        name: statement__isempty
+        schema:
+          type: boolean
       - in: query
         name: team_id
         schema:


### PR DESCRIPTION
Like it was done in #522, filter on emptiness by more fields has been implemented: cve_description, cwe_id, statement, mitigation, owner, and cvss_scores.

Like with cve_id, to use this filter through the API one may set {field_name}__isempty to either 1 or 0 (empty or non-empty).

Closes OSIDB-2815.