### PR TITLE
RFC: Treat most ingress (write APIs, bzimport) with row locks

### DIFF
--- a/collectors/bzimport/collectors.py
+++ b/collectors/bzimport/collectors.py
@@ -445,8 +445,13 @@ class FlawCollector(Collector):
 
         return None
 
+    @transaction.atomic
     def sync_flaw(self, flaw_id):
         """fetch-convert-save flaw with give Bugzilla ID"""
+
+        # See SelectForUpdateMixin for reasoning
+        Flaw.objects.filter(meta_attr__bz_id=flaw_id).select_for_update()
+
         # 1) fetch flaw data
         try:
             flaw_data = self.bz_querier.get_bug_data(flaw_id)
@@ -523,6 +528,7 @@ class FlawCollector(Collector):
         msg += " Nothing new to fetch." if not flaw_ids else ""
         return msg
 
+    # TODO: Unused method, except for tests. Delete.
     def collect_flaw(self, flaw_id, total_retries=0):
         """
         collect flaw by the given ID

--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -14,6 +14,7 @@ from jira.exceptions import JIRAError
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.trackers.models import JiraProjectFields
 from collectors.framework.models import Collector, CollectorMetadata
+from osidb.locks import apply_lock, apply_lock_state_template
 from osidb.models import Affect, Flaw, PsModule, Tracker
 from osidb.sync_manager import JiraTrackerLinkManager
 
@@ -27,113 +28,6 @@ from .exceptions import (
 )
 
 logger = get_task_logger(__name__)
-
-LOCKED_FLAW_UUIDS = "locked_flaw_uuids"
-LOCKED_AFFECT_UUIDS = "locked_affect_uuids"
-LOCKED_TRACKER_UUIDS = "locked_tracker_uuids"
-
-
-def apply_lock_state_template():
-    """
-    Shared state to be used by apply_lock within a transaction.
-    """
-    return {
-        LOCKED_FLAW_UUIDS: set(),
-        LOCKED_AFFECT_UUIDS: set(),
-        LOCKED_TRACKER_UUIDS: set(),
-    }
-
-
-def apply_lock(
-    state, new_flaw_uuids=None, new_affect_uuids=None, new_tracker_uuids=None
-):
-    """
-    Locks Flaw, Affect, Tracker models based on the provided UUIDs.
-    Flaw, Affect and Tracker relationships are traversed and the whole graph
-    is locked always in the order:
-    1. all identified Flaws,
-    2. all identified Affects
-    3. all identified Trackers
-    A deadlock is possible if two threads use this function to first lock
-    two different sets of models, then each wants to additionally lock
-    some of models already locked by the other thread. Discovering as much
-    of the related models before the first locking in the transaction helps
-    avoid that. If it happens, Postgresql should detect it and abort the
-    transaction.
-    It shouldn't happen though because:
-    - When Jira*Collector collects a time range, it locks incrementally
-      (because it can't know all IDs in advance), but only a single instance
-      of such a process should run at a time.
-    - When Jira*Collector collects an object identified by an ID, it most
-      probably performs only one round of locking.
-    For reasoning about locking, see SelectForUpdateMixin.
-    Modifies the "state" argument.
-    The new*uuids arguments must be iterable.
-    Must be run inside a transaction.
-    """
-
-    new_flaw_uuids = set(new_flaw_uuids) if new_flaw_uuids else set()
-    new_affect_uuids = set(new_affect_uuids) if new_affect_uuids else set()
-    new_tracker_uuids = set(new_tracker_uuids) if new_tracker_uuids else set()
-
-    all_flaw_uuids = state[LOCKED_FLAW_UUIDS] | set(new_flaw_uuids)
-    all_affect_uuids = state[LOCKED_AFFECT_UUIDS] | set(new_affect_uuids)
-    all_tracker_uuids = state[LOCKED_TRACKER_UUIDS] | set(new_tracker_uuids)
-
-    for i in range(2):
-        # Twice to discover the whole graph. Any of the new_*_uuids sets
-        # can be empty/nonempty, requiring different directions in
-        # the graph traversal. A single direction iterated twice is simpler
-        # to understand.
-
-        # discover flaw uuids from affect
-        all_flaw_uuids.update(
-            set(
-                Affect.objects.filter(uuid__in=all_affect_uuids).values_list(
-                    "flaw__uuid", flat=True
-                )
-            )
-        )
-
-        # discover affect uuids from flaw
-        all_affect_uuids.update(
-            set(
-                Flaw.objects.filter(uuid__in=all_flaw_uuids).values_list(
-                    "affects__uuid", flat=True
-                )
-            )
-        )
-
-        # discover affect uuids from tracker
-        all_affect_uuids.update(
-            set(
-                Tracker.objects.filter(uuid__in=all_tracker_uuids).values_list(
-                    "affects__uuid", flat=True
-                )
-            )
-        )
-
-        # discover tracker uuids from affect
-        all_tracker_uuids.update(
-            set(
-                Tracker.objects.filter(affects__uuid__in=all_affect_uuids).values_list(
-                    "uuid", flat=True
-                )
-            )
-        )
-
-    nonlocked_flaw_uuids = all_flaw_uuids - state[LOCKED_FLAW_UUIDS]
-    nonlocked_affect_uuids = all_affect_uuids - state[LOCKED_AFFECT_UUIDS]
-    nonlocked_tracker_uuids = all_tracker_uuids - state[LOCKED_TRACKER_UUIDS]
-
-    Flaw.objects.filter(uuid__in=nonlocked_flaw_uuids).select_for_update()
-    state[LOCKED_FLAW_UUIDS].update(nonlocked_flaw_uuids)
-
-    Affect.objects.filter(uuid__in=nonlocked_affect_uuids).select_for_update()
-    state[LOCKED_AFFECT_UUIDS].update(nonlocked_affect_uuids)
-
-    Tracker.objects.filter(uuid__in=nonlocked_tracker_uuids).select_for_update()
-    state[LOCKED_TRACKER_UUIDS].update(nonlocked_tracker_uuids)
 
 
 class JiraTaskCollector(Collector):

--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -25,6 +25,7 @@ from .exceptions import MetadataCollectorInsufficientDataJiraffeException
 logger = get_task_logger(__name__)
 
 
+# TODO use select_for_update appropriately. See SelectForUpdateMixin for reasoning.
 class JiraTaskCollector(Collector):
     """
     Jira task collector
@@ -117,6 +118,7 @@ class JiraTaskCollector(Collector):
         return msg
 
 
+# TODO use select_for_update appropriately. See SelectForUpdateMixin for reasoning.
 class JiraTrackerCollector(Collector):
     """
     Jira tracker collector

--- a/collectors/jiraffe/exceptions.py
+++ b/collectors/jiraffe/exceptions.py
@@ -9,6 +9,12 @@ class JiraffeException(Exception):
     """
 
 
+class JiraTaskCollectorConcurrentEditAvoided(JiraffeException):
+    """
+    detected a concurrent edit of the Flaw model in DB when collecting tasks
+    """
+
+
 class JiraTrackerCollectorConcurrentEditAvoided(JiraffeException):
     """
     detected a concurrent edit of the tracker model in DB, or of the related flaw

--- a/collectors/jiraffe/exceptions.py
+++ b/collectors/jiraffe/exceptions.py
@@ -9,6 +9,12 @@ class JiraffeException(Exception):
     """
 
 
+class JiraTrackerCollectorConcurrentEditAvoided(JiraffeException):
+    """
+    detected a concurrent edit of the tracker model in DB, or of the related flaw
+    """
+
+
 class NonRecoverableJiraffeException(JiraffeException):
     """
     permanent exceptions consistent between runs

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Handle flaw comments with&without bzimport or bifurcated history (OSIDB-3030)
 - Alerts constrained unique so that bzimport doesn't block user requests (OSIDB-3048)
 - Duplicate Alerts created concurrently in multiple threads handled correctly (OSIDB-3048)
+- Parallelism issues fixed, such as rolling back already-saved changes (OSIDB-3122, OSIDB-3085)
 
 ## [4.1.2] - 2024-07-03
 ### Added

--- a/osidb/locks.py
+++ b/osidb/locks.py
@@ -20,6 +20,14 @@ def apply_lock(
     """
     Locks Flaw, Affect, Tracker models based on the provided UUIDs.
 
+    For general reasoning about locking in OSIDB, see SelectForUpdateMixin.
+
+    SelectForUpdateMixin is for a more limited usecase, much simpler and
+    easier to understand, hence the split implementation and split explanation.
+
+    For reasoning about using a consistent reusable approach outside of
+    SelectForUpdateMixin and usage of this function, read on:
+
     Flaw, Affect and Tracker relationships are traversed and the whole graph
     is locked always in the order:
     1. all identified Flaws,
@@ -56,8 +64,6 @@ def apply_lock(
     - When a collector collects an object identified by an ID, it
       usually performs only one round of locking, or it does its best
       to make the first round of locking as complete as possible.
-
-    For reasoning about locking, see SelectForUpdateMixin.
 
     Modifies the "state" argument.
 

--- a/osidb/locks.py
+++ b/osidb/locks.py
@@ -1,0 +1,109 @@
+LOCKED_FLAW_UUIDS = "locked_flaw_uuids"
+LOCKED_AFFECT_UUIDS = "locked_affect_uuids"
+LOCKED_TRACKER_UUIDS = "locked_tracker_uuids"
+
+
+def apply_lock_state_template():
+    """
+    Shared state to be used by apply_lock within a transaction.
+    """
+    return {
+        LOCKED_FLAW_UUIDS: set(),
+        LOCKED_AFFECT_UUIDS: set(),
+        LOCKED_TRACKER_UUIDS: set(),
+    }
+
+
+def apply_lock(
+    state, new_flaw_uuids=None, new_affect_uuids=None, new_tracker_uuids=None
+):
+    """
+    Locks Flaw, Affect, Tracker models based on the provided UUIDs.
+    Flaw, Affect and Tracker relationships are traversed and the whole graph
+    is locked always in the order:
+    1. all identified Flaws,
+    2. all identified Affects
+    3. all identified Trackers
+    A deadlock is possible if two threads use this function to first lock
+    two different sets of models, then each wants to additionally lock
+    some of models already locked by the other thread. Discovering as much
+    of the related models before the first locking in the transaction helps
+    avoid that. If it happens, Postgresql should detect it and abort the
+    transaction.
+    It shouldn't happen though because:
+    - When Jira*Collector collects a time range, it locks incrementally
+      (because it can't know all IDs in advance), but only a single instance
+      of such a process should run at a time.
+    - When Jira*Collector collects an object identified by an ID, it most
+      probably performs only one round of locking.
+    For reasoning about locking, see SelectForUpdateMixin.
+    Modifies the "state" argument.
+    The new*uuids arguments must be iterable.
+    Must be run inside a transaction.
+    """
+
+    # Prevent circular imports
+    from osidb.models import Affect, Flaw, Tracker
+
+    new_flaw_uuids = set(new_flaw_uuids) if new_flaw_uuids else set()
+    new_affect_uuids = set(new_affect_uuids) if new_affect_uuids else set()
+    new_tracker_uuids = set(new_tracker_uuids) if new_tracker_uuids else set()
+
+    all_flaw_uuids = state[LOCKED_FLAW_UUIDS] | set(new_flaw_uuids)
+    all_affect_uuids = state[LOCKED_AFFECT_UUIDS] | set(new_affect_uuids)
+    all_tracker_uuids = state[LOCKED_TRACKER_UUIDS] | set(new_tracker_uuids)
+
+    for i in range(2):
+        # Twice to discover the whole graph. Any of the new_*_uuids sets
+        # can be empty/nonempty, requiring different directions in
+        # the graph traversal. A single direction iterated twice is simpler
+        # to understand.
+
+        # discover flaw uuids from affect
+        all_flaw_uuids.update(
+            set(
+                Affect.objects.filter(uuid__in=all_affect_uuids).values_list(
+                    "flaw__uuid", flat=True
+                )
+            )
+        )
+
+        # discover affect uuids from flaw
+        all_affect_uuids.update(
+            set(
+                Flaw.objects.filter(uuid__in=all_flaw_uuids).values_list(
+                    "affects__uuid", flat=True
+                )
+            )
+        )
+
+        # discover affect uuids from tracker
+        all_affect_uuids.update(
+            set(
+                Tracker.objects.filter(uuid__in=all_tracker_uuids).values_list(
+                    "affects__uuid", flat=True
+                )
+            )
+        )
+
+        # discover tracker uuids from affect
+        all_tracker_uuids.update(
+            set(
+                Tracker.objects.filter(affects__uuid__in=all_affect_uuids).values_list(
+                    "uuid", flat=True
+                )
+            )
+        )
+
+    nonlocked_flaw_uuids = all_flaw_uuids - state[LOCKED_FLAW_UUIDS]
+    nonlocked_affect_uuids = all_affect_uuids - state[LOCKED_AFFECT_UUIDS]
+    nonlocked_tracker_uuids = all_tracker_uuids - state[LOCKED_TRACKER_UUIDS]
+
+    Flaw.objects.filter(uuid__in=nonlocked_flaw_uuids).select_for_update()
+    state[LOCKED_FLAW_UUIDS].update(nonlocked_flaw_uuids)
+
+    Affect.objects.filter(uuid__in=nonlocked_affect_uuids).select_for_update()
+    state[LOCKED_AFFECT_UUIDS].update(nonlocked_affect_uuids)
+
+    Tracker.objects.filter(uuid__in=nonlocked_tracker_uuids).select_for_update()
+    state[LOCKED_TRACKER_UUIDS].update(nonlocked_tracker_uuids)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -482,6 +482,11 @@ class FlawManager(ACLMixinManager, TrackingMixinManager):
 
         full match means that we match on both Bugzilla and CVE ID
         """
+        # NOTE: This method is susceptible to race conditions when
+        #       creating a new flaw, but it's expected that multiple
+        #       Flaws with the same cve_id would be created at the
+        #       same time, so not handled for now.
+        #       See SelectForUpdateMixin for reasoning.
         try:
             cve_id = extra_fields.get("cve_id")
             if full_match:

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -390,6 +390,7 @@ class BZTrackerLinkManager(SyncManager):
     Tracker and Affects are updated.
     """
 
+    # TODO use select_for_update appropriately. See SelectForUpdateMixin for reasoning.
     @staticmethod
     def link_tracker_with_affects(tracker_id):
         # Code adapted from collectors.bzimport.convertors.BugzillaTrackerConvertor.affects

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -529,6 +529,7 @@ class BZTrackerLinkManager(SyncManager):
         return result
 
 
+# TODO use select_for_update appropriately. See SelectForUpdateMixin for reasoning.
 class BZSyncManager(SyncManager):
     """
     Sync manager class for OSIDB => Bugzilla synchronization.


### PR DESCRIPTION
Treat most ingress (write APIs, bzimport) with row locks to resolve widespread data loss on writes.
Related to OSIDB-3122
Related to OSIDB-3085

<s>Most notably, it **does not** </s>resolve the issue documented yesterday by @costaconrado from task collector side:

> I believe task collector is the one conflicting and "rolling back" the state of a flaw, only making it thread safe probably would not solve this issue because I believe the race condition is in Jira side e.g.:
>
> - user update the flaw
> - collector start at the same time and query a batch of tasks in jira
> - user finish to save the flaw
> - collector uses the outdated version of jira task to update flaw
>
> in this case both user and collector were able to "proper" save the flaw instance because collector will get the user updated instance of the flaw and the outdated instance of the jira task
>
> I believe we need to take into consideration the last updated from jira and compare it with the flaw timestamp

EDIT: Now task collector is treated, but a thorough review is needed, and I'll prefer @costaconrado 's solution because I know too little about the tasks that JiraTaskCollector deals with.