### PR TITLE
Fix SLA data migration

### DIFF
--- a/apps/sla/migrations/0002_alter_sla_start_dates.py
+++ b/apps/sla/migrations/0002_alter_sla_start_dates.py
@@ -8,7 +8,7 @@ from django.db import migrations, models
 def convert_array_to_json(apps, schema_editor):
     SLA = apps.get_model("sla", "SLA")
     for instance in SLA.objects.all():
-        instance.temp_json_field = json.dumps(instance.start_dates)
+        instance.temp_json_field["flaw"] = instance.start_dates
         instance.save()
 
 

--- a/collectors/ps_constants/core.py
+++ b/collectors/ps_constants/core.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.db import transaction
 from requests_gssapi import HTTPSPNEGOAuth
 
-from apps.sla.models import SLAPolicy
+from apps.sla.models import SLA, SLAPolicy
 from osidb.models import (
     CompliancePriority,
     ContractPriority,
@@ -102,6 +102,7 @@ def sync_sla_policies(sla_policies):
     """
     Sync SLA policy data
     """
+    SLA.objects.all().delete()
     SLAPolicy.objects.all().delete()
     for order, policy_desc in enumerate(sla_policies):
         # In SLA policies order is important so it is passed down to the model


### PR DESCRIPTION
The start_dates field was incorrectly being migrated as it was converted into a string instead of a dict. Additionally, properly clean up the old SLAs in the collector.

Closes OSIDB-3276.