### PR TITLE
change external sync order for serializers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Keep vulnerability-draft BZ component when rejecting flaw draft (OSIDB-3023)
+- Fix external sync order in serializers (OSIDB-3029)
 
 ## [4.1.0] - 2024-06-25
 ### Added

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -832,20 +832,11 @@ class AffectView(
                 {"flaw": "Provided affects belong to multiple flaws."}
             )
 
-        def dummy(*args, **kwargs):
-            pass
-
         # Second, save the updated affects to the database, but not sync with BZ.
         ret = []
         for serializer in validated_serializers:
-            # NOTE This takes about 300 milliseconds on local laptop per instance.
-
-            # Make the serializer's and model's mixins and .bzsync() not make requests to bugzilla.
-            # Leave the jira token as is, so that AffectSerializer.update() can still update
-            # Trackers in Jira as necessary.
-            serializer.get_bz_api_key = dummy
-            self.perform_update(serializer)
-
+            # Make the serializer skip the sync for each affect
+            serializer.save(skip_bz_sync=True)
             ret.append(serializer.data)
 
         # Third, proxy the update to Bugzilla
@@ -892,23 +883,11 @@ class AffectView(
                 {"flaw": "Provided affects belong to multiple flaws."}
             )
 
-        def dummy(*args, **kwargs):
-            pass
-
         # Second, save the updated affects to the database, but not sync with BZ.
         ret = []
         for serializer in validated_serializers:
-            # NOTE This takes about 300 milliseconds on local laptop per instance.
-
-            # Make the serializer's and model's mixins and .bzsync() not make requests to bugzilla.
-            # Leave the jira token as is, so that AffectSerializer.update() can still update
-            # Trackers in Jira as necessary.
-            # This also inherently performs additional validation, e.g. for
-            # duplicates among the submitted affects. Relying on the whole
-            # transaction being aborted if a validation fails.
-            serializer.get_bz_api_key = dummy
-            self.perform_update(serializer)
-
+            # Make the serializer skip the sync for each affect
+            serializer.save(skip_bz_sync=True)
             ret.append(serializer.data)
 
         # Third, proxy the update to Bugzilla

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -852,8 +852,11 @@ class BugzillaSyncMixinSerializer(BugzillaAPIKeyMixin, serializers.ModelSerializ
         perform the ordinary instance create
         with providing BZ API key while saving
         """
+        skip_bz_sync = validated_data.pop("skip_bz_sync", False)
+
         instance = super().create(validated_data)
-        instance.bzsync(bz_api_key=self.get_bz_api_key())
+        if not skip_bz_sync:
+            instance.bzsync(bz_api_key=self.get_bz_api_key())
         return instance
 
     def update(self, instance, validated_data):
@@ -861,8 +864,11 @@ class BugzillaSyncMixinSerializer(BugzillaAPIKeyMixin, serializers.ModelSerializ
         perform the ordinary instance update
         with providing BZ API key while saving
         """
+        skip_bz_sync = validated_data.pop("skip_bz_sync", False)
+
         instance = super().update(instance, validated_data)
-        instance.bzsync(bz_api_key=self.get_bz_api_key())
+        if not skip_bz_sync:
+            instance.bzsync(bz_api_key=self.get_bz_api_key())
         return instance
 
     class Meta:

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -841,7 +841,7 @@ class BugzillaBareSyncMixinSerializer(BugzillaAPIKeyMixin, serializers.ModelSeri
         abstract = True
 
 
-class BugzillaSyncMixinSerializer(BugzillaBareSyncMixinSerializer):
+class BugzillaSyncMixinSerializer(BugzillaAPIKeyMixin, serializers.ModelSerializer):
     """
     serializer mixin class implementing special handling of the models
     which need to perform Bugzilla sync as part of the save procedure
@@ -852,12 +852,8 @@ class BugzillaSyncMixinSerializer(BugzillaBareSyncMixinSerializer):
         perform the ordinary instance create
         with providing BZ API key while saving
         """
-        # NOTE: This won't work for many-to-many fields as
-        # some logic from original .create() was overwritten.
-        # Consider BugzillaBareSyncMixinSerializer for these.
-
-        instance = self.Meta.model(**validated_data)
-        instance = super().create(instance)
+        instance = super().create(validated_data)
+        instance.bzsync(bz_api_key=self.get_bz_api_key())
         return instance
 
     def update(self, instance, validated_data):
@@ -865,14 +861,8 @@ class BugzillaSyncMixinSerializer(BugzillaBareSyncMixinSerializer):
         perform the ordinary instance update
         with providing BZ API key while saving
         """
-        # NOTE: This won't work for many-to-many fields as
-        # some logic from original .create() was overwritten
-        # Consider BugzillaBareSyncMixinSerializer for these.
-
-        for attr, value in validated_data.items():
-            setattr(instance, attr, value)
-
-        instance = super().update(instance)
+        instance = super().update(instance, validated_data)
+        instance.bzsync(bz_api_key=self.get_bz_api_key())
         return instance
 
     class Meta:
@@ -1489,8 +1479,8 @@ class FlawCVSSPutSerializer(FlawCVSSSerializer):
 
 class FlawSerializer(
     ACLMixinSerializer,
-    JiraTaskSyncMixinSerializer,
     BugzillaSyncMixinSerializer,
+    JiraTaskSyncMixinSerializer,
     TrackingMixinSerializer,
     WorkflowModelSerializer,
     IncludeExcludeFieldsMixin,

--- a/osidb/tests/endpoints/test_endpoints.py
+++ b/osidb/tests/endpoints/test_endpoints.py
@@ -11,7 +11,7 @@ from rest_framework.test import APIClient
 
 from osidb.core import generate_acls, set_user_acls
 from osidb.helpers import ensure_list
-from osidb.models import Affect, Flaw
+from osidb.models import Affect, Flaw, Impact
 from osidb.tests.factories import AffectFactory, FlawFactory
 
 pytestmark = pytest.mark.unit
@@ -342,11 +342,21 @@ class TestEndpointsBZAPIKey:
         flaw_data = {
             "title": "Foo",
             "comment_zero": "test",
+            "components": ["test"],
+            "impact": Impact.LOW,
+            "source": "REDHAT",
             "reported_dt": "2022-11-22T15:55:22.830Z",
             "unembargo_dt": "2000-1-1T22:03:26.065Z",
             "embargoed": False,
+            "jira_api_key": "SECRET",
         }
-        response = auth_client().post(f"{test_api_uri}/flaws", flaw_data, format="json")
+
+        response = auth_client().post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_JIRA_API_KEY="SECRET",
+        )
         assert response.status_code == 400
         assert '"Bugzilla-Api-Key":"This HTTP header is required."' in str(
             response.content


### PR DESCRIPTION
This PR changes the order that serializers are called in Flaw API.

This PR also modifies `BugzillaSyncMixinSerializer` so it delegates creation to `serializers.ModelSerializer.create` method, this allow all validations to run before syncing to Bugzilla and also works with many-to-many models.
This PR also modifies `BugzillaSyncMixinSerializer.update` and  `AffectView.bulk_put` methods in order to skip `bzsync` model method, avoiding saving flaw multiple times during bulk operation.

Closes OSIDB-3029.