### PR TITLE
Fix incorrect changes in CHANGELOG

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Keep vulnerability-draft BZ component when rejecting flaw draft (OSIDB-3023)
 - Fix external sync order in serializers (OSIDB-3029)
+- Make Taskman service validate Jira token (OSIDB-2203)
 
 ## [4.1.0] - 2024-06-25
 ### Added
@@ -22,7 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Update the SLA policy
-- Make Taskman service validate Jira token (OSIDB-2203)
 
 ### Fixed
 - Workflow state of flaws without task automatically changes to 'NEW' (OSIDB-2989)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Workflow state of flaws without task automatically changes to 'NEW' (OSIDB-2989)
 - Fixed Flaw CC list builder to generate CCs in Bugzilla format
   for both Bugzilla and Jira tracked PS modules (OSIDB-2985)
-- Flaw commments create action respects is_private (OSIDB-3003)
+- Flaw comments create action respects is_private (OSIDB-3003)
 
 ## [4.0.0] - 2024-06-17
 ### Added


### PR DESCRIPTION
This PR fixes the incorrect order of recent changes in CHANGELOG introduced in #601.
The change should be in the `## [4.1.1] - 2024-06-28` section.