### PR TITLE
Allow setting empty impact value

### DIFF
--- a/apps/workflows/workflows/default.yml
+++ b/apps/workflows/workflows/default.yml
@@ -30,7 +30,6 @@ states:
     jira_resolution: null
     requirements:
       - has affects
-      - has impact
       - has source
       - has title
       - has trackers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   special_consideration_flaw_missing_cve_description (OSIDB-2955)
 - special_handling_flaw_missing_statement Alert to
   special_consideration_flaw_missing_statement (OSIDB-2955)
+- Allow setting empty impact value on flaw (OSIDB-3128)
 
 ### Fixed
 - Fix duplicate comment issue leading in internal server error (OSIDB-3086)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1095,16 +1095,6 @@ class Flaw(
             else:
                 raise err
 
-    def _validate_nonempty_impact(self):
-        """
-        check that the impact is not empty
-
-        we cannot enforce this by model definition
-        as the old flaws may have no impact
-        """
-        if not self.impact:
-            raise ValidationError("Impact value is required.")
-
     def _validate_nonempty_components(self):
         """
         check that the component list is not empty

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1708,13 +1708,6 @@ class TestFlawValidators:
         assert flaw3.save() is None
         assert flaw3.alerts.filter(name="_validate_flaw_without_affect").exists()
 
-    def test_no_impact(self):
-        """
-        test that flaw cannot have an empty impact
-        """
-        with pytest.raises(ValidationError, match="Impact value is required"):
-            FlawFactory(impact=None)
-
     def test_no_component(self):
         """
         test that flaw cannot have an empty component


### PR DESCRIPTION
This PR removes impact validation and thus enables saving a flaw with an empty impact. This logic should be revisited as part of the workflow rework.

Closes OSIDB-3128