### PR TITLE
Fix taskman JiraERROR handling

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Taskman throwing away logs upon JSON decode error (OSIDB-3296)
+
 ## [4.1.7] - 2024-08-22
 ### Added
 - Command for manual syncing Jira metadata (OSIDB-3219)

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -15,6 +15,8 @@ from celery._state import get_current_task
 from django.db import models
 from django.utils.timezone import datetime, make_aware
 from django_deprecate_fields import DeprecatedField, logger
+from requests.exceptions import JSONDecodeError
+from requests.models import Response
 
 from osidb.validators import CVE_RE_STR, restrict_regex
 
@@ -225,3 +227,14 @@ def deprecate_field(field_instance, return_instead=None):
 
     field_instance.null = True
     return field_instance
+
+
+def safe_get_response_content(response: Response):
+    """
+    Returns either JSON or plaintext response content based
+    on the response content type
+    """
+    try:
+        return response.json()
+    except JSONDecodeError:
+        return response.text


### PR DESCRIPTION
This PR:
* fixes taskman JiraERROR handling cases when error response didn't contain JSON-serializable content

Closes OSIDB-3296