### PR TITLE
Simplify setting of component in BBSync

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -129,7 +129,9 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         generate component to differentiate between flaw and flaw draft
         """
         self._query["component"] = (
-            "vulnerability-draft" if self.flaw.is_draft else "vulnerability"
+            "vulnerability-draft"
+            if self.flaw.workflow_state == Flaw.WorkflowState.NEW
+            else "vulnerability"
         )
 
     def generate_unconditional(self):

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -193,24 +193,22 @@ class TestGenerateBasics:
         assert bbq.query["summary"] == "hammer: is too heavy"
 
     @pytest.mark.parametrize(
-        "is_draft,result",
+        "workflow_state,result",
         [
-            (True, "vulnerability-draft"),
-            (False, "vulnerability"),
+            (WorkflowModel.WorkflowState.NOVALUE, "vulnerability"),
+            (WorkflowModel.WorkflowState.NEW, "vulnerability-draft"),
+            (WorkflowModel.WorkflowState.TRIAGE, "vulnerability"),
+            (WorkflowModel.WorkflowState.PRE_SECONDARY_ASSESSMENT, "vulnerability"),
+            (WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT, "vulnerability"),
+            (WorkflowModel.WorkflowState.DONE, "vulnerability"),
+            (WorkflowModel.WorkflowState.REJECTED, "vulnerability"),
         ],
     )
-    def test_generate_component(self, is_draft, result):
+    def test_generate_component(self, workflow_state, result):
         """
         test generating of component
         """
-        flaw = FlawFactory(
-            cve_id="CVE-2000-1001",
-            workflow_state=WorkflowModel.WorkflowState.NEW,
-            meta_attr={
-                "bz_id": "1000",
-                "bz_component": "vulnerability-draft" if is_draft else "vulnerability",
-            },
-        )
+        flaw = FlawFactory(workflow_state=workflow_state)
 
         bbq = FlawBugzillaQueryBuilder(flaw)
         assert bbq.query["component"] == result


### PR DESCRIPTION
This PR simplifies the setting of a `component` in BBSync. If a flaw is in the `NEW` state (i.e. a Jira task was successfully created), the `component` is set to `vulnerability-draft`. Otherwise, `vulnerability` is set.

Related to OSIDB-2986