### PR TITLE
do not save to backend systems in JiraTaskSaver

### DIFF
--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -11,9 +11,7 @@ from functools import cached_property
 from django.conf import settings
 from django.db import transaction
 
-from apps.taskman.constants import JIRA_AUTH_TOKEN
 from apps.workflows.workflow import WorkflowFramework
-from collectors.bzimport.constants import BZ_API_KEY
 from osidb.core import generate_acls, set_user_acls
 from osidb.models import Flaw, Tracker
 from osidb.validators import CVE_RE_STR
@@ -151,8 +149,6 @@ class JiraTaskSaver:
     def save(self):
         self.flaw.save(
             auto_timestamps=False,
-            bz_api_key=BZ_API_KEY,
-            jira_token=JIRA_AUTH_TOKEN,
             raise_validation_error=False,
         )
 

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -7,7 +7,6 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 import collectors.jiraffe.collectors as collectors
-import collectors.jiraffe.convertors as convertors
 import osidb.models as models
 from apps.taskman.constants import JIRA_AUTH_TOKEN
 from apps.taskman.service import JiraTaskmanQuerier
@@ -42,7 +41,6 @@ class TestJiraTaskCollector:
         """
         jira_token = JIRA_AUTH_TOKEN if JIRA_AUTH_TOKEN else "USER_JIRA_TOKEN"
         monkeypatch.setattr(models, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
-        monkeypatch.setattr(convertors, "JIRA_AUTH_TOKEN", jira_token)
         monkeypatch.setattr(collectors, "JIRA_TOKEN", jira_token)
 
         collector = JiraTaskCollector()
@@ -109,7 +107,6 @@ class TestJiraTaskCollector:
         """
         jira_token = JIRA_AUTH_TOKEN if JIRA_AUTH_TOKEN else "USER_JIRA_TOKEN"
         monkeypatch.setattr(models, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
-        monkeypatch.setattr(convertors, "JIRA_AUTH_TOKEN", jira_token)
         monkeypatch.setattr(collectors, "JIRA_TOKEN", jira_token)
 
         jtq = JiraTaskmanQuerier(token=jira_token)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make task collector ignore outdated issues (OSIDB-3085)
 - Allow Flaw API to proper unassign owner in Jira (OSIDB-3145)
 - Remove sync from Bugzilla from the async sync to Bugzilla (OSIDB-3199)
+- Do not save to backend systems in JiraTaskSaver (OSIDB-3087)
 
 ## [4.1.3] - 2024-07-25
 ### Changed


### PR DESCRIPTION
as it is only supposed to store the collector result to the DB

Closes OSIDB-3087