### PR TITLE
Enable one SLA test for Jira trackers

### DIFF
--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -2119,13 +2119,13 @@ class TestTrackerJiraQueryBuilderSla:
     """
 
     def test_generate_sla(self, clean_policies):
-        return
         """
         test that the query for the Jira SLA timestamps is generated correctly
         """
         flaw = FlawFactory(
             embargoed=False,
             reported_dt=make_aware(datetime(2000, 1, 1)),
+            source="REDHAT",
         )
         ps_module = PsModuleFactory(bts_name="bugzilla", bts_key="FOOPROJECT")
         affect = AffectFactory(


### PR DESCRIPTION
Two of these tests were recently disabled, and when enabled simultaneously they fail. However we can enable one of them to not lose coverage of this functionality, and both of the tests are similar anyway so this is much better than having both disabled.

Closes OSIDB-3505.