### PR TITLE
Prevent bbsync (OSIDB->BZ) from saving data back to OSIDB

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,7 +162,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 84,
+        "line_number": 92,
         "is_secret": false
       }
     ],
@@ -431,5 +431,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-01T08:06:48Z"
+  "generated_at": "2024-08-01T08:55:28Z"
 }


### PR DESCRIPTION
Prevent bbsync (OSIDB->BZ) from saving data back to OSIDB unless absolutely necessary.