### PR TITLE
add contract priority description in trackers

### DIFF
--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -101,7 +101,7 @@ class TrackerQueryBuilder:
             if len(summary) <= MAX_SUMMARY_LENGTH:
                 break
 
-            cves, description = self._summary_shorten(cves, description)
+            cves, description = TrackerQueryBuilder._summary_shorten(cves, description)
 
         return summary
 
@@ -137,7 +137,7 @@ class TrackerQueryBuilder:
         # add a trailing space to separate from the rest
         return " ".join(sorted(prefixes)) + " "
 
-    def _summary_shorten(self, cves, description):
+    def _summary_shorten(cves, description):
         """
         shorten the aligable parts of the tracker summary
         """
@@ -220,7 +220,7 @@ class TrackerQueryBuilder:
 
         # 4) another extra bit for kernel
         if self.ps_component in KERNEL_PACKAGES:
-            description_parts.extend(self._description_kernel())
+            description_parts.extend(TrackerQueryBuilder._description_kernel())
 
         # 5) join the parts by empty lines
         return "\n\n".join(description_parts)
@@ -277,7 +277,7 @@ class TrackerQueryBuilder:
         return description_parts
 
     # TODO this should be eventually replaced by the OSIM/OSIDB link
-    def _description_bugzilla_link(self, bz_id):
+    def _description_bugzilla_link(bz_id):
         """
         generate link to Bugzilla bug with the given ID
         """
@@ -295,7 +295,10 @@ class TrackerQueryBuilder:
         )
         description_parts.append(
             "\n".join(
-                [self._description_bugzilla_link(flaw.bz_id) for flaw in self.flaws]
+                [
+                    TrackerQueryBuilder._description_bugzilla_link(flaw.bz_id)
+                    for flaw in self.flaws
+                ]
             )
         )
         description_parts.append(
@@ -339,7 +342,7 @@ class TrackerQueryBuilder:
         )
 
         for flaw in self.flaws:
-            reference_url = self._description_bugzilla_link(flaw.bz_id)
+            reference_url = TrackerQueryBuilder._description_bugzilla_link(flaw.bz_id)
 
             description_parts.append(f"{flaw.title}\n{reference_url}")
             description_parts.append(flaw.comment_zero)
@@ -366,7 +369,7 @@ class TrackerQueryBuilder:
 
         return description_parts
 
-    def _description_kernel(self):
+    def _description_kernel():
         """
         generate kernel tracker description text
         """

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -206,15 +206,21 @@ class TrackerQueryBuilder:
             if self.ps_update_stream.rhsa_sla_applicable:
                 pass  # TODO
 
-            # 3e) embargo text
+            # 3e) Contract priority text
+            if self.tracker.is_contract_priority:
+                description_parts.extend(
+                    TrackerQueryBuilder._description_contract_priority()
+                )
+
+            # 3f) embargo text
             if self.tracker.is_embargoed:
                 description_parts.extend(self._description_embargoed())
 
-            # 3f) Jira footer
+            # 3g) Jira footer
             if self.tracker.type == Tracker.TrackerType.JIRA:
                 description_parts.extend(self._description_jira_footer())
 
-            # 3g) Bugzilla footer
+            # 3h) Bugzilla footer
             if self.tracker.type == Tracker.TrackerType.BUGZILLA:
                 description_parts.extend(self._description_bugzilla_footer())
 
@@ -331,6 +337,19 @@ class TrackerQueryBuilder:
             )
 
         return description_parts
