### PR TITLE
Allow trackers to have manually set SLAs

### DIFF
--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -394,6 +394,10 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         generate query for Jira SLA timestamps
         """
+        # Tracker has a manually defined due date
+        if "nonstandard-sla" in self._query["fields"]["labels"]:
+            return
+
         if not self.tracker.external_system_id:
             # Workaround for when a new tracker is filed. At this point in the code it
             # has not been fully saved so created_dt is not a valid date, but the SLAs

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -589,6 +589,12 @@ sla:
         assert "duedate" in query["fields"]
         assert query["fields"]["duedate"] == "2000-01-11T00:00:00+00:00"
 
+        # SLA was manually marked to not be calculated
+        tracker.meta_attr["labels"] = json.dumps(["nonstandard-sla"])
+        query = OldTrackerJiraQueryBuilder(tracker).query
+        assert target_start_id not in query["fields"]
+        assert "duedate" not in query["fields"]
+
     @pytest.mark.parametrize(
         "embargoed, private, valid_jira_field",
         [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Add CVEorg collector (OSIDB-2234)
+- Allow trackers to have manually set SLAs (OSIDB-3374)
 
 ### Changed
 - Handle frequent Taskman, Trackers and Collectors exceptions


### PR DESCRIPTION
This PR allows trackers to have manually set SLAs by setting a custom label.

Closes OSIDB-3374.