### PR TITLE
Introduce empty workflow_state and migrate data

### DIFF
--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -151,6 +151,7 @@ class WorkflowModel(models.Model):
     class WorkflowState(models.TextChoices):
         """allowable workflow states"""
 
+        NOVALUE = ""
         NEW = "NEW"
         TRIAGE = "TRIAGE"
         PRE_SECONDARY_ASSESSMENT = "PRE_SECONDARY_ASSESSMENT"
@@ -163,7 +164,7 @@ class WorkflowModel(models.Model):
         choices=WorkflowState.choices,
         max_length=24,
         blank=True,
-        default=WorkflowState.NEW,
+        default=WorkflowState.NOVALUE,
     )
     owner = models.CharField(max_length=60, blank=True)
     group_key = models.CharField(max_length=60, blank=True)

--- a/apps/workflows/workflows/default.yml
+++ b/apps/workflows/workflows/default.yml
@@ -15,7 +15,7 @@ states:
   - name: TRIAGE
     description: >
       Queue captain has taken a ticket off the incoming queue and will
-      evalute if it should be rejected or qualified for further steps in
+      evaluate if it should be rejected or qualified for further steps in
       the workflow.
     jira_state: Refinement
     jira_resolution: null

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add audit history to Flaws and Affects (OSIDB-2269)
 - Implement search on emptiness for several fields (OSIDB-2815)
 - Add major_incident_start_dt field (OSIDB-2728)
+- Add empty value to workflow_state (OSIDB-2881)
 
 ### Changed
 - Make workflows API RESTful (OSIDB-1716)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -64,7 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove "meta_attr" field from FlawReference (OSIDB-2854)
 - Remove "meta_attr" field from FlawAcknowledgment (OSIDB-2854)
 - Remove "component" field from Flaw (OSIDB-2839)
-- Remove "meta_attr" field from from FlawComment (OSIDB-2747)
+- Remove "meta_attr" field from FlawComment (OSIDB-2747)
 
 ## [3.7.3] - 2024-05-28
 ### Fixed

--- a/openapi.yml
+++ b/openapi.yml
@@ -3673,6 +3673,7 @@ paths:
           items:
             type: string
             enum:
+            - ''
             - DONE
             - NEW
             - PRE_SECONDARY_ASSESSMENT
@@ -7803,6 +7804,7 @@ components:
             state:
               type: string
               enum:
+              - ''
               - NEW
               - TRIAGE
               - PRE_SECONDARY_ASSESSMENT
@@ -8475,6 +8477,7 @@ components:
             state:
               type: string
               enum:
+              - ''
               - NEW
               - TRIAGE
               - PRE_SECONDARY_ASSESSMENT

--- a/osidb/migrations/0148_alter_workflow_state.py
+++ b/osidb/migrations/0148_alter_workflow_state.py
@@ -1,0 +1,75 @@
+"""
+Written manually on 2024-06-14.
+"""
+from django.conf import settings
+from django.db import migrations, models
+
+from osidb.core import set_user_acls
+
+BATCH_SIZE = 1000
+
+
+def forwards_func(apps, schema_editor):
+    set_user_acls(settings.ALL_GROUPS)
+    Flaw = apps.get_model("osidb", "Flaw")
+
+    flaws = Flaw.objects.all().iterator(chunk_size=BATCH_SIZE)
+
+    batch = []
+    for i, flaw in enumerate(flaws, 1):
+        if flaw.workflow_state == "NEW" and not flaw.task_key:
+            flaw.workflow_state = ""
+        batch.append(flaw)
+
+        if i % BATCH_SIZE == 0:
+            Flaw.objects.bulk_update(batch, ["workflow_state"])
+            batch = []
+
+    if batch:
+        Flaw.objects.bulk_update(batch, ["workflow_state"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("osidb", "0147_flaw_major_incident_start_dt"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="flaw",
+            name="workflow_state",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("", "Novalue"),
+                    ("NEW", "New"),
+                    ("TRIAGE", "Triage"),
+                    ("PRE_SECONDARY_ASSESSMENT", "Pre Secondary Assessment"),
+                    ("SECONDARY_ASSESSMENT", "Secondary Assessment"),
+                    ("DONE", "Done"),
+                    ("REJECTED", "Rejected"),
+                ],
+                default="",
+                max_length=24,
+            ),
+        ),
+        migrations.AlterField(
+            model_name="flawaudit",
+            name="workflow_state",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("", "Novalue"),
+                    ("NEW", "New"),
+                    ("TRIAGE", "Triage"),
+                    ("PRE_SECONDARY_ASSESSMENT", "Pre Secondary Assessment"),
+                    ("SECONDARY_ASSESSMENT", "Secondary Assessment"),
+                    ("DONE", "Done"),
+                    ("REJECTED", "Rejected"),
+                ],
+                default="",
+                max_length=24,
+            ),
+        ),
+        migrations.RunPython(forwards_func, migrations.RunPython.noop, atomic=True),
+    ]

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -1,6 +1,7 @@
 import pytest
 
-from apps.workflows.workflow import WorkflowModel
+from apps.workflows.models import Workflow
+from apps.workflows.workflow import WorkflowFramework, WorkflowModel
 from osidb.models import Flaw, FlawCVSS, FlawReference, Snippet
 from osidb.tests.factories import FlawFactory, SnippetFactory
 
@@ -26,6 +27,25 @@ class TestSnippet:
         """
         Tests the creation of a flaw from a snippet.
         """
+        workflow = Workflow(
+            {
+                "name": "main workflow",
+                "description": "a workflow to test classification",
+                "priority": 100,
+                "conditions": [],
+                "states": [
+                    {
+                        "name": WorkflowModel.WorkflowState.NEW,
+                        "requirements": [],
+                        "jira_state": "New",
+                        "jira_resolution": None,
+                    }
+                ],
+            }
+        )
+        workflow_framework = WorkflowFramework()
+        workflow_framework.register_workflow(workflow)
+
         snippet = SnippetFactory(source=Snippet.Source.NVD)
         content = snippet.content
 


### PR DESCRIPTION
This PR introduces a new `""` value for `workflow_state`. This value is set as default and is meant for flaws without a task (either legacy or new flaws). It also migrates the corresponding data for all legacy flaws.

Closes OSIDB-2881