### PR TITLE
Fix Flaw CC list builder to produce CCs in BZ format

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Workflow state of flaws without task automatically changes to 'NEW' (OSIDB-2989)
+- Fixed Flaw CC list builder to generate CCs in Bugzilla format
+  for both Bugzilla and Jira tracked PS modules (OSIDB-2985)
 
 ## [4.0.0] - 2024-06-17
 ### Added


### PR DESCRIPTION
This PR adds new ` bts_name_override` parameter to `BaseAffectCCBuilder` so we can easily override the CC format to Bugzilla even for Jira tracker PS modules. This is important for `BugzillaFlawCCBuilder` as currently it is generating a mixture of Bugzilla and Jira formated CCs which Bugzilla refuses to work with. This hot fix kinda violates the initial separation of concerns philosophy in the `osidb/cc.py` module, however this is probably the fastest way how to fix it and not spend more time refactoring it. In the future we would like to refactor this anyway (and also when leaving Bugzilla). 

Closes OSIDB-2985