### PR TITLE
Fix incorrect changes in CHANGELOG

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Tracker validations skipping (OSIDB-3336)
 
 ## [4.2.0] - 2024-08-30
 ### Added
@@ -20,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Taskman throwing away logs upon JSON decode error (OSIDB-3296)
 - Wrong due date when filing new Jira tracker (OSIDB-3376)
 - Fix date format error (OSIDB-3364)
-- Tracker validations skipping (OSIDB-3336)
 
 ## [4.1.7] - 2024-08-22
 ### Added


### PR DESCRIPTION
This PR fixes the incorrect order of recent changes in CHANGELOG caused by enabling auto-merge.
#715 was added into the merge queue after #708, and thus, it was outdated.