### PR TITLE
Do not generate empty-string versions for jira trackers.

### DIFF
--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -290,7 +290,7 @@ class TrackerJiraQueryBuilder(TrackerQueryBuilder):
             project_key=self.ps_module.bts_key, field_name="Affects Version/s"
         )
         # project may or may not support versions so it is optional
-        if versions.exists() and self.ps_update_stream.version is not None:
+        if versions.exists() and self.ps_update_stream.version:
             self._query["fields"]["versions"] = [
                 {"name": self.ps_update_stream.version}
             ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - fix OSIDB-Bugzilla mid-air collision issues (OSIDB-3083)
+- Null version of PsUpdateStream is not sent to Jira when creating a tracker (OSIDB-3078)
 
 ## [4.1.1] - 2024-06-28
 ### Added


### PR DESCRIPTION
Closes OSIDB-3078