### PR TITLE
update python-bugzilla

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -32,8 +32,7 @@ packageurl-python
 psycogreen
 psycopg2
 pyjwt==2.4.0
-# to get the readable Bugzilla errors we need not yet released version
-python-bugzilla @ https://github.com/python-bugzilla/python-bugzilla/archive/c2b4fedda606ef91202941de70916fb1a32d8add.zip
+python-bugzilla
 python-ldap>=3.4.0
 pyyaml
 redis[hiredis]

--- a/requirements.txt
+++ b/requirements.txt
@@ -569,8 +569,8 @@ pyrsistent==0.18.0 \
     --hash=sha256:f3ef98d7b76da5eb19c37fda834d50262ff9167c65658d1d8f974d2e4d90676b \
     --hash=sha256:f4c8cabb46ff8e5d61f56a037974228e978f26bfefce4f61a4b1ac0ba7a2ab72
     # via jsonschema
-python-bugzilla @ https://github.com/python-bugzilla/python-bugzilla/archive/c2b4fedda606ef91202941de70916fb1a32d8add.zip \
-    --hash=sha256:f377c797af15c6922bfb3ac02044ac339152e94d99f8db919f1ed77a6a27f698
+python-bugzilla==3.3.0 \
+    --hash=sha256:e18220171e033eb3ba600c4d139359d01aa1acec1daebc4308910e450763de47
     # via -r requirements.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \


### PR DESCRIPTION
The maintainers finally released a new version 3.3.0 so we do not have to pin a specific necessary commit any more.

https://github.com/python-bugzilla/python-bugzilla/releases/tag/v3.3.0
https://pypi.org/project/python-bugzilla/