### PR TITLE
run task collector every minute

### DIFF
--- a/collectors/jiraffe/tasks.py
+++ b/collectors/jiraffe/tasks.py
@@ -19,8 +19,7 @@ logger = get_task_logger(__name__)
 
 @collector(
     base=JiraTaskCollector,
-    # run once a day at 8:53pm
-    crontab=crontab(hour=20, minute=53),
+    crontab=crontab(),  # run every minute
     data_models=[Flaw],
     enabled=JIRA_TASK_COLLECTOR_ENABLED,
 )


### PR DESCRIPTION
Jira issues underlying the task management may potentially change frequently in there (unlike eg. project metadata) and each change like this might lead into a mid-air collision in OSIDB. Therefore I think that we should check for the changes frequently. Most of the time there will probably be nothing so it should be a low volume data sync anyway.