### PR TITLE
Fix test_create_jira_task_param randomly failing

### DIFF
--- a/apps/taskman/tests/test_flaw_model_integration.py
+++ b/apps/taskman/tests/test_flaw_model_integration.py
@@ -225,7 +225,6 @@ class TestFlawModelIntegration(object):
     ):
         def mock_create_or_update_task(self, flaw):
             flaw.task_key = "TASK-123"
-            flaw.save()
             return Response(
                 data={
                     "key": "TASK-123",
@@ -287,4 +286,4 @@ class TestFlawModelIntegration(object):
         )
         assert response.status_code == 200
         flaw = Flaw.objects.get(uuid=flaw.uuid)
-        assert flaw.task_key
+        assert flaw.task_key == "TASK-123"


### PR DESCRIPTION
This test used a mock for `create_or_update_task` which included a redundant `save` call to the flaw. This seemingly harmless extra save could create a discrepancy between the `updated_dt` passed as a parameter in the original PUT call and the `updated_dt` that the flaw has by the time it hits its actual save call.

Since the save is usually fast and `updated_dt` has a precision of seconds, the test usually passed, but sometimes there would be a discrepancy of one second and the test would fail.

This commit removes the redundant save, making sure the `updated_dt` stays consistent throughout the flaw update process and the test does not fail.