### PR TITLE
add list of skipped labels instead of single label

### DIFF
--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -26,6 +26,7 @@ from apps.trackers.exceptions import (
 from apps.trackers.models import JiraProjectFields
 from collectors.jiraffe.constants import JIRA_BZ_ID_LABEL_RE
 from osidb.cc import JiraAffectCCBuilder
+from osidb.constants import SKIPPED_JIRA_SLA_LABELS
 from osidb.helpers import cve_id_comparator
 from osidb.models import Affect, AffectCVSS, Flaw, FlawSource, Impact
 from osidb.validators import CVE_RE_STR
@@ -357,7 +358,11 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         generate query for Jira SLA timestamps
         """
         # Tracker has a manually defined due date
-        if "nonstandard-sla" in self._query["fields"]["labels"]:
+        if any(
+            label
+            for label in self._query["fields"]["labels"]
+            if label in SKIPPED_JIRA_SLA_LABELS
+        ):
             return
 
         if not self.tracker.external_system_id:

--- a/osidb/constants.py
+++ b/osidb/constants.py
@@ -90,3 +90,7 @@ AFFECTEDNESS_HISTORICAL_VALID_RESOLUTIONS = {
         Affect.AffectResolution.WONTFIX,
     ],
 }
+
+SKIPPED_JIRA_SLA_LABELS = [
+    "nonstandard-sla",
+]


### PR DESCRIPTION
This PR adds a list of labels that should not compute SLA in Jira.

This is a request to allow multiple labels to have SLA skipped since we have different reasons to add it manually. This currently does not change the behavior but allows a constant list of labels in the future.

This is a improvement of OSIDB-3374.