### PR TITLE
Keep vulnerability-draft BZ component when rejecting flaw draft.

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -128,11 +128,16 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         """
         generate component to differentiate between flaw and flaw draft
         """
-        self._query["component"] = (
-            "vulnerability-draft"
-            if self.flaw.workflow_state == Flaw.WorkflowState.NEW
-            else "vulnerability"
-        )
+
+        component = "vulnerability"
+
+        if self.flaw.workflow_state in [
+            Flaw.WorkflowState.NEW,
+            Flaw.WorkflowState.REJECTED,
+        ] and self.flaw.meta_attr.get("bz_component") in [None, "vulnerability-draft"]:
+            component = "vulnerability-draft"
+
+        self._query["component"] = component
 
     def generate_unconditional(self):
         """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed Flaw CC list builder to generate CCs in Bugzilla format
   for both Bugzilla and Jira tracked PS modules (OSIDB-2985)
 - Flaw commments create action respects is_private (OSIDB-3003)
+- Keep vulnerability-draft BZ component when rejecting flaw draft (OSIDB-3023)
 
 ## [4.0.0] - 2024-06-17
 ### Added


### PR DESCRIPTION
Closes OSIDB-3023

This begs some questions I don't have the answers for:

- Is the `vulnerability` / `vulnerability-draft` component only for bugzilla and nowhere else?
- Should we track it in a better way?
- Will meta_attr["bz_component"] be correctly populated once we turn of bzimport? (Perhaps I could test it but didn't yet. Maybe someone knows the answer already.)