### PR TITLE
fix duplicate comment issue leading in internal server error

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fix duplicate comment issue leading in internal server error (OSIDB-3086)
+
 ## [4.1.2] - 2024-07-03
 ### Added
 - Extend flaw-task linking to primarily use the CVE ID

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -2729,11 +2729,13 @@ class FlawCommentManager(ACLMixinManager, TrackingMixinManager):
             # keeping the first instance deterministically keeps that one
             # instance even if this is also run multiple times concurrently.
 
-            f = FlawComment.objects.filter(
+            comments = FlawComment.objects.filter(
                 flaw=flaw, external_system_id=external_system_id
             )
+            comment_uuid = comments.first().uuid
             # "Cannot use 'limit' or 'offset' with delete", so can't do f[1:].delete()
-            f.exclude(uuid=f.first().uuid).delete()
+            comments.exclude(uuid=comment_uuid).delete()
+            return FlawComment.objects.get(uuid=comment_uuid)
         except ObjectDoesNotExist:
             return FlawComment(
                 flaw=flaw,

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -611,6 +611,26 @@ class TestFlaw:
             assert f.major_incident_start_dt == timezone.now()
 
 
+class TestFlawComment:
+    def test_multiple_objects_returned(self):
+        """
+        test that the MultipleObjectsReturned case of create_flawcomment is handled well
+        this is the reproducer for https://issues.redhat.com/browse/OSIDB-3086
+        """
+        flaw = FlawFactory()
+        flaw_comment = FlawCommentFactory(flaw=flaw)
+        FlawCommentFactory(
+            flaw=flaw, external_system_id=flaw_comment.external_system_id
+        )
+        assert (
+            FlawComment.objects.create_flawcomment(
+                flaw,
+                flaw_comment.external_system_id,
+            )
+            is not None
+        ), "FlawComment.create_flawcomment returned None"
+
+
 class TestImpact:
     @pytest.mark.parametrize(
         "first,second",


### PR DESCRIPTION
This is probably a rare situation but today it lead to blocking on flaw sync and consequently to breaking the task collector. The main issue was the missing `return` statement.

Closes OSIDB-3086