### PR TITLE
change order of validations and jira sync

### DIFF
--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1655,15 +1655,15 @@ class FlawSerializer(
         if old_flaw.is_embargoed and self._is_public(new_flaw, validated_data):
             new_flaw.unembargo()
 
+        # perform regular flaw update
+        new_flaw = super().update(new_flaw, validated_data)
+
         # Force Jira task creation if requested
         request = self.context.get("request")
         if request:
             create_jira_task = request.query_params.get("create_jira_task")
             if create_jira_task:
                 new_flaw.tasksync(jira_token=self.get_jira_token(), force_creation=True)
-
-        # perform regular flaw update
-        new_flaw = super().update(new_flaw, validated_data)
 
         ##########################
         # 3) post-update actions #


### PR DESCRIPTION
This PR changes the order in which validations run when create_jira_task=True.
This would make a task no be created if a validation fails the flaw regular update.

Closes OSIDB-3059.