### PR TITLE
Use ADP data in CVEorg

### DIFF
--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -322,6 +322,7 @@ class CVEorgCollector(Collector):
             if published := data["cveMetadata"].get("datePublished"):
                 return published if published.endswith("Z") else f"{published}Z"
             # If datePublished is missing, check dateUpdated as it has a similar meaning
+            # This is tracked in https://github.com/CVEProject/cvelistV5/issues/66
             if updated := data["containers"]["cna"]["providerMetadata"].get(
                 "dateUpdated"
             ):


### PR DESCRIPTION
This PR is a follow-up to #706, and it updates the CVEorg collector to include data from all CNA and ADP containers when a new flaw draft is created.