### PR TITLE
Allow creating Jira task for a flaw on demand

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement a way to switch off each collector (OSIDB-2884)
 - Generate Jira tracker "components" field (OSIDB-2988)
 - Rudimentary API request logging (OSIDB-2514)
+- Add query param to force creation of Jira task for old flaws on update (OSIDB-2882)
 
 ### Changed
 - Update the SLA policy

--- a/openapi.yml
+++ b/openapi.yml
@@ -5628,6 +5628,12 @@ paths:
           type: string
         description: User generated api key for Jira authentication.
         required: true
+      - in: query
+        name: create_jira_task
+        schema:
+          type: boolean
+        description: If set to true, it will trigger the creation of a Jira task if
+          the flaw doesn't already have one associated.
       - in: path
         name: id
         schema:

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -456,7 +456,18 @@ def include_exclude_fields_extend_schema_view(
     ),
     update=extend_schema(
         responses=FlawSerializer,
-        parameters=[id_param],
+        parameters=[
+            id_param,
+            OpenApiParameter(
+                "create_jira_task",
+                type={"type": "boolean"},
+                location=OpenApiParameter.QUERY,
+                description=(
+                    "If set to true, it will trigger the creation of a Jira task if "
+                    "the flaw doesn't already have one associated."
+                ),
+            ),
+        ],
     ),
 )
 class FlawView(RudimentaryUserPathLoggingMixin, ModelViewSet):

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1659,6 +1659,13 @@ class FlawSerializer(
         if old_flaw.is_embargoed and self._is_public(new_flaw, validated_data):
             new_flaw.unembargo()
 
+        # Force Jira task creation if requested
+        request = self.context.get("request")
+        if request:
+            create_jira_task = request.query_params.get("create_jira_task")
+            if create_jira_task:
+                new_flaw.tasksync(jira_token=self.get_jira_token(), force_creation=True)
+
         # perform regular flaw update
         new_flaw = super().update(new_flaw, validated_data)
 


### PR DESCRIPTION
OSIDB-authored flaws should create a Jira task when created. But for old flaws inherited from SFM2, although they should be considered OSIDB-authored (they don't come from a collector), they don't have an associated Jira task and right now there is no way to create and associate a task for them. These flaws can be recognised as they should have an empty workflow state.

This commit adds the option to force the creation of a Jira task if the flaw does not have one. When updating a flaw through the API, setting the query parameter `create_jira_task` will trigger the creation of the Jira task if it does not exist, and set the `task_key` and workflow state fields.

Closes OSIDB-2882.