### PR TITLE
Keep the save to Jira and BZ separate everywhere

### DIFF
--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -285,7 +285,10 @@ class WorkflowModel(models.Model):
         if not save:
             return
 
-        self.save(jira_token=jira_token, raise_validation_error=False, **kwargs)
+        # keep the save to Jira and BZ separate because BZ can be done asynchronously
+        # (Jira token is passed directly, but BZ token is in kwargs)
+        self.save(jira_token=jira_token, raise_validation_error=False)
+        self.save(raise_validation_error=False, **kwargs)
 
     def reject(self, save=True, jira_token=None, **kwargs):
         """
@@ -306,7 +309,10 @@ class WorkflowModel(models.Model):
         if not save:
             return
 
-        self.save(jira_token=jira_token, raise_validation_error=False, **kwargs)
+        # keep the save to Jira and BZ separate because BZ can be done asynchronously
+        # (Jira token is passed directly, but BZ token is in kwargs)
+        self.save(jira_token=jira_token, raise_validation_error=False)
+        self.save(raise_validation_error=False, **kwargs)
 
     def jira_status(self):
         return WorkflowFramework().jira_status(self)


### PR DESCRIPTION
This PR is a follow-up to #657. The save to Jira and BZ should be always separate.

Fixes OSIDB-3203