### PR TITLE
OSIDB-3482: Remove duplicates from advanced search

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Create custom DjangoQL lookup field for Flaw.components (OSIDB-3479)
 
+### Fixed
+- Remove duplicate results from advanced search (OSIDB-3482)
+
 ## [4.3.3] - 2024-09-30
 ### Added
 - Update Vulnerability trackers on components change (OSIDB-3323)

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -404,7 +404,7 @@ class FlawFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilterS
     )
 
     def query_filter(self, queryset, name, value):
-        return apply_search(queryset, value, schema=FlawQLSchema)
+        return apply_search(queryset, value, schema=FlawQLSchema).distinct()
 
     def changed_after_filter(self, queryset, name, value):
         """


### PR DESCRIPTION
On some cases with advanced queries (specially with relations on different models) osidb is returning the same results multiple times, just needed to add a `distinct` to the query search to solve it.

For example, if a flaw has 10 affects without trackers, when searching for `affects.trackers != None` the same flaw will be returned 10 times

Closes OSIDB-3482