### PR TITLE
Add Severity field mapping for additional schemes

### DIFF
--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -127,15 +127,51 @@ class JiraSeverity:
     NONE = "None"
 
 
+class JiraSeverityAlternative:
+    """
+    Allowed Jira severity values NOT compatible with
+    https://access.redhat.com/security/updates/classification
+    but used in some Jira projects.
+    """
+
+    # "Schema 2"
+    BLOCKER = "Blocker"
+    CRITICAL = "Critical"
+    MAJOR = "Major"
+    NORMAL = "Normal"
+    MINOR = "Minor"
+    TRIVIAL = "Trivial"
+
+    # "Schema 3"
+    URGENT = "Urgent"
+    HIGH = "High"
+    MEDIUM = "Medium"
+    LOW = "Low"
+
+
 IMPACT_TO_JIRA_SEVERITY = {
-    Impact.CRITICAL: JiraSeverity.CRITICAL,
-    Impact.IMPORTANT: JiraSeverity.IMPORTANT,
-    Impact.MODERATE: JiraSeverity.MODERATE,
-    Impact.LOW: JiraSeverity.LOW,
-    # mapping below is just safeguard
-    # but we should never file such trackers
-    Impact.NOVALUE: JiraSeverity.NONE,
+    Impact.CRITICAL: [
+        JiraSeverity.CRITICAL,
+        JiraSeverityAlternative.CRITICAL,
+        JiraSeverityAlternative.URGENT,
+    ],
+    Impact.IMPORTANT: [
+        JiraSeverity.IMPORTANT,
+        JiraSeverityAlternative.MAJOR,
+        JiraSeverityAlternative.HIGH,
+    ],
+    Impact.MODERATE: [
+        JiraSeverity.MODERATE,
+        JiraSeverityAlternative.NORMAL,
+        JiraSeverityAlternative.MEDIUM,
+    ],
+    Impact.LOW: [
+        JiraSeverity.LOW,
+        JiraSeverityAlternative.MINOR,
+        JiraSeverityAlternative.LOW,
+    ],
 }
+
 
 # NOTE that these four values can change, as they are for sanity-checking
 # allowed values for Jira field Special Handling.
@@ -600,16 +636,23 @@ class TrackerJiraQueryBuilder(OldTrackerJiraQueryBuilder):
     # TODO write tests - tracked in OSIDB-2980
     def generate_severity(self):
         field_name = "Severity"
-        # Allowed should be ['Critical', 'Important', 'Moderate', 'Low', 'None']
         allowed_values, field_id = self.field_check_and_get_values_and_id(field_name)
 
