### PR TITLE
Handle internal server errors

### DIFF
--- a/apps/trackers/exceptions.py
+++ b/apps/trackers/exceptions.py
@@ -21,6 +21,10 @@ class MissingPriorityError(BTSException):
     """exception class for missing correct priority corresponding to Impact"""
 
 
+class MissingJiraProjectMetadata(BTSException):
+    """exception class for missing Jira Project Metadata"""
+
+
 class MissingSecurityLevelError(BTSException):
     """exception class for missing correct Security Level in the particular project"""
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Handle frequent Taskman, Trackers and Collectors exceptions
+  instead of internal server error 500 (OSIDB-3280)
+
 ### Fixed
 - Tracker validations skipping (OSIDB-3336)
 


### PR DESCRIPTION
This PR:
* raises new exception on missing Jira project metadata so it can be later handled
* adds handling of currently most frequent exceptions which are normally handled like generic `Internal Server Error 500` (see Jira issue for the splunk analysis)

Closes OSIDB-3280