### PR TITLE
OSIDB-3349: Update `requires_cve_description` on `cve_description` change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Implement DjangoQL for Flaw filtering (OSIDB-3337)
 - Support Vulnerability issuetype for Trackers (OSIDB-2980)
+- Set requires_cve_description to REQUESTED when unset and the flaw
+  has cve_description (OSIDB-3349)
 
 ### Changed
 - Extend CVSS vector length (OSIDB-3362)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -863,6 +863,25 @@ class Flaw(
                 f"missing."
             )
 
+    def _validate_requires_cve_description(self, **kwargs):
+        """
+        Checks that if requires_cve_description was already set to
+        something other than NOVALUE, it cannot be set to NOVALUE.
+        """
+        if self._state.adding:
+            # we're creating a new flaw so we don't need to check whether we're
+            # changing from one state to another
+            return
+
+        old_flaw = Flaw.objects.get(pk=self.pk)
+        if (
+            old_flaw.requires_cve_description != self.FlawRequiresCVEDescription.NOVALUE
+            and self.requires_cve_description == self.FlawRequiresCVEDescription.NOVALUE
+        ):
+            raise ValidationError(
+                "requires_cve_description cannot be unset if it was previously set to something other than NOVALUE"
+            )
+
     def _validate_nonempty_source(self, **kwargs):
         """
         checks that the source is not empty


### PR DESCRIPTION
The field `requires_cve_description` was automatically set to `REQUESTED` by **Bugzilla** when `cve_description` changed, but since we no longer sync back to bugzilla, we lost this behavior and now flaws are created with `cve_description` without `requires_cve_description`

This change adds that behavior back as well as a validation to prevent setting the `rquires_cve_description` to `NOVALUE` if the field was already set

Closes OSIDB-3349