### PR TITLE
Handle OperationalError when thrown during concurrent requests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Temporarily move has trackers workflow requirement (OSIDB-3098)
 - Handle Bugzilla errors in API request as 422 instead of
   500 internal server error (OSIDB-3126)
+- Handle DB deadlock errors triggered by concurrent API requests
+  as 409 instead of 500 internal server error (OSIDB-3048)
 
 ### Fixed
 - Fix duplicate comment issue leading in internal server error (OSIDB-3086)


### PR DESCRIPTION
An example of a response a client sees in case of an aborted transaction due to a deadlock (generated by OSIDB when `DEBUG = False`):

```
{"detail":"[OperationalError] Concurrent access to the same model by you and someone else. For example, two clients editing the same Flaw. Exception details: deadlock detected\nDETAIL:  Process 423 waits for ShareLock on transaction 59013; blocked by process 415.\nProcess 415 waits for ShareLock on transaction 61660; blocked by process 423.\nHINT:  See server log for query details.\nCONTEXT:  while updating tuple (362,9) in relation \"osidb_alert\"\n","dt":"2024-07-24T18:10:45.589941Z","revision":"unknown","version":"4.1.2","env":"local"}
```

Closes OSIDB-3048