### PR TITLE
Update public date for collector flaws

### DIFF
--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -162,8 +162,7 @@ class NVDQuerier:
                     "references": get_references(vulnerability),
                     "source": Snippet.Source.NVD,
                     "title": "From NVD collector",
-                    # required for ignoring historical data
-                    "published_in_nvd": f"{vulnerability.published}Z",
+                    "unembargo_dt": f"{vulnerability.published}Z",
                 }
             )
 
@@ -260,7 +259,7 @@ class NVDCollector(Collector, NVDQuerier):
             if self.snippet_creation_enabled:
                 if self.snippet_creation_start_date and (
                     self.snippet_creation_start_date
-                    >= dateparse.parse_datetime(item["published_in_nvd"])
+                    >= dateparse.parse_datetime(item["unembargo_dt"])
                 ):
                     continue
 

--- a/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
+++ b/collectors/nvd/tests/cassettes/test_collectors/TestNVDCollector.test_snippet_and_flaw_created.yaml
@@ -312,7 +312,7 @@ interactions:
       string: '{"resultsPerPage": 1, "startIndex": 0, "totalResults": 1, "format":
         "NVD_CVE", "version": "2.0", "timestamp": "2024-06-17T11:30:09.960", "vulnerabilities":
         [{"cve": {"id": "CVE-2017-7542", "sourceIdentifier": "secalert@redhat.com",
-        "published": "2024-01-21T16:29:00.393", "lastModified": "2023-02-12T23:30:40.070",
+        "published": "2024-01-21T16:29:00.393", "lastModified": "2024-01-21T16:29:00.393",
         "vulnStatus": "Modified", "descriptions": [{"lang": "en", "value": "The ip6_find_1stfragopt
         function allows local users to cause a denial of service."}, {"lang": "es", "value":
         "La funci\u00f3n ip6_find_1stfragopt en el archivo net/ipv6/output_core.c
@@ -1014,7 +1014,7 @@ interactions:
       From NVD collector", "description": "The ip6_find_1stfragopt function allows local users to cause
       a denial of service.", "comment_is_private": false, "alias": ["CVE-2017-7542"], "keywords":
       ["Security"], "flags": [], "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"reported\":
-      \"2024-06-17T11:30:16Z\", \"external_ids\": [\"CVE-2017-7542\"],
+      \"2024-06-17T11:30:16Z\", \"public\": \"2024-01-21T16:29:00Z\", \"external_ids\": [\"CVE-2017-7542\"],
       \"references\": [{\"type\": \"source\", \"url\": \"https://nvd.nist.gov/vuln/detail/CVE-2017-7542\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"http://www.debian.org/security/2017/dsa-3927\",
       \"description\": null}], \"source\": \"nvd\", \"cwe\": \"(CWE-190|CWE-835)\"}"}'
@@ -1180,7 +1180,7 @@ interactions:
     uri: https://example.com/rest/bug/2293428?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"bugs": [{"cf_srtnotes": "{\"reported\": \"2024-06-17T11:30:16Z\",
+      string: '{"bugs": [{"cf_srtnotes": "{\"reported\": \"2024-06-17T11:30:16Z\", \"public\": \"2024-01-21T16:29:00Z\",
         \"external_ids\": [\"CVE-2017-7542\"], \"references\": [{\"type\":
         \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2017-7542\", \"description\":
         null}, {\"type\": \"external\", \"url\": \"https://example.com/security/2017/dsa-3927\",
@@ -1269,7 +1269,7 @@ interactions:
         ["---"], "platform": "All", "assigned_to": "prodsec-dev@redhat.com", "cf_clone_of":
         null, "cf_major_incident": null, "cf_pgm_internal": "", "is_cc_accessible":
         true, "cf_devel_whiteboard": "", "is_creator_accessible": true, "qa_contact":
-        "", "cf_srtnotes": "{\"reported\": \"2024-06-17T11:30:16Z\", \"external_ids\":
+        "", "cf_srtnotes": "{\"reported\": \"2024-06-17T11:30:16Z\", \"public\": \"2024-01-21T16:29:00Z\", \"external_ids\":
         [\"CVE-2017-7542\"], \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vuln/detail/CVE-2017-7542\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"http://www.example.com/security/2017/dsa-3927\",
         \"description\": null}], \"source\": \"nvd\", \"cwe\": \"(CWE-190|CWE-835)\"}",

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -270,14 +270,14 @@ class TestNVDCollector:
             ],
             "source": Snippet.Source.NVD,
             "title": "From NVD collector",
-            "published_in_nvd": "2024-01-21T16:29:00.393Z",
+            "unembargo_dt": "2024-01-21T16:29:00.393Z",
         }
         cve_id = snippet_content["cve_id"]
 
         # Default data
         if has_flaw:
             data = dict(snippet_content)
-            for i in ["cvss_scores", "references", "published_in_nvd"]:
+            for i in ["cvss_scores", "references"]:
                 data.pop(i)
 
             f = FlawFactory(

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -180,7 +180,7 @@ class OSVCollector(Collector):
 
         if self.snippet_creation_start_date and (
             self.snippet_creation_start_date
-            >= dateparse.parse_datetime(content["published_in_osv"])
+            >= dateparse.parse_datetime(content["unembargo_dt"])
         ):
             return 0, 0
 
@@ -297,12 +297,11 @@ class OSVCollector(Collector):
             "cwe_id": get_cwes(osv_vuln),
             "references": get_refs(osv_vuln),
             "source": Snippet.Source.OSV,
+            "unembargo_dt": osv_vuln.get("published"),
             # Unused fields that we may extract additional data from later.
             "osv_id": osv_id,
             "osv_affected": osv_vuln.get("affected"),
             "osv_acknowledgments": osv_vuln.get("credits"),
-            # Required for ignoring historical data
-            "published_in_osv": osv_vuln.get("published"),
         }
 
         return osv_id, cve_ids, content

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_multi_cve_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_multi_cve_osv_record.yaml
@@ -38,11 +38,11 @@ interactions:
       Content-Length:
       - '1600'
       Date:
-      - Fri, 28 Jun 2024 12:01:50 GMT
+      - Wed, 14 Aug 2024 12:48:31 GMT
       Server:
       - Google Frontend
       X-Cloud-Trace-Context:
-      - 08f8a51e6f29b8e560c15f42485b1f40
+      - a9108374b66e33e20a8dc78a352760a6
       alt-svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       content-type:
@@ -81,7 +81,7 @@ interactions:
     body:
       string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
         "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
-        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        issues for a specific project.", "havePermission": false}, "VIEW_WORKFLOW_READONLY":
         {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
         "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
         "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
@@ -104,9 +104,9 @@ interactions:
         Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
         "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
         "description": "Ability to administer a project in Jira.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        false, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
         "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
-        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        edit all comments made on issues.", "havePermission": false, "deprecatedKey":
         true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
         "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
         with this permission may delete own attachments.", "havePermission": true,
@@ -126,7 +126,7 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
         {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "havePermission": false, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
         "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
         "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
         "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
@@ -134,7 +134,7 @@ interactions:
         permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
         {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        attachments.", "havePermission": false}, "ASSIGN_ISSUE": {"id": "13", "key":
         "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
         "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
         true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
@@ -147,7 +147,7 @@ interactions:
         "PROJECT", "description": "Users with this permission may create attachments.",
         "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
         "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
-        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        edit all worklogs made on issues.", "havePermission": false}, "SCHEDULE_ISSUE":
         {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
         "description": "Ability to view or edit an issue''s due date.", "havePermission":
         true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
@@ -161,16 +161,16 @@ interactions:
         Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
         due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
         "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
-        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "Ability to delete all worklogs made on issues.", "havePermission": false,
         "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
         "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
         to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
         true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
         "Administer Projects", "type": "PROJECT", "description": "Ability to administer
-        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        a project in Jira.", "havePermission": false}, "DELETE_ALL_COMMENTS": {"id":
         "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "havePermission": false}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
         "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
         and reopen issues. This includes the ability to set a fix version.", "havePermission":
         true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
@@ -221,12 +221,12 @@ interactions:
         Results OKRs (Objective and key results) that are linked to a given issue",
         "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
         "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
-        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        issues for a specific project.", "havePermission": false}, "BROWSE_ARCHIVE":
         {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
         "PROJECT", "description": "Ability to browse archived issues from a specific
-        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
-        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
-        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        project.", "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL":
+        {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate
+        users in A4J global scope", "type": "GLOBAL", "description": "Having the permission
         allows to select other user as automation rule actor", "havePermission": true},
         "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
         "View Development Tools", "type": "PROJECT", "description": "Allows users
@@ -242,15 +242,15 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
         true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
         "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
-        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        worklogs made on issues.", "havePermission": false, "deprecatedKey": true},
         "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
         All Comments", "type": "PROJECT", "description": "Ability to edit all comments
-        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        made on issues.", "havePermission": false}, "DELETE_ISSUE": {"id": "16", "key":
         "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
         "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
         "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
         "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
-        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        sprints.", "havePermission": false}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
         "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
         a user or group from a popup window as well as the ability to use the ''share''
         issues feature. Users with this permission will also be able to see names
@@ -260,7 +260,7 @@ interactions:
         with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
         {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        attachments.", "havePermission": false, "deprecatedKey": true}, "DELETE_ISSUES":
         {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
         "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
         {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
@@ -269,27 +269,31 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
         true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
         "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
-        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        all worklogs made on issues.", "havePermission": false}, "LINK_ISSUES": {"id":
         "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
         "Ability to link issues together and create linked issues. Only useful if
         issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
@@ -304,9 +308,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:50 GMT
+      - Wed, 14 Aug 2024 12:48:32 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:01:50 GMT
+      - Wed, 14 Aug 2024 12:48:32 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -319,17 +323,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16555'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 721x215564x1
+      - 768x29603x2
       x-asessionid:
-      - lwzaw8
+      - 1554j7c
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -341,9 +345,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576110.8a468307
+      - 0.52071002.1723639712.1e046f83
       x-rh-edge-request-id:
-      - 8a468307
+      - 1e046f83
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -485,7 +489,9 @@ interactions:
         Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
         new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
         Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
+        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12402","id":"12402","description":"Track
+        underlying causes of incidents. Created by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56262&avatarType=issuetype","name":"Problem","subtask":false,"avatarId":56262},{"self":"https://example.com/rest/api/2/issuetype/12401","id":"12401","description":"Created
+        by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56261&avatarType=issuetype","name":"Change","subtask":false,"avatarId":56261}]'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -494,9 +500,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:50 GMT
+      - Wed, 14 Aug 2024 12:48:32 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:01:50 GMT
+      - Wed, 14 Aug 2024 12:48:32 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -507,19 +513,19 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '25109'
+      - '25736'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 721x215565x1
+      - 768x29604x2
       x-asessionid:
-      - 1uscv4a
+      - 11ogl6r
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -531,9 +537,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576110.8a4685ba
+      - 0.52071002.1723639712.1e047118
       x-rh-edge-request-id:
-      - 8a4685ba
+      - 1e047118
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -592,11 +598,14 @@ interactions:
         program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
         "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
         "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
+        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
+        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
+        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
+        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
+        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
+        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
+        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
+        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
         Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
@@ -611,9 +620,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:51 GMT
+      - Wed, 14 Aug 2024 12:48:33 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:01:51 GMT
+      - Wed, 14 Aug 2024 12:48:33 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -624,19 +633,19 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '4024'
+      - '4215'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 721x215566x1
+      - 768x29605x2
       x-asessionid:
-      - ldg06m
+      - 19ez8ea
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -648,9 +657,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576110.8a468b59
+      - 0.52071002.1723639713.1e047369
       x-rh-edge-request-id:
-      - 8a468b59
+      - 1e047369
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -666,8 +675,9 @@ interactions:
       encrypted by the V1 EncryptionClient using either the AES-CBC content cipher
       or the KMS key wrap algorithm are vulnerable. Users should migrate to the V1
       EncryptionClientV2 API, which will not create vulnerable files. Old files will
-      remain vulnerable until re-encrypted with the new client.", "labels": ["flawuuid:38b49df1-f211-41b0-b100-7bcc283c0870",
-      "impact:"], "priority": {"name": "Undefined"}}}'
+      remain vulnerable until re-encrypted with the new client.", "labels": ["flawuuid:a30e5ac7-8ae0-4165-819b-a2dec5fd5e35",
+      "impact:", "CVE-2020-8911"], "priority": {"name": "Undefined"}, "assignee":
+      {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -678,7 +688,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '730'
+      - '773'
       Content-Type:
       - application/json
       User-Agent:
@@ -689,44 +699,41 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16090953", "key": "OSIM-503", "self": "https://example.com/rest/api/2/issue/16090953"}'
+      string: '{"id": "16111750", "key": "OSIM-7510", "self": "https://example.com/rest/api/2/issue/16111750"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
-      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:52 GMT
+      - Wed, 14 Aug 2024 12:48:34 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:01:52 GMT
+      - Wed, 14 Aug 2024 12:48:34 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
-      Transfer-Encoding:
-      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '101'
+      - '102'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 721x215567x1
+      - 768x29606x2
       x-asessionid:
-      - 1y7fg79
+      - 19r19xf
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -738,9 +745,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576111.8a468fd3
+      - 0.52071002.1723639713.1e0475e1
       x-rh-edge-request-id:
-      - 8a468fd3
+      - 1e0475e1
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -766,91 +773,98 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-503
+    uri: https://example.com/rest/api/2/issue/OSIM-7510
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090953", "self": "https://example.com/rest/api/2/issue/16090953",
-        "key": "OSIM-503", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@55a632b9[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5c01e6d6[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16111750", "self": "https://example.com/rest/api/2/issue/16111750",
+        "key": "OSIM-7510", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2f041841[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@240f5ba6[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@68e67054[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3b020cc8[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1014e387[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@11602424[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4adf828c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6190a353[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@562f7c3d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@46fe23d8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70830269[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@14edad11[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f327c8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@5aff9e9b[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@632011b8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3fc130a2[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@22919df5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4bcc47a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6772a884[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5100d0e8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f508108[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1dad158c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-503/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:01:51.121+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": null, "customfield_12325241": null, "customfield_12313140":
+        null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:38b49df1-f211-41b0-b100-7bcc283c0870",
-        "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:01:51.121+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Undefined", "id": "10300"}, "labels": ["CVE-2020-8911", "flawuuid:a30e5ac7-8ae0-4165-819b-a2dec5fd5e35",
+        "impact:"], "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions":
+        [], "issuelinks": [], "customfield_12325240": null, "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "The Go AWS S3 Crypto SDK
-        contains vulnerabilities that can permit an attacker with write access to
-        a bucket to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "customfield_12314040": null, "customfield_12320844":
-        null, "archiveddate": null, "timetracking": {}, "customfield_12320842": null,
-        "customfield_12310243": null, "attachment": [], "aggregatetimeestimate": null,
-        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-8911
-        Use of risky cryptographic algorithm in github.com/aws/aws-sdk-go", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-503/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "archiveddate": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
+        "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
+        "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-7510/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7j:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "workratio": -1, "customfield_12317379": null,
+        "customfield_12316840": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-7510/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-08-14T12:48:33.435+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": null,
+        "customfield_12325042": null, "customfield_12325041": null, "updated": "2024-08-14T12:48:33.435+0000",
+        "customfield_12324841": null, "customfield_12324840": null, "timeoriginalestimate":
+        null, "description": "The Go AWS S3 Crypto SDK contains vulnerabilities that
+        can permit an attacker with write access to a bucket to decrypt files in that
+        bucket.\n\nFiles encrypted by the V1 EncryptionClient using either the AES-CBC
+        content cipher or the KMS key wrap algorithm are vulnerable. Users should
+        migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
+        files. Old files will remain vulnerable until re-encrypted with the new client.",
+        "customfield_12324843": null, "customfield_12324842": [], "timetracking":
+        {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12310840": "9223372036854775807",
+        "customfield_12316544": "None", "summary": "CVE-2020-8911 Use of risky cryptographic
+        algorithm in github.com/aws/aws-sdk-go", "customfield_12323640": null, "customfield_12323642":
+        null, "customfield_12323641": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i140dj:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -859,9 +873,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:52 GMT
+      - Wed, 14 Aug 2024 12:48:34 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:01:52 GMT
+      - Wed, 14 Aug 2024 12:48:34 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -874,17 +888,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '9256'
+      - '9741'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 721x215568x1
+      - 768x29607x2
       x-asessionid:
-      - dmryff
+      - o6cn4w
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -896,9 +910,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576112.8a46ab47
+      - 0.52071002.1723639714.1e0480d5
       x-rh-edge-request-id:
-      - 8a46ab47
+      - 1e0480d5
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -923,7 +937,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -934,11 +948,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:53 GMT
+      - Wed, 14 Aug 2024 12:48:36 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -948,9 +962,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576112.330c87e0
+      - 0.52071002.1723639715.1e048536
       x-rh-edge-request-id:
-      - 330c87e0
+      - 1e048536
     status:
       code: 200
       message: OK
@@ -971,8 +985,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "id": 1, "email": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com",
+        "can_login": true, "real_name": "Need Real Name", "id": 1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -987,7 +1001,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:54 GMT
+      - Wed, 14 Aug 2024 12:48:36 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -997,9 +1011,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576113.330c90e6
+      - 0.52071002.1723639716.1e048d82
       x-rh-edge-request-id:
-      - 330c90e6
+      - 1e048d82
     status:
       code: 200
       message: OK
@@ -1015,10 +1029,10 @@ interactions:
       API, which will not create vulnerable files. Old files will remain vulnerable
       until re-encrypted with the new client.", "comment_is_private": false, "alias":
       ["CVE-2020-8911"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
-      "cc": [], "cf_srtnotes": "{\"reported\": \"2024-06-28T12:01:50Z\", \"external_ids\":
-      [\"GO-2022-0646/CVE-2020-8911\"], \"references\": [{\"type\": \"source\", \"url\":
-      \"https://osv.dev/vulnerability/GO-2022-0646\", \"description\": null}, {\"type\":
-      \"external\", \"url\": \"https://aws.amazon.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
+      "cc": [], "cf_srtnotes": "{\"public\": \"2022-02-11T23:26:26Z\", \"reported\":
+      \"2024-08-14T12:48:32Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
+      \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2022-0646\",
+      \"description\": null}, {\"type\": \"external\", \"url\": \"https://aws.amazon.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/aws/aws-sdk-go/pull/3403\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
       \"description\": null}], \"source\": \"osv\"}"}'
@@ -1030,7 +1044,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1548'
+      - '1586'
       Content-Type:
       - application/json
       User-Agent:
@@ -1039,7 +1053,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2294457}'
+      string: '{"id": 2298928}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1054,7 +1068,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:55 GMT
+      - Wed, 14 Aug 2024 12:48:39 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1064,9 +1078,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576114.330c9a7f
+      - 0.52071002.1723639716.1e04920b
       x-rh-edge-request-id:
-      - 330c9a7f
+      - 1e04920b
     status:
       code: 200
       message: OK
@@ -1087,7 +1101,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1098,11 +1112,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:56 GMT
+      - Wed, 14 Aug 2024 12:48:40 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1112,9 +1126,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576115.330cb0ac
+      - 0.52071002.1723639719.1e04ae19
       x-rh-edge-request-id:
-      - 330cb0ac
+      - 1e04ae19
     status:
       code: 200
       message: OK
@@ -1135,8 +1149,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"can_login": true, "email": "aander07@packetmaster.com",
-        "id": 1, "name": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
+      string: '{"users": [{"email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com",
+        "can_login": true, "id": 1, "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1151,7 +1165,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:56 GMT
+      - Wed, 14 Aug 2024 12:48:41 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1161,9 +1175,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576116.330cb692
+      - 0.52071002.1723639720.1e04bba8
       x-rh-edge-request-id:
-      - 330cb692
+      - 1e04bba8
     status:
       code: 200
       message: OK
@@ -1181,148 +1195,54 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2294457?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
+    uri: https://example.com/rest/bug/2298928?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"faults": [], "bugs": [{"component": ["vulnerability-draft"], "cf_doc_type":
-        "If docs needed, set a value", "severity": "unspecified", "resolution": "",
-        "cf_pm_score": "0", "cf_clone_of": null, "cf_qe_conditional_nak": [], "blocks":
-        [], "alias": ["CVE-2020-8911"], "description": "The Go AWS S3 Crypto SDK contains
-        vulnerabilities that can permit an attacker with write access to a bucket
-        to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "remaining_time": 0, "is_cc_accessible": true, "actual_time":
-        0, "cf_embargoed": null, "creator": "conrado@redhat.com", "sub_components":
-        {}, "tags": [], "summary": "CVE-2020-8911 Use of risky cryptographic algorithm
-        in github.com/aws/aws-sdk-go", "creator_detail": {"partner": false, "id":
-        482384, "insider": true, "email": "conrado@redhat.com", "real_name": "Conrado
-        Costa", "name": "conrado@redhat.com", "active": true}, "cf_internal_whiteboard":
-        "", "is_creator_accessible": true, "cf_last_closed": null, "url": "", "estimated_time":
-        0, "cf_pgm_internal": "", "cf_conditional_nak": [], "classification": "Other",
-        "groups": ["redhat"], "deadline": null, "cf_major_incident": null, "status":
-        "NEW", "cf_fixed_in": "", "dupe_of": null, "flags": [], "cc_detail": [], "qa_contact":
-        "", "cf_environment": "", "assigned_to_detail": {"insider": true, "id": 377884,
-        "email": "prodsec-dev@redhat.com", "partner": false, "active": true, "real_name":
-        "Product Security DevOps Team", "name": "prodsec-dev@redhat.com"}, "cf_release_notes":
-        "", "product": "Security Response", "docs_contact": "", "priority": "unspecified",
-        "target_release": ["---"], "cf_qa_whiteboard": "", "is_open": true, "is_confirmed":
-        true, "assigned_to": "prodsec-dev@redhat.com", "version": ["unspecified"],
-        "whiteboard": "", "comments": [{"id": 18021218, "creation_time": "2024-06-28T12:01:55Z",
-        "attachment_id": null, "count": 0, "bug_id": 2294457, "is_private": false,
-        "creator_id": 482384, "creator": "conrado@redhat.com", "tags": [], "text":
-        "The Go AWS S3 Crypto SDK contains vulnerabilities that can permit an attacker
-        with write access to a bucket to decrypt files in that bucket.\n\nFiles encrypted
-        by the V1 EncryptionClient using either the AES-CBC content cipher or the
-        KMS key wrap algorithm are vulnerable. Users should migrate to the V1 EncryptionClientV2
-        API, which will not create vulnerable files. Old files will remain vulnerable
-        until re-encrypted with the new client.", "time": "2024-06-28T12:01:55Z",
-        "private_groups": []}], "creation_time": "2024-06-28T12:01:55Z", "id": 2294457,
-        "cf_devel_whiteboard": "", "depends_on": [], "op_sys": "Linux", "cc": [],
-        "last_change_time": "2024-06-28T12:01:55Z", "cf_cust_facing": "---", "cf_srtnotes":
-        "{\"reported\": \"2024-06-28T12:01:50Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
-        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
-        \"description\": null}], \"source\": \"osv\"}", "keywords": ["Security"],
-        "data_category": "Red Hat", "cf_build_id": "", "external_bugs": [], "target_milestone":
-        "---", "platform": "All"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:01:58 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '3624'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576117.330cbdde
-      x-rh-edge-request-id:
-      - 330cbdde
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294457?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_last_closed": null, "cf_major_incident": null, "status":
-        "NEW", "classification": "Other", "groups": ["redhat"], "deadline": null,
-        "cf_conditional_nak": [], "cf_pgm_internal": "", "estimated_time": 0, "url":
-        "", "alias": ["CVE-2020-8911"], "description": "The Go AWS S3 Crypto SDK contains
-        vulnerabilities that can permit an attacker with write access to a bucket
-        to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "cf_clone_of": null, "blocks": [], "cf_qe_conditional_nak":
-        [], "cf_pm_score": "0", "component": ["vulnerability-draft"], "cf_doc_type":
-        "If docs needed, set a value", "resolution": "", "severity": "unspecified",
-        "is_creator_accessible": true, "tags": [], "creator": "conrado@redhat.com",
-        "sub_components": {}, "summary": "CVE-2020-8911 Use of risky cryptographic
-        algorithm in github.com/aws/aws-sdk-go", "creator_detail": {"active": true,
-        "real_name": "Conrado Costa", "name": "conrado@redhat.com", "insider": true,
-        "id": 482384, "email": "conrado@redhat.com", "partner": false}, "cf_internal_whiteboard":
-        "", "is_cc_accessible": true, "actual_time": 0, "remaining_time": 0, "cf_embargoed":
-        null, "cf_cust_facing": "---", "cf_srtnotes": "{\"reported\": \"2024-06-28T12:01:50Z\",
+      string: '{"bugs": [{"assigned_to_detail": {"name": "prodsec-dev@redhat.com",
+        "email": "prodsec-dev@redhat.com", "partner": false, "insider": true, "real_name":
+        "Product Security DevOps Team", "id": 377884, "active": true}, "id": 2298928,
+        "target_release": ["---"], "assigned_to": "prodsec-dev@redhat.com", "comments":
+        [{"id": 18026779, "is_private": false, "private_groups": [], "time": "2024-08-14T12:48:38Z",
+        "creator": "nobody@redhat.com", "creation_time": "2024-08-14T12:48:38Z",
+        "count": 0, "creator_id": 425662, "attachment_id": null, "tags": [], "bug_id":
+        2298928, "text": "The Go AWS S3 Crypto SDK contains vulnerabilities that can
+        permit an attacker with write access to a bucket to decrypt files in that
+        bucket.\n\nFiles encrypted by the V1 EncryptionClient using either the AES-CBC
+        content cipher or the KMS key wrap algorithm are vulnerable. Users should
+        migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
+        files. Old files will remain vulnerable until re-encrypted with the new client."}],
+        "blocks": [], "is_open": true, "cf_pm_score": "0", "flags": [], "cf_srtnotes":
+        "{\"public\": \"2022-02-11T23:26:26Z\", \"reported\": \"2024-08-14T12:48:32Z\",
         \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"], \"references\": [{\"type\":
         \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\", \"description\":
         null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
-        \"description\": null}], \"source\": \"osv\"}", "cc": [], "op_sys": "Linux",
-        "last_change_time": "2024-06-28T12:01:55Z", "cf_devel_whiteboard": "", "depends_on":
-        [], "target_milestone": "---", "platform": "All", "external_bugs": [], "data_category":
-        "Red Hat", "cf_build_id": "", "keywords": ["Security"], "assigned_to_detail":
-        {"active": true, "name": "prodsec-dev@redhat.com", "real_name": "Product Security
-        DevOps Team", "email": "prodsec-dev@redhat.com", "insider": true, "id": 377884,
-        "partner": false}, "cf_release_notes": "", "product": "Security Response",
-        "qa_contact": "", "cf_environment": "", "dupe_of": null, "flags": [], "cc_detail":
-        [], "cf_fixed_in": "", "comments": [{"is_private": false, "creator_id": 482384,
-        "creator": "conrado@redhat.com", "tags": [], "text": "The Go AWS S3 Crypto
-        SDK contains vulnerabilities that can permit an attacker with write access
-        to a bucket to decrypt files in that bucket.\n\nFiles encrypted by the V1
-        EncryptionClient using either the AES-CBC content cipher or the KMS key wrap
-        algorithm are vulnerable. Users should migrate to the V1 EncryptionClientV2
-        API, which will not create vulnerable files. Old files will remain vulnerable
-        until re-encrypted with the new client.", "private_groups": [], "time": "2024-06-28T12:01:55Z",
-        "id": 18021218, "creation_time": "2024-06-28T12:01:55Z", "count": 0, "attachment_id":
-        null, "bug_id": 2294457}], "creation_time": "2024-06-28T12:01:55Z", "id":
-        2294457, "is_open": true, "is_confirmed": true, "assigned_to": "prodsec-dev@redhat.com",
-        "version": ["unspecified"], "whiteboard": "", "cf_qa_whiteboard": "", "docs_contact":
-        "", "priority": "unspecified", "target_release": ["---"]}], "faults": []}'
+        \"description\": null}], \"source\": \"osv\"}", "cf_pgm_internal": "", "cf_clone_of":
+        null, "depends_on": [], "resolution": "", "creation_time": "2024-08-14T12:48:38Z",
+        "sub_components": {}, "cc_detail": [], "cf_conditional_nak": [], "whiteboard":
+        "", "summary": "CVE-2020-8911 Use of risky cryptographic algorithm in github.com/aws/aws-sdk-go",
+        "component": ["vulnerability-draft"], "priority": "unspecified", "url": "",
+        "version": ["unspecified"], "cf_release_notes": "", "external_bugs": [], "cf_devel_whiteboard":
+        "", "cf_environment": "", "cf_qe_conditional_nak": [], "cf_internal_whiteboard":
+        "", "product": "Security Response", "keywords": ["Security"], "creator": "nobody@redhat.com",
+        "actual_time": 0, "alias": ["CVE-2020-8911"], "status": "NEW", "data_category":
+        "Red Hat", "tags": [], "docs_contact": "", "cf_cust_facing": "---", "remaining_time":
+        0, "platform": "All", "description": "The Go AWS S3 Crypto SDK contains vulnerabilities
+        that can permit an attacker with write access to a bucket to decrypt files
+        in that bucket.\n\nFiles encrypted by the V1 EncryptionClient using either
+        the AES-CBC content cipher or the KMS key wrap algorithm are vulnerable. Users
+        should migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
+        files. Old files will remain vulnerable until re-encrypted with the new client.",
+        "is_cc_accessible": true, "cf_doc_type": "If docs needed, set a value", "is_creator_accessible":
+        true, "is_confirmed": true, "op_sys": "Linux", "estimated_time": 0, "cf_embargoed":
+        null, "creator_detail": {"active": true, "id": 425662, "real_name": "nobody",
+        "insider": true, "partner": false, "name": "nobody@redhat.com",
+        "email": "nobody@redhat.com"}, "groups": ["redhat"], "classification": "Other",
+        "cf_qa_whiteboard": "", "cf_major_incident": null, "target_milestone": "---",
+        "severity": "unspecified", "cf_fixed_in": "", "cf_build_id": "", "cc": [],
+        "cf_last_closed": null, "last_change_time": "2024-08-14T12:48:38Z", "deadline":
+        null, "dupe_of": null, "qa_contact": ""}], "faults": []}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1335,7 +1255,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:58 GMT
+      - Wed, 14 Aug 2024 12:48:42 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1345,13 +1265,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '3624'
+      - '3668'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576118.330cc97b
+      - 0.52071002.1723639721.1e04c56d
       x-rh-edge-request-id:
-      - 330cc97b
+      - 1e04c56d
     status:
       code: 200
       message: OK
@@ -1369,19 +1289,113 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2294457/comment
+    uri: https://example.com/rest/bug/2298928?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"bugs": {"2294457": {"comments": [{"id": 18021218, "creation_time":
-        "2024-06-28T12:01:55Z", "attachment_id": null, "count": 0, "bug_id": 2294457,
-        "creator_id": 482384, "is_private": false, "tags": [], "creator": "conrado@redhat.com",
-        "text": "The Go AWS S3 Crypto SDK contains vulnerabilities that can permit
-        an attacker with write access to a bucket to decrypt files in that bucket.\n\nFiles
-        encrypted by the V1 EncryptionClient using either the AES-CBC content cipher
-        or the KMS key wrap algorithm are vulnerable. Users should migrate to the
-        V1 EncryptionClientV2 API, which will not create vulnerable files. Old files
-        will remain vulnerable until re-encrypted with the new client.", "private_groups":
-        [], "time": "2024-06-28T12:01:55Z"}]}}, "comments": {}}'
+      string: '{"faults": [], "bugs": [{"severity": "unspecified", "is_confirmed":
+        true, "cf_build_id": "", "data_category": "Red Hat", "actual_time": 0, "blocks":
+        [], "tags": [], "cc": [], "cf_srtnotes": "{\"public\": \"2022-02-11T23:26:26Z\",
+        \"reported\": \"2024-08-14T12:48:32Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8911\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
+        \"description\": null}], \"source\": \"osv\"}", "product": "Security Response",
+        "last_change_time": "2024-08-14T12:48:38Z", "priority": "unspecified", "remaining_time":
+        0, "is_creator_accessible": true, "cf_cust_facing": "---", "cf_major_incident":
+        null, "cf_qe_conditional_nak": [], "dupe_of": null, "assigned_to": "prodsec-dev@redhat.com",
+        "cc_detail": [], "cf_qa_whiteboard": "", "description": "The Go AWS S3 Crypto
+        SDK contains vulnerabilities that can permit an attacker with write access
+        to a bucket to decrypt files in that bucket.\n\nFiles encrypted by the V1
+        EncryptionClient using either the AES-CBC content cipher or the KMS key wrap
+        algorithm are vulnerable. Users should migrate to the V1 EncryptionClientV2
+        API, which will not create vulnerable files. Old files will remain vulnerable
+        until re-encrypted with the new client.", "cf_embargoed": null, "assigned_to_detail":
+        {"real_name": "Product Security DevOps Team", "insider": true, "email": "prodsec-dev@redhat.com",
+        "id": 377884, "partner": false, "active": true, "name": "prodsec-dev@redhat.com"},
+        "target_milestone": "---", "creation_time": "2024-08-14T12:48:38Z", "cf_fixed_in":
+        "", "cf_environment": "", "cf_conditional_nak": [], "estimated_time": 0, "cf_pm_score":
+        "0", "depends_on": [], "is_cc_accessible": true, "classification": "Other",
+        "is_open": true, "keywords": ["Security"], "platform": "All", "cf_clone_of":
+        null, "comments": [{"private_groups": [], "creator_id": 425662, "time": "2024-08-14T12:48:38Z",
+        "id": 18026779, "text": "The Go AWS S3 Crypto SDK contains vulnerabilities
+        that can permit an attacker with write access to a bucket to decrypt files
+        in that bucket.\n\nFiles encrypted by the V1 EncryptionClient using either
+        the AES-CBC content cipher or the KMS key wrap algorithm are vulnerable. Users
+        should migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
+        files. Old files will remain vulnerable until re-encrypted with the new client.",
+        "creation_time": "2024-08-14T12:48:38Z", "tags": [], "attachment_id": null,
+        "bug_id": 2298928, "creator": "nobody@redhat.com", "is_private": false,
+        "count": 0}], "creator_detail": {"email": "nobody@redhat.com", "id": 425662,
+        "insider": true, "real_name": "nobody", "partner": false, "active":
+        true, "name": "nobody@redhat.com"}, "resolution": "", "cf_last_closed":
+        null, "docs_contact": "", "status": "NEW", "cf_pgm_internal": "", "flags":
+        [], "whiteboard": "", "groups": ["redhat"], "alias": ["CVE-2020-8911"], "qa_contact":
+        "", "summary": "CVE-2020-8911 Use of risky cryptographic algorithm in github.com/aws/aws-sdk-go",
+        "sub_components": {}, "external_bugs": [], "version": ["unspecified"], "id":
+        2298928, "cf_doc_type": "If docs needed, set a value", "url": "", "cf_devel_whiteboard":
+        "", "cf_internal_whiteboard": "", "creator": "nobody@redhat.com", "cf_release_notes":
+        "", "deadline": null, "op_sys": "Linux", "component": ["vulnerability-draft"],
+        "target_release": ["---"]}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Aug 2024 12:48:43 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '3668'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.52071002.1723639722.1e04d504
+      x-rh-edge-request-id:
+      - 1e04d504
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2298928/comment
+  response:
+    body:
+      string: '{"bugs": {"2298928": {"comments": [{"attachment_id": null, "bug_id":
+        2298928, "tags": [], "is_private": false, "count": 0, "creator": "nobody@redhat.com",
+        "private_groups": [], "creator_id": 425662, "text": "The Go AWS S3 Crypto
+        SDK contains vulnerabilities that can permit an attacker with write access
+        to a bucket to decrypt files in that bucket.\n\nFiles encrypted by the V1
+        EncryptionClient using either the AES-CBC content cipher or the KMS key wrap
+        algorithm are vulnerable. Users should migrate to the V1 EncryptionClientV2
+        API, which will not create vulnerable files. Old files will remain vulnerable
+        until re-encrypted with the new client.", "time": "2024-08-14T12:48:38Z",
+        "id": 18026779, "creation_time": "2024-08-14T12:48:38Z"}]}}, "comments": {}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1392,11 +1406,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '732'
+      - '733'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:01:59 GMT
+      - Wed, 14 Aug 2024 12:48:43 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1406,9 +1420,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576118.330cd1cd
+      - 0.52071002.1723639723.1e04e15b
       x-rh-edge-request-id:
-      - 330cd1cd
+      - 1e04e15b
     status:
       code: 200
       message: OK
@@ -1435,7 +1449,7 @@ interactions:
     body:
       string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
         "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
-        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        issues for a specific project.", "havePermission": false}, "VIEW_WORKFLOW_READONLY":
         {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
         "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
         "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
@@ -1458,9 +1472,9 @@ interactions:
         Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
         "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
         "description": "Ability to administer a project in Jira.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        false, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
         "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
-        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        edit all comments made on issues.", "havePermission": false, "deprecatedKey":
         true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
         "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
         with this permission may delete own attachments.", "havePermission": true,
@@ -1480,7 +1494,7 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
         {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "havePermission": false, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
         "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
         "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
         "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
@@ -1488,7 +1502,7 @@ interactions:
         permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
         {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        attachments.", "havePermission": false}, "ASSIGN_ISSUE": {"id": "13", "key":
         "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
         "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
         true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
@@ -1501,7 +1515,7 @@ interactions:
         "PROJECT", "description": "Users with this permission may create attachments.",
         "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
         "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
-        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        edit all worklogs made on issues.", "havePermission": false}, "SCHEDULE_ISSUE":
         {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
         "description": "Ability to view or edit an issue''s due date.", "havePermission":
         true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
@@ -1515,16 +1529,16 @@ interactions:
         Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
         due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
         "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
-        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "Ability to delete all worklogs made on issues.", "havePermission": false,
         "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
         "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
         to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
         true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
         "Administer Projects", "type": "PROJECT", "description": "Ability to administer
-        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        a project in Jira.", "havePermission": false}, "DELETE_ALL_COMMENTS": {"id":
         "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "havePermission": false}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
         "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
         and reopen issues. This includes the ability to set a fix version.", "havePermission":
         true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
@@ -1575,12 +1589,12 @@ interactions:
         Results OKRs (Objective and key results) that are linked to a given issue",
         "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
         "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
-        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        issues for a specific project.", "havePermission": false}, "BROWSE_ARCHIVE":
         {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
         "PROJECT", "description": "Ability to browse archived issues from a specific
-        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
-        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
-        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        project.", "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL":
+        {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate
+        users in A4J global scope", "type": "GLOBAL", "description": "Having the permission
         allows to select other user as automation rule actor", "havePermission": true},
         "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
         "View Development Tools", "type": "PROJECT", "description": "Allows users
@@ -1596,15 +1610,15 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
         true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
         "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
-        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        worklogs made on issues.", "havePermission": false, "deprecatedKey": true},
         "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
         All Comments", "type": "PROJECT", "description": "Ability to edit all comments
-        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        made on issues.", "havePermission": false}, "DELETE_ISSUE": {"id": "16", "key":
         "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
         "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
         "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
         "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
-        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        sprints.", "havePermission": false}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
         "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
         a user or group from a popup window as well as the ability to use the ''share''
         issues feature. Users with this permission will also be able to see names
@@ -1614,7 +1628,7 @@ interactions:
         with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
         {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        attachments.", "havePermission": false, "deprecatedKey": true}, "DELETE_ISSUES":
         {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
         "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
         {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
@@ -1623,27 +1637,31 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
         true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
         "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
-        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        all worklogs made on issues.", "havePermission": false}, "LINK_ISSUES": {"id":
         "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
         "Ability to link issues together and create linked issues. Only useful if
         issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
@@ -1658,9 +1676,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:00 GMT
+      - Wed, 14 Aug 2024 12:48:44 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:02:00 GMT
+      - Wed, 14 Aug 2024 12:48:44 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1673,7 +1691,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16555'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1681,9 +1699,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 722x591147x1
+      - 768x29609x2
       x-asessionid:
-      - 4eg86y
+      - 1fkgtut
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1695,9 +1713,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576119.8a476335
+      - 0.52071002.1723639724.1e04f500
       x-rh-edge-request-id:
-      - 8a476335
+      - 1e04f500
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1839,7 +1857,9 @@ interactions:
         Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
         new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
         Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
+        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12402","id":"12402","description":"Track
+        underlying causes of incidents. Created by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56262&avatarType=issuetype","name":"Problem","subtask":false,"avatarId":56262},{"self":"https://example.com/rest/api/2/issuetype/12401","id":"12401","description":"Created
+        by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56261&avatarType=issuetype","name":"Change","subtask":false,"avatarId":56261}]'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1848,9 +1868,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:00 GMT
+      - Wed, 14 Aug 2024 12:48:44 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:02:00 GMT
+      - Wed, 14 Aug 2024 12:48:44 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1861,9 +1881,9 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '25109'
+      - '25736'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1871,9 +1891,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 722x591148x1
+      - 768x29610x2
       x-asessionid:
-      - 1uxjqs8
+      - 79h3dm
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1885,9 +1905,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576120.8a476ae0
+      - 0.52071002.1723639724.1e04f777
       x-rh-edge-request-id:
-      - 8a476ae0
+      - 1e04f777
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1946,11 +1966,14 @@ interactions:
         program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
         "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
         "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
+        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
+        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
+        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
+        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
+        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
+        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
+        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
+        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
         Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
@@ -1965,9 +1988,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:00 GMT
+      - Wed, 14 Aug 2024 12:48:45 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:02:00 GMT
+      - Wed, 14 Aug 2024 12:48:45 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1978,9 +2001,9 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '4024'
+      - '4215'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1988,9 +2011,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 722x591149x1
+      - 768x29611x2
       x-asessionid:
-      - d7aeuo
+      - 24tbm3
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2002,9 +2025,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576120.8a476e05
+      - 0.52071002.1723639724.1e04fa44
       x-rh-edge-request-id:
-      - 8a476e05
+      - 1e04fa44
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2020,8 +2043,9 @@ interactions:
       encrypted by the V1 EncryptionClient using either the AES-CBC content cipher
       or the KMS key wrap algorithm are vulnerable. Users should migrate to the V1
       EncryptionClientV2 API, which will not create vulnerable files. Old files will
-      remain vulnerable until re-encrypted with the new client.", "labels": ["flawuuid:e31c253c-6e09-4c5c-8aeb-b56a089c8b8a",
-      "impact:"], "priority": {"name": "Undefined"}}}'
+      remain vulnerable until re-encrypted with the new client.", "labels": ["flawuuid:157ace7e-f18d-4f98-9a1f-ef82254efa28",
+      "impact:", "CVE-2020-8912"], "priority": {"name": "Undefined"}, "assignee":
+      {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -2032,7 +2056,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '730'
+      - '773'
       Content-Type:
       - application/json
       User-Agent:
@@ -2043,7 +2067,7 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16091065", "key": "OSIM-504", "self": "https://example.com/rest/api/2/issue/16091065"}'
+      string: '{"id": "16111751", "key": "OSIM-7511", "self": "https://example.com/rest/api/2/issue/16111751"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2053,9 +2077,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:01 GMT
+      - Wed, 14 Aug 2024 12:48:46 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:02:01 GMT
+      - Wed, 14 Aug 2024 12:48:46 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2070,7 +2094,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '101'
+      - '102'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2078,9 +2102,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 722x591152x3
+      - 768x29612x2
       x-asessionid:
-      - 1iurap4
+      - 1ak8lc6
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2092,9 +2116,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576120.8a47739e
+      - 0.52071002.1723639725.1e04fd5f
       x-rh-edge-request-id:
-      - 8a47739e
+      - 1e04fd5f
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2120,91 +2144,98 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-504
+    uri: https://example.com/rest/api/2/issue/OSIM-7511
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091065", "self": "https://example.com/rest/api/2/issue/16091065",
-        "key": "OSIM-504", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@68db6cc4[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1153a520[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16111751", "self": "https://example.com/rest/api/2/issue/16111751",
+        "key": "OSIM-7511", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@35ffd93d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@53241ed2[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f11482a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@53e78c4d[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7355d616[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@627acae1[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@377f8e9c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5895e9da[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@52d61b8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@31b48e3e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a74fdfa[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@d581057[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@302bda48[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@438a8011[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@57cc101d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1ac67f68[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@74510fe2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@63cc9371[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@54b73bed[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7d23232c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1711d75[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6a15131[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-504/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:02:00.803+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": null, "customfield_12325241": null, "customfield_12313140":
+        null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:e31c253c-6e09-4c5c-8aeb-b56a089c8b8a",
-        "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:02:00.803+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Undefined", "id": "10300"}, "labels": ["CVE-2020-8912", "flawuuid:157ace7e-f18d-4f98-9a1f-ef82254efa28",
+        "impact:"], "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions":
+        [], "issuelinks": [], "customfield_12325240": null, "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "The Go AWS S3 Crypto SDK
-        contains vulnerabilities that can permit an attacker with write access to
-        a bucket to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "customfield_12314040": null, "customfield_12320844":
-        null, "archiveddate": null, "timetracking": {}, "customfield_12320842": null,
-        "customfield_12310243": null, "attachment": [], "aggregatetimeestimate": null,
-        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-8912
-        Use of risky cryptographic algorithm in github.com/aws/aws-sdk-go", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-504/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "archiveddate": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
+        "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
+        "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-7511/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7r:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "workratio": -1, "customfield_12317379": null,
+        "customfield_12316840": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-7511/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-08-14T12:48:45.307+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": null,
+        "customfield_12325042": null, "customfield_12325041": null, "updated": "2024-08-14T12:48:45.307+0000",
+        "customfield_12324841": null, "customfield_12324840": null, "timeoriginalestimate":
+        null, "description": "The Go AWS S3 Crypto SDK contains vulnerabilities that
+        can permit an attacker with write access to a bucket to decrypt files in that
+        bucket.\n\nFiles encrypted by the V1 EncryptionClient using either the AES-CBC
+        content cipher or the KMS key wrap algorithm are vulnerable. Users should
+        migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
+        files. Old files will remain vulnerable until re-encrypted with the new client.",
+        "customfield_12324843": null, "customfield_12324842": [], "timetracking":
+        {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12310840": "9223372036854775807",
+        "customfield_12316544": "None", "summary": "CVE-2020-8912 Use of risky cryptographic
+        algorithm in github.com/aws/aws-sdk-go", "customfield_12323640": null, "customfield_12323642":
+        null, "customfield_12323641": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i140dr:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2213,9 +2244,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:02 GMT
+      - Wed, 14 Aug 2024 12:48:46 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:02:02 GMT
+      - Wed, 14 Aug 2024 12:48:46 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2228,7 +2259,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '9254'
+      - '9741'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2236,9 +2267,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 722x591154x1
+      - 768x29613x2
       x-asessionid:
-      - 3d0djw
+      - 5rw1iu
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2250,9 +2281,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576121.8a479285
+      - 0.52071002.1723639726.1e050ff4
       x-rh-edge-request-id:
-      - 8a479285
+      - 1e050ff4
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2277,7 +2308,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2288,11 +2319,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:02 GMT
+      - Wed, 14 Aug 2024 12:48:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -2302,9 +2333,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576122.330cfb5b
+      - 0.52071002.1723639727.1e051543
       x-rh-edge-request-id:
-      - 330cfb5b
+      - 1e051543
     status:
       code: 200
       message: OK
@@ -2325,8 +2356,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"id": 1, "email": "aander07@packetmaster.com", "can_login":
-        true, "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"can_login": true, "email": "aander07@packetmaster.com",
+        "name": "aander07@packetmaster.com", "id": 1, "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2341,7 +2372,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:03 GMT
+      - Wed, 14 Aug 2024 12:48:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -2351,9 +2382,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576122.330cff1a
+      - 0.52071002.1723639727.1e05183a
       x-rh-edge-request-id:
-      - 330cff1a
+      - 1e05183a
     status:
       code: 200
       message: OK
@@ -2369,10 +2400,10 @@ interactions:
       API, which will not create vulnerable files. Old files will remain vulnerable
       until re-encrypted with the new client.", "comment_is_private": false, "alias":
       ["CVE-2020-8912"], "keywords": ["Security"], "flags": [], "groups": ["redhat"],
-      "cc": [], "cf_srtnotes": "{\"reported\": \"2024-06-28T12:01:59Z\", \"external_ids\":
-      [\"GO-2022-0646/CVE-2020-8912\"], \"references\": [{\"type\": \"source\", \"url\":
-      \"https://osv.dev/vulnerability/GO-2022-0646\", \"description\": null}, {\"type\":
-      \"external\", \"url\": \"https://aws.amazon.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
+      "cc": [], "cf_srtnotes": "{\"public\": \"2022-02-11T23:26:26Z\", \"reported\":
+      \"2024-08-14T12:48:44Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"],
+      \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2022-0646\",
+      \"description\": null}, {\"type\": \"external\", \"url\": \"https://aws.amazon.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/aws/aws-sdk-go/pull/3403\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
       \"description\": null}], \"source\": \"osv\"}"}'
@@ -2384,7 +2415,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1548'
+      - '1586'
       Content-Type:
       - application/json
       User-Agent:
@@ -2393,7 +2424,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2294458}'
+      string: '{"id": 2298929}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2408,7 +2439,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:04 GMT
+      - Wed, 14 Aug 2024 12:48:50 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -2418,9 +2449,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576123.330d0b11
+      - 0.52071002.1723639728.1e0521e1
       x-rh-edge-request-id:
-      - 330d0b11
+      - 1e0521e1
     status:
       code: 200
       message: OK
@@ -2441,7 +2472,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2452,11 +2483,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:05 GMT
+      - Wed, 14 Aug 2024 12:48:51 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -2466,9 +2497,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576124.330d1d9f
+      - 0.52071002.1723639730.1e053e9e
       x-rh-edge-request-id:
-      - 330d1d9f
+      - 1e053e9e
     status:
       code: 200
       message: OK
@@ -2489,8 +2520,9 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"email": "aander07@packetmaster.com", "id": 1, "real_name":
-        "Need Real Name", "can_login": true, "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"name": "aander07@packetmaster.com", "can_login": true,
+        "real_name": "Need Real Name", "email": "aander07@packetmaster.com", "id":
+        1}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2505,7 +2537,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:06 GMT
+      - Wed, 14 Aug 2024 12:48:51 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -2515,9 +2547,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576125.330d2579
+      - 0.52071002.1723639731.1e0540e1
       x-rh-edge-request-id:
-      - 330d2579
+      - 1e0540e1
     status:
       code: 200
       message: OK
@@ -2535,148 +2567,55 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2294458?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
+    uri: https://example.com/rest/bug/2298929?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"faults": [], "bugs": [{"is_confirmed": true, "cf_conditional_nak":
-        [], "flags": [], "cf_doc_type": "If docs needed, set a value", "cf_environment":
-        "", "priority": "unspecified", "is_open": true, "remaining_time": 0, "assigned_to_detail":
-        {"name": "prodsec-dev@redhat.com", "partner": false, "real_name": "Product
-        Security DevOps Team", "id": 377884, "active": true, "email": "prodsec-dev@redhat.com",
-        "insider": true}, "docs_contact": "", "cf_last_closed": null, "comments":
-        [{"creation_time": "2024-06-28T12:02:04Z", "bug_id": 2294458, "attachment_id":
-        null, "text": "The Go AWS S3 Crypto SDK contains vulnerabilities that can
-        permit an attacker with write access to a bucket to decrypt files in that
+      string: '{"bugs": [{"qa_contact": "", "summary": "CVE-2020-8912 Use of risky
+        cryptographic algorithm in github.com/aws/aws-sdk-go", "groups": ["redhat"],
+        "alias": ["CVE-2020-8912"], "whiteboard": "", "deadline": null, "op_sys":
+        "Linux", "component": ["vulnerability-draft"], "target_release": ["---"],
+        "cf_devel_whiteboard": "", "cf_internal_whiteboard": "", "creator": "nobody@redhat.com",
+        "cf_release_notes": "", "cf_doc_type": "If docs needed, set a value", "version":
+        ["unspecified"], "id": 2298929, "url": "", "sub_components": {}, "external_bugs":
+        [], "comments": [{"creation_time": "2024-08-14T12:48:49Z", "text": "The Go
+        AWS S3 Crypto SDK contains vulnerabilities that can permit an attacker with
+        write access to a bucket to decrypt files in that bucket.\n\nFiles encrypted
+        by the V1 EncryptionClient using either the AES-CBC content cipher or the
+        KMS key wrap algorithm are vulnerable. Users should migrate to the V1 EncryptionClientV2
+        API, which will not create vulnerable files. Old files will remain vulnerable
+        until re-encrypted with the new client.", "time": "2024-08-14T12:48:49Z",
+        "id": 18026780, "creator_id": 425662, "private_groups": [], "creator": "nobody@redhat.com",
+        "count": 0, "is_private": false, "tags": [], "bug_id": 2298929, "attachment_id":
+        null}], "cf_clone_of": null, "creator_detail": {"name": "nobody@redhat.com",
+        "active": true, "partner": false, "id": 425662, "real_name": "nobody",
+        "insider": true, "email": "nobody@redhat.com"}, "is_open": true, "keywords":
+        ["Security"], "platform": "All", "classification": "Other", "depends_on":
+        [], "is_cc_accessible": true, "flags": [], "cf_pgm_internal": "", "docs_contact":
+        "", "status": "NEW", "cf_last_closed": null, "resolution": "", "cf_embargoed":
+        null, "assigned_to_detail": {"name": "prodsec-dev@redhat.com", "active": true,
+        "partner": false, "insider": true, "id": 377884, "email": "prodsec-dev@redhat.com",
+        "real_name": "Product Security DevOps Team"}, "target_milestone": "---", "cf_qa_whiteboard":
+        "", "description": "The Go AWS S3 Crypto SDK contains vulnerabilities that
+        can permit an attacker with write access to a bucket to decrypt files in that
         bucket.\n\nFiles encrypted by the V1 EncryptionClient using either the AES-CBC
         content cipher or the KMS key wrap algorithm are vulnerable. Users should
         migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
         files. Old files will remain vulnerable until re-encrypted with the new client.",
-        "is_private": false, "tags": [], "creator_id": 482384, "time": "2024-06-28T12:02:04Z",
-        "count": 0, "private_groups": [], "id": 18021219, "creator": "conrado@redhat.com"}],
-        "cf_internal_whiteboard": "", "description": "The Go AWS S3 Crypto SDK contains
-        vulnerabilities that can permit an attacker with write access to a bucket
-        to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "is_cc_accessible": true, "summary": "CVE-2020-8912
-        Use of risky cryptographic algorithm in github.com/aws/aws-sdk-go", "qa_contact":
-        "", "cf_release_notes": "", "creator_detail": {"insider": true, "email": "conrado@redhat.com",
-        "active": true, "id": 482384, "real_name": "Conrado Costa", "partner": false,
-        "name": "conrado@redhat.com"}, "platform": "All", "groups": ["redhat"], "target_release":
-        ["---"], "cf_clone_of": null, "depends_on": [], "blocks": [], "cf_pm_score":
-        "0", "deadline": null, "product": "Security Response", "cf_qa_whiteboard":
-        "", "op_sys": "Linux", "target_milestone": "---", "dupe_of": null, "cf_srtnotes":
-        "{\"reported\": \"2024-06-28T12:01:59Z\", \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"],
-        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
-        \"description\": null}], \"source\": \"osv\"}", "alias": ["CVE-2020-8912"],
-        "cf_major_incident": null, "status": "NEW", "keywords": ["Security"], "classification":
-        "Other", "estimated_time": 0, "cf_embargoed": null, "cf_cust_facing": "---",
-        "cc": [], "cf_pgm_internal": "", "data_category": "Red Hat", "resolution":
-        "", "cc_detail": [], "creator": "conrado@redhat.com", "component": ["vulnerability-draft"],
-        "whiteboard": "", "sub_components": {}, "is_creator_accessible": true, "url":
-        "", "cf_build_id": "", "actual_time": 0, "version": ["unspecified"], "external_bugs":
-        [], "tags": [], "cf_devel_whiteboard": "", "id": 2294458, "cf_qe_conditional_nak":
-        [], "creation_time": "2024-06-28T12:02:04Z", "last_change_time": "2024-06-28T12:02:04Z",
-        "severity": "unspecified", "cf_fixed_in": "", "assigned_to": "prodsec-dev@redhat.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:02:06 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '3624'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576126.330d2998
-      x-rh-edge-request-id:
-      - 330d2998
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294458?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"faults": [], "bugs": [{"classification": "Other", "deadline": null,
-        "groups": ["redhat"], "status": "NEW", "cf_major_incident": null, "estimated_time":
-        0, "url": "", "cf_conditional_nak": [], "cf_pgm_internal": "", "cf_last_closed":
-        null, "is_creator_accessible": true, "is_cc_accessible": true, "actual_time":
-        0, "remaining_time": 0, "cf_embargoed": null, "cf_internal_whiteboard": "",
-        "creator": "conrado@redhat.com", "summary": "CVE-2020-8912 Use of risky cryptographic
-        algorithm in github.com/aws/aws-sdk-go", "tags": [], "sub_components": {},
-        "creator_detail": {"name": "conrado@redhat.com", "real_name": "Conrado Costa",
-        "active": true, "partner": false, "email": "conrado@redhat.com", "id": 482384,
-        "insider": true}, "blocks": [], "cf_qe_conditional_nak": [], "cf_clone_of":
-        null, "alias": ["CVE-2020-8912"], "description": "The Go AWS S3 Crypto SDK
-        contains vulnerabilities that can permit an attacker with write access to
-        a bucket to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "cf_doc_type": "If docs needed, set a value", "severity":
-        "unspecified", "resolution": "", "component": ["vulnerability-draft"], "cf_pm_score":
-        "0", "external_bugs": [], "target_milestone": "---", "platform": "All", "keywords":
-        ["Security"], "cf_build_id": "", "data_category": "Red Hat", "last_change_time":
-        "2024-06-28T12:02:04Z", "cc": [], "op_sys": "Linux", "cf_cust_facing": "---",
-        "cf_srtnotes": "{\"reported\": \"2024-06-28T12:01:59Z\", \"external_ids\":
-        [\"GO-2022-0646/CVE-2020-8912\"], \"references\": [{\"type\": \"source\",
-        \"url\": \"https://example.com/vulnerability/GO-2022-0646\", \"description\":
+        "cf_qe_conditional_nak": [], "assigned_to": "prodsec-dev@redhat.com", "dupe_of":
+        null, "cc_detail": [], "is_creator_accessible": true, "cf_major_incident":
+        null, "cf_cust_facing": "---", "estimated_time": 0, "cf_pm_score": "0", "cf_conditional_nak":
+        [], "creation_time": "2024-08-14T12:48:49Z", "cf_fixed_in": "", "cf_environment":
+        "", "tags": [], "cc": [], "data_category": "Red Hat", "actual_time": 0, "blocks":
+        [], "cf_build_id": "", "is_confirmed": true, "severity": "unspecified", "remaining_time":
+        0, "cf_srtnotes": "{\"public\": \"2022-02-11T23:26:26Z\", \"reported\": \"2024-08-14T12:48:44Z\",
+        \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"], \"references\": [{\"type\":
+        \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\", \"description\":
         null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
         \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
-        \"description\": null}], \"source\": \"osv\"}", "depends_on": [], "cf_devel_whiteboard":
-        "", "version": ["unspecified"], "whiteboard": "", "is_confirmed": true, "is_open":
-        true, "assigned_to": "prodsec-dev@redhat.com", "id": 2294458, "comments":
-        [{"id": 18021219, "creation_time": "2024-06-28T12:02:04Z", "count": 0, "attachment_id":
-        null, "bug_id": 2294458, "is_private": false, "creator_id": 482384, "tags":
-        [], "creator": "conrado@redhat.com", "text": "The Go AWS S3 Crypto SDK contains
-        vulnerabilities that can permit an attacker with write access to a bucket
-        to decrypt files in that bucket.\n\nFiles encrypted by the V1 EncryptionClient
-        using either the AES-CBC content cipher or the KMS key wrap algorithm are
-        vulnerable. Users should migrate to the V1 EncryptionClientV2 API, which will
-        not create vulnerable files. Old files will remain vulnerable until re-encrypted
-        with the new client.", "private_groups": [], "time": "2024-06-28T12:02:04Z"}],
-        "creation_time": "2024-06-28T12:02:04Z", "target_release": ["---"], "docs_contact":
-        "", "priority": "unspecified", "cf_qa_whiteboard": "", "cf_environment": "",
-        "qa_contact": "", "cf_release_notes": "", "product": "Security Response",
-        "assigned_to_detail": {"email": "prodsec-dev@redhat.com", "id": 377884, "insider":
-        true, "partner": false, "active": true, "name": "prodsec-dev@redhat.com",
-        "real_name": "Product Security DevOps Team"}, "cf_fixed_in": "", "flags":
-        [], "cc_detail": [], "dupe_of": null}]}'
+        \"description\": null}], \"source\": \"osv\"}", "product": "Security Response",
+        "last_change_time": "2024-08-14T12:48:49Z", "priority": "unspecified"}], "faults":
+        []}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2689,7 +2628,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:07 GMT
+      - Wed, 14 Aug 2024 12:48:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -2699,13 +2638,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '3624'
+      - '3668'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576126.330d31f3
+      - 0.52071002.1723639731.1e054632
       x-rh-edge-request-id:
-      - 330d31f3
+      - 1e054632
     status:
       code: 200
       message: OK
@@ -2723,19 +2662,114 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2294458/comment
+    uri: https://example.com/rest/bug/2298929?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"bugs": {"2294458": {"comments": [{"creator_id": 482384, "time": "2024-06-28T12:02:04Z",
-        "tags": [], "private_groups": [], "count": 0, "id": 18021219, "creator": "conrado@redhat.com",
-        "creation_time": "2024-06-28T12:02:04Z", "bug_id": 2294458, "is_private":
-        false, "attachment_id": null, "text": "The Go AWS S3 Crypto SDK contains vulnerabilities
+      string: '{"faults": [], "bugs": [{"remaining_time": 0, "platform": "All", "is_cc_accessible":
+        true, "description": "The Go AWS S3 Crypto SDK contains vulnerabilities that
+        can permit an attacker with write access to a bucket to decrypt files in that
+        bucket.\n\nFiles encrypted by the V1 EncryptionClient using either the AES-CBC
+        content cipher or the KMS key wrap algorithm are vulnerable. Users should
+        migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
+        files. Old files will remain vulnerable until re-encrypted with the new client.",
+        "cf_doc_type": "If docs needed, set a value", "is_confirmed": true, "is_creator_accessible":
+        true, "status": "NEW", "data_category": "Red Hat", "alias": ["CVE-2020-8912"],
+        "tags": [], "docs_contact": "", "cf_cust_facing": "---", "cc": [], "cf_last_closed":
+        null, "dupe_of": null, "deadline": null, "qa_contact": "", "last_change_time":
+        "2024-08-14T12:48:49Z", "estimated_time": 0, "op_sys": "Linux", "groups":
+        ["redhat"], "cf_embargoed": null, "creator_detail": {"insider": true, "partner":
+        false, "name": "nobody@redhat.com", "email": "nobody@redhat.com", "active":
+        true, "id": 425662, "real_name": "nobody"}, "target_milestone": "---",
+        "classification": "Other", "cf_qa_whiteboard": "", "cf_major_incident": null,
+        "cf_fixed_in": "", "severity": "unspecified", "cf_build_id": "", "cf_srtnotes":
+        "{\"public\": \"2022-02-11T23:26:26Z\", \"reported\": \"2024-08-14T12:48:44Z\",
+        \"external_ids\": [\"GO-2022-0646/CVE-2020-8912\"], \"references\": [{\"type\":
+        \"source\", \"url\": \"https://example.com/vulnerability/GO-2022-0646\", \"description\":
+        null}, {\"type\": \"external\", \"url\": \"https://example.com/blogs/developer/updates-to-the-amazon-s3-encryption-client/?s=09\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/pull/3403\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/aws/aws-sdk-go/commit/ae9b9fd92af132cfd8d879809d8611825ba135f4\",
+        \"description\": null}], \"source\": \"osv\"}", "flags": [], "cf_clone_of":
+        null, "cf_pgm_internal": "", "creation_time": "2024-08-14T12:48:49Z", "sub_components":
+        {}, "resolution": "", "depends_on": [], "assigned_to_detail": {"active": true,
+        "real_name": "Product Security DevOps Team", "id": 377884, "insider": true,
+        "partner": false, "name": "prodsec-dev@redhat.com", "email": "prodsec-dev@redhat.com"},
+        "comments": [{"count": 0, "attachment_id": null, "creator_id": 425662, "tags":
+        [], "text": "The Go AWS S3 Crypto SDK contains vulnerabilities that can permit
+        an attacker with write access to a bucket to decrypt files in that bucket.\n\nFiles
+        encrypted by the V1 EncryptionClient using either the AES-CBC content cipher
+        or the KMS key wrap algorithm are vulnerable. Users should migrate to the
+        V1 EncryptionClientV2 API, which will not create vulnerable files. Old files
+        will remain vulnerable until re-encrypted with the new client.", "bug_id":
+        2298929, "is_private": false, "private_groups": [], "id": 18026780, "time":
+        "2024-08-14T12:48:49Z", "creator": "nobody@redhat.com", "creation_time":
+        "2024-08-14T12:48:49Z"}], "id": 2298929, "assigned_to": "prodsec-dev@redhat.com",
+        "target_release": ["---"], "blocks": [], "cf_pm_score": "0", "is_open": true,
+        "cf_release_notes": "", "version": ["unspecified"], "cf_internal_whiteboard":
+        "", "cf_qe_conditional_nak": [], "external_bugs": [], "cf_devel_whiteboard":
+        "", "cf_environment": "", "keywords": ["Security"], "product": "Security Response",
+        "actual_time": 0, "creator": "nobody@redhat.com", "whiteboard": "", "cc_detail":
+        [], "cf_conditional_nak": [], "component": ["vulnerability-draft"], "summary":
+        "CVE-2020-8912 Use of risky cryptographic algorithm in github.com/aws/aws-sdk-go",
+        "url": "", "priority": "unspecified"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Aug 2024 12:48:53 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '3668'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.52071002.1723639732.1e055100
+      x-rh-edge-request-id:
+      - 1e055100
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2298929/comment
+  response:
+    body:
+      string: '{"bugs": {"2298929": {"comments": [{"is_private": false, "count": 0,
+        "creator": "nobody@redhat.com", "attachment_id": null, "bug_id": 2298929,
+        "tags": [], "creation_time": "2024-08-14T12:48:49Z", "creator_id": 425662,
+        "private_groups": [], "text": "The Go AWS S3 Crypto SDK contains vulnerabilities
         that can permit an attacker with write access to a bucket to decrypt files
         in that bucket.\n\nFiles encrypted by the V1 EncryptionClient using either
         the AES-CBC content cipher or the KMS key wrap algorithm are vulnerable. Users
         should migrate to the V1 EncryptionClientV2 API, which will not create vulnerable
-        files. Old files will remain vulnerable until re-encrypted with the new client."}]}},
-        "comments": {}}'
+        files. Old files will remain vulnerable until re-encrypted with the new client.",
+        "id": 18026780, "time": "2024-08-14T12:48:49Z"}]}}, "comments": {}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -2746,11 +2780,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '732'
+      - '733'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:02:08 GMT
+      - Wed, 14 Aug 2024 12:48:53 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -2760,9 +2794,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576127.330d3959
+      - 0.52071002.1723639733.1e055d0f
       x-rh-edge-request-id:
-      - 330d3959
+      - 1e055d0f
     status:
       code: 200
       message: OK

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record.yaml
@@ -3,6 +3,58 @@ interactions:
     body: null
     headers:
       Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.32.0
+    method: GET
+    uri: https://example.com/v1/vulns/GO-2023-1494
+  response:
+    body:
+      string: '{"id": "GO-2023-1494", "summary": "SQL injection in github.com/elgs/gosqljson",
+        "details": "There is a potential for SQL injection through manipulation of
+        the sqlStatement argument.", "aliases": ["CVE-2014-125064", "GHSA-g7mw-9pf9-p2pm"],
+        "modified": "2024-05-20T16:03:47Z", "published": "2023-02-01T23:23:34Z", "database_specific":
+        {"url": "https://example.com/vuln/GO-2023-1494", "review_status": "REVIEWED"},
+        "references": [{"type": "FIX", "url": "https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a"}],
+        "affected": [{"package": {"name": "github.com/elgs/gosqljson", "ecosystem":
+        "Go", "purl": "pkg:golang/github.com/elgs/gosqljson"}, "ranges": [{"type":
+        "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.0.0-20220916234230-750f26ee23c7"}]}],
+        "ecosystem_specific": {"imports": [{"symbols": ["ExecDb", "QueryDbToArray",
+        "QueryDbToArrayJson", "QueryDbToMap", "QueryDbToMapJson"], "path": "github.com/elgs/gosqljson"}]},
+        "database_specific": {"source": "https://example.com/ID/GO-2023-1494.json"}}],
+        "schema_version": "1.6.0"}'
+    headers:
+      Content-Length:
+      - '1007'
+      Date:
+      - Wed, 14 Aug 2024 12:19:57 GMT
+      Server:
+      - Google Frontend
+      X-Cloud-Trace-Context:
+      - d21c4ffbbd98fc613f838b3a36e3d4a6
+      alt-svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      content-type:
+      - application/json
+      grpc-accept-encoding:
+      - identity, deflate, gzip
+      grpc-message:
+      - ''
+      grpc-status:
+      - '0'
+      x-envoy-decorator-operation:
+      - ingress GetVulnById
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
       - application/json,*.*;q=0.9
       Accept-Encoding:
       - gzip, deflate
@@ -22,7 +74,7 @@ interactions:
     body:
       string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
         "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
-        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        issues for a specific project.", "havePermission": false}, "VIEW_WORKFLOW_READONLY":
         {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
         "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
         "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
@@ -45,9 +97,9 @@ interactions:
         Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
         "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
         "description": "Ability to administer a project in Jira.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        false, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
         "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
-        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        edit all comments made on issues.", "havePermission": false, "deprecatedKey":
         true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
         "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
         with this permission may delete own attachments.", "havePermission": true,
@@ -67,7 +119,7 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
         {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "havePermission": false, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
         "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
         "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
         "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
@@ -75,7 +127,7 @@ interactions:
         permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
         {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        attachments.", "havePermission": false}, "ASSIGN_ISSUE": {"id": "13", "key":
         "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
         "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
         true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
@@ -88,7 +140,7 @@ interactions:
         "PROJECT", "description": "Users with this permission may create attachments.",
         "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
         "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
-        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        edit all worklogs made on issues.", "havePermission": false}, "SCHEDULE_ISSUE":
         {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
         "description": "Ability to view or edit an issue''s due date.", "havePermission":
         true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
@@ -102,16 +154,16 @@ interactions:
         Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
         due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
         "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
-        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "Ability to delete all worklogs made on issues.", "havePermission": false,
         "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
         "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
         to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
         true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
         "Administer Projects", "type": "PROJECT", "description": "Ability to administer
-        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        a project in Jira.", "havePermission": false}, "DELETE_ALL_COMMENTS": {"id":
         "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "havePermission": false}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
         "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
         and reopen issues. This includes the ability to set a fix version.", "havePermission":
         true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
@@ -162,12 +214,12 @@ interactions:
         Results OKRs (Objective and key results) that are linked to a given issue",
         "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
         "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
-        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        issues for a specific project.", "havePermission": false}, "BROWSE_ARCHIVE":
         {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
         "PROJECT", "description": "Ability to browse archived issues from a specific
-        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
-        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
-        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        project.", "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL":
+        {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate
+        users in A4J global scope", "type": "GLOBAL", "description": "Having the permission
         allows to select other user as automation rule actor", "havePermission": true},
         "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
         "View Development Tools", "type": "PROJECT", "description": "Allows users
@@ -183,15 +235,15 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
         true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
         "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
-        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        worklogs made on issues.", "havePermission": false, "deprecatedKey": true},
         "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
         All Comments", "type": "PROJECT", "description": "Ability to edit all comments
-        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        made on issues.", "havePermission": false}, "DELETE_ISSUE": {"id": "16", "key":
         "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
         "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
         "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
         "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
-        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        sprints.", "havePermission": false}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
         "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
         a user or group from a popup window as well as the ability to use the ''share''
         issues feature. Users with this permission will also be able to see names
@@ -201,7 +253,7 @@ interactions:
         with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
         {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        attachments.", "havePermission": false, "deprecatedKey": true}, "DELETE_ISSUES":
         {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
         "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
         {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
@@ -210,27 +262,31 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
         true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
         "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
-        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        all worklogs made on issues.", "havePermission": false}, "LINK_ISSUES": {"id":
         "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
         "Ability to link issues together and create linked issues. Only useful if
         issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
@@ -245,9 +301,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 27 Jun 2024 17:50:29 GMT
+      - Wed, 14 Aug 2024 12:19:57 GMT
       Expires:
-      - Thu, 27 Jun 2024 17:50:29 GMT
+      - Wed, 14 Aug 2024 12:19:57 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -260,7 +316,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16555'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -268,9 +324,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 1070x164041x1
+      - 739x17786x1
       x-asessionid:
-      - 1lc0unb
+      - 1hlu3yl
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -282,65 +338,13 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719510629.224f3631
+      - 0.4b071002.1723637997.1927afe9
       x-rh-edge-request-id:
-      - 224f3631
+      - 1927afe9
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.32.0
-    method: GET
-    uri: https://example.com/v1/vulns/GO-2023-1494
-  response:
-    body:
-      string: '{"id": "GO-2023-1494", "summary": "SQL injection in github.com/elgs/gosqljson",
-        "details": "There is a potential for SQL injection through manipulation of
-        the sqlStatement argument.", "aliases": ["CVE-2014-125064", "GHSA-g7mw-9pf9-p2pm"],
-        "modified": "2024-05-20T16:03:47Z", "published": "2023-02-01T23:23:34Z", "database_specific":
-        {"url": "https://example.com/vuln/GO-2023-1494", "review_status": "REVIEWED"},
-        "references": [{"type": "FIX", "url": "https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a"}],
-        "affected": [{"package": {"name": "github.com/elgs/gosqljson", "ecosystem":
-        "Go", "purl": "pkg:golang/github.com/elgs/gosqljson"}, "ranges": [{"type":
-        "SEMVER", "events": [{"introduced": "0"}, {"fixed": "0.0.0-20220916234230-750f26ee23c7"}]}],
-        "ecosystem_specific": {"imports": [{"symbols": ["ExecDb", "QueryDbToArray",
-        "QueryDbToArrayJson", "QueryDbToMap", "QueryDbToMapJson"], "path": "github.com/elgs/gosqljson"}]},
-        "database_specific": {"source": "https://example.com/ID/GO-2023-1494.json"}}],
-        "schema_version": "1.6.0"}'
-    headers:
-      Content-Length:
-      - '1007'
-      Date:
-      - Mon, 17 Jun 2024 12:31:17 GMT
-      Server:
-      - Google Frontend
-      X-Cloud-Trace-Context:
-      - a90a0c83c58ee002d599fe1b8ff7e9dd
-      alt-svc:
-      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-      content-type:
-      - application/json
-      grpc-accept-encoding:
-      - identity, deflate, gzip
-      grpc-message:
-      - ''
-      grpc-status:
-      - '0'
-      x-envoy-decorator-operation:
-      - ingress GetVulnById
     status:
       code: 200
       message: OK
@@ -372,7 +376,12 @@ interactions:
         problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
         by Jira Software - do not edit or delete. Issue type for a big user story
         that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
+        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
+        large product/portfolio goal or focus area that has clear start and completion
+        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
+        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
+        objective focused on a measurable outcome. May be in support of larger strategic
+        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
         requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
         Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
         enhancement to or refactoring of existing functionality that is not configurable
@@ -396,22 +405,10 @@ interactions:
         Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
         task tracking an update to a bundled component or revision of component upstream
         of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12200","id":"12200","description":"Represents
-        a Test","iconUrl":"https://example.com/download/resources/com.xpandit.plugins.xray/images/test.png","name":"Test","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/12201","id":"12201","description":"Represents
-        a Test Set","iconUrl":"https://example.com/download/resources/com.xpandit.plugins.xray/images/test-set.png","name":"Test
-        Set","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/12202","id":"12202","description":"Represents
-        a Test Execution","iconUrl":"https://example.com/download/resources/com.xpandit.plugins.xray/images/test-execution.png","name":"Test
-        Execution","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/12203","id":"12203","description":"Represents
-        a Pre-Condition","iconUrl":"https://example.com/download/resources/com.xpandit.plugins.xray/images/pre-condition.png","name":"Pre-Condition","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/12204","id":"12204","description":"Represents
-        a Test Plan","iconUrl":"https://example.com/download/resources/com.xpandit.plugins.xray/images/test-plan.png","name":"Test
-        Plan","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/12205","id":"12205","description":"Represents
-        a Sub Test Execution","iconUrl":"https://example.com/download/resources/com.xpandit.plugins.xray/images/sub-test-execution.png","name":"Sub
-        Test Execution","subtask":true},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
+        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
+        or a well-defined set of functionality that delivers business value. Features
+        can include additions or changes to existing functionality. Features can easily
+        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
         of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
         Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
         clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
@@ -432,10 +429,7 @@ interactions:
         Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
         Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
         and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
+        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
         issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
         issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
         Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
@@ -456,7 +450,7 @@ interactions:
         Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
         Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
         is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
+        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
         issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
         PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
         Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
@@ -483,10 +477,14 @@ interactions:
         Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
         strategic focus area typically defined by leadership teams to achieve organizational
         long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=53261&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":53261},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
+        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
+        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
+        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
         new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
         Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
+        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12402","id":"12402","description":"Track
+        underlying causes of incidents. Created by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56262&avatarType=issuetype","name":"Problem","subtask":false,"avatarId":56262},{"self":"https://example.com/rest/api/2/issuetype/12401","id":"12401","description":"Created
+        by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56261&avatarType=issuetype","name":"Change","subtask":false,"avatarId":56261}]'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -495,9 +493,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:18 GMT
+      - Wed, 14 Aug 2024 12:19:58 GMT
       Expires:
-      - Mon, 17 Jun 2024 12:31:18 GMT
+      - Wed, 14 Aug 2024 12:19:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -506,11 +504,11 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '-1'
+      - '5'
       X-RateLimit-Remaining:
-      - '9223372036854775807'
+      - '3'
       content-length:
-      - '26200'
+      - '25736'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -518,23 +516,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 751x420293x2
+      - 739x17787x1
       x-asessionid:
-      - 1y4lvmp
+      - 1r2wdbj
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '-1'
+      - '5'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627477.f9473bc
+      - 0.4b071002.1723637997.1927b228
       x-rh-edge-request-id:
-      - f9473bc
+      - 1927b228
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -593,11 +591,14 @@ interactions:
         program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
         "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
         "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
+        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
+        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
+        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
+        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
+        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
+        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
+        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
+        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
         Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
@@ -612,9 +613,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:18 GMT
+      - Wed, 14 Aug 2024 12:19:58 GMT
       Expires:
-      - Mon, 17 Jun 2024 12:31:18 GMT
+      - Wed, 14 Aug 2024 12:19:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -623,11 +624,11 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '-1'
+      - '5'
       X-RateLimit-Remaining:
-      - '9223372036854775807'
+      - '4'
       content-length:
-      - '4024'
+      - '4215'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -635,23 +636,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 751x420294x2
+      - 739x17788x1
       x-asessionid:
-      - 1c3xp0e
+      - 1q3wunm
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '-1'
+      - '5'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627478.f9474e2
+      - 0.4b071002.1723637998.1927b4c0
       x-rh-edge-request-id:
-      - f9474e2
+      - 1927b4c0
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -663,8 +664,9 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2014-125064 SQL injection in github.com/elgs/gosqljson", "description":
       "There is a potential for SQL injection through manipulation of the sqlStatement
-      argument.", "labels": ["flawuuid:3deb3486-3894-4a82-af55-25ba255fe1f7", "impact:"],
-      "priority": {"name": "Undefined"}}}'
+      argument.", "labels": ["flawuuid:c5876943-05a1-4ad5-bb76-f22831cc125d", "impact:",
+      "CVE-2014-125064"], "priority": {"name": "Undefined"}, "assignee": {"name":
+      ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -675,7 +677,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '358'
+      - '403'
       Content-Type:
       - application/json
       User-Agent:
@@ -686,31 +688,34 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "15942625", "key": "OSIM-16311", "self": "https://example.com/rest/api/2/issue/15942625"}'
+      string: '{"id": "16111844", "key": "OSIM-7503", "self": "https://example.com/rest/api/2/issue/16111844"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
+      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:19 GMT
+      - Wed, 14 Aug 2024 12:19:59 GMT
       Expires:
-      - Mon, 17 Jun 2024 12:31:19 GMT
+      - Wed, 14 Aug 2024 12:19:59 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
+      Transfer-Encoding:
+      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '-1'
+      - '5'
       X-RateLimit-Remaining:
-      - '9223372036854775807'
+      - '4'
       content-length:
-      - '103'
+      - '102'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -718,23 +723,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 751x420295x2
+      - 739x17789x1
       x-asessionid:
-      - jn2ziv
+      - xo1rmq
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '-1'
+      - '5'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627478.f94761d
+      - 0.4b071002.1723637998.1927b8d3
       x-rh-edge-request-id:
-      - f94761d
+      - 1927b8d3
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -760,69 +765,42 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-16311
+    uri: https://example.com/rest/api/2/issue/OSIM-7503
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "15942625", "self": "https://example.com/rest/api/2/issue/15942625",
-        "key": "OSIM-16311", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12324544":
-        "0.0", "customfield_12318341": null, "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3c774c17[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@11f0bdf8[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16111844", "self": "https://example.com/rest/api/2/issue/16111844",
+        "key": "OSIM-7503", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@f22e350[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6018e5ed[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2be0eeb4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3f6b894d[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b7ac14a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2e69268c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d0f8bb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6112384d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3c3fc5b4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5b05c9f9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e95e702[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2e356ccd[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@749c5c95[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@538cf866[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@78d4e666[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@74b506df[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@62db9428[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@56200fdd[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@99834a9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@554748bb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6b03ecef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3d0b58b5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-16311/watchers", "watchCount":
-        1, "isWatching": true}, "created": "2024-06-17T12:31:18.656+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": null, "customfield_12325241": null, "customfield_12313140":
+        null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:3deb3486-3894-4a82-af55-25ba255fe1f7",
-        "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
-        null, "assignee": null, "updated": "2024-06-17T12:31:18.656+0000", "customfield_12313942":
+        "Undefined", "id": "10300"}, "labels": ["CVE-2014-125064", "flawuuid:c5876943-05a1-4ad5-bb76-f22831cc125d",
+        "impact:"], "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions":
+        [], "issuelinks": [], "customfield_12325240": null, "assignee": null, "customfield_12313942":
         null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "There is a potential for
-        SQL injection through manipulation of the sqlStatement argument.", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
-        "9223372036854775807", "customfield_12316544": "None", "customfield_12323640":
-        null, "summary": "CVE-2014-125064 SQL injection in github.com/elgs/gosqljson",
-        "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        [], "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "archiveddate": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
         "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
         "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
         "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
         "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
         "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
         "reporter": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
         "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
         "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
@@ -830,17 +808,51 @@ interactions:
         "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
         "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
         "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
-        "customfield_12320850": null, "aggregateprogress": {"progress": 0, "total":
-        0}, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
-        null, "customfield_12323645": null, "environment": null, "customfield_12315542":
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-7503/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "workratio": -1, "customfield_12317379": null,
+        "customfield_12316840": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-7503/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-08-14T12:19:58.643+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": null,
+        "customfield_12325042": null, "customfield_12325041": null, "updated": "2024-08-14T12:19:58.643+0000",
+        "customfield_12324841": null, "customfield_12324840": null, "timeoriginalestimate":
+        null, "description": "There is a potential for SQL injection through manipulation
+        of the sqlStatement argument.", "customfield_12324843": null, "customfield_12324842":
+        [], "timetracking": {}, "attachment": [], "customfield_12316542": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14655", "value": "False",
+        "id": "14655", "disabled": false}, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
+        "9223372036854775807", "customfield_12316544": "None", "summary": "CVE-2014-125064
+        SQL injection in github.com/elgs/gosqljson", "customfield_12323640": null,
+        "customfield_12323642": null, "customfield_12323641": null, "customfield_12325143":
+        null, "customfield_12325142": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
         null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
-        "0.0", "customfield_12313240": null, "duedate": null, "customfield_12311140":
-        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes":
-        {"self": "https://example.com/rest/api/2/issue/OSIM-16311/votes", "votes":
-        0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "1|zemjow:"}}'
+        "0.0", "duedate": null, "customfield_12311140": null, "comment": {"comments":
+        [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141": null,
+        "customfield_12325140": null, "customfield_12310213": null, "customfield_12311940":
+        "2|i140av:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -849,9 +861,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:19 GMT
+      - Wed, 14 Aug 2024 12:19:59 GMT
       Expires:
-      - Mon, 17 Jun 2024 12:31:19 GMT
+      - Wed, 14 Aug 2024 12:19:59 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -860,11 +872,11 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '-1'
+      - '5'
       X-RateLimit-Remaining:
-      - '9223372036854775807'
+      - '4'
       content-length:
-      - '8854'
+      - '9371'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -872,23 +884,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 751x420296x2
+      - 739x17791x1
       x-asessionid:
-      - 126x8jm
+      - yevu5i
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '-1'
+      - '5'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627479.f947ad4
+      - 0.4b071002.1723637999.1927c667
       x-rh-edge-request-id:
-      - f947ad4
+      - 1927c667
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -913,7 +925,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh97"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -924,11 +936,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:20 GMT
+      - Wed, 14 Aug 2024 12:20:00 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -938,9 +950,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1718627480.c37bbfc
+      - 0.52071002.1723638000.1dbcc89d
       x-rh-edge-request-id:
-      - c37bbfc
+      - 1dbcc89d
     status:
       code: 200
       message: OK
@@ -961,8 +973,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "id": 1, "email":
-        "aander07@packetmaster.com", "real_name": "Need Real Name", "can_login": true}]}'
+      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
+        Real Name", "id": 1, "email": "aander07@packetmaster.com", "can_login": true}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -977,7 +989,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:20 GMT
+      - Wed, 14 Aug 2024 12:20:00 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -987,9 +999,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1718627480.c37bd0b
+      - 0.52071002.1723638000.1dbcc9c1
       x-rh-edge-request-id:
-      - c37bd0b
+      - 1dbcc9c1
     status:
       code: 200
       message: OK
@@ -1000,10 +1012,10 @@ interactions:
       SQL injection in github.com/elgs/gosqljson", "description": "There is a potential
       for SQL injection through manipulation of the sqlStatement argument.", "comment_is_private":
       false, "alias": ["CVE-2014-125064"], "keywords": ["Security"], "flags": [],
-      "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"reported\": \"2024-06-17T12:31:17Z\",
-      \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"], \"references\": [{\"type\":
-      \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2023-1494\", \"description\":
-      null}, {\"type\": \"external\", \"url\": \"https://github.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
+      "groups": ["redhat"], "cc": [], "cf_srtnotes": "{\"public\": \"2023-02-01T23:23:34Z\",
+      \"reported\": \"2024-08-14T12:19:57Z\", \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
+      \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GO-2023-1494\",
+      \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
       \"description\": null}], \"source\": \"osv\"}"}'
     headers:
       Accept:
@@ -1013,7 +1025,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '922'
+      - '960'
       Content-Type:
       - application/json
       User-Agent:
@@ -1022,7 +1034,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2293430}'
+      string: '{"id": 2298924}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1037,7 +1049,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:22 GMT
+      - Wed, 14 Aug 2024 12:20:02 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1047,9 +1059,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1718627480.c37be6f
+      - 0.52071002.1723638001.1dbccd38
       x-rh-edge-request-id:
-      - c37be6f
+      - 1dbccd38
     status:
       code: 200
       message: OK
@@ -1070,7 +1082,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh97"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1081,11 +1093,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:22 GMT
+      - Wed, 14 Aug 2024 12:20:03 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1095,9 +1107,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627482.f948728
+      - 0.52071002.1723638003.1dbcdadf
       x-rh-edge-request-id:
-      - f948728
+      - 1dbcdadf
     status:
       code: 200
       message: OK
@@ -1118,8 +1130,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"real_name": "Need Real Name", "can_login": true, "email":
-        "aander07@packetmaster.com", "name": "aander07@packetmaster.com", "id": 1}]}'
+      string: '{"users": [{"can_login": true, "email": "aander07@packetmaster.com",
+        "id": 1, "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1134,7 +1146,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:23 GMT
+      - Wed, 14 Aug 2024 12:20:03 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1144,9 +1156,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627482.f9487ac
+      - 0.52071002.1723638003.1dbcdda6
       x-rh-edge-request-id:
-      - f9487ac
+      - 1dbcdda6
     status:
       code: 200
       message: OK
@@ -1164,44 +1176,42 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2293430?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
+    uri: https://example.com/rest/bug/2298924?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"faults": [], "bugs": [{"resolution": "", "cf_doc_type": "If docs
-        needed, set a value", "cf_internal_whiteboard": "", "dupe_of": null, "is_confirmed":
-        true, "priority": "unspecified", "comments": [{"time": "2024-06-17T12:31:21Z",
-        "creator": "nobody@redhat.com", "creation_time": "2024-06-17T12:31:21Z",
-        "bug_id": 2293430, "text": "There is a potential for SQL injection through
-        manipulation of the sqlStatement argument.", "private_groups": [], "attachment_id":
-        null, "tags": [], "creator_id": 425662, "is_private": false, "count": 0, "id":
-        18020057}], "status": "NEW", "url": "", "groups": ["redhat"], "external_bugs":
-        [], "cf_last_closed": null, "version": ["unspecified"], "creator": "nobody@redhat.com",
-        "cf_pm_score": "0", "is_open": true, "id": 2293430, "depends_on": [], "component":
-        ["vulnerability-draft"], "whiteboard": "", "deadline": null, "blocks": [],
-        "cf_major_incident": null, "cf_environment": "", "flags": [], "alias": ["CVE-2014-125064"],
-        "op_sys": "Linux", "last_change_time": "2024-06-17T12:31:21Z", "cf_qe_conditional_nak":
-        [], "sub_components": {}, "creator_detail": {"email": "nobody@redhat.com",
-        "partner": false, "name": "nobody@redhat.com", "id": 425662, "insider":
-        true, "real_name": "nobody", "active": true}, "cf_cust_facing": "---",
-        "assigned_to_detail": {"id": 377884, "email": "prodsec-dev@redhat.com", "partner":
-        false, "name": "prodsec-dev@redhat.com", "active": true, "real_name": "Product
-        Security DevOps Team", "insider": true}, "cf_build_id": "", "data_category":
-        "Red Hat", "cc": [],
-        "cf_srtnotes": "{\"reported\": \"2024-06-17T12:31:17Z\", \"external_ids\":
-        [\"GO-2023-1494/CVE-2014-125064\"], \"references\": [{\"type\": \"source\",
-        \"url\": \"https://example.com/vulnerability/GO-2023-1494\", \"description\":
-        null}, {\"type\": \"external\", \"url\": \"https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
-        \"description\": null}], \"source\": \"osv\"}", "cf_embargoed": null, "creation_time":
-        "2024-06-17T12:31:21Z", "description": "There is a potential for SQL injection
-        through manipulation of the sqlStatement argument.", "cf_conditional_nak":
-        [], "target_release": ["---"], "target_milestone": "---", "is_creator_accessible":
-        true, "cc_detail": [], "tags": [], "remaining_time": 0, "cf_pgm_internal":
-        "", "cf_qa_whiteboard": "", "product": "Security Response", "platform": "All",
-        "actual_time": 0, "is_cc_accessible": true, "qa_contact": "", "severity":
-        "unspecified", "summary": "CVE-2014-125064 SQL injection in github.com/elgs/gosqljson",
-        "assigned_to": "prodsec-dev@redhat.com", "cf_release_notes": "", "cf_clone_of":
-        null, "docs_contact": "", "cf_fixed_in": "", "classification": "Other", "keywords":
-        ["Security"], "cf_devel_whiteboard": "", "estimated_time": 0}]}'
+      string: '{"bugs": [{"whiteboard": "", "groups": ["redhat"], "alias": ["CVE-2014-125064"],
+        "summary": "CVE-2014-125064 SQL injection in github.com/elgs/gosqljson", "qa_contact":
+        "", "sub_components": {}, "external_bugs": [], "cf_doc_type": "If docs needed,
+        set a value", "id": 2298924, "version": ["unspecified"], "url": "", "cf_internal_whiteboard":
+        "", "cf_devel_whiteboard": "", "cf_release_notes": "", "creator": "nobody@redhat.com",
+        "op_sys": "Linux", "deadline": null, "target_release": ["---"], "component":
+        ["vulnerability-draft"], "depends_on": [], "is_cc_accessible": true, "classification":
+        "Other", "keywords": ["Security"], "is_open": true, "platform": "All", "creator_detail":
+        {"name": "nobody@redhat.com", "active": true, "partner": false, "real_name":
+        "nobody", "id": 425662, "email": "nobody@redhat.com", "insider":
+        true}, "cf_clone_of": null, "comments": [{"count": 0, "is_private": false,
+        "creator": "nobody@redhat.com", "bug_id": 2298924, "attachment_id": null,
+        "tags": [], "creation_time": "2024-08-14T12:20:02Z", "text": "There is a potential
+        for SQL injection through manipulation of the sqlStatement argument.", "id":
+        18026775, "time": "2024-08-14T12:20:02Z", "creator_id": 425662, "private_groups":
+        []}], "cf_last_closed": null, "resolution": "", "docs_contact": "", "status":
+        "NEW", "cf_pgm_internal": "", "flags": [], "is_creator_accessible": true,
+        "cf_major_incident": null, "cf_cust_facing": "---", "assigned_to": "prodsec-dev@redhat.com",
+        "dupe_of": null, "cf_qe_conditional_nak": [], "cc_detail": [], "cf_qa_whiteboard":
+        "", "description": "There is a potential for SQL injection through manipulation
+        of the sqlStatement argument.", "target_milestone": "---", "assigned_to_detail":
+        {"partner": false, "insider": true, "email": "prodsec-dev@redhat.com", "id":
+        377884, "real_name": "Product Security DevOps Team", "name": "prodsec-dev@redhat.com",
+        "active": true}, "cf_embargoed": null, "creation_time": "2024-08-14T12:20:02Z",
+        "cf_environment": "", "cf_fixed_in": "", "cf_conditional_nak": [], "estimated_time":
+        0, "cf_pm_score": "0", "severity": "unspecified", "cf_build_id": "", "is_confirmed":
+        true, "actual_time": 0, "data_category": "Red Hat", "blocks": [], "cc": [],
+        "tags": [], "product": "Security Response", "cf_srtnotes": "{\"public\": \"2023-02-01T23:23:34Z\",
+        \"reported\": \"2024-08-14T12:19:57Z\", \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2023-1494\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
+        \"description\": null}], \"source\": \"osv\"}", "last_change_time": "2024-08-14T12:20:02Z",
+        "priority": "unspecified", "remaining_time": 0}], "faults": []}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1214,7 +1224,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:23 GMT
+      - Wed, 14 Aug 2024 12:20:04 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1224,13 +1234,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2653'
+      - '2691'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627483.f94896f
+      - 0.52071002.1723638004.1dbce212
       x-rh-edge-request-id:
-      - f94896f
+      - 1dbce212
     status:
       code: 200
       message: OK
@@ -1248,44 +1258,42 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2293430?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
+    uri: https://example.com/rest/bug/2298924?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"bugs": [{"cf_fixed_in": "", "docs_contact": "", "classification":
-        "Other", "keywords": ["Security"], "cf_devel_whiteboard": "", "estimated_time":
-        0, "qa_contact": "", "assigned_to": "prodsec-dev@redhat.com", "severity":
-        "unspecified", "summary": "CVE-2014-125064 SQL injection in github.com/elgs/gosqljson",
-        "cf_release_notes": "", "cf_clone_of": null, "cf_qa_whiteboard": "", "cf_pgm_internal":
-        "", "product": "Security Response", "platform": "All", "actual_time": 0, "is_cc_accessible":
-        true, "is_creator_accessible": true, "cc_detail": [], "tags": [], "remaining_time":
-        0, "cf_srtnotes": "{\"reported\": \"2024-06-17T12:31:17Z\", \"external_ids\":
-        [\"GO-2023-1494/CVE-2014-125064\"], \"references\": [{\"type\": \"source\",
-        \"url\": \"https://example.com/vulnerability/GO-2023-1494\", \"description\":
-        null}, {\"type\": \"external\", \"url\": \"https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
-        \"description\": null}], \"source\": \"osv\"}", "creation_time": "2024-06-17T12:31:21Z",
-        "cf_embargoed": null, "description": "There is a potential for SQL injection
-        through manipulation of the sqlStatement argument.", "target_release": ["---"],
-        "cf_conditional_nak": [], "target_milestone": "---", "op_sys": "Linux", "cf_environment":
-        "", "alias": ["CVE-2014-125064"], "flags": [], "cf_major_incident": null,
-        "last_change_time": "2024-06-17T12:31:21Z", "cf_qe_conditional_nak": [], "creator_detail":
-        {"id": 425662, "partner": false, "email": "nobody@redhat.com", "name": "nobody@redhat.com",
-        "active": true, "real_name": "nobody", "insider": true}, "sub_components":
-        {}, "assigned_to_detail": {"id": 377884, "email": "prodsec-dev@redhat.com",
-        "name": "prodsec-dev@redhat.com", "partner": false, "real_name": "Product
-        Security DevOps Team", "insider": true, "active": true}, "data_category":
-        "Red Hat", "cf_build_id": "", "cf_cust_facing": "---",
-        "cc": [], "url": "", "status": "NEW", "external_bugs": [], "groups": ["redhat"],
-        "creator": "nobody@redhat.com", "version": ["unspecified"], "cf_last_closed":
-        null, "is_open": true, "cf_pm_score": "0", "depends_on": [], "id": 2293430,
-        "component": ["vulnerability-draft"], "whiteboard": "", "blocks": [], "deadline":
-        null, "resolution": "", "cf_internal_whiteboard": "", "cf_doc_type": "If docs
-        needed, set a value", "dupe_of": null, "is_confirmed": true, "comments": [{"text":
-        "There is a potential for SQL injection through manipulation of the sqlStatement
-        argument.", "private_groups": [], "time": "2024-06-17T12:31:21Z", "creator":
-        "nobody@redhat.com", "creation_time": "2024-06-17T12:31:21Z", "bug_id":
-        2293430, "creator_id": 425662, "tags": [], "is_private": false, "count": 0,
-        "id": 18020057, "attachment_id": null}], "priority": "unspecified"}], "faults":
-        []}'
+      string: '{"bugs": [{"deadline": null, "op_sys": "Linux", "target_release": ["---"],
+        "component": ["vulnerability-draft"], "cf_internal_whiteboard": "", "cf_devel_whiteboard":
+        "", "creator": "nobody@redhat.com", "cf_release_notes": "", "version": ["unspecified"],
+        "id": 2298924, "cf_doc_type": "If docs needed, set a value", "url": "", "sub_components":
+        {}, "external_bugs": [], "summary": "CVE-2014-125064 SQL injection in github.com/elgs/gosqljson",
+        "qa_contact": "", "groups": ["redhat"], "alias": ["CVE-2014-125064"], "whiteboard":
+        "", "flags": [], "cf_pgm_internal": "", "docs_contact": "", "status": "NEW",
+        "cf_last_closed": null, "resolution": "", "creator_detail": {"partner": false,
+        "insider": true, "id": 425662, "real_name": "nobody", "email": "nobody@redhat.com",
+        "name": "nobody@redhat.com", "active": true}, "cf_clone_of": null, "comments":
+        [{"tags": [], "attachment_id": null, "bug_id": 2298924, "creator": "nobody@redhat.com",
+        "is_private": false, "count": 0, "private_groups": [], "creator_id": 425662,
+        "time": "2024-08-14T12:20:02Z", "id": 18026775, "text": "There is a potential
+        for SQL injection through manipulation of the sqlStatement argument.", "creation_time":
+        "2024-08-14T12:20:02Z"}], "keywords": ["Security"], "is_open": true, "platform":
+        "All", "classification": "Other", "depends_on": [], "is_cc_accessible": true,
+        "estimated_time": 0, "cf_pm_score": "0", "cf_conditional_nak": [], "creation_time":
+        "2024-08-14T12:20:02Z", "cf_environment": "", "cf_fixed_in": "", "target_milestone":
+        "---", "assigned_to_detail": {"name": "prodsec-dev@redhat.com", "active":
+        true, "partner": false, "real_name": "Product Security DevOps Team", "email":
+        "prodsec-dev@redhat.com", "insider": true, "id": 377884}, "cf_embargoed":
+        null, "description": "There is a potential for SQL injection through manipulation
+        of the sqlStatement argument.", "cf_qa_whiteboard": "", "assigned_to": "prodsec-dev@redhat.com",
+        "dupe_of": null, "cf_qe_conditional_nak": [], "cc_detail": [], "is_creator_accessible":
+        true, "cf_major_incident": null, "cf_cust_facing": "---", "remaining_time":
+        0, "product": "Security Response", "cf_srtnotes": "{\"public\": \"2023-02-01T23:23:34Z\",
+        \"reported\": \"2024-08-14T12:19:57Z\", \"external_ids\": [\"GO-2023-1494/CVE-2014-125064\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GO-2023-1494\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/elgs/gosqljson/commit/2740b331546cb88eb61771df4c07d389e9f0363a\",
+        \"description\": null}], \"source\": \"osv\"}", "last_change_time": "2024-08-14T12:20:02Z",
+        "priority": "unspecified", "cc": [], "tags": [], "actual_time": 0, "data_category":
+        "Red Hat", "blocks": [], "cf_build_id": "", "is_confirmed": true, "severity":
+        "unspecified"}], "faults": []}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1298,7 +1306,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:24 GMT
+      - Wed, 14 Aug 2024 12:20:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -1308,13 +1316,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '2653'
+      - '2691'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627483.f948c2e
+      - 0.52071002.1723638004.1dbce949
       x-rh-edge-request-id:
-      - f948c2e
+      - 1dbce949
     status:
       code: 200
       message: OK
@@ -1332,14 +1340,14 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2293430/comment
+    uri: https://example.com/rest/bug/2298924/comment
   response:
     body:
-      string: '{"comments": {}, "bugs": {"2293430": {"comments": [{"bug_id": 2293430,
-        "is_private": false, "attachment_id": null, "creation_time": "2024-06-17T12:31:21Z",
-        "private_groups": [], "id": 18020057, "count": 0, "text": "There is a potential
-        for SQL injection through manipulation of the sqlStatement argument.", "tags":
-        [], "creator": "nobody@redhat.com", "creator_id": 425662, "time": "2024-06-17T12:31:21Z"}]}}}'
+      string: '{"comments": {}, "bugs": {"2298924": {"comments": [{"tags": [], "attachment_id":
+        null, "bug_id": 2298924, "creator": "nobody@redhat.com", "is_private": false,
+        "count": 0, "private_groups": [], "creator_id": 425662, "text": "There is
+        a potential for SQL injection through manipulation of the sqlStatement argument.",
+        "time": "2024-08-14T12:20:02Z", "id": 18026775, "creation_time": "2024-08-14T12:20:02Z"}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1354,7 +1362,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 17 Jun 2024 12:31:24 GMT
+      - Wed, 14 Aug 2024 12:20:06 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1364,9 +1372,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1718627484.f948edb
+      - 0.52071002.1723638006.1dbcf1b8
       x-rh-edge-request-id:
-      - f948edb
+      - 1dbcf1b8
     status:
       code: 200
       message: OK

--- a/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record_without_cve.yaml
+++ b/collectors/osv/tests/cassettes/test_collectors/TestOSVCollector.test_collect_osv_record_without_cve.yaml
@@ -37,11 +37,11 @@ interactions:
       Content-Length:
       - '1676'
       Date:
-      - Fri, 28 Jun 2024 11:49:42 GMT
+      - Wed, 14 Aug 2024 12:44:41 GMT
       Server:
       - Google Frontend
       X-Cloud-Trace-Context:
-      - 413bbdf9f71ec7b22752b28475398985
+      - bdda5bcabe9db84deb48675f75e5ffac
       alt-svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       content-type:
@@ -80,7 +80,7 @@ interactions:
     body:
       string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
         "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
-        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        issues for a specific project.", "havePermission": false}, "VIEW_WORKFLOW_READONLY":
         {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
         "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
         "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
@@ -103,9 +103,9 @@ interactions:
         Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
         "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
         "description": "Ability to administer a project in Jira.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        false, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
         "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
-        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        edit all comments made on issues.", "havePermission": false, "deprecatedKey":
         true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
         "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
         with this permission may delete own attachments.", "havePermission": true,
@@ -125,7 +125,7 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
         {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "havePermission": false, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
         "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
         "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
         "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
@@ -133,7 +133,7 @@ interactions:
         permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
         {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        attachments.", "havePermission": false}, "ASSIGN_ISSUE": {"id": "13", "key":
         "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
         "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
         true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
@@ -146,7 +146,7 @@ interactions:
         "PROJECT", "description": "Users with this permission may create attachments.",
         "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
         "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
-        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        edit all worklogs made on issues.", "havePermission": false}, "SCHEDULE_ISSUE":
         {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
         "description": "Ability to view or edit an issue''s due date.", "havePermission":
         true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
@@ -160,16 +160,16 @@ interactions:
         Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
         due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
         "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
-        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "Ability to delete all worklogs made on issues.", "havePermission": false,
         "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
         "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
         to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
         true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
         "Administer Projects", "type": "PROJECT", "description": "Ability to administer
-        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        a project in Jira.", "havePermission": false}, "DELETE_ALL_COMMENTS": {"id":
         "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
         "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "havePermission": false}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
         "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
         and reopen issues. This includes the ability to set a fix version.", "havePermission":
         true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
@@ -220,12 +220,12 @@ interactions:
         Results OKRs (Objective and key results) that are linked to a given issue",
         "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
         "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
-        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        issues for a specific project.", "havePermission": false}, "BROWSE_ARCHIVE":
         {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
         "PROJECT", "description": "Ability to browse archived issues from a specific
-        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
-        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
-        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        project.", "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL":
+        {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate
+        users in A4J global scope", "type": "GLOBAL", "description": "Having the permission
         allows to select other user as automation rule actor", "havePermission": true},
         "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
         "View Development Tools", "type": "PROJECT", "description": "Allows users
@@ -241,15 +241,15 @@ interactions:
         "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
         true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
         "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
-        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        worklogs made on issues.", "havePermission": false, "deprecatedKey": true},
         "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
         All Comments", "type": "PROJECT", "description": "Ability to edit all comments
-        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        made on issues.", "havePermission": false}, "DELETE_ISSUE": {"id": "16", "key":
         "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
         "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
         "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
         "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
-        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        sprints.", "havePermission": false}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
         "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
         a user or group from a popup window as well as the ability to use the ''share''
         issues feature. Users with this permission will also be able to see names
@@ -259,7 +259,7 @@ interactions:
         with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
         {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
         "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        attachments.", "havePermission": false, "deprecatedKey": true}, "DELETE_ISSUES":
         {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
         "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
         {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
@@ -268,27 +268,31 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
         true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
         "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
-        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        all worklogs made on issues.", "havePermission": false}, "LINK_ISSUES": {"id":
         "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
         "Ability to link issues together and create linked issues. Only useful if
         issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
@@ -303,9 +307,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:43 GMT
+      - Wed, 14 Aug 2024 12:44:42 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:49:43 GMT
+      - Wed, 14 Aug 2024 12:44:42 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -318,17 +322,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16555'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 709x590603x1
+      - 764x20653x1
       x-asessionid:
-      - tx6zyk
+      - my3bp3
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -340,9 +344,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575383.89fcaeae
+      - 0.4b071002.1723639481.196b75d7
       x-rh-edge-request-id:
-      - 89fcaeae
+      - 196b75d7
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -484,7 +488,9 @@ interactions:
         Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
         new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
         Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
+        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12402","id":"12402","description":"Track
+        underlying causes of incidents. Created by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56262&avatarType=issuetype","name":"Problem","subtask":false,"avatarId":56262},{"self":"https://example.com/rest/api/2/issuetype/12401","id":"12401","description":"Created
+        by Jira Service Management.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=56261&avatarType=issuetype","name":"Change","subtask":false,"avatarId":56261}]'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -493,9 +499,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:43 GMT
+      - Wed, 14 Aug 2024 12:44:42 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:49:43 GMT
+      - Wed, 14 Aug 2024 12:44:42 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -506,19 +512,19 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '25109'
+      - '25736'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 709x590604x1
+      - 764x20654x1
       x-asessionid:
-      - 1fnost9
+      - 156b0ob
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -530,9 +536,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575383.89fcb28a
+      - 0.4b071002.1723639482.196b7835
       x-rh-edge-request-id:
-      - 89fcb28a
+      - 196b7835
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -591,11 +597,14 @@ interactions:
         program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
         "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
         "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
+        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
+        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
+        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
+        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
+        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
+        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
+        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
+        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
         Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
@@ -610,9 +619,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:43 GMT
+      - Wed, 14 Aug 2024 12:44:42 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:49:43 GMT
+      - Wed, 14 Aug 2024 12:44:42 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -623,19 +632,19 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '4024'
+      - '4215'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 709x590605x1
+      - 764x20655x1
       x-asessionid:
-      - 1j12eay
+      - 1gdtpx4
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -647,9 +656,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575383.89fcb6b5
+      - 0.4b071002.1723639482.196b7bed
       x-rh-edge-request-id:
-      - 89fcb6b5
+      - 196b7bed
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -666,8 +675,8 @@ interactions:
       This vulnerability can be exploited by sending a specially crafted request to
       the API with a large payload.\n\nAn attacker can exploit this vulnerability
       to cause a denial of service (DoS) attack on the s42.app API, resulting in unavailability
-      of the API for legitimate users.", "labels": ["flawuuid:87fefeaa-2631-4820-b56c-262598e538ae",
-      "impact:"], "priority": {"name": "Undefined"}}}'
+      of the API for legitimate users.", "labels": ["flawuuid:95494f57-1878-4022-9830-d7148646167c",
+      "impact:"], "priority": {"name": "Undefined"}, "assignee": {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -678,7 +687,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '791'
+      - '817'
       Content-Type:
       - application/json
       User-Agent:
@@ -689,41 +698,44 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16091061", "key": "OSIM-497", "self": "https://example.com/rest/api/2/issue/16091061"}'
+      string: '{"id": "16111847", "key": "OSIM-7509", "self": "https://example.com/rest/api/2/issue/16111847"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - close
+      - keep-alive
+      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:45 GMT
+      - Wed, 14 Aug 2024 12:44:43 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:49:45 GMT
+      - Wed, 14 Aug 2024 12:44:43 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
+      Transfer-Encoding:
+      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       content-length:
-      - '101'
+      - '102'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 709x590606x1
+      - 764x20656x1
       x-asessionid:
-      - 6ue42n
+      - 53vrkj
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -735,9 +747,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575383.89fcbc23
+      - 0.4b071002.1723639482.196b7ded
       x-rh-edge-request-id:
-      - 89fcbc23
+      - 196b7ded
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -763,92 +775,99 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-497
+    uri: https://example.com/rest/api/2/issue/OSIM-7509
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091061", "self": "https://example.com/rest/api/2/issue/16091061",
-        "key": "OSIM-497", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@66c9078e[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9e4be4b[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16111847", "self": "https://example.com/rest/api/2/issue/16111847",
+        "key": "OSIM-7509", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2f2f640c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@c4ce250[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a34ba02[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@768e41e9[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@78352cc0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@75e4f926[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@affb932[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@efa208d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5ff85ebe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@d87b1ae[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ac6af05[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@25e71698[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1a088c0f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@713da37c[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3d6004d1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6f974046[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3121c14f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2d1ba254[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10e06daa[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@45209a80[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a3410d2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@acd04c2[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-497/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T11:49:43.701+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": null, "customfield_12325241": null, "customfield_12313140":
+        null, "priority": {"self": "https://example.com/rest/api/2/priority/10300",
         "iconUrl": "https://example.com/images/icons/priorities/trivial.svg", "name":
-        "Undefined", "id": "10300"}, "labels": ["flawuuid:87fefeaa-2631-4820-b56c-262598e538ae",
-        "impact:"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T11:49:43.701+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Undefined", "id": "10300"}, "labels": ["flawuuid:95494f57-1878-4022-9830-d7148646167c",
+        "impact:"], "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions":
+        [], "issuelinks": [], "customfield_12325240": null, "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "A security vulnerability
-        has been identified in the GraphQL parser used by the API of s42.app. An attacker
-        can overload the parser and cause the API pod to crash. With a bit of threading,
-        the attacker can bring down the entire API, resulting in an unhealthy stream.
-        This vulnerability can be exploited by sending a specially crafted request
-        to the API with a large payload.\n\nAn attacker can exploit this vulnerability
-        to cause a denial of service (DoS) attack on the s42.app API, resulting in
-        unavailability of the API for legitimate users.", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Stud42
-        vulnerable to denial of service", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-497/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "customfield_12320842":
+        null, "archiveddate": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
+        "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=nobody%40redhat.com",
+        "name": "nobody@redhat.com", "key": "nobody", "emailAddress": "nobody+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=nobody&avatarId=29772",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=nobody&avatarId=29772",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=nobody&avatarId=29772",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=nobody&avatarId=29772"},
+        "displayName": "nobody", "active": true, "timeZone": "Europe/Prague"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-7509/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z67:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "workratio": -1, "customfield_12317379": null,
+        "customfield_12316840": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-7509/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-08-14T12:44:42.850+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": null,
+        "customfield_12325042": null, "customfield_12325041": null, "updated": "2024-08-14T12:44:42.850+0000",
+        "customfield_12324841": null, "customfield_12324840": null, "timeoriginalestimate":
+        null, "description": "A security vulnerability has been identified in the
+        GraphQL parser used by the API of s42.app. An attacker can overload the parser
+        and cause the API pod to crash. With a bit of threading, the attacker can
+        bring down the entire API, resulting in an unhealthy stream. This vulnerability
+        can be exploited by sending a specially crafted request to the API with a
+        large payload.\n\nAn attacker can exploit this vulnerability to cause a denial
+        of service (DoS) attack on the s42.app API, resulting in unavailability of
+        the API for legitimate users.", "customfield_12324843": null, "customfield_12324842":
+        [], "timetracking": {}, "attachment": [], "customfield_12316542": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14655", "value": "False",
+        "id": "14655", "disabled": false}, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
+        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
+        "9223372036854775807", "customfield_12316544": "None", "summary": "Stud42
+        vulnerable to denial of service", "customfield_12323640": null, "customfield_12323642":
+        null, "customfield_12323641": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i140cn:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -857,9 +876,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:52 GMT
+      - Wed, 14 Aug 2024 12:44:44 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:49:52 GMT
+      - Wed, 14 Aug 2024 12:44:44 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -872,17 +891,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '9313'
+      - '9786'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 709x590610x1
+      - 764x20657x1
       x-asessionid:
-      - 6z2lso
+      - imsjx8
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -894,9 +913,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575391.89fdb5f1
+      - 0.4b071002.1723639483.196b8bd9
       x-rh-edge-request-id:
-      - 89fdb5f1
+      - 196b8bd9
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -921,7 +940,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -932,11 +951,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:53 GMT
+      - Wed, 14 Aug 2024 12:44:44 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -946,9 +965,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575392.89fdc892
+      - 0.4b071002.1723639484.196b9308
       x-rh-edge-request-id:
-      - 89fdc892
+      - 196b9308
     status:
       code: 200
       message: OK
@@ -969,8 +988,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"email": "aander07@packetmaster.com", "id": 1, "can_login":
-        true, "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"name": "aander07@packetmaster.com", "id": 1, "can_login":
+        true, "email": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -985,7 +1004,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:53 GMT
+      - Wed, 14 Aug 2024 12:44:45 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -995,9 +1014,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575393.89fde646
+      - 0.4b071002.1723639484.196b95d1
       x-rh-edge-request-id:
-      - 89fde646
+      - 196b95d1
     status:
       code: 200
       message: OK
@@ -1014,9 +1033,10 @@ interactions:
       to cause a denial of service (DoS) attack on the s42.app API, resulting in unavailability
       of the API for legitimate users.", "comment_is_private": false, "alias": ["GHSA-3hwm-922r-47hw"],
       "keywords": ["Security"], "flags": [], "groups": ["redhat"], "cc": [], "cf_srtnotes":
-      "{\"reported\": \"2024-06-28T11:49:42Z\", \"external_ids\": [\"GHSA-3hwm-922r-47hw\"],
-      \"references\": [{\"type\": \"source\", \"url\": \"https://osv.dev/vulnerability/GHSA-3hwm-922r-47hw\",
-      \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
+      "{\"public\": \"2023-03-31T19:33:44Z\", \"reported\": \"2024-08-14T12:44:41Z\",
+      \"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\": [{\"type\": \"source\",
+      \"url\": \"https://osv.dev/vulnerability/GHSA-3hwm-922r-47hw\", \"description\":
+      null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42/issues/412\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17\",
       \"description\": null}, {\"type\": \"external\", \"url\": \"https://github.com/42Atomys/stud42\",
@@ -1029,7 +1049,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '1725'
+      - '1763'
       Content-Type:
       - application/json
       User-Agent:
@@ -1038,7 +1058,7 @@ interactions:
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2294454}'
+      string: '{"id": 2298927}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1053,7 +1073,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:55 GMT
+      - Wed, 14 Aug 2024 12:44:47 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1063,9 +1083,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575393.89fdf38e
+      - 0.4b071002.1723639485.196b9d36
       x-rh-edge-request-id:
-      - 89fdf38e
+      - 196b9d36
     status:
       code: 200
       message: OK
@@ -1086,7 +1106,7 @@ interactions:
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh100"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1097,11 +1117,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:55 GMT
+      - Wed, 14 Aug 2024 12:44:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1111,9 +1131,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575395.89fe2021
+      - 0.4b071002.1723639487.196bbadc
       x-rh-edge-request-id:
-      - 89fe2021
+      - 196bbadc
     status:
       code: 200
       message: OK
@@ -1134,9 +1154,8 @@ interactions:
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "email": "aander07@packetmaster.com", "id":
-        1}]}'
+      string: '{"users": [{"id": 1, "can_login": true, "email": "aander07@packetmaster.com",
+        "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1151,7 +1170,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:56 GMT
+      - Wed, 14 Aug 2024 12:44:48 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1161,9 +1180,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575395.89fe32b4
+      - 0.4b071002.1723639488.196bc151
       x-rh-edge-request-id:
-      - 89fe32b4
+      - 196bc151
     status:
       code: 200
       message: OK
@@ -1181,209 +1200,37 @@ interactions:
       User-Agent:
       - python-bugzilla/3.2.0
     method: GET
-    uri: https://example.com/rest/bug/2294454?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
+    uri: https://example.com/rest/bug/2298927?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"faults": [], "bugs": [{"cf_embargoed": null, "status": "NEW", "keywords":
-        ["Security"], "estimated_time": 0, "classification": "Other", "alias": ["GHSA-3hwm-922r-47hw"],
-        "cf_major_incident": null, "dupe_of": null, "cf_srtnotes": "{\"reported\":
-        \"2024-06-28T11:49:42Z\", \"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\":
-        [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-3hwm-922r-47hw\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/issues/412\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42\",
-        \"description\": null}], \"source\": \"osv\", \"cwe\": \"CWE-400\"}", "op_sys":
-        "Linux", "target_milestone": "---", "product": "Security Response", "cf_qa_whiteboard":
-        "", "severity": "unspecified", "cf_fixed_in": "", "assigned_to": "prodsec-dev@redhat.com",
-        "cf_qe_conditional_nak": [], "creation_time": "2024-06-28T11:49:54Z", "last_change_time":
-        "2024-06-28T11:49:54Z", "id": 2294454, "version": ["unspecified"], "tags":
-        [], "external_bugs": [], "cf_devel_whiteboard": "", "url": "", "is_creator_accessible":
-        true, "actual_time": 0, "cf_build_id": "", "whiteboard": "", "sub_components":
-        {}, "data_category": "Red Hat", "resolution": "", "cc_detail": [], "component":
-        ["vulnerability-draft"], "creator": "conrado@redhat.com", "cf_cust_facing":
-        "---", "cc": [], "cf_pgm_internal": "", "summary": "Stud42 vulnerable to denial
-        of service", "qa_contact": "", "cf_release_notes": "", "creator_detail": {"active":
-        true, "id": 482384, "email": "conrado@redhat.com", "insider": true, "partner":
-        false, "name": "conrado@redhat.com", "real_name": "Conrado Costa"}, "is_cc_accessible":
-        true, "description": "A security vulnerability has been identified in the
-        GraphQL parser used by the API of s42.app. An attacker can overload the parser
-        and cause the API pod to crash. With a bit of threading, the attacker can
-        bring down the entire API, resulting in an unhealthy stream. This vulnerability
-        can be exploited by sending a specially crafted request to the API with a
-        large payload.\n\nAn attacker can exploit this vulnerability to cause a denial
-        of service (DoS) attack on the s42.app API, resulting in unavailability of
-        the API for legitimate users.", "docs_contact": "", "cf_last_closed": null,
-        "cf_internal_whiteboard": "", "comments": [{"is_private": false, "text": "A
-        security vulnerability has been identified in the GraphQL parser used by the
-        API of s42.app. An attacker can overload the parser and cause the API pod
-        to crash. With a bit of threading, the attacker can bring down the entire
-        API, resulting in an unhealthy stream. This vulnerability can be exploited
-        by sending a specially crafted request to the API with a large payload.\n\nAn
+      string: '{"faults": [], "bugs": [{"component": ["vulnerability-draft"], "target_release":
+        ["---"], "op_sys": "Linux", "deadline": null, "cf_release_notes": "", "creator":
+        "nobody@redhat.com", "cf_devel_whiteboard": "", "cf_internal_whiteboard":
+        "", "url": "", "cf_doc_type": "If docs needed, set a value", "id": 2298927,
+        "version": ["unspecified"], "external_bugs": [], "sub_components": {}, "qa_contact":
+        "", "summary": "Stud42 vulnerable to denial of service", "alias": ["GHSA-3hwm-922r-47hw"],
+        "groups": ["redhat"], "whiteboard": "", "flags": [], "cf_pgm_internal": "",
+        "status": "NEW", "docs_contact": "", "cf_last_closed": null, "resolution":
+        "", "cf_clone_of": null, "comments": [{"creation_time": "2024-08-14T12:44:46Z",
+        "creator_id": 425662, "private_groups": [], "time": "2024-08-14T12:44:46Z",
+        "text": "A security vulnerability has been identified in the GraphQL parser
+        used by the API of s42.app. An attacker can overload the parser and cause
+        the API pod to crash. With a bit of threading, the attacker can bring down
+        the entire API, resulting in an unhealthy stream. This vulnerability can be
+        exploited by sending a specially crafted request to the API with a large payload.\n\nAn
         attacker can exploit this vulnerability to cause a denial of service (DoS)
         attack on the s42.app API, resulting in unavailability of the API for legitimate
-        users.", "attachment_id": null, "creation_time": "2024-06-28T11:49:54Z", "bug_id":
-        2294454, "private_groups": [], "count": 0, "id": 18021215, "creator": "conrado@redhat.com",
-        "creator_id": 482384, "time": "2024-06-28T11:49:54Z", "tags": []}], "remaining_time":
-        0, "assigned_to_detail": {"name": "prodsec-dev@redhat.com", "partner": false,
-        "real_name": "Product Security DevOps Team", "id": 377884, "active": true,
-        "insider": true, "email": "prodsec-dev@redhat.com"}, "cf_environment": "",
-        "priority": "unspecified", "is_open": true, "cf_doc_type": "If docs needed,
-        set a value", "is_confirmed": true, "cf_conditional_nak": [], "flags": [],
-        "deadline": null, "cf_pm_score": "0", "target_release": ["---"], "groups":
-        ["redhat"], "cf_clone_of": null, "depends_on": [], "blocks": [], "platform":
-        "All"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:49:57 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '3903'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719575396.89fe4ed3
-      x-rh-edge-request-id:
-      - 89fe4ed3
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294454?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"faults": [], "bugs": [{"deadline": null, "cf_pm_score": "0", "platform":
-        "All", "target_release": ["---"], "groups": ["redhat"], "cf_clone_of": null,
-        "blocks": [], "depends_on": [], "description": "A security vulnerability has
-        been identified in the GraphQL parser used by the API of s42.app. An attacker
-        can overload the parser and cause the API pod to crash. With a bit of threading,
-        the attacker can bring down the entire API, resulting in an unhealthy stream.
-        This vulnerability can be exploited by sending a specially crafted request
-        to the API with a large payload.\n\nAn attacker can exploit this vulnerability
-        to cause a denial of service (DoS) attack on the s42.app API, resulting in
-        unavailability of the API for legitimate users.", "docs_contact": "", "cf_internal_whiteboard":
-        "", "comments": [{"creation_time": "2024-06-28T11:49:54Z", "bug_id": 2294454,
-        "is_private": false, "text": "A security vulnerability has been identified
-        in the GraphQL parser used by the API of s42.app. An attacker can overload
-        the parser and cause the API pod to crash. With a bit of threading, the attacker
-        can bring down the entire API, resulting in an unhealthy stream. This vulnerability
-        can be exploited by sending a specially crafted request to the API with a
-        large payload.\n\nAn attacker can exploit this vulnerability to cause a denial
-        of service (DoS) attack on the s42.app API, resulting in unavailability of
-        the API for legitimate users.", "attachment_id": null, "time": "2024-06-28T11:49:54Z",
-        "creator_id": 482384, "tags": [], "id": 18021215, "private_groups": [], "count":
-        0, "creator": "conrado@redhat.com"}], "cf_last_closed": null, "cf_release_notes":
-        "", "qa_contact": "", "summary": "Stud42 vulnerable to denial of service",
-        "creator_detail": {"email": "conrado@redhat.com", "insider": true, "active":
-        true, "id": 482384, "real_name": "Conrado Costa", "name": "conrado@redhat.com",
-        "partner": false}, "is_cc_accessible": true, "cf_doc_type": "If docs needed,
-        set a value", "is_confirmed": true, "cf_conditional_nak": [], "flags": [],
-        "remaining_time": 0, "assigned_to_detail": {"partner": false, "name": "prodsec-dev@redhat.com",
-        "real_name": "Product Security DevOps Team", "id": 377884, "active": true,
-        "email": "prodsec-dev@redhat.com", "insider": true}, "is_open": true, "cf_environment":
-        "", "priority": "unspecified", "id": 2294454, "version": ["unspecified"],
-        "external_bugs": [], "cf_devel_whiteboard": "", "tags": [], "severity": "unspecified",
-        "assigned_to": "prodsec-dev@redhat.com", "cf_fixed_in": "", "creation_time":
-        "2024-06-28T11:49:54Z", "cf_qe_conditional_nak": [], "last_change_time": "2024-06-28T11:49:54Z",
-        "resolution": "", "cc_detail": [], "data_category": "Red Hat", "component":
-        ["vulnerability-draft"], "creator": "conrado@redhat.com", "cc": [], "cf_cust_facing":
-        "---", "cf_pgm_internal": "", "url": "", "is_creator_accessible": true, "actual_time":
-        0, "cf_build_id": "", "whiteboard": "", "sub_components": {}, "status": "NEW",
-        "classification": "Other", "estimated_time": 0, "keywords": ["Security"],
-        "cf_major_incident": null, "alias": ["GHSA-3hwm-922r-47hw"], "cf_embargoed":
-        null, "cf_qa_whiteboard": "", "product": "Security Response", "dupe_of": null,
-        "cf_srtnotes": "{\"reported\": \"2024-06-28T11:49:42Z\", \"external_ids\":
-        [\"GHSA-3hwm-922r-47hw\"], \"references\": [{\"type\": \"source\", \"url\":
-        \"https://example.com/vulnerability/GHSA-3hwm-922r-47hw\", \"description\":
-        null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/issues/412\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17\",
-        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42\",
-        \"description\": null}], \"source\": \"osv\", \"cwe\": \"CWE-400\"}", "op_sys":
-        "Linux", "target_milestone": "---"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:49:58 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '3903'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719575397.89fe5ee6
-      x-rh-edge-request-id:
-      - 89fe5ee6
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294454/comment
-  response:
-    body:
-      string: '{"comments": {}, "bugs": {"2294454": {"comments": [{"creator_id": 482384,
-        "time": "2024-06-28T11:49:54Z", "tags": [], "creator": "conrado@redhat.com",
-        "private_groups": [], "count": 0, "id": 18021215, "bug_id": 2294454, "creation_time":
-        "2024-06-28T11:49:54Z", "is_private": false, "attachment_id": null, "text":
+        users.", "id": 18026778, "creator": "nobody@redhat.com", "is_private": false,
+        "count": 0, "tags": [], "attachment_id": null, "bug_id": 2298927}], "creator_detail":
+        {"active": true, "name": "nobody@redhat.com", "real_name": "nobody",
+        "id": 425662, "insider": true, "email": "nobody@redhat.com", "partner":
+        false}, "platform": "All", "is_open": true, "keywords": ["Security"], "classification":
+        "Other", "is_cc_accessible": true, "depends_on": [], "cf_pm_score": "0", "estimated_time":
+        0, "cf_conditional_nak": [], "cf_fixed_in": "", "cf_environment": "", "creation_time":
+        "2024-08-14T12:44:46Z", "cf_embargoed": null, "assigned_to_detail": {"active":
+        true, "name": "prodsec-dev@redhat.com", "real_name": "Product Security DevOps
+        Team", "id": 377884, "email": "prodsec-dev@redhat.com", "insider": true, "partner":
+        false}, "target_milestone": "---", "cf_qa_whiteboard": "", "description":
         "A security vulnerability has been identified in the GraphQL parser used by
         the API of s42.app. An attacker can overload the parser and cause the API
         pod to crash. With a bit of threading, the attacker can bring down the entire
@@ -1391,7 +1238,179 @@ interactions:
         by sending a specially crafted request to the API with a large payload.\n\nAn
         attacker can exploit this vulnerability to cause a denial of service (DoS)
         attack on the s42.app API, resulting in unavailability of the API for legitimate
-        users."}]}}}'
+        users.", "cc_detail": [], "cf_qe_conditional_nak": [], "dupe_of": null, "assigned_to":
+        "prodsec-dev@redhat.com", "cf_major_incident": null, "cf_cust_facing": "---",
+        "is_creator_accessible": true, "remaining_time": 0, "priority": "unspecified",
+        "last_change_time": "2024-08-14T12:44:46Z", "cf_srtnotes": "{\"public\": \"2023-03-31T19:33:44Z\",
+        \"reported\": \"2024-08-14T12:44:41Z\", \"external_ids\": [\"GHSA-3hwm-922r-47hw\"],
+        \"references\": [{\"type\": \"source\", \"url\": \"https://example.com/vulnerability/GHSA-3hwm-922r-47hw\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/issues/412\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42\",
+        \"description\": null}], \"source\": \"osv\", \"cwe\": \"CWE-400\"}", "product":
+        "Security Response", "tags": [], "cc": [], "blocks": [], "data_category":
+        "Red Hat", "actual_time": 0, "is_confirmed": true, "cf_build_id": "", "severity":
+        "unspecified"}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Aug 2024 12:44:49 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '3947'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.4b071002.1723639488.196bc8ba
+      x-rh-edge-request-id:
+      - 196bc8ba
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2298927?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
+  response:
+    body:
+      string: '{"faults": [], "bugs": [{"cf_qe_conditional_nak": [], "cf_internal_whiteboard":
+        "", "external_bugs": [], "cf_environment": "", "cf_devel_whiteboard": "",
+        "cf_release_notes": "", "version": ["unspecified"], "actual_time": 0, "creator":
+        "nobody@redhat.com", "keywords": ["Security"], "product": "Security Response",
+        "component": ["vulnerability-draft"], "summary": "Stud42 vulnerable to denial
+        of service", "whiteboard": "", "cc_detail": [], "cf_conditional_nak": [],
+        "url": "", "priority": "unspecified", "cf_clone_of": null, "cf_pgm_internal":
+        "", "cf_srtnotes": "{\"public\": \"2023-03-31T19:33:44Z\", \"reported\": \"2024-08-14T12:44:41Z\",
+        \"external_ids\": [\"GHSA-3hwm-922r-47hw\"], \"references\": [{\"type\": \"source\",
+        \"url\": \"https://example.com/vulnerability/GHSA-3hwm-922r-47hw\", \"description\":
+        null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/security/advisories/GHSA-3hwm-922r-47hw\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/issues/412\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42/commit/a70bfc72fba721917bf681d72a58093fb9deee17\",
+        \"description\": null}, {\"type\": \"external\", \"url\": \"https://example.com/42Atomys/stud42\",
+        \"description\": null}], \"source\": \"osv\", \"cwe\": \"CWE-400\"}", "flags":
+        [], "creation_time": "2024-08-14T12:44:46Z", "sub_components": {}, "depends_on":
+        [], "resolution": "", "assigned_to_detail": {"email": "prodsec-dev@redhat.com",
+        "name": "prodsec-dev@redhat.com", "partner": false, "insider": true, "id":
+        377884, "real_name": "Product Security DevOps Team", "active": true}, "blocks":
+        [], "is_open": true, "cf_pm_score": "0", "comments": [{"creator": "nobody@redhat.com",
+        "creation_time": "2024-08-14T12:44:46Z", "is_private": false, "private_groups":
+        [], "id": 18026778, "time": "2024-08-14T12:44:46Z", "bug_id": 2298927, "text":
+        "A security vulnerability has been identified in the GraphQL parser used by
+        the API of s42.app. An attacker can overload the parser and cause the API
+        pod to crash. With a bit of threading, the attacker can bring down the entire
+        API, resulting in an unhealthy stream. This vulnerability can be exploited
+        by sending a specially crafted request to the API with a large payload.\n\nAn
+        attacker can exploit this vulnerability to cause a denial of service (DoS)
+        attack on the s42.app API, resulting in unavailability of the API for legitimate
+        users.", "tags": [], "count": 0, "attachment_id": null, "creator_id": 425662}],
+        "id": 2298927, "assigned_to": "prodsec-dev@redhat.com", "target_release":
+        ["---"], "cf_last_closed": null, "cc": [], "deadline": null, "dupe_of": null,
+        "qa_contact": "", "last_change_time": "2024-08-14T12:44:46Z", "groups": ["redhat"],
+        "cf_embargoed": null, "creator_detail": {"real_name": "nobody", "id":
+        425662, "active": true, "email": "nobody@redhat.com", "name": "nobody@redhat.com",
+        "partner": false, "insider": true}, "estimated_time": 0, "op_sys": "Linux",
+        "cf_fixed_in": "", "severity": "unspecified", "cf_build_id": "", "target_milestone":
+        "---", "classification": "Other", "cf_major_incident": null, "cf_qa_whiteboard":
+        "", "is_cc_accessible": true, "description": "A security vulnerability has
+        been identified in the GraphQL parser used by the API of s42.app. An attacker
+        can overload the parser and cause the API pod to crash. With a bit of threading,
+        the attacker can bring down the entire API, resulting in an unhealthy stream.
+        This vulnerability can be exploited by sending a specially crafted request
+        to the API with a large payload.\n\nAn attacker can exploit this vulnerability
+        to cause a denial of service (DoS) attack on the s42.app API, resulting in
+        unavailability of the API for legitimate users.", "remaining_time": 0, "platform":
+        "All", "is_confirmed": true, "is_creator_accessible": true, "cf_doc_type":
+        "If docs needed, set a value", "tags": [], "status": "NEW", "data_category":
+        "Red Hat", "alias": ["GHSA-3hwm-922r-47hw"], "cf_cust_facing": "---", "docs_contact":
+        ""}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Wed, 14 Aug 2024 12:44:51 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      Vary:
+      - Accept-Encoding
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      content-length:
+      - '3947'
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.4b071002.1723639489.196bd51d
+      x-rh-edge-request-id:
+      - 196bd51d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.2.0
+    method: GET
+    uri: https://example.com/rest/bug/2298927/comment
+  response:
+    body:
+      string: '{"comments": {}, "bugs": {"2298927": {"comments": [{"private_groups":
+        [], "creator_id": 425662, "text": "A security vulnerability has been identified
+        in the GraphQL parser used by the API of s42.app. An attacker can overload
+        the parser and cause the API pod to crash. With a bit of threading, the attacker
+        can bring down the entire API, resulting in an unhealthy stream. This vulnerability
+        can be exploited by sending a specially crafted request to the API with a
+        large payload.\n\nAn attacker can exploit this vulnerability to cause a denial
+        of service (DoS) attack on the s42.app API, resulting in unavailability of
+        the API for legitimate users.", "id": 18026778, "time": "2024-08-14T12:44:46Z",
+        "creation_time": "2024-08-14T12:44:46Z", "attachment_id": null, "bug_id":
+        2298927, "tags": [], "is_private": false, "count": 0, "creator": "nobody@redhat.com"}]}}}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -1402,11 +1421,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '834'
+      - '835'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:49:58 GMT
+      - Wed, 14 Aug 2024 12:44:52 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -1416,9 +1435,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719575398.89fe759b
+      - 0.4b071002.1723639491.196beb58
       x-rh-edge-request-id:
-      - 89fe759b
+      - 196beb58
     status:
       code: 200
       message: OK

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -37,10 +37,11 @@ class TestOSVCollector:
 
         assert Flaw.objects.count() == 1
         flaw = Flaw.objects.all().first()
-        assert flaw.task_key == "OSIM-16311"
+        assert flaw.task_key == "OSIM-7503"
         assert json.loads(flaw.meta_attr["alias"]) == [cve_id]
         assert json.loads(flaw.meta_attr["external_ids"]) == [f"{osv_id}/{cve_id}"]
         assert flaw.reported_dt
+        assert flaw.unembargo_dt
 
     @pytest.mark.vcr
     @pytest.mark.default_cassette("TestOSVCollector.test_collect_osv_record.yaml")
@@ -78,7 +79,7 @@ class TestOSVCollector:
         assert Flaw.objects.count() == 1
         flaw = Flaw.objects.first()
         assert flaw.cve_id is None
-        assert flaw.task_key == "OSIM-497"
+        assert flaw.task_key == "OSIM-7509"
         assert json.loads(flaw.meta_attr["alias"]) == [osv_id]
         assert json.loads(flaw.meta_attr["external_ids"]) == [osv_id]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Saving models only triggers validations once (OSIDB-3108)
 - Update ACLs of linked objects to match collector flaw (OSIDB-3253)
 - Allow start dates to come from multiple sources in SLA (OSIDB-3221)
+- Update public date for collector flaws (OSIDB-3212)
 
 ### Fixed
 - Cannot modify CVE of existing flaws (OSIDB-3102)

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -522,7 +522,7 @@ class SnippetFactory(factory.django.DjangoModelFactory):
             ],
             "source": self.source,
             "title": f"From {self.source} collector",
-            f"published_in_{self.source.lower()}": "2024-01-21T16:29:00.393Z",
+            "unembargo_dt": "2024-01-21T16:29:00.393Z",
         }
 
         return data

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -64,9 +64,11 @@ class TestSnippet:
         assert flaw.meta_attr == {"external_ids": content["cve_id"]}
         assert flaw.references.count() == 1
         assert flaw.reported_dt
+        assert flaw.reported_dt == flaw.created_dt
         assert flaw.snippets.count() == 1
         assert flaw.source == snippet.source
         assert flaw.title == content["title"]
+        assert flaw.unembargo_dt
         assert flaw.workflow_state == WorkflowModel.WorkflowState.NOVALUE
 
         flaw_cvss = flaw.cvss_scores.all().first()


### PR DESCRIPTION
This PR updates the `unembargo_dt` field to match the date when a collector flaw was published in its respective source (NVD or OSV) because these sources are public.

Closes OSIDB-3212