### PR TITLE
OSIDB-3338: Create djangoql suggestions endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Create new API endpoints for DjangoQL (OSIDB-3338)
+
 ### Fixed
 - Unable to unembargo flaws with trackers (OSIDB-3398)
 

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -260,6 +260,33 @@ class FlawQLSchema(DjangoQLSchema):
     any field in the model, which is not desirable in this case.
     """
 
+    include = (
+        Affect,
+        Flaw,
+        FlawAcknowledgment,
+        FlawCVSS,
+        FlawReference,
+        Package,
+        Tracker,
+    )
+
+    suggest_options = {
+        Affect: ["affectedness", "impact", "ps_component", "ps_module", "resolution"],
+        Flaw: [
+            "components",
+            "impact",
+            "major_incident_state",
+            "nist_cvss_validation",
+            "owner",
+            "requires_cve_description",
+            "source",
+            "workflow_state",
+        ],
+        FlawCVSS: ["issuer", "version"],
+        FlawReference: ["type"],
+        Tracker: ["resolution", "status", "type"],
+    }
+
     def get_fields(self, model):
         fields = super(FlawQLSchema, self).get_fields(model)
         exclude = ["acl_read", "acl_write"]

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -16,8 +16,10 @@ from .api_views import (
     FlawAcknowledgmentView,
     FlawCommentView,
     FlawCVSSView,
+    FlawIntrospectionView,
     FlawPackageVersionView,
     FlawReferenceView,
+    FlawSuggestionsView,
     FlawView,
     JiraStageForwarderView,
     ManifestView,
@@ -81,6 +83,20 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="schema"),
     ),
 ]
+
+urlpatterns.append(
+    path(
+        f"api/{OSIDB_API_VERSION}/suggestions",
+        FlawSuggestionsView.as_view(),
+    )
+)
+
+urlpatterns.append(
+    path(
+        f"api/{OSIDB_API_VERSION}/introspection",
+        FlawIntrospectionView.as_view(),
+    )
+)
 
 # TODO: undocumented endpoint only is enabled on non production environments and will be removed in the future.
 if get_env() != "prod":


### PR DESCRIPTION
This pull request introduces new API endpoints for DjangoQL and includes several related changes across multiple files. 

### New API Endpoints:

* **FlawIntrospectionView**: This endpoint return a json of all the models (included in the schema) with the type of the fields and the possible values

* **FlawSuggestionsView**: This endpoint returns the possible values for a given field specified in the schema, for giving suggestions to the user while typing


>[!NOTE]
>I have chosen the models and fields a bit “blindly”, it may be necessary to discuss which fields need suggestions and which models we allow for the search.

Closes OSIDB-3338