### PR TITLE
Workflow state of flaws without task automatically changes to 'NEW'

### DIFF
--- a/apps/workflows/signals.py
+++ b/apps/workflows/signals.py
@@ -7,5 +7,9 @@ from apps.workflows.workflow import WorkflowModel
 @receiver(pre_save)
 def auto_adjust_classification(sender, instance, **kwargs):
     if issubclass(sender, WorkflowModel):
-        if not all([instance.workflow_name, instance.workflow_state]):
+        # Classify only if there is a task associated, otherwise the state is
+        # and should be an empty value
+        if instance.task_key and not all(
+            [instance.workflow_name, instance.workflow_state]
+        ):
             instance.adjust_classification(save=False)

--- a/apps/workflows/tests/test_endpoints.py
+++ b/apps/workflows/tests/test_endpoints.py
@@ -190,7 +190,7 @@ class TestEndpoints(object):
         """
         test authenticated workflow classification adjusting API endpoint with no flaw modification
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(workflow_state=WorkflowModel.WorkflowState.NEW)
         response = auth_client().post(f"{test_api_uri}/workflows/{flaw.uuid}/adjust")
         assert response.status_code == 200
         body = response.json()
@@ -398,7 +398,7 @@ class TestEndpoints(object):
         AffectFactory(flaw=flaw)
 
         assert flaw.classification["workflow"] == "DEFAULT"
-        assert flaw.classification["state"] == WorkflowModel.WorkflowState.NEW
+        assert flaw.classification["state"] == WorkflowModel.WorkflowState.NOVALUE
         headers = {"HTTP_JIRA_API_KEY": user_token}
 
         response = auth_client().post(
@@ -412,7 +412,7 @@ class TestEndpoints(object):
         set_user_acls(settings.ALL_GROUPS)
         flaw = Flaw.objects.get(pk=flaw.pk)
         assert flaw.classification["workflow"] == "DEFAULT"
-        assert flaw.classification["state"] == WorkflowModel.WorkflowState.NEW
+        assert flaw.classification["state"] == WorkflowModel.WorkflowState.NOVALUE
 
         response = auth_client().post(
             f"{test_api_uri_osidb}/flaws/{flaw.uuid}/reject",

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -661,7 +661,7 @@ class TestFlaw:
         """test that flaw gets workflow:state assigned on creation"""
         flaw = FlawFactory()
         assert flaw.workflow_name
-        assert flaw.workflow_state
+        assert flaw.workflow_state == WorkflowModel.WorkflowState.NOVALUE
 
     @pytest.mark.enable_signals
     def test_adjust(self):
@@ -739,7 +739,9 @@ class TestFlaw:
     @pytest.mark.enable_signals
     def test_adjust_no_change(self):
         """test that adjusting classification has no effect without flaw modification"""
-        flaw = FlawFactory()  # random flaw
+        flaw = FlawFactory(
+            workflow_state=WorkflowModel.WorkflowState.NEW
+        )  # random flaw
         classification = flaw.classification
         flaw.adjust_classification()
         assert classification == flaw.classification
@@ -782,7 +784,11 @@ class TestFlaw:
         )
         workflow_framework.register_workflow(workflow)
 
-        flaw = FlawFactory(cwe_id="", cve_description="")
+        flaw = FlawFactory(
+            cwe_id="",
+            cve_description="",
+            workflow_state=WorkflowModel.WorkflowState.NEW,
+        )
         AffectFactory(flaw=flaw)
 
         assert flaw.classification["workflow"] == "DEFAULT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update the SLA policy
 
+### Fixed
+- Workflow state of flaws without task automatically changes to 'NEW' (OSIDB-2989)
+
 ## [4.0.0] - 2024-06-17
 ### Added
 - Add new OSV option into FlawSource

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -66,7 +66,7 @@ class TestSnippet:
         assert flaw.snippets.count() == 1
         assert flaw.source == snippet.source
         assert flaw.title == content["title"]
-        assert flaw.workflow_state == WorkflowModel.WorkflowState.NEW
+        assert flaw.workflow_state == WorkflowModel.WorkflowState.NOVALUE
 
         flaw_cvss = flaw.cvss_scores.all().first()
         assert flaw_cvss.issuer == FlawCVSS.CVSSIssuer.NIST


### PR DESCRIPTION
This commit fixes the error where a flaw with no associated Jira task (and therefore an empty workflow state) has its state automatically changed to 'NEW' whenever any modification is done to it.

This was caused by a signal which attempts to classify flaws with no workflow state.

Closes OSIDB-2989.