### PR TITLE
Make flaw draft creation independent of BZ data

### DIFF
--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -149,7 +149,7 @@ class TestOSVCollector:
         assert Snippet.objects.count() == 1
         assert Snippet.objects.first().external_id == osv_id
         assert Flaw.objects.count() == 1
-        assert Flaw.objects.first().meta_attr == {"external_ids": f"{osv_id}"}
+        assert Flaw.objects.first().meta_attr == {"external_ids": osv_id}
 
         # Snippet disappeared and OSV is trying to create a flaw which already exists
         Snippet.objects.all().delete()
@@ -161,4 +161,4 @@ class TestOSVCollector:
         assert Snippet.objects.count() == 1
         assert Snippet.objects.first().external_id == osv_id
         assert Flaw.objects.count() == 1
-        assert Flaw.objects.first().meta_attr == {"external_ids": f"{osv_id}"}
+        assert Flaw.objects.first().meta_attr == {"external_ids": osv_id}

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -519,54 +519,6 @@ class TestFlaw:
         assert Flaw.objects.first().local_updated_dt > og_local_updated_dt
 
     @pytest.mark.parametrize(
-        "bz_id,bz_component,workflow_state,is_draft",
-        [
-            ("", "", "", True),
-            ("1000", "vulnerability", WorkflowModel.WorkflowState.NEW, False),
-            (
-                "1000",
-                "vulnerability",
-                WorkflowModel.WorkflowState.TRIAGE,
-                False,
-            ),
-            (
-                "1000",
-                "vulnerability-draft",
-                WorkflowModel.WorkflowState.NEW,
-                True,
-            ),
-            (
-                "1000",
-                "vulnerability-draft",
-                WorkflowModel.WorkflowState.TRIAGE,
-                False,
-            ),
-            ("1000", "", WorkflowModel.WorkflowState.NEW, False),
-            ("1000", "", WorkflowModel.WorkflowState.TRIAGE, False),
-        ],
-    )
-    def test_flaw_draft(
-        self,
-        bz_id,
-        bz_component,
-        workflow_state,
-        is_draft,
-    ):
-        """
-        test that flaw draft is set correctly
-        """
-        meta_attr = {}
-        if bz_id:
-            meta_attr["bz_id"] = bz_id
-        if bz_component:
-            meta_attr["bz_component"] = bz_component
-
-        flaw = FlawFactory(
-            cve_id="CVE-2000-1001", workflow_state=workflow_state, meta_attr=meta_attr
-        )
-        assert flaw.is_draft is is_draft
-
-    @pytest.mark.parametrize(
         "ps_module_name,ps_product_name",
         [
             ("rhel-8", "Red Hat Enterprise Linux"),

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -143,7 +143,7 @@ class TestSnippet:
             assert snippet.content["cve_id"] == flaw.cve_id
         # flaw is newly created, so meta_attr contains custom data
         if identifier == "external_id" and not flaw_present:
-            assert flaw.meta_attr == {"external_ids": f"{ext_id}"}
+            assert flaw.meta_attr == {"external_ids": ext_id}
         # flaw already got synced to BZ, so meta_attr contains data created by BZ sync
         if identifier == "external_id" and flaw_present:
             assert flaw.meta_attr == {"external_ids": f"['{ext_id}']"}


### PR DESCRIPTION
This PR simplifies checking whether a flaw is a draft. It removes the dependency on full BZ sync and only checks the state of the associated Jira task and BZ ID, which should be sufficient.

This PR also included the ACLs change when promoting/rejecting a flaw. However, I struggled with tests, so @costaconrado helped me finish this change in #654. Thank you one more time for all your help, I really appreciate it!

Closes OSIDB-3175