### PR TITLE
remove mixin loop

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Alert users when Bugzilla sync failed (OSIDB-3252)
 
+### Fixed
+- Remove infinite recursion when SYNC_FLAWS_TO_BZ is disabled (OSIDB-3430)
+
 ## [4.3.2] - 2024-09-19
 ### Changed
 - Update the release documentation (OSIDB-3384)

--- a/osidb/models.py
+++ b/osidb/models.py
@@ -46,7 +46,6 @@ from .mixins import (
     NullStrFieldsMixin,
     TrackingMixin,
     TrackingMixinManager,
-    ValidateMixin,
 )
 from .sync_manager import BZSyncManager, FlawDownloadManager, JiraTaskDownloadManager
 from .validators import no_future_date, validate_cve_id, validate_cwe_id
@@ -1328,13 +1327,6 @@ class Flaw(
         Bugzilla sync of the Flaw instance
         """
         if not SYNC_FLAWS_TO_BZ:
-            # up until now the parent save methods run in sequence of
-            # 1) TrackingMixin with auto-timestamps on
-            # 2) JiraTaskSyncMixin syncing the task if enabled
-            # 3) BugzillaSyncMixin running the validations
-            # so we do not need to run any other mixins
-            kwargs.pop("raise_validation_error", None)
-            super(ValidateMixin, self).save(*args, **kwargs)
             return
 
         # switch of sync/async processing


### PR DESCRIPTION
This PR removes a infinite recursion in save method when sync to bugzilla is disabled.

This commit https://github.com/RedHatProductSecurity/osidb/pull/686/commits/db2cc6f588e453ee7e04b519f0e40fd0559fc74d introduced a infinite recursion in environments that don't sync to bugzilla, when validations were separated from BugzillaSyncMixin, was no need to bzsync method to skip mixins / call the next save method, making this infinite loop.

The way the 409 used to happen was by calling save method multiple times until the current save call have a different timestamp from the 1st save call, throwing the exception presented in  https://github.com/RedHatProductSecurity/osidb/blob/master/osidb/mixins.py#L52

Closes OSIDB-3430.