### PR TITLE
minor - Fix changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,10 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Cannot modify CVE of existing flaws (OSIDB-3102)
+
 ## [4.1.6] - 2024-08-02
 ### Fixed
 - Cannot fill trackers concurrently (OSIDB-3230)
-- Cannot modify CVE of existing flaws (OSIDB-3102)
 
 ## [4.1.5] - 2024-08-01
 ### Removed


### PR DESCRIPTION
This PR:
* fixes changelog to correctly reflect reality as a6ce6a96c339500afed209f8678be048c51c2755 wrongly added https://github.com/RedHatProductSecurity/osidb/pull/673 to the 4.1.6 release although it was not released yet