-        severity = IMPACT_TO_JIRA_SEVERITY[self.impact]
-        if severity not in allowed_values:
-            raise MissingSeverityError(
-                f"Jira project {self.ps_module.bts_key} does not have the {field_name} field value "
-                f"{severity}; allowed values are: {', '.join(allowed_values)}"
+        if self.impact is Impact.NOVALUE:
+            raise TrackerCreationError(
+                "Tracker has disallowed Impact value Impact.NOVALUE (empty string)."
             )
-        self._query["fields"][field_id] = {"value": severity}
+
+        for severity in IMPACT_TO_JIRA_SEVERITY[self.impact]:
+            if severity in allowed_values:
+                self._query["fields"][field_id] = {"value": severity}
+                return
+
+        raise MissingSeverityError(
+            f"Jira project {self.ps_module.bts_key} does not have the {field_name} field value appropriate for "
+            f"severity {severity}, which is one of {', '.join(IMPACT_TO_JIRA_SEVERITY[self.impact])}; "
+            f"allowed values are: {', '.join(allowed_values)}"
+        )
 
     # TODO write tests - tracked in OSIDB-2980
     def generate_source(self):

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -18,6 +18,7 @@ from apps.trackers.jira.constants import PS_ADDITIONAL_FIELD_TO_JIRA
 from apps.trackers.jira.query import (
     JiraPriority,
     JiraSeverity,
+    JiraSeverityAlternative,
     OldTrackerJiraQueryBuilder,
     TrackerJiraQueryBuilder,
 )
@@ -1272,6 +1273,200 @@ class TestTrackerJiraQueryBuilder:
 
         if not flaw.cwe_id:
             del expected1["fields"]["customfield_12324747"]
+
+        quer_builder = TrackerJiraQueryBuilder(tracker)
+        quer_builder.generate()
+        validate_minimum_key_value(minimum=expected1, evaluated=quer_builder._query)
+
+    @pytest.mark.parametrize(
+        "schema",
+        [
+            (1,),
+            (2,),
+            (3,),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "flaw_impact,affect_impact,expected_severity",
+        [
+            (Impact.LOW, Impact.LOW, JiraSeverity.LOW),
+            (Impact.LOW, Impact.MODERATE, JiraSeverity.MODERATE),
+            (Impact.LOW, Impact.IMPORTANT, JiraSeverity.IMPORTANT),
+            (Impact.LOW, Impact.CRITICAL, JiraSeverity.CRITICAL),
+        ],
+    )
+    def test_severity_field(
+        self, schema, flaw_impact, affect_impact, expected_severity
+    ):
+        """
+        Test that the severity field is populated correctly.
+        To make the test parameters less prone to mistake, the expected results
+        are translated from JiraSeverity ("Schema 1") to JiraSeverityAlternative
+        ("Schema 2" and "Schema 3"), not encoded directly in the test parameters.
+        """
+        # if schema == 1:
+        #   just run the test to double-check the sanity of the input test parameters
+
+        if schema == 2:
+            MAPPING = {
+                JiraSeverity.CRITICAL: JiraSeverityAlternative.CRITICAL,
+                JiraSeverity.IMPORTANT: JiraSeverityAlternative.MAJOR,
+                JiraSeverity.MODERATE: JiraSeverityAlternative.NORMAL,
+                JiraSeverity.LOW: JiraSeverityAlternative.MINOR,
+            }
+            expected_severity = MAPPING[expected_severity]
+
+        if schema == 3:
+            MAPPING = {
+                JiraSeverity.CRITICAL: JiraSeverityAlternative.URGENT,
+                JiraSeverity.IMPORTANT: JiraSeverityAlternative.HIGH,
+                JiraSeverity.MODERATE: JiraSeverityAlternative.MEDIUM,
+                JiraSeverity.LOW: JiraSeverityAlternative.LOW,
+            }
+            expected_severity = MAPPING[expected_severity]
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12316142",
+            field_name="Severity",
+            allowed_values=[
+                "Critical",
+                "Important",
+                "Moderate",
+                "Low",
+                "An Irrelevant Value To Be Ignored",
+                "None",
+            ],
+        ).save()
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324746",
+            field_name="Source",
+            # Severely pruned for the test
+            allowed_values=["Red Hat", "Upstream"],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324749",
+            field_name="CVE ID",
+            allowed_values=[],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324748",
+            field_name="CVSS Score",
+            allowed_values=[],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324747",
+            field_name="CWE ID",
+            allowed_values=[],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324752",
+            field_name="Downstream Component Name",
+            allowed_values=[],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324751",
+            field_name="Upstream Affected Component",
+            allowed_values=[],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324750",
+            field_name="Embargo Status",
+            allowed_values=["True", "False"],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="customfield_12324753",
+            field_name="Special Handling",
+            allowed_values=[
+                "Major Incident",
+                "KEV (active exploit case)",
+                "Compliance Priority",
+                "Contract Priority",
+            ],
+        ).save()
+
+        JiraProjectFields(
+            project_key="FOOPROJECT",
+            field_id="versions",
+            field_name="Affects Version/s",
+            allowed_values=["1.2.3"],
+        ).save()
+
+        flaw = FlawFactory(
+            embargoed=False,
+            bz_id="123",
+            cve_id="CVE-2999-1000",
+            impact=flaw_impact,
+            major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+            title="some description",
+            source="REDHAT",
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module="foo-module",
+            ps_component="foo-component",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            impact=affect_impact,
+        )
+        ps_module = PsModuleFactory(
+            name="foo-module", bts_name="jboss", bts_key="FOOPROJECT"
+        )
+        stream = PsUpdateStreamFactory(
+            ps_module=ps_module, name="bar-1.2.3", version="1.2.3"
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            type=Tracker.TrackerType.JIRA,
+            ps_update_stream=stream.name,
+            embargoed=flaw.is_embargoed,
+        )
+        JiraProjectFieldsFactory(
+            project_key=ps_module.bts_key,
+            field_id="security",
+            field_name="Security Level",
+            allowed_values=[
+                "Embargoed Security Issue",
+                "Red Hat Employee",
+                "Red Hat Engineering Authorized",
+                "Red Hat Partner",
+                "Restricted",
+                "Team",
+            ],
+        )
+        expected1 = {
+            "fields": {
+                "project": {"key": "FOOPROJECT"},
+                "issuetype": {"name": "Vulnerability"},
+                "summary": "CVE-2999-1000 foo-component: some description [bar-1.2.3]",
+                "labels": [
+                    "CVE-2999-1000",
+                    "pscomponent:foo-component",
+                    "SecurityTracking",
+                    "Security",
+                ],
+                "versions": [
+                    {"name": "1.2.3"},
+                ],
+                #
+                # Severity
+                "customfield_12316142": {"value": expected_severity},
+            }
+        }
 
         quer_builder = TrackerJiraQueryBuilder(tracker)
         quer_builder.generate()


### PR DESCRIPTION
Add Severity field mapping for additional schemes since not all projects are able to convert based on the original spec.
Closes OSIDB-3386