### PR TITLE
Remove redundant BugzillaAPIKeyMixin

### DIFF
--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -978,7 +978,6 @@ class AffectSerializer(
     TrackingMixinSerializer,
     IncludeExcludeFieldsMixin,
     IncludeMetaAttrMixin,
-    BugzillaAPIKeyMixin,
     JiraAPIKeyMixin,
     HistoryMixinSerializer,
 ):
@@ -1491,7 +1490,6 @@ class FlawSerializer(
     WorkflowModelSerializer,
     IncludeExcludeFieldsMixin,
     IncludeMetaAttrMixin,
-    BugzillaAPIKeyMixin,
     JiraAPIKeyMixin,
     AlertMixinSerializer,
     HistoryMixinSerializer,


### PR DESCRIPTION
This PR removes `BugzillaAPIKeyMixin` from `FlawSerializer` and `AffectSerializer` as this mixin is already included in `BugzillaSyncMixinSerializer`.