### PR TITLE
New trackers not using the tracker creation date in SLA computation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Taskman throwing away logs upon JSON decode error (OSIDB-3296)
+- Wrong due date when filing new Jira tracker (OSIDB-3376)
 
 ## [4.1.7] - 2024-08-22
 ### Added


### PR DESCRIPTION
The new SLAs use the tracker creation date, instead of the flaw creation date, as one of the parameters. However, when creating a new tracker, the SLA is computed with the instance before it is fully saved, therefore not having a `created_dt`, and resulting in an incorrect Due Date in the Jira tracker.

This commit introduces a simple workaround to not have to change the logic of when the Jira query is done, by setting a temporary created_dt for the tracker as the current date when the tracker is being newly created.

Closes OSIDB-3376.