### PR TITLE
temporarily move has trackers workflow requirement

### DIFF
--- a/apps/taskman/tests/test_service.py
+++ b/apps/taskman/tests/test_service.py
@@ -9,7 +9,6 @@ import pytest
 
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.workflows.workflow import WorkflowModel
-from osidb.models import Affect
 from osidb.tests.factories import AffectFactory, FlawFactory
 
 pytestmark = pytest.mark.unit
@@ -30,11 +29,6 @@ class TestTaskmanService(object):
         """
         # Remove randomness to reuse VCR every possible time
         flaw = FlawFactory(embargoed=False, uuid="9d9b3b14-0c44-4030-883c-8610f7e2879b")
-        AffectFactory(
-            flaw=flaw,
-            affectedness=Affect.AffectAffectedness.AFFECTED,
-            resolution=Affect.AffectResolution.DELEGATED,
-        )
         taskman = JiraTaskmanQuerier(token=user_token)
 
         response1 = taskman.create_or_update_task(flaw=flaw)
@@ -57,7 +51,7 @@ class TestTaskmanService(object):
 
         assert flaw.workflow_state == WorkflowModel.WorkflowState.TRIAGE
         flaw.workflow_state = WorkflowModel.WorkflowState.PRE_SECONDARY_ASSESSMENT
-        flaw.save()
+        flaw.save(raise_validation_error=False)
         response3 = taskman.create_or_update_task(flaw=flaw)
         assert response3.status_code == 200
         status, _ = flaw.jira_status()

--- a/apps/workflows/workflows/default.yml
+++ b/apps/workflows/workflows/default.yml
@@ -32,7 +32,6 @@ states:
       - has affects
       - has source
       - has title
-      - has trackers
 
   - name: SECONDARY_ASSESSMENT
     description: An analyst assigned the task to themselves.
@@ -47,4 +46,5 @@ states:
       published, but it is not a requirement.
     jira_state: Closed
     jira_resolution: Done
-    requirements: []
+    requirements:
+      - has trackers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - special_handling_flaw_missing_statement Alert to
   special_consideration_flaw_missing_statement (OSIDB-2955)
 - Allow setting empty impact value on flaw (OSIDB-3128)
+- Temporarily move has trackers workflow requirement (OSIDB-3098)
 
 ### Fixed
 - Fix duplicate comment issue leading in internal server error (OSIDB-3086)


### PR DESCRIPTION
so the community trackers absence does not block the embargoed flaws promotion before we can properly rework the workflows

Closes OSIDB-3098