### PR TITLE
UnackedHandler only recommends active unacked streams (OSIDB-3160)

### DIFF
--- a/apps/trackers/product_definition_handlers/unacked_handler.py
+++ b/apps/trackers/product_definition_handlers/unacked_handler.py
@@ -13,6 +13,13 @@ class UnackedHandler(ProductDefinitionHandler):
     """
 
     def get_offer(self, affect: Affect, impact: Impact, ps_module: PsModule, offers):
+        unacked_stream = ps_module.unacked_ps_update_stream.first()
+        if not unacked_stream:
+            # Nothing to handle
+            return offers
+        if not ps_module.active_ps_update_streams.filter(name=unacked_stream.name):
+            # Ignore unacked stream that is not active for this module
+            return offers
         if UBIHandler.will_modify_offers(affect, impact, ps_module):
             # If UBI streams are selected, the unacked stream must not be selected.
             return offers
@@ -25,13 +32,11 @@ class UnackedHandler(ProductDefinitionHandler):
             Flaw.FlawMajorIncident.APPROVED,
             Flaw.FlawMajorIncident.CISA_APPROVED,
         ] and impact in [Impact.MODERATE, Impact.LOW]
-        unacked_stream = ps_module.unacked_ps_update_stream.first()
-        if unacked_stream:
-            offers[unacked_stream.name] = {
-                "ps_update_stream": unacked_stream.name,
-                "selected": unacked_preselected,
-                "aus": False,
-                "eus": False,
-                "acked": False,
-            }
+        offers[unacked_stream.name] = {
+            "ps_update_stream": unacked_stream.name,
+            "selected": unacked_preselected,
+            "aus": False,
+            "eus": False,
+            "acked": False,
+        }
         return offers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   500 internal server error (OSIDB-3126)
 - Handle DB deadlock errors triggered by concurrent API requests
   as 409 instead of 500 internal server error (OSIDB-3048)
+- UnackedHandler only recommends active unacked streams (OSIDB-3160)
 
 ### Fixed
 - Fix duplicate comment issue leading in internal server error (OSIDB-3086)


### PR DESCRIPTION
This PR modifies UnackedHandler so it only recommends unacked streams when listed in active streams.

Closes OSIDB-3160.