+
+    def _description_contract_priority():
+        """
+        generate description text for contract priority
+        """
+        return [
+            "Contract priorities are scoped by at the "
+            "product/version level and include all severities "
+            "and all components within that product/version. "
+            "All severities (including low) must be resolved "
+            "within the allotted SLA time. \n"
+            "https://source.redhat.com/departments/products_and_global_engineering/product_security/ops/product_security_wiki/contract_prioritization_faq"
+        ]
 
     def _description_jira_footer(self):
         """

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -327,10 +327,9 @@ class TestTrackerQueryBuilderDescription:
         tqb.instance = tracker
 
         assert tqb.description == (
-            """\
-special-module tracking bug for large-component: see the bugs linked in the "Blocks" field of this bug for full details of the security issue(s).
-
-This bug is never intended to be made public, please put any public notes in the blocked bugs."""
+            "special-module tracking bug for large-component: see the bugs linked "
+            'in the "Blocks" field of this bug for full details of the security issue(s).\n\n'
+            "This bug is never intended to be made public, please put any public notes in the blocked bugs."
         )
 
     def test_bugzilla_embargoed(self):
@@ -371,14 +370,11 @@ This bug is never intended to be made public, please put any public notes in the
         tqb.instance = tracker
 
         assert tqb.description == (
-            """\
-special-module tracking bug for large-component: see the bugs linked in the "Blocks" field of this bug for full details of the security issue(s).
-
-This bug is never intended to be made public, please put any public notes in the blocked bugs.
-
-NOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.
-
-WARNING: NOTICE THAT REMOVING THE "SECURITY" GROUP FROM THIS TRACKER MAY BREAK THE EMBARGO."""
+            "special-module tracking bug for large-component: see the bugs linked "
+            'in the "Blocks" field of this bug for full details of the security issue(s).\n\n'
+            "This bug is never intended to be made public, please put any public notes in the blocked bugs.\n\n"
+            "NOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\n"
+            'WARNING: NOTICE THAT REMOVING THE "SECURITY" GROUP FROM THIS TRACKER MAY BREAK THE EMBARGO.'
         )
 
     def test_bugzilla_rhel(self):
@@ -405,13 +401,9 @@ WARNING: NOTICE THAT REMOVING THE "SECURITY" GROUP FROM THIS TRACKER MAY BREAK T
         tqb.instance = tracker
 
         assert (
-            (
-                """\
-For the Enterprise Linux security issues handling process overview see:
-https://source.redhat.com/groups/public/product-security/content/product_security_wiki/eus_z_stream_and_security_bugs"""
-            )
-            in tqb.description
-        )
+            "For the Enterprise Linux security issues handling process overview see:\n"
+            "https://source.redhat.com/groups/public/product-security/content/product_security_wiki/eus_z_stream_and_security_bugs"
+        ) in tqb.description
 
     @pytest.mark.parametrize("ps_component", ["xen", "kvm", "kernel-xen"])
     def test_bugzilla_virtualizaiton(self, ps_component):
@@ -439,14 +431,10 @@ https://source.redhat.com/groups/public/product-security/content/product_securit
         tqb.instance = tracker
 
         assert (
-            (
-                """\
-Information with regards to this bug is considered Red Hat Confidential \
-until the embargo has lifted. Please post the patch only to the \
-'rhkernel-team-list' and/or 'virt-devel' mailing lists for review and acks."""
-            )
-            in tqb.description
-        )
+            "Information with regards to this bug is considered Red Hat Confidential "
+            "until the embargo has lifted. Please post the patch only to the "
+            "'rhkernel-team-list' and/or 'virt-devel' mailing lists for review and acks."
+        ) in tqb.description
 
     @pytest.mark.parametrize("flaw_count", [1, 2, 3])
     def test_community(self, flaw_count):
