### PR TITLE
OSIDB-3281: Move DEFER from historical to current possible affect resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ tests/htmlcov
 .vscode/
 *.db.gz
 osidb_data_backup_dump*
+.DS_Store

--- a/apps/trackers/tests/test_file_offer.py
+++ b/apps/trackers/tests/test_file_offer.py
@@ -40,7 +40,21 @@ class TestTrackerSuggestions:
                 Affect.AffectResolution.WONTFIX,
                 False,
             ),
-            (Affect.AffectAffectedness.NEW, Affect.AffectResolution.WONTFIX, False),
+            (
+                Affect.AffectAffectedness.NEW,
+                Affect.AffectResolution.WONTFIX,
+                False,
+            ),
+            (
+                Affect.AffectAffectedness.AFFECTED,
+                Affect.AffectResolution.DEFER,
+                False,
+            ),
+            (
+                Affect.AffectAffectedness.NEW,
+                Affect.AffectResolution.DEFER,
+                False,
+            ),
         ],
     )
     def test_trackers_file_offer_invalid(

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -253,6 +253,11 @@ class TestCheck:
             ),
             (
                 Affect.AffectAffectedness.NEW,
+                Affect.AffectResolution.DEFER,
+                False,
+            ),
+            (
+                Affect.AffectAffectedness.NEW,
                 Affect.AffectResolution.OOSS,
                 False,
             ),
@@ -264,6 +269,11 @@ class TestCheck:
             (
                 Affect.AffectAffectedness.AFFECTED,
                 Affect.AffectResolution.WONTFIX,
+                False,
+            ),
+            (
+                Affect.AffectAffectedness.AFFECTED,
+                Affect.AffectResolution.DEFER,
                 False,
             ),
             (
@@ -298,6 +308,7 @@ class TestCheck:
 
         affect = AffectFactory(
             flaw=flaw,
+            impact=Impact.LOW,
             affectedness=affectedness,
             resolution=resolution,
         )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use OSIDB Bugzilla service account API key for majority of bzsync
   instead of user ones (OSIDB-3261)
 - Adjust synchronous bzsync to only work one-way
+- Move DEFER from historical to current possible affect resolution (OSIDB-3281)
 
 ### Fixed
 - Cannot modify CVE of existing flaws (OSIDB-3102)

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -61,11 +61,13 @@ SERVICES_PRODUCTS = [
 AFFECTEDNESS_VALID_RESOLUTIONS = {
     Affect.AffectAffectedness.NEW: [
         Affect.AffectResolution.NOVALUE,
+        Affect.AffectResolution.DEFER,
         Affect.AffectResolution.WONTFIX,
         Affect.AffectResolution.OOSS,
     ],
     Affect.AffectAffectedness.AFFECTED: [
         Affect.AffectResolution.DELEGATED,
+        Affect.AffectResolution.DEFER,
         Affect.AffectResolution.WONTFIX,
         Affect.AffectResolution.OOSS,
     ],
@@ -77,12 +79,9 @@ AFFECTEDNESS_VALID_RESOLUTIONS = {
 
 # Historical affectedness/resolution combinations that were valid in the past
 AFFECTEDNESS_HISTORICAL_VALID_RESOLUTIONS = {
-    Affect.AffectAffectedness.NEW: [
-        Affect.AffectResolution.DEFER,
-    ],
+    Affect.AffectAffectedness.NEW: [],
     Affect.AffectAffectedness.AFFECTED: [
         Affect.AffectResolution.FIX,
-        Affect.AffectResolution.DEFER,
         Affect.AffectResolution.WONTREPORT,
     ],
     Affect.AffectAffectedness.NOTAFFECTED: [],

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -294,7 +294,12 @@ class AffectFactory(BaseFactory):
     )
     ps_module = factory.sequence(lambda n: f"ps-module-{n}")
     ps_component = factory.sequence(lambda n: f"ps-component-{n}")
-    impact = factory.Faker("random_element", elements=list(Impact))
+    impact = factory.Faker(
+        "random_element",
+        elements=filter(lambda i: i != "LOW", list(Impact))
+        if resolution == "DEFER"
+        else list(Impact),
+    )
 
     created_dt = factory.Faker("date_time", tzinfo=UTC)
     updated_dt = factory.Faker("date_time", tzinfo=UTC)


### PR DESCRIPTION
Move DEFER from historical to current possible affect resolution, disallows filing trackers for such affects.

Closes OSIDB-3290. Closes OSIDB-3330. 