### PR TITLE
Proper rollback on atomic requets

### DIFF
--- a/osidb/exception_handlers.py
+++ b/osidb/exception_handlers.py
@@ -2,7 +2,6 @@ import logging
 
 from bugzilla.exceptions import BugzillaError
 from django.core.exceptions import ValidationError as DjangoValidationError
-from django.db import transaction
 from django.db.utils import OperationalError
 from jira.exceptions import JIRAError
 from rest_framework import status
@@ -10,13 +9,14 @@ from rest_framework.exceptions import ValidationError as DRFValidationError
 from rest_framework.response import Response
 from rest_framework.serializers import as_serializer_error
 from rest_framework.views import exception_handler as drf_exception_handler
+from rest_framework.views import set_rollback
 
 logger = logging.getLogger(__name__)
 
 
 def exception_handler(exc, context):
     if http_code := getattr(type(exc), "http_code", False):
-        transaction.set_rollback(True)
+        set_rollback()
         # serialize custom exceptions when raised as part of the
         # request-response lifecycle by using an `http_code` class variable
         # as an interface
@@ -27,19 +27,19 @@ def exception_handler(exc, context):
         return Response(response_data, status=http_code)
 
     if isinstance(exc, BugzillaError):
-        transaction.set_rollback(True)
+        set_rollback()
         logger.exception(exc)
         data = {"detail": str(exc)}
         return Response(data, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
     if isinstance(exc, JIRAError):
-        transaction.set_rollback(True)
+        set_rollback()
         logger.exception(exc)
         data = {"detail": exc.text}
         return Response(data, status=status.HTTP_422_UNPROCESSABLE_ENTITY)
 
     if isinstance(exc, OperationalError):
-        transaction.set_rollback(True)
+        set_rollback()
         logger.exception(exc)
         details = str(exc)
         if "deadlock" in details:


### PR DESCRIPTION
This PR improves changes introduced in #666 so the rollback is performed more safely and the behaviour matches DRF rollback.