@@ -493,39 +481,32 @@ until the embargo has lifted. Please post the patch only to the \
 
         if flaw_count == 1:
             assert tqb.description == (
-                """\
-More information about this security flaw is available in the following bug:
-
-https://example.com/show_bug.cgi?id=0
-
-Disclaimer: Community trackers are created by Red Hat Product Security team on a \
-best effort basis. Package maintainers are required to ascertain if the flaw indeed \
-affects their package, before starting the update process."""
+                "More information about this security flaw is available in the following bug:\n\n"
+                "https://example.com/show_bug.cgi?id=0\n\n"
+                "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
+                "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
+                "affects their package, before starting the update process."
             )
         elif flaw_count == 2:
             assert tqb.description == (
-                """\
-More information about these security flaws is available in the following bugs:
-
-https://example.com/show_bug.cgi?id=0
-https://example.com/show_bug.cgi?id=1
-
-Disclaimer: Community trackers are created by Red Hat Product Security team on a \
-best effort basis. Package maintainers are required to ascertain if the flaw indeed \
-affects their package, before starting the update process."""
+                "More information about these security flaws is available in the following bugs:\n\n"
+                "https://example.com/show_bug.cgi?id=0\n"
+                "https://example.com/show_bug.cgi?id=1\n\n"
+                "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
+                "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
+                "affects their package, before starting the update process."
             )
         elif flaw_count == 3:
             assert tqb.description == (
-                """\
-More information about these security flaws is available in the following bugs:
-
-https://example.com/show_bug.cgi?id=0
-https://example.com/show_bug.cgi?id=1
-https://example.com/show_bug.cgi?id=2
-
-Disclaimer: Community trackers are created by Red Hat Product Security team on a \
-best effort basis. Package maintainers are required to ascertain if the flaw indeed \
-affects their package, before starting the update process."""
+                (
+                    "More information about these security flaws is available in the following bugs:\n\n"
+                    "https://example.com/show_bug.cgi?id=0\n"
+                    "https://example.com/show_bug.cgi?id=1\n"
+                    "https://example.com/show_bug.cgi?id=2\n\n"
+                    "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
+                    "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
+                    "affects their package, before starting the update process."
+                )
             )
 
     def test_jira_basic(self):
@@ -568,20 +549,14 @@ affects their package, before starting the update process."""
         tqb.instance = tracker
 
         assert tqb.description == (
-            """\
-Security Tracking Issue
-
-Do not make this issue public.
-
-Flaw:
------
-
-serious flaw
-https://example.com/show_bug.cgi?id=12345
-
-this flaw is very hard to fix
-
-~~~"""
+            "Security Tracking Issue\n\n"
+            "Do not make this issue public.\n\n"
+            "Flaw:\n"
+            "-----\n\n"
+            "serious flaw\n"
+            "https://example.com/show_bug.cgi?id=12345\n\n"
+            "this flaw is very hard to fix\n\n"
+            "~~~"
         )
 
     def test_jira_embargoed(self):
@@ -624,24 +599,16 @@ this flaw is very hard to fix
         tqb.instance = tracker
 
         assert tqb.description == (
-            """\
-Security Tracking Issue
-
-Do not make this issue public.
-
-NOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.
-
-WARNING: NOTICE THAT CHANGING THE SECURITY LEVEL FROM "SECURITY ISSUE" TO "RED HAT INTERNAL" MAY BREAK THE EMBARGO.
-
-Flaw:
------
-
-serious flaw
-https://example.com/show_bug.cgi?id=12345
-
-this flaw is very hard to fix
-
-~~~"""
+            "Security Tracking Issue\n\n"
+            "Do not make this issue public.\n\n"
+            "NOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\n"
+            'WARNING: NOTICE THAT CHANGING THE SECURITY LEVEL FROM "SECURITY ISSUE" TO "RED HAT INTERNAL" MAY BREAK THE EMBARGO.\n\n'
+            "Flaw:\n"
+            "-----\n\n"
+            "serious flaw\n"
+            "https://example.com/show_bug.cgi?id=12345\n\n"
+            "this flaw is very hard to fix\n\n"
+            "~~~"
         )
 
     @pytest.mark.parametrize("bts_name", ["bugzilla", "jboss"])
@@ -675,14 +642,10 @@ this flaw is very hard to fix
 
         if bts_name == "bugzilla" and embargoed:
             assert (
-                (
-                    """\
-Information with regards to this bug is considered Red Hat Confidential \
-until the embargo has lifted. Please post the patch only to the \
-'rhkernel-team-list' mailing list for review and acks."""
-                )
-                in tqb.description
-            )
+                "Information with regards to this bug is considered Red Hat Confidential "
+                "until the embargo has lifted. Please post the patch only to the "
+                "'rhkernel-team-list' mailing list for review and acks."
+            ) in tqb.description
 
         assert tqb.description.endswith(
             "Reproducers, if any, will remain confidential and never be made public, unless done so by the security team."

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Implement message throttling in the API (OSIDB-894)
+- Added contract priority description in trackers (OSIDB-3165)
 
 ### Changed
 - special_handling_flaw_missing_cve_description Alert to


### PR DESCRIPTION
This PR adds a description and a FAQ url into trackers tagged as `contract-priority`.

Closes OSIDB-3165.