### PR TITLE
show only official collectors at the collector status endpoint

### DIFF
--- a/collectors/framework/api.py
+++ b/collectors/framework/api.py
@@ -116,7 +116,9 @@ class status(RudimentaryUserPathLoggingMixin, APIView):
                         "state": collector.collector_state,
                         "updated_until": collector.updated_until_dt,
                     }
+                    # the official collectors are always in the tasks directory
                     for name, collector in CollectorFramework.collectors().items()
+                    if "tasks" in name
                 },
             }
         )

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update public date for collector flaws (OSIDB-3212)
 - Tracker collector ignores up-to-date entries (OSIDB-3244)
 - Adjust BBSync to work in one-way mode (OSIDB-3251)
+- Show only official collectors at the collector status endpoint
 
 ### Fixed
 - Cannot modify CVE of existing flaws (OSIDB-3102)


### PR DESCRIPTION
small adjustment to fix notification service and hide unnecessary random manually created collectors