### PR TITLE
Keep the save to Jira and BZ separate for collector flaws

### DIFF
--- a/osidb/models.py
+++ b/osidb/models.py
@@ -1562,8 +1562,10 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
         self.flaw = flaw
         self.save()
 
-        # kwargs contains jira_token
-        flaw.save(bz_api_key=BZ_API_KEY, raise_validation_error=False, *args, **kwargs)
+        # keep the save to Jira and BZ separate because BZ can be done asynchronously
+        # (BZ token is passed directly, but Jira token is in kwargs)
+        flaw.save(raise_validation_error=False, *args, **kwargs)
+        flaw.save(bz_api_key=BZ_API_KEY, raise_validation_error=False, *args)
 
         return Flaw.objects.get(uuid=flaw.uuid)
 


### PR DESCRIPTION
This PR fixes the partial save for collector flaws caused by the asynchronous BZ. Separating the save for Jira and BZ enables Jira changes to be done immediately.

Fixes OSIDB-3188