### PR TITLE
Update ACLs of linked objects to match collector flaw

### DIFF
--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -326,6 +326,8 @@ class WorkflowModel(models.Model):
 
         if self.workflow_state not in internal_supported and self.is_internal:
             self.set_public()
+            # updates ACLs of all related objects except for snippets
+            self.set_public_nested()
 
         if save:
             self.save()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Saving models only triggers validations once (OSIDB-3108)
+- Update ACLs of linked objects to match collector flaw (OSIDB-3253)
 
 ### Fixed
 - Cannot modify CVE of existing flaws (OSIDB-3102)


### PR DESCRIPTION
This PR is a follow-up to #654 and ensures that all related objects of a collector flaw will have adjusted ACLs if necessary after the flaw is promoted.

This will fix a situation like when an affect had internal ACLs because it was created for an internal (not promoted) flaw.

Closes OSIDB-3253