### PR TITLE
Fix error on unembargo when trackers exist

### DIFF
--- a/apps/sla/models.py
+++ b/apps/sla/models.py
@@ -278,10 +278,14 @@ class SLAPolicy(models.Model):
 
         # computing the SLA is not simple as we have to consider multi-flaw trackers where
         # the SLA start must be computed for the flaw which results in the earlist SLA end
-        sla_contexts = [
-            SLAContext(affect=affect, flaw=affect.flaw, tracker=instance)
-            for affect in instance.affects.all()
-        ]
+        sla_contexts = []
+        for affect in instance.affects.all():
+            # Make sure we are getting the latest data from the database and not the possibly
+            # incomplete data from the tracker which may be being saved
+            affect = Affect.objects.get(uuid=affect.uuid)
+            sla_contexts.append(
+                SLAContext(affect=affect, flaw=affect.flaw, tracker=instance)
+            )
 
         # filter out the SLA contexts not accepted by this SLA policy
         sla_contexts = [context for context in sla_contexts if self.accepts(context)]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Unable to unembargo flaws with trackers (OSIDB-3398)
 
 ## [4.3.0] - 2024-09-04
 ### Added


### PR DESCRIPTION
The SLA computation is expecting a value for the `unembargo_dt` when we unembargo, but we are using a version of the tracker that is not saved yet and therefore does not have this updated information.

This commit fixes this by getting the latest version of the affect, which is already saved (and therefore the latest version of the flaw), instead of the version of the affect/flaw that the unsaved tracker has, to perform the SLA computation.

Closes OSIDB-3398.