### PR TITLE
Fix Jira metadata collector

### DIFF
--- a/collectors/jiraffe/tasks.py
+++ b/collectors/jiraffe/tasks.py
@@ -43,8 +43,7 @@ def jira_tracker_collector(collector_obj):
 
 @collector(
     base=MetadataCollector,
-    # run once a day at 2:35
-    crontab=crontab(hour=2, minute=35),
+    crontab=crontab(minute="0", hour="*/3"),  # run every three hours
     depends_on=["collectors.product_definitions.tasks.product_definitions_collector"],
     enabled=JIRA_METADATA_COLLECTOR_ENABLED,
 )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Command for manual syncing Jira metadata (OSIDB-3219)
+
 ### Fixed
 - Cannot modify CVE of existing flaws (OSIDB-3102)
 - Jira metadata collector is not deleting metadata on failure (OSIDB-3219)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Cannot modify CVE of existing flaws (OSIDB-3102)
+- Jira metadata collector is not deleting metadata on failure (OSIDB-3219)
 
 ## [4.1.6] - 2024-08-02
 ### Fixed

--- a/osidb/management/commands/sync_jira_metadata.py
+++ b/osidb/management/commands/sync_jira_metadata.py
@@ -1,0 +1,21 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+from collectors.framework.models import CollectorMetadata
+from collectors.jiraffe.collectors import MetadataCollector
+
+
+class Command(BaseCommand):
+    help = "Synchronizes Jira metadata to OSIDB"
+
+    def handle(self, *args, **options):
+        now = timezone.now()
+        mc = MetadataCollector()
+        mc.collect()
+
+        cm = CollectorMetadata.objects.get(
+            name="collectors.jiraffe.tasks.metadata_collector"
+        )
+        cm.updated_until_dt = now
+        cm.data_state = "COMPLETE"
+        cm.save()


### PR DESCRIPTION
This PR:
* fixes Jira metadata collector so the metadata are not deleted after failure as this might cause important projects to miss for even a couple of days if the failure is consecutive
* bumps the frequency of the jira metadata collector from running only once per day to once every 3 hours
* minor - adds django management command to run jira metadata collector manually

Closes OSIDB-3219