### PR TITLE
Implement message throttling in the API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -388,7 +388,7 @@
         "filename": "osidb/tests/endpoints/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 99,
+        "line_number": 117,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-06-21T01:09:05Z"
+  "generated_at": "2024-07-02T13:56:11Z"
 }

--- a/config/settings.py
+++ b/config/settings.py
@@ -255,7 +255,11 @@ if DEBUG:
     CACHES = {
         "default": {
             "BACKEND": "django.core.cache.backends.dummy.DummyCache",
-        }
+        },
+        # Used for tests which require a cache
+        "locmem": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        },
     }
 
 # Settings for the drf-spectacular package

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -132,6 +132,24 @@ CISA_COLLECTOR_CRONTAB = crontab(minute=0)
 LOG_FILE_SIZE = 1024 * 1024 * 10  # 10mb
 LOG_FILE_COUNT = 3
 
+# Global API throttle rates. Note that these can be customized per view if needed.
+ANON_API_THROTTLE_RATE = get_env("ANON_API_THROTTLE_RATE", default="10/minute")
+USER_API_THROTTLE_RATE = get_env("USER_API_THROTTLE_RATE", default="100/minute")
+
+# Set up message throttling in the API
+REST_FRAMEWORK.update(
+    {
+        "DEFAULT_THROTTLE_CLASSES": [
+            "rest_framework.throttling.AnonRateThrottle",
+            "rest_framework.throttling.UserRateThrottle",
+        ],
+        "DEFAULT_THROTTLE_RATES": {
+            "anon": ANON_API_THROTTLE_RATE,
+            "user": USER_API_THROTTLE_RATE,
+        },
+    }
+)
+
 # To not disrupt the logging of OSIDB instance running in PSI
 # this guard ensures that only OSIDB running in MPP logs to filesystem
 # TODO: Remove after OSIDB is fully migrated to MPP

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Implement message throttling in the API (OSIDB-894)
+
 ### Changed
 - special_handling_flaw_missing_cve_description Alert to
   special_consideration_flaw_missing_cve_description (OSIDB-2955)

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -72,6 +72,7 @@ from .serializer import (
     TrackerSerializer,
     UserSerializer,
 )
+from .throttles import AffectUserRateThrottle
 from .validators import CVE_RE_STR
 
 # Use only for RudimentaryUserPathLoggingMixin
@@ -785,6 +786,7 @@ class AffectView(
     filterset_class = AffectFilter
     http_method_names = get_valid_http_methods(ModelViewSet)
     permission_classes = [IsAuthenticatedOrReadOnly]
+    throttle_classes = [AffectUserRateThrottle]
 
     @extend_schema(
         request=AffectBulkPutSerializer(many=True),

--- a/osidb/tests/endpoints/test_endpoints.py
+++ b/osidb/tests/endpoints/test_endpoints.py
@@ -1,4 +1,5 @@
 import uuid
+from unittest.mock import patch
 
 import pytest
 from django.conf import settings
@@ -9,10 +10,12 @@ from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIClient
 
+from osidb.api_views import FlawView
 from osidb.core import generate_acls, set_user_acls
 from osidb.helpers import ensure_list
 from osidb.models import Affect, Flaw, Impact
 from osidb.tests.factories import AffectFactory, FlawFactory
+from osidb.tests.models import LowRateThrottle
 
 pytestmark = pytest.mark.unit
 
@@ -55,6 +58,21 @@ class TestEndpoints(object):
         assert res["email"] == "monke@banana.com"
         assert "data-prodsec" in res["groups"]
         assert res["profile"] is None
+
+    @pytest.mark.django_db
+    def test_throttling(self, auth_client, test_api_uri):
+        """
+        Test that throttling works by using a very low rate throttle on the flaws view.
+        """
+
+        with patch.object(FlawView, "throttle_classes", [LowRateThrottle]):
+            response = auth_client().get(f"{test_api_uri}/flaws")
+            assert response.status_code == 200
+            response = auth_client().get(f"{test_api_uri}/flaws")
+            assert response.status_code == 200
+            # Rate is 2/day so third request should fail
+            response = auth_client().get(f"{test_api_uri}/flaws")
+            assert response.status_code == 429
 
 
 class TestEndpointsACLs:

--- a/osidb/tests/models.py
+++ b/osidb/tests/models.py
@@ -1,7 +1,10 @@
 import uuid
 
+from django.core.cache import caches
 from django.db import models
+from rest_framework.throttling import UserRateThrottle
 
+from config.settings import DEBUG
 from osidb.mixins import AlertMixin
 from osidb.models import ComparableTextChoices
 
@@ -26,3 +29,12 @@ class ComparableTextChoices_1(ComparableTextChoices):
 
 class ComparableTextChoices_2(ComparableTextChoices):
     TEST = "TEST"
+
+
+class LowRateThrottle(UserRateThrottle):
+    """Throttle class with very low rate to test that throttling works."""
+
+    rate = "2/day"
+    # In the test env there is no cache but for throttling to work a cache is required
+    if DEBUG:
+        cache = caches["locmem"]

--- a/osidb/throttles.py
+++ b/osidb/throttles.py
@@ -1,0 +1,13 @@
+from rest_framework.throttling import UserRateThrottle
+
+
+class AffectUserRateThrottle(UserRateThrottle):
+    """
+    Custom throttling rate to use for the affects view since the bulk operations
+    are not accessible through the bindings yet, so there may be lots
+    of requests to update a flaw with many affects.
+    """
+
+    # TODO: When bulk operations are supported in the bindings, remove this class
+    # so that the affects view uses the same rate as everything else
+    rate = "600/min"


### PR DESCRIPTION
This commit introduces message throttling for the prod environment, allowing only a certain amount of requests per hour for authenticated and unauthenticated users. The rates can be individually modified through env variables.

Closes OSIDB-894.