### PR TITLE
OSIDB-3337: Implement DjangoQL library for Flaw filtering

### DIFF
--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 
 from apps.bbsync.models import BugzillaComponent, BugzillaProduct
 from collectors.bzimport.collectors import BugzillaQuerier, MetadataCollector
+from collectors.bzimport.constants import BZ_DT_FMT
 from osidb.models import Affect, Flaw, FlawComment, Package, Tracker
 from osidb.sync_manager import BZTrackerLinkManager
 from osidb.tests.factories import (
@@ -305,6 +306,7 @@ class TestBugzillaTrackerCollector:
             external_system_id="1765663",
             type=Tracker.TrackerType.BUGZILLA,
             embargoed=False,
+            updated_dt=timezone.datetime.strptime("1970-01-01T00:00:00Z", BZ_DT_FMT),
         )
         # make sure the links are there
         tracker = Tracker.objects.first()

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -337,6 +337,7 @@ class TestJiraTrackerCollector:
             type=Tracker.TrackerType.JIRA,
             external_system_id=tracker_id,
             affects=[affect1, affect2],
+            updated_dt=timezone.datetime.strptime("1970-01-01T00:00:00Z", BZ_DT_FMT),
         )
         collector = JiraTrackerCollector()
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -69,6 +69,7 @@ INSTALLED_APPS = [
     "psqlextra",
     "rest_framework",
     "rest_framework_simplejwt",
+    "djangoql",
 ]
 
 MIDDLEWARE = [

--- a/config/settings.py
+++ b/config/settings.py
@@ -35,8 +35,6 @@ READONLY_MODE: bool = get_env("OSIDB_READONLY_MODE", default="False", is_bool=Tr
 
 # Application definition
 INSTALLED_APPS = [
-    "pgtrigger",
-    "pghistory",
     "apps.bbsync",
     "apps.exploits",
     "apps.sla",
@@ -55,21 +53,23 @@ INSTALLED_APPS = [
     "collectors.product_definitions",
     "collectors.ps_constants",
     "corsheaders",
+    "django_extensions",
+    "django_filters",
     "django.contrib.auth",
     "django.contrib.contenttypes",
     "django.contrib.messages",
     "django.contrib.postgres",
     "django.contrib.sessions",
     "django.contrib.staticfiles",
-    "django_extensions",
-    "django_filters",
+    "djangoql",
     "drf_spectacular",
     "osidb",
+    "pghistory",
+    "pgtrigger",
     "polymorphic",
     "psqlextra",
-    "rest_framework",
     "rest_framework_simplejwt",
-    "djangoql",
+    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Taskman throwing away logs upon JSON decode error (OSIDB-3296)
 
+### Added
+  - Implement DjangoQL for Flaw filtering (OSIDB-3337)
+
 ## [4.1.7] - 2024-08-22
 ### Added
 - Command for manual syncing Jira metadata (OSIDB-3219)

--- a/openapi.yml
+++ b/openapi.yml
@@ -3344,6 +3344,12 @@ paths:
         schema:
           type: boolean
       - in: query
+        name: query
+        schema:
+          type: string
+        description: Advanced filter with special syntax. See https://github.com/ivelum/djangoql
+          for more information.
+      - in: query
         name: references__created_dt
         schema:
           type: string
@@ -5580,6 +5586,12 @@ paths:
           wildcards eg. `include_meta_attr=*,related_model.*` for retrieving all the
           keys from meta_attr. Omit this parameter to not include meta_attr fields
           at all. '
+      - in: query
+        name: query
+        schema:
+          type: string
+        description: Advanced filter with special syntax. See https://github.com/ivelum/djangoql
+          for more information.
       - in: query
         name: tracker_ids
         schema:

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -351,6 +351,17 @@ jira_api_key_param = OpenApiParameter(
     description="User generated api key for Jira authentication.",
 )
 
+query_api_param = OpenApiParameter(
+    name="query",
+    required=False,
+    type=str,
+    location=OpenApiParameter.QUERY,
+    description=(
+        "Advanced filter with special syntax. "
+        "See https://github.com/ivelum/djangoql for more information."
+    ),
+)
+
 
 def jira_api_key_extend_schema_view(
     cls: Type[ViewSetMixin],
@@ -412,6 +423,22 @@ def include_exclude_fields_extend_schema_view(
     )(cls)
 
 
+def query_extend_schema_view(
+    cls: Type[ViewSetMixin],
+) -> Type[ViewSetMixin]:
+    """
+    Decorator which adds `query` query parameter description into the schema
+    for `list` and `retrieve` methods
+    """
+    return (
+        extend_schema_view(
+            list=extend_schema(parameters=[query_api_param]),
+            retrieve=extend_schema(parameters=[query_api_param]),
+        )
+    )(cls)
+
+
+@query_extend_schema_view
 @include_meta_attr_extend_schema_view
 @include_exclude_fields_extend_schema_view
 @bz_api_key_extend_schema_view

--- a/requirements.in
+++ b/requirements.in
@@ -42,3 +42,4 @@ requests_cache
 requests_gssapi
 # workaround as rhubarb is not on std PyPI and registrations seem to be closed
 rhubarb @ https://github.com/RedHatProductSecurity/rhubarb/releases/download/0.1.0/rhubarb-0.1.0-py3-none-any.whl
+djangoql

--- a/requirements.txt
+++ b/requirements.txt
@@ -251,6 +251,9 @@ django-postgres-extra==2.0.3 \
     --hash=sha256:447b24b91146f9ad19f960922c19e5885663cf282100529baeae5152775aa4c0 \
     --hash=sha256:c5e65ec3750b01352112526de1572f3dc0ed4d2022ba324c0521907925d29ac6
     # via -r requirements.in
+djangoql==0.18.1 \
+    --hash=sha256:51b3085a805627ebb43cfd0aa861137cdf8f69cc3c9244699718fe04a6c8e26d
+    # via -r requirements.in
 djangorestframework==3.12.4 \
     --hash=sha256:6d1d59f623a5ad0509fe0d6bfe93cbdfe17b8116ebc8eda86d45f6e16e819aaf \
     --hash=sha256:f747949a8ddac876e879190df194b925c177cdeb725a099db1460872f7c0a7f2
@@ -486,6 +489,10 @@ packageurl-python==0.9.6 \
     --hash=sha256:676dcb8278721df952e2444bfcd8d7bf3518894498050f0c6a5faddbe0860cd0 \
     --hash=sha256:c01fbaf62ad2eb791e97158d1f30349e830bee2dd3e9503a87f6c3ffae8d1cf0
     # via -r requirements.in
+ply==3.11 \
+    --hash=sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3 \
+    --hash=sha256:096f9b8350b65ebd2fd1346b12452efe5b9607f7482813ffca50c22722a807ce
+    # via djangoql
 prometheus-client==0.13.1 \
     --hash=sha256:357a447fd2359b0a1d2e9b311a0c5778c330cfbe186d880ad5a6b39884652316 \
     --hash=sha256:ada41b891b79fca5638bd5cfe149efa86512eaa55987893becd2c6d8d0a5dfc5


### PR DESCRIPTION
This pull request introduces DjangoQL for advanced querying capabilities in the `osidb` application. The main changes include adding DjangoQL to the project dependencies, integrating it into the filters, and creating tests for the new query functionality.

### Integration of DjangoQL:

* [`config/settings.py`](diffhunk://#diff-935426a2f59d34e9506987404f8d78b5b5b43431694101f5be37ad65af4cf193R72): Added `djangoql` to the list of installed apps.
* [`requirements.in`](diffhunk://#diff-de469cc9cf8992ffaec661b4e087cfded3ec6da722072ec1fdf11f61690fd1b8R45): Added `djangoql` to the project dependencies.

### Changes in `osidb/filters.py`:

* Imported `apply_search` and `DjangoQLSchema` from `djangoql`.
* Added `FlawQLSchema` class to limit queryable fields in DjangoQL queries.
* Added `query` field to `FlawFilter` for handling DjangoQL queries.
* Implemented `query_filter` method in `FlawFilter` to apply DjangoQL search.

### Testing:

* [`osidb/tests/test_search.py`](diffhunk://#diff-b35fb454828f773c9be8c6b43348df82443f820b99cd100d77e6fa3f90112faaR312-R378): Added a test case `test_search_flaws_by_query` to verify searching flaws using DjangoQL queries.

---
### Broken Tests

Two weeks ago on #688 we added this piece of code https://github.com/RedHatProductSecurity/osidb/blob/2620784875c0f0c2ab74384737f28e588966d3a4/collectors/jiraffe/convertors.py#L262-L263

Intended to prevent updating a tracker with old data if the stored `updated_dt` is newer than the one in the data.
This means that tests that were previously time independent, now depends on time to work.

For the two tests fixed on this PR, the problem is that the `TrackerFactory` uses a random time between 1970 and today https://github.com/RedHatProductSecurity/osidb/blob/2620784875c0f0c2ab74384737f28e588966d3a4/osidb/tests/factories.py#L591-L592 so, at random the `updated_dt` will be greater than the date set on the cassette (2014) and the test fails.

I set the `updated_dt` manually for both tests to fix it, I haven't found any more tests with this error, but there could be more


Closes OSIDB-3337