### PR TITLE
Fix IntegrityError during Tracker filing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Collect Jira field metadata for only one issuetype for each project (OSIDB-3485)
 - parent_uuid field in Alert had wrong type in OpenAPI schema (OSIDB-3451)
 - Fix Jira Tracker collector to account for Vulnerability issue type (OSIDB-3489)
+- IntegrityError duplicate key during tracker filing (OSIDB-3433)
 
 
 ## [4.3.3] - 2024-09-30

--- a/osidb/dmodels/tracker.py
+++ b/osidb/dmodels/tracker.py
@@ -5,6 +5,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 from django.db.models import Q
+from django.db.utils import IntegrityError
 from psqlextra.fields import HStoreField
 
 from apps.bbsync.constants import SYNC_TRACKERS_TO_BZ
@@ -224,31 +225,25 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
 
         # regular save otherwise
         else:
-            # TODO: Following try/except block is a temporary measurement to get
-            # better insight on frequently occuring IntegrityError caused by
-            # unique constraint violation (see OSIDB-3433)
-            from django.db import transaction
-            from django.db.utils import IntegrityError
-
             try:
-                # transaction atomic needs to be present in order to keep unit
-                # tests which are throwing IntegrityError on purpose working
-                # see: https://stackoverflow.com/questions/21458387/transactionmanagementerror-you-cant-execute-queries-until-the-end-of-the-atom
-                with transaction.atomic():
-                    super().save(*args, **kwargs)
+                super().save(*args, **kwargs)
             except IntegrityError as e:
-                other_trackers_with_same_id = Tracker.objects.filter(
-                    external_system_id=self.external_system_id
-                ).values_list("external_system_id", "uuid")
-                error_msg = (
-                    f"{e} occured for tracker with external system id '{self.external_system_id}' and uuid '{self.uuid}',\n"
-                    f"PS Update stream: '{self.ps_update_stream}',\n"
-                    f"Affect: '{self.affects.first()}',\n"
-                    f"Labels: '{self.meta_attr.get('labels')}',\n"
-                    f"Other trackers with same external system id: '{other_trackers_with_same_id}'\n"
-                )
-                logger.error(error_msg)
-                raise e
+                exc_msg = str(e)
+                if (
+                    "duplicate key value violates unique constraint" in exc_msg
+                    and "osidb_tracker_type_external_system_id" in exc_msg
+                ):
+                    # Tracker collector collected this tracker before the whole saving process finished
+                    # in the OSIDB, skip the saving and log it
+                    warning_msg = (
+                        f"{e} occured for tracker with external system id '{self.external_system_id}' and uuid '{self.uuid}',"
+                        "skipping the exception as tracker with this external system id was already collected "
+                        "by Tracker Collector."
+                    )
+                    logger.warning(warning_msg)
+                else:
+                    # Other IntegrityError, reraise the exception
+                    raise e
 
     def _validate_tracker_affect(self, **kwargs):
         """


### PR DESCRIPTION
This PR:
* fixes occasional `IntegrityError` duplicate external system id  happening during the tracker filing (see commit description reasoning)

Note: as the actual situation happens concurrently and in transactions, it is very nontrivial to actually write some meaningful tests in this case.

Closes OSIDB-3433