### PR TITLE
make internal flaws public on promote

### DIFF
--- a/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_promote.yaml
+++ b/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_promote.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.0
+    method: GET
+    uri: https://example.com/v1/vulns/GHSA-3hwm-922r-47hw
+  response:
+    body:
+      string: '{"id": "GHSA-3hwm-922r-47hw", "summary": "Stud42 vulnerable to denial
+        of service", "details": "A security vulnerability has been identified in the
+        GraphQL parser used by the API of s42.app. An attacker can overload the parser
+        and cause the API pod to crash. With a bit of threading, the attacker can
+        bring down the entire API, resulting in an unhealthy stream. This vulnerability
+        can be exploited by sending a specially crafted request to the API with a
+        large payload.\n\nAn attacker can exploit this vulnerability to cause a denial
+        of service (DoS) attack on the s42.app API, resulting in unavailability of
+        the API for legitimate users.", "modified": "2023-04-25T23:06:52Z", "published":
+        "2023-03-31T19:33:44Z", "database_specific": {"cwe_ids": ["CWE-400"], "github_reviewed":
+        true, "severity": "HIGH", "github_reviewed_at": "2023-03-31T19:33:44Z", "nvd_published_at":
+        null}, "references": [{"type": "WEB", "url": "https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw"},
+        {"type": "WEB", "url": "https://example.com/42Atomys/stud42/issues/412"},
+        {"type": "WEB", "url": "https://example.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17"},
+        {"type": "PACKAGE", "url": "https://example.com/42Atomys/stud42"}], "affected":
+        [{"package": {"name": "atomys.codes/stud42", "ecosystem": "Go", "purl": "pkg:golang/atomys.codes/stud42"},
+        "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.23.0"}]}],
+        "database_specific": {"source": "https://example.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/03/GHSA-3hwm-922r-47hw/GHSA-3hwm-922r-47hw.json"}}],
+        "schema_version": "1.6.0", "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"}]}'
+    headers:
+      Content-Length:
+      - '1676'
+      Date:
+      - Thu, 25 Jul 2024 20:23:47 GMT
+      Server:
+      - Google Frontend
+      X-Cloud-Trace-Context:
+      - 6a13b1807a6264b5971e4bfde8c28277
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-type:
+      - application/json
+      grpc-accept-encoding:
+      - identity, deflate, gzip
+      grpc-message:
+      - ''
+      grpc-status:
+      - '0'
+      x-envoy-decorator-operation:
+      - ingress GetVulnById
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_reject.yaml
+++ b/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_reject.yaml
@@ -1,0 +1,60 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.0
+    method: GET
+    uri: https://example.com/v1/vulns/GHSA-3hwm-922r-47hw
+  response:
+    body:
+      string: '{"id": "GHSA-3hwm-922r-47hw", "summary": "Stud42 vulnerable to denial
+        of service", "details": "A security vulnerability has been identified in the
+        GraphQL parser used by the API of s42.app. An attacker can overload the parser
+        and cause the API pod to crash. With a bit of threading, the attacker can
+        bring down the entire API, resulting in an unhealthy stream. This vulnerability
+        can be exploited by sending a specially crafted request to the API with a
+        large payload.\n\nAn attacker can exploit this vulnerability to cause a denial
+        of service (DoS) attack on the s42.app API, resulting in unavailability of
+        the API for legitimate users.", "modified": "2023-04-25T23:06:52Z", "published":
+        "2023-03-31T19:33:44Z", "database_specific": {"cwe_ids": ["CWE-400"], "github_reviewed":
+        true, "severity": "HIGH", "github_reviewed_at": "2023-03-31T19:33:44Z", "nvd_published_at":
+        null}, "references": [{"type": "WEB", "url": "https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw"},
+        {"type": "WEB", "url": "https://example.com/42Atomys/stud42/issues/412"},
+        {"type": "WEB", "url": "https://example.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17"},
+        {"type": "PACKAGE", "url": "https://example.com/42Atomys/stud42"}], "affected":
+        [{"package": {"name": "atomys.codes/stud42", "ecosystem": "Go", "purl": "pkg:golang/atomys.codes/stud42"},
+        "ranges": [{"type": "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.23.0"}]}],
+        "database_specific": {"source": "https://example.com/github/advisory-database/blob/main/advisories/github-reviewed/2023/03/GHSA-3hwm-922r-47hw/GHSA-3hwm-922r-47hw.json"}}],
+        "schema_version": "1.6.0", "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"}]}'
+    headers:
+      Content-Length:
+      - '1676'
+      Date:
+      - Thu, 25 Jul 2024 20:23:52 GMT
+      Server:
+      - Google Frontend
+      X-Cloud-Trace-Context:
+      - 0ab4c1ff858f90419b9f96749ab305bb
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-type:
+      - application/json
+      grpc-accept-encoding:
+      - identity, deflate, gzip
+      grpc-message:
+      - ''
+      grpc-status:
+      - '0'
+      x-envoy-decorator-operation:
+      - ingress GetVulnById
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -310,3 +310,16 @@ class WorkflowModel(models.Model):
 
     def jira_status(self):
         return WorkflowFramework().jira_status(self)
+
+    def adjust_acls(self, save=True):
+        # Only new and rejected state can have internal ACLs
+        internal_supported = [
+            WorkflowModel.WorkflowState.NEW,
+            WorkflowModel.WorkflowState.REJECTED,
+        ]
+
+        if self.workflow_state not in internal_supported and self.is_internal:
+            self.set_public()
+
+        if save:
+            self.save()

--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -139,6 +139,7 @@ class JiraTaskConvertor:
             flaw.workflow_name = self.task_data["workflow_name"]
             flaw.workflow_state = self.task_data["workflow_state"]
             flaw.task_updated_dt = self.task_data["task_updated_dt"]
+            flaw.adjust_acls(save=False)
             return JiraTaskSaver(flaw)
         return None
 

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1440,6 +1440,7 @@ class Flaw(
                 self.task_updated_dt = datetime.strptime(
                     issue.data["fields"]["updated"], "%Y-%m-%dT%H:%M:%S.%f%z"
                 )
+                self.adjust_acls(save=False)
                 self.save(*args, **kwargs)
         except Flaw.DoesNotExist:
             # we're handling a new OSIDB-authored flaw -- create


### PR DESCRIPTION
This PR change Workflows in order to only allow internal flaws in new/draft state and rejected flaws.