### PR TITLE
add delay between Jira metadata fetch calls to prevent rate limiting

### DIFF
--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -2,6 +2,7 @@
 Jira collector
 """
 
+from time import sleep
 from typing import List, Optional, Union
 
 from celery.utils.log import get_task_logger
@@ -292,6 +293,10 @@ class MetadataCollector(Collector):
                 start_at = 0
                 is_last = False
                 try:
+                    # here we repeatedly hit the rate limiting probably by firing the requrests too
+                    # fast after each other so let us introduce a short delay - there is no danger
+                    # of race condition as this collector is the only code writing this metadata
+                    sleep(1)
                     if project not in project_fields:
                         project_fields[project] = []
                     while not is_last:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Jira metadata collector is not deleting metadata on failure (OSIDB-3219)
 - Avoid deadlocks by not triggering nested validations in m2m relationships (OSIDB-3244)
 - Manually run validation avoiding duplicated trackers (OSIDB-3234)
+- Add delay between Jira metadata fetch calls to prevent rate limiting (OSIDB-3298)
 
 ## [4.1.6] - 2024-08-02
 ### Fixed


### PR DESCRIPTION
I was not able to reproduce this locally but on the production it hits the rate limit all the time. I tried the code there with and without this delay and it fixes the issue. It will make the collector run to last currently about 2 minutes longer which is no big deal. It will not cause any race conditions as this collector is the only code writing the Jira metadata and it runs once every 3 hours.

Closes OSIDB-3298