### PR TITLE
Alert when Bugzilla sync failed

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Update Vulnerability trackers on components change (OSIDB-3323)
 
+### Changed
+- Alert users when Bugzilla sync failed (OSIDB-3252)
+
 ## [4.3.2] - 2024-09-19
 ### Changed
 - Update the release documentation (OSIDB-3384)


### PR DESCRIPTION
Now that bzsync can be asynchronous, it can be the case that the flaw is correctly saved, but the sync to Bugzilla failed for some reason. In this scenario, there may be data discrepancies between OSIDB and Bugzilla, and as of now, there is no way for the user to know this happened.

With this commit, when there is an error during bzsync, an alert is raised on the flaw, so that the user knows that there may be data not synced to Bugzilla.

Closes OSIDB-3361.