### PR TITLE
Sensible Bugzilla errors from API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   special_consideration_flaw_missing_statement (OSIDB-2955)
 - Allow setting empty impact value on flaw (OSIDB-3128)
 - Temporarily move has trackers workflow requirement (OSIDB-3098)
+- Handle Bugzilla errors in API request as 422 instead of
+  500 internal server error (OSIDB-3126)
 
 ### Fixed
 - Fix duplicate comment issue leading in internal server error (OSIDB-3086)

--- a/osidb/exception_handlers.py
+++ b/osidb/exception_handlers.py
@@ -1,4 +1,6 @@
+from bugzilla.exceptions import BugzillaError
 from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import status
 from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.response import Response
 from rest_framework.serializers import as_serializer_error
@@ -14,6 +16,11 @@ def exception_handler(exc, context):
             "detail": str(exc),
         }
         return Response(response_data, status=http_code)
+
+    if isinstance(exc, BugzillaError):
+        data = {"detail": str(exc)}
+        return Response(data, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
+
     if isinstance(exc, DjangoValidationError):
         exc = DRFValidationError(as_serializer_error(exc))
     return drf_exception_handler(exc, context)


### PR DESCRIPTION
This PR:
* handles any BugzillaError exception when thrown during any API requests and returns it as 422 response with the exception text (full traceback is not included) instead of basic 500 internal server error

Closes OSIDB-3126