### PR TITLE
Fix migration in SLA app

### DIFF
--- a/apps/sla/migrations/0002_alter_sla_start_dates.py
+++ b/apps/sla/migrations/0002_alter_sla_start_dates.py
@@ -2,14 +2,13 @@
 
 import json
 
-import django.contrib.postgres.fields.jsonb
 from django.db import migrations, models
 
 
 def convert_array_to_json(apps, schema_editor):
     SLA = apps.get_model("sla", "SLA")
     for instance in SLA.objects.all():
-        instance.temp_json_field = json.dumps(instance.array_field)
+        instance.temp_json_field = json.dumps(instance.start_dates)
         instance.save()
 
 


### PR DESCRIPTION
Fix error in migration which causes it to fail if there is existing SLA data.

Related to OSIDB-3221.