### PR TITLE
Make NVD and OSV atomic

### DIFF
--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_atomicity.yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_atomicity.yaml
@@ -1,0 +1,54 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.0
+      content-type:
+      - application/json
+    method: GET
+    uri: https://example.com/rest/json/cves/2.0?cveId=CVE-2024-2231
+  response:
+    body:
+      string: '{"resultsPerPage": 1, "startIndex": 0, "totalResults": 1, "format":
+        "NVD_CVE", "version": "2.0", "timestamp": "2024-07-04T06:48:20.823", "vulnerabilities":
+        [{"cve": {"id": "CVE-2024-2231", "sourceIdentifier": "contact@wpscan.com",
+        "published": "2024-07-03T06:15:03.147", "lastModified": "2024-07-03T12:53:24.977",
+        "vulnStatus": "Awaiting Analysis", "cveTags": [], "descriptions": [{"lang":
+        "en", "value": "The  allows any authenticated user to join a private group
+        due to a missing authorization check on a function"}, {"lang": "es", "value":
+        "Permite que cualquier usuario autenticado se una a un grupo privado debido
+        a que falta una verificaci\u00f3n de autorizaci\u00f3n en una funci\u00f3n."}],
+        "metrics": {}, "references": [{"url": "https://wpscan.com/vulnerability/119d2d93-3b71-4ce9-b385-4e6f57b162cb/",
+        "source": "contact@wpscan.com"}]}}]}'
+    headers:
+      access-control-allow-credentials:
+      - 'false'
+      access-control-allow-headers:
+      - accept, apiKey, content-type, origin, x-requested-with
+      access-control-allow-methods:
+      - GET, HEAD, OPTIONS
+      access-control-allow-origin:
+      - '*'
+      apikey:
+      - 'No'
+      content-length:
+      - '799'
+      content-type:
+      - application/json
+      date:
+      - Thu, 04 Jul 2024 06:48:20 GMT
+      strict-transport-security:
+      - max-age=31536000
+      x-frame-options:
+      - SAMEORIGIN
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -130,13 +130,12 @@ class OSVCollector(Collector):
                         continue
                     try:
                         created, updated = self.save_snippet(osv_id, cve_ids, content)
+                        new_count += created
+                        updated_count += updated
                     except Exception as exc:
                         logger.error(
                             f"Failed to save snippet data for {osv_id} (error: {exc}): {content}"
                         )
-                        continue
-                    new_count += created
-                    updated_count += updated
             except requests.exceptions.RequestException as exc:
                 logger.error(f"Failed to fetch OSV vulns for {ecosystem}: {exc}")
                 continue

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_atomicity.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_atomicity.yaml
@@ -1,0 +1,61 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.0
+    method: GET
+    uri: https://example.com/v1/vulns/GO-2023-1602
+  response:
+    body:
+      string: '{"id": "GO-2023-1602", "summary": "Denial of service via deflate decompression
+        bomb in github.com/russellhaering/gosaml2", "details": "A bug in SAML authentication
+        library can result in Denial of Service attacks.\n\nAttackers can craft a
+        \"deflate\"-compressed request which will consume significantly more memory
+        during processing than the size of the original request. This may eventually
+        lead to memory exhaustion and the process being killed.", "aliases": ["CVE-2023-26483",
+        "GHSA-6gc3-crp7-25w5"], "modified": "2024-05-20T16:03:47Z", "published": "2023-03-03T17:17:54Z",
+        "database_specific": {"url": "https://example.com/vuln/GO-2023-1602", "review_status":
+        "REVIEWED"}, "references": [{"type": "ADVISORY", "url": "https://example.com/advisories/GHSA-6gc3-crp7-25w5"},
+        {"type": "FIX", "url": "https://example.com/russellhaering/gosaml2/commit/f9d66040241093e8702649baff50cc70d2c683c0"},
+        {"type": "WEB", "url": "https://example.com/russellhaering/gosaml2/releases/tag/v0.9.0"}],
+        "affected": [{"package": {"name": "github.com/russellhaering/gosaml2", "ecosystem":
+        "Go", "purl": "pkg:golang/github.com/russellhaering/gosaml2"}, "ranges": [{"type":
+        "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.9.0"}]}], "ecosystem_specific":
+        {"imports": [{"symbols": ["DecodeUnverifiedBaseResponse", "DecodeUnverifiedLogoutResponse",
+        "SAMLServiceProvider.RetrieveAssertionInfo", "SAMLServiceProvider.ValidateEncodedLogoutRequestPOST",
+        "SAMLServiceProvider.ValidateEncodedLogoutResponsePOST", "SAMLServiceProvider.ValidateEncodedResponse",
+        "SAMLServiceProvider.validationContext", "maybeDeflate", "parseResponse"],
+        "path": "github.com/russellhaering/gosaml2"}]}, "database_specific": {"source":
+        "https://example.com/ID/GO-2023-1602.json"}}], "schema_version": "1.6.0"}'
+    headers:
+      Content-Length:
+      - '1693'
+      Date:
+      - Wed, 03 Jul 2024 14:49:19 GMT
+      Server:
+      - Google Frontend
+      X-Cloud-Trace-Context:
+      - a37d9a3d1c08a07c928a11dfc5044cba
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-type:
+      - application/json
+      grpc-accept-encoding:
+      - identity, deflate, gzip
+      grpc-message:
+      - ''
+      grpc-status:
+      - '0'
+      x-envoy-decorator-operation:
+      - ingress GetVulnById
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
This PR updates the way NVD and OSV collectors handle incorrectly created flaws. This creation should be an atomic operation. For example, when creating a BZ task or an associated Jira task fails, a flaw should be deleted in OSIDB, and a collector should try to recreate it in its next run.

Closes OSIDB-3084