### PR TITLE
OSIDB-3479: Allow searching for flaw components

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Create custom DjangoQL lookup field for Flaw.components (OSIDB-3479)
 
 ## [4.3.3] - 2024-09-30
 ### Added

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -16,7 +16,7 @@ from django_filters.rest_framework import (
     OrderingFilter,
 )
 from djangoql.queryset import apply_search
-from djangoql.schema import DjangoQLSchema
+from djangoql.schema import DjangoQLSchema, StrField
 
 from apps.workflows.workflow import WorkflowModel
 from osidb.dmodels.package_versions import Package
@@ -292,8 +292,43 @@ class FlawQLSchema(DjangoQLSchema):
         exclude = ["acl_read", "acl_write"]
         if model == Flaw:
             exclude += ["snippets", "local_updated_dt"]
-
+            fields.remove("components")
+            fields += [FlawComponentField()]
         return set(fields) - set(exclude)
+
+
+class FlawComponentField(StrField):
+    model = Flaw
+    name = "components"
+    suggest_options = True
+
+    def get_options(self, search):
+        options = super(FlawComponentField, self).get_options(search)
+        flat_list = []
+        for option in options:
+            flat_list += option
+        return flat_list
+
+    def get_lookup(self, path, operator, value):
+        lookup = "contains" if len(value) > 1 else "exact"
+        value = [component for component in value.split(",") if component]
+
+        if operator == "in":
+            result = None
+            for component in value:
+                condition = self.get_lookup(path, "=", component)
+                result = condition if result is None else result | condition
+            return result
+        elif operator == "not in":
+            result = None
+            for component in value:
+                condition = self.get_lookup(path, "!=", component)
+                result = condition if result is None else result & condition
+            return result
+        elif operator == "!=":
+            return ~Q(**{f"components__{lookup}": value})
+        elif operator == "=":
+            return Q(**{f"components__{lookup}": value})
 
 
 class FlawFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilterSet):


### PR DESCRIPTION
DjangoQL lacks suport for `ArrayField` type, so searching for flaw components was not working, neither the suggestions.

I implemented a custom field that allows searching for the components, I added it below the `FlawQLSchema` class but it can be moved somewhere else, also the naming can be improved, right now this is the only custom field but I can imagine creating a couple more, so maybe is worth having them in a separate file?

Some example queries and explanations:

* `components = "openssl"`:  Any flaw that has at least one component named *openssl*
* `components in ("openssl", "kernel")`: Any flaw that has at least one component named *openssl* **or** *kernel*
* `components = "openssl,kernel"`: Any flaw that has both *openssl* **and** *kernel* components
* `components = ""`: Any flaw that does not have any components
* `components != ""`: Any flaw that hast at least one component

Created following the documentation from https://docs.djangoproject.com/en/5.1/ref/models/querysets/#field-lookups and https://github.com/ivelum/djangoql?tab=readme-ov-file#custom-search-fields

Closes OSIDB-3479