### PR TITLE
Make sync managers less prone to race conditions

### DIFF
--- a/collectors/bzimport/collectors.py
+++ b/collectors/bzimport/collectors.py
@@ -495,8 +495,7 @@ class FlawCollector(Collector):
         FlawDownloadManager.check_for_reschedules()
 
         for flaw_id, _ in flaw_ids:
-            download_manager = FlawDownloadManager.get_sync_manager(flaw_id)
-            download_manager.schedule()
+            FlawDownloadManager.schedule(flaw_id)
             successes.append(flaw_id)
 
         # with specified batch we stop here
@@ -639,8 +638,7 @@ class BugzillaTrackerCollector(Collector):
 
         tracker_ids = self.get_batch()
         for tracker_id, _ in tracker_ids:
-            download_manager = BZTrackerDownloadManager.get_sync_manager(tracker_id)
-            download_manager.schedule()
+            BZTrackerDownloadManager.schedule(tracker_id)
             successes.append(tracker_id)
 
         complete = bool(self.is_complete or len(tracker_ids) < self.BATCH_SIZE)

--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -193,8 +193,7 @@ class JiraTrackerCollector(Collector):
 
         # Schedule linking tracker => affect
         for updated_tracker_id in updated_trackers:
-            link_manager = JiraTrackerLinkManager.get_sync_manager(updated_tracker_id)
-            link_manager.schedule()
+            JiraTrackerLinkManager.schedule(updated_tracker_id)
 
         logger.info(
             f"Jira trackers were updated for the following IDs: {', '.join(updated_trackers)}"


### PR DESCRIPTION
Change the sync managers code so it is making  changes directly in the query and does not hold and refresh its objects in memory. This should avoid race conditions when updating database objects.

OSIDB-3131