### PR TITLE
implement validation of PS module and PS update stream correspondance

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -354,7 +354,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1323,
+        "line_number": 1344,
         "is_secret": false
       }
     ],
@@ -384,7 +384,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_unembargo.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 74,
         "is_secret": false
       }
     ],
@@ -394,7 +394,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_update_trackers.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 88,
         "is_secret": false
       }
     ],
@@ -404,7 +404,7 @@
         "filename": "osidb/tests/endpoints/test_affects.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 73,
+        "line_number": 74,
         "is_secret": false
       }
     ],
@@ -467,5 +467,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-14T12:56:35Z"
+  "generated_at": "2024-10-21T03:57:39Z"
 }

--- a/apps/bbsync/tests/test_query.py
+++ b/apps/bbsync/tests/test_query.py
@@ -15,6 +15,7 @@ from osidb.tests.factories import (
     PackageFactory,
     PackageVerFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     SnippetFactory,
     TrackerFactory,
 )
@@ -281,9 +282,11 @@ class TestGenerateGroups:
                 ]
             },
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.is_embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -309,9 +312,11 @@ class TestGenerateGroups:
                 ]
             },
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.is_embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -341,9 +346,11 @@ class TestGenerateGroups:
                 ]
             },
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.is_embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -372,9 +379,11 @@ class TestGenerateGroups:
                 ]
             },
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.is_embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -409,9 +418,11 @@ class TestGenerateGroups:
                 ]
             },
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.is_embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 

--- a/apps/sla/tests/test_framework.py
+++ b/apps/sla/tests/test_framework.py
@@ -8,6 +8,7 @@ from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -191,9 +192,11 @@ sla:
                 resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 
@@ -269,9 +272,11 @@ sla:
                 ps_module=ps_module.name,
                 ps_component=affect1.ps_component,
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect1, affect2],
                 embargoed=flaw1.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 

--- a/apps/sla/tests/test_models.py
+++ b/apps/sla/tests/test_models.py
@@ -327,9 +327,11 @@ class TestSLA:
                 resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
             for attribute, value in context.get("tracker", {}):
@@ -730,9 +732,11 @@ class TestSLAPolicy:
                 ps_module=ps_module.name,
                 impact=Impact.MODERATE,
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 
@@ -803,9 +807,11 @@ class TestSLAPolicy:
                 ps_component="dnf",
                 impact=Impact.LOW,
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect1, affect2],
                 embargoed=flaw1.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 
@@ -864,9 +870,11 @@ class TestSLAPolicy:
                 resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 
@@ -928,9 +936,11 @@ class TestSLAPolicy:
                 ps_module=ps_module.name,
                 ps_component="dnf",
             )
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect1, affect2],
                 embargoed=flaw1.embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 

--- a/apps/trackers/tests/test_bugzilla.py
+++ b/apps/trackers/tests/test_bugzilla.py
@@ -109,9 +109,11 @@ class TestTrackerBugzillaQueryBuilder:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
 

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -180,8 +180,10 @@ class TestOldTrackerJiraQueryBuilder:
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect1],
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.JIRA,
             embargoed=flaw1.is_embargoed,
         )
@@ -2212,9 +2214,11 @@ class TestOldTrackerJiraQueryBuilderSla:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
 
@@ -2311,9 +2315,11 @@ class TestTrackerJiraQueryBuilderSla:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
 

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -11,6 +11,7 @@ from osidb.tests.factories import (
     FlawReferenceFactory,
     PackageFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -168,8 +169,12 @@ class TestCheck:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
-            affects=[affect], embargoed=False, type=Tracker.TrackerType.BUGZILLA
+            affects=[affect],
+            embargoed=False,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.BUGZILLA,
         )
 
         check = Check("aggregated impact is low", cls=Tracker)

--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -210,9 +210,11 @@ class TestBugzillaTrackerCollector:
             ps_component="jhead",
         )
         creation_dt = datetime(2011, 1, 1, tzinfo=timezone.utc)
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory.create(
             affects=(affect,),
             external_system_id="1629664",
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
             embargoed=affect.flaw.is_embargoed,
             created_dt=creation_dt,
@@ -301,9 +303,11 @@ class TestBugzillaTrackerCollector:
             ps_component="novnc",
         )
 
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect1, affect2],
             external_system_id="1765663",
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
             embargoed=False,
             updated_dt=timezone.datetime.strptime("1970-01-01T00:00:00Z", BZ_DT_FMT),

--- a/collectors/errata/tests/test_core.py
+++ b/collectors/errata/tests/test_core.py
@@ -7,6 +7,7 @@ from osidb.tests.factories import (
     AffectFactory,
     ErratumFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -120,16 +121,20 @@ class TestErrataToolCollection:
             resolution=Affect.AffectResolution.DELEGATED,
         )
 
+        ps_update_stream1 = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory.create(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
             external_system_id="2021161",
+            ps_update_stream=ps_update_stream1.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
+        ps_update_stream2 = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory.create(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
             external_system_id="2021168",
+            ps_update_stream=ps_update_stream2.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
         link_bugs_to_errata(
@@ -178,30 +183,38 @@ class TestErrataToolCollection:
             resolution=Affect.AffectResolution.DELEGATED,
         )
 
+        ps_update_stream11 = PsUpdateStreamFactory(ps_module=ps_module1)
         TrackerFactory.create(
             affects=[affect1],
             embargoed=affect1.flaw.embargoed,
             external_system_id="2021161",
+            ps_update_stream=ps_update_stream11.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
+        ps_update_stream12 = PsUpdateStreamFactory(ps_module=ps_module1)
         TrackerFactory.create(
             affects=[affect1],
             embargoed=affect1.flaw.embargoed,
             external_system_id="2021168",
+            ps_update_stream=ps_update_stream12.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
 
         # extra trackers
+        ps_update_stream13 = PsUpdateStreamFactory(ps_module=ps_module1)
         bugzilla_tracker = TrackerFactory.create(
             affects=[affect1],
             embargoed=affect1.flaw.embargoed,
             external_system_id="7",
+            ps_update_stream=ps_update_stream13.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
+        ps_update_stream2 = PsUpdateStreamFactory(ps_module=ps_module2)
         jira_tracker = TrackerFactory.create(
             affects=[affect2],
             embargoed=affect2.flaw.embargoed,
             external_system_id="PROJECT-7",
+            ps_update_stream=ps_update_stream2.name,
             type=Tracker.TrackerType.JIRA,
         )
 
@@ -250,10 +263,12 @@ class TestErrataToolCollection:
         )
 
         # The test uses the same code as above, but no errata I've checked have both Bugzilla and Jira trackers
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory.create(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
             external_system_id="LOG-2064",
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.JIRA,
         )
         link_bugs_to_errata(
@@ -348,16 +363,20 @@ class TestErrataToolCollection:
             resolution=Affect.AffectResolution.DELEGATED,
         )
 
+        ps_update_stream1 = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory.create(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
             external_system_id="2021161",
+            ps_update_stream=ps_update_stream1.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
+        ps_update_stream2 = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory.create(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
             external_system_id="2021168",
+            ps_update_stream=ps_update_stream2.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
 

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -269,11 +269,13 @@ class TestJiraTrackerCollector:
             ps_module=ps_module.name,
         )
         tracker_id = "ENTMQ-755"
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             type=Tracker.TrackerType.JIRA,
             embargoed=affect.flaw.embargoed,
             external_system_id=tracker_id,
+            ps_update_stream=ps_update_stream.name,
             status="New",
             resolution=None,
             # collector only modify trackers

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Add new flaw reference type "UPSTREAM"
+- Implement validation of PS module and PS update stream correspondance (OSIDB-3584)
 
 ### Changed
 - Check title for keywords in CVEorg collector (OSIDB-3545)

--- a/osidb/models/tracker.py
+++ b/osidb/models/tracker.py
@@ -275,6 +275,31 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
                 "Tracker must be associated with a valid PS update stream"
             )
 
+    def _validate_tracker_ps_module_ps_update_stream(self, **kwargs):
+        """
+        check that the tracker is associated with a PS update stream corresponding to its PS module
+        """
+        if not self.affects.exists():
+            return
+
+        ps_module = PsModule.objects.filter(name=self.affects.first().ps_module).first()
+        # PS module is checked by a different validation
+        if not ps_module:
+            return
+
+        ps_update_stream = PsUpdateStream.objects.filter(
+            name=self.ps_update_stream
+        ).first()
+        # PS update stream is checked by a different validation
+        if not ps_update_stream:
+            return
+
+        if ps_update_stream not in ps_module.ps_update_streams.all():
+            raise ValidationError(
+                f"PS update stream {ps_update_stream.name} does "
+                f"not belong to PS module {ps_module.name}."
+            )
+
     def _validate_tracker_flaw_accesses(self, **kwargs):
         """
         Check whether an public tracker is associated with an embargoed flaw.

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -353,9 +353,11 @@ class TestEndpointsFlaws:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=(affect,),
             embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
         )
         future_dt = datetime(2021, 11, 27)
@@ -450,9 +452,11 @@ class TestEndpointsFlaws:
             resolution=Affect.AffectResolution.DELEGATED,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=(affect,),
             embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
             type=Tracker.TrackerType.BUGZILLA,
         )
@@ -538,15 +542,18 @@ class TestEndpointsFlaws:
             resolution=Affect.AffectResolution.DELEGATED,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker1 = TrackerFactory(
             affects=(affect1,),
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
             type=Tracker.TrackerType.BUGZILLA,
         )
         tracker2 = TrackerFactory(
             affects=(affect2,),
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             updated_dt=datetime(2021, 11, 23, tzinfo=timezone.utc),
             type=Tracker.TrackerType.BUGZILLA,
         )
@@ -683,6 +690,7 @@ class TestEndpointsFlaws:
         assert body["count"] == 0
 
         ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         flaw = FlawFactory()
         for _ in range(5):
             affect = AffectFactory(
@@ -694,6 +702,7 @@ class TestEndpointsFlaws:
             TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.is_embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
 
@@ -733,6 +742,7 @@ class TestEndpointsFlaws:
         assert body["count"] == 0
 
         ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         flaw = FlawFactory()
         for _ in range(5):
             affect = AffectFactory(
@@ -744,6 +754,7 @@ class TestEndpointsFlaws:
             TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.is_embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
 
@@ -793,6 +804,7 @@ class TestEndpointsFlaws:
         assert body["count"] == 0
 
         ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         flaw = FlawFactory()
         for _ in range(5):
             affect = AffectFactory(
@@ -804,6 +816,7 @@ class TestEndpointsFlaws:
             TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.is_embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
 
@@ -840,6 +853,7 @@ class TestEndpointsFlaws:
         assert body["count"] == 0
 
         ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         flaw = FlawFactory()
         for _ in range(5):
             affect = AffectFactory(
@@ -851,6 +865,7 @@ class TestEndpointsFlaws:
             TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.is_embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
 
@@ -1047,6 +1062,7 @@ class TestEndpointsFlaws:
 
         for _ in range(2):
             ps_module = PsModuleFactory(bts_name="bugzilla")
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             flaw = FlawFactory(meta_attr={f"test_key_{i}": "test" for i in range(5)})
             for _ in range(3):
                 affect = AffectFactory(
@@ -1060,6 +1076,7 @@ class TestEndpointsFlaws:
                     affects=[affect],
                     embargoed=flaw.is_embargoed,
                     meta_attr={f"test_key_{i}": "test" for i in range(5)},
+                    ps_update_stream=ps_update_stream.name,
                     type=Tracker.TrackerType.BUGZILLA,
                 )
 
@@ -1156,6 +1173,7 @@ class TestEndpointsFlaws:
         """retrieve specific flaw with various meta_attr keys in nested serializers"""
 
         ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         flaw = FlawFactory(meta_attr={f"test_key_{i}": "test" for i in range(5)})
         for _ in range(3):
             affect = AffectFactory(
@@ -1169,6 +1187,7 @@ class TestEndpointsFlaws:
                 affects=[affect],
                 embargoed=flaw.is_embargoed,
                 meta_attr={f"test_key_{i}": "test" for i in range(5)},
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
 
@@ -1224,7 +1243,9 @@ class TestEndpointsFlaws:
 
     def test_flaw_including_delegated_resolution(self, auth_client, test_api_uri):
         ps_module = PsModuleFactory(bts_name="bugzilla")
-        PsUpdateStreamFactory(name="rhel-7.0", active_to_ps_module=ps_module)
+        PsUpdateStreamFactory(
+            name="rhel-7.0", active_to_ps_module=ps_module, ps_module=ps_module
+        )
         flaw = FlawFactory()
         delegated_affect = AffectFactory(
             flaw=flaw,
@@ -1684,10 +1705,12 @@ class TestEndpointsFlaws:
             for _ in range(5)
         ]
 
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         trackers_to_fetch = [
             TrackerFactory(
                 affects=[affects_with_trackers_to_fetch[idx]],
                 embargoed=flaw.is_embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
             for idx in range(5)
@@ -1696,6 +1719,7 @@ class TestEndpointsFlaws:
             TrackerFactory(
                 affects=[other_affects[idx]],
                 embargoed=flaw.is_embargoed,
+                ps_update_stream=ps_update_stream.name,
                 type=Tracker.TrackerType.BUGZILLA,
             )
 

--- a/osidb/tests/endpoints/flaws/test_unembargo.py
+++ b/osidb/tests/endpoints/flaws/test_unembargo.py
@@ -26,6 +26,7 @@ from osidb.tests.factories import (
     FlawReferenceFactory,
     PackageFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -108,19 +109,24 @@ class TestEndpointsFlawsUnembargo:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream1 = PsUpdateStreamFactory(ps_module=ps_module)
+        ps_update_stream2 = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect1],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream1.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
         TrackerFactory(
             affects=[affect1],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream2.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
         TrackerFactory(
             affects=[affect2],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream1.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -197,9 +203,11 @@ class TestEndpointsFlawsUnembargo:
             ps_module=ps_module.name,
             ps_component=affect1.ps_component,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect1, affect2],
             embargoed=flaw1.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 

--- a/osidb/tests/endpoints/flaws/test_update_trackers.py
+++ b/osidb/tests/endpoints/flaws/test_update_trackers.py
@@ -11,6 +11,7 @@ from osidb.tests.factories import (
     FlawFactory,
     PsModuleFactory,
     PsProductFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -36,15 +37,19 @@ class TestEndpointsFlawsUpdateTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module1.name,
         )
+        ps_update_stream11 = PsUpdateStreamFactory(ps_module=ps_module1)
         tracker1 = TrackerFactory(
             affects=[affect1],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream11.name,
             status="NEW",
             type=Tracker.BTS2TYPE[ps_module1.bts_name],
         )
+        ps_update_stream12 = PsUpdateStreamFactory(ps_module=ps_module1)
         TrackerFactory(
             affects=[affect1],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream12.name,
             status="CLOSED",  # already resolved
             type=Tracker.BTS2TYPE[ps_module1.bts_name],
         )
@@ -57,9 +62,11 @@ class TestEndpointsFlawsUpdateTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module2.name,
         )
+        ps_update_stream2 = PsUpdateStreamFactory(ps_module=ps_module2)
         TrackerFactory(
             affects=[affect2],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream2.name,
             status="NEW",
             type=Tracker.BTS2TYPE[ps_module2.bts_name],
         )
@@ -189,9 +196,11 @@ class TestEndpointsFlawsUpdateTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
             meta_attr=tracker_meta_attr,
         )

--- a/osidb/tests/endpoints/test_affects.py
+++ b/osidb/tests/endpoints/test_affects.py
@@ -10,6 +10,7 @@ from osidb.tests.factories import (
     FlawFactory,
     PsModuleFactory,
     PsProductFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -445,15 +446,19 @@ class TestEndpointsAffectsUpdateTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module1.name,
         )
+        ps_update_stream11 = PsUpdateStreamFactory(ps_module=ps_module1)
         tracker1 = TrackerFactory(
             affects=[affect1],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream11.name,
             status="NEW",
             type=Tracker.BTS2TYPE[ps_module1.bts_name],
         )
+        ps_update_stream12 = PsUpdateStreamFactory(ps_module=ps_module1)
         TrackerFactory(
             affects=[affect1],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream12.name,
             status="CLOSED",  # already resolved
             type=Tracker.BTS2TYPE[ps_module1.bts_name],
         )
@@ -467,9 +472,11 @@ class TestEndpointsAffectsUpdateTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module2.name,
         )
+        ps_update_stream2 = PsUpdateStreamFactory(ps_module=ps_module2)
         TrackerFactory(
             affects=[affect2],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream2.name,
             status="NEW",
             type=Tracker.BTS2TYPE[ps_module2.bts_name],
         )
@@ -536,9 +543,11 @@ class TestEndpointsAffectsUpdateTrackers:
             ps_module=ps_module.name,
             **to_create,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -575,9 +584,11 @@ class TestEndpointsAffectsUpdateTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         TrackerFactory(
             affects=[affect],
             embargoed=flaw1.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 

--- a/osidb/tests/endpoints/test_trackers.py
+++ b/osidb/tests/endpoints/test_trackers.py
@@ -151,9 +151,11 @@ class TestEndpointsTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
         response = auth_client().get(f"{test_api_uri}/trackers/{tracker.uuid}")
@@ -191,9 +193,11 @@ class TestEndpointsTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect1],
             embargoed=affect1.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -230,9 +234,11 @@ class TestEndpointsTrackers:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
         tracker_url = f"{test_api_uri}/trackers/{tracker.uuid}"

--- a/osidb/tests/test_factories.py
+++ b/osidb/tests/test_factories.py
@@ -9,6 +9,7 @@ from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
     PsModuleFactory,
+    PsUpdateStreamFactory,
     TrackerFactory,
 )
 
@@ -32,9 +33,11 @@ class TestTrackerFactory:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_module=ps_module.name,
         )
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
             created_dt="2000-10-10T00:00:00Z",
             updated_dt="2000-10-10T00:00:00Z",

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -59,10 +59,12 @@ class TestTracker:
         )
 
         ps_module = PsModuleFactory(name=affect1.ps_module)
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
 
         tracker = TrackerFactory(
             affects=[affect1, affect2],
             embargoed=flaw1.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
         assert tracker.aggregated_impact == expected_impact
@@ -89,10 +91,12 @@ class TestTracker:
             ps_component=affect1.ps_component,
         )
         ps_module = PsModuleFactory(name=affect1.ps_module)
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
 
         tracker = TrackerFactory(
             affects=[affect1, affect2],
             embargoed=flaw1.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
@@ -132,9 +136,11 @@ class TestTracker:
             resolution=Affect.AffectResolution.DELEGATED,
         )
         ps_module = PsModuleFactory(name=affect.ps_module)
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         tracker = TrackerFactory(
             affects=[affect],
             embargoed=flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
         assert tracker.last_impact_increase_dt is None
@@ -235,7 +241,7 @@ class TestTrackerValidators:
                 resolution=Affect.AffectResolution.DELEGATED,
                 ps_module=ps_module.name,
             )
-            ps_update_stream = PsUpdateStreamFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             # do not raise here
             # validation is run on save
             TrackerFactory(
@@ -368,6 +374,7 @@ class TestTrackerValidators:
         test that the tracker type corresponds to its BTS
         """
         ps_module = PsModuleFactory(bts_name=bts)
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         affect = AffectFactory(
             affectedness=Affect.AffectAffectedness.NEW, ps_module=ps_module.name
         )
@@ -381,6 +388,7 @@ class TestTrackerValidators:
                     acl_read=affect.acl_read,
                     acl_write=affect.acl_write,
                     affects=[affect],
+                    ps_update_stream=ps_update_stream.name,
                     type=tracker_type,
                 )
         else:
@@ -388,5 +396,6 @@ class TestTrackerValidators:
                 acl_read=affect.acl_read,
                 acl_write=affect.acl_write,
                 affects=[affect],
+                ps_update_stream=ps_update_stream.name,
                 type=tracker_type,
             )


### PR DESCRIPTION
and quite a number of test updates as up until now we were allowed to be imprecise and leave the PS module and PS updates stream incorrespondence which is not possible any more

Closes OSIDB-3584