### PR TITLE
Set Impact for collector flaws based on CVSS severity

### DIFF
--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from decimal import Decimal
 from time import sleep
 from typing import Union
 
@@ -16,7 +17,7 @@ from collectors.constants import SNIPPET_CREATION_ENABLED
 from collectors.cveorg.constants import CELERY_PVC_PATH
 from collectors.framework.models import Collector
 from collectors.keywords import should_create_snippet
-from collectors.utils import handle_urls
+from collectors.utils import convert_cvss_score_to_impact, handle_urls
 from osidb.core import set_user_acls
 from osidb.dmodels.snippet import Snippet
 from osidb.models import FlawCVSS, FlawReference
@@ -256,25 +257,32 @@ class CVEorgCollector(Collector):
                 if re.match(self.EN_LANG, d["lang"])
             ][0]
 
-        def get_cvss(data: dict) -> list:
+        def get_cvss_and_impact(data: dict) -> tuple[list, str]:
+
             # Collect all metrics from CNA and ADP containers
             all_metrics = data["containers"]["cna"].get("metrics", [])
             for a in data["containers"].get("adp", []):
                 all_metrics.extend(a.get("metrics", []))
 
-            # Keep only data we are interested in (version and vector)
+            # Keep only data we are interested in (version, vector, score)
             cvss_pairs = dict()
             for cvss in all_metrics:
                 for version, metrics in cvss.items():
                     if version in self.CVSS_TO_FLAWCVSS and version not in cvss_pairs:
-                        cvss_pairs[version] = metrics["vectorString"]
+                        cvss_pairs[version] = [
+                            metrics["baseScore"],
+                            metrics["vectorString"],
+                        ]
 
             # Only one CVSS v3 can be stored
             if bool(cvss_pairs.get("cvssV3_0") and cvss_pairs.get("cvssV3_1")):
                 cvss_pairs.pop("cvssV3_0")
 
+            # Create resulted CVSS and get the highest score for Impact calculation
             cvss_data = []
-            for version, vector in cvss_pairs.items():
+            highest_score = Decimal("0.0")
+            for version, values in cvss_pairs.items():
+                score, vector = values
                 cvss_data.append(
                     {
                         "issuer": FlawCVSS.CVSSIssuer.CVEORG,
@@ -283,7 +291,13 @@ class CVEorgCollector(Collector):
                         # Actual score is generated automatically when FlawCVSS is saved
                     }
                 )
-            return cvss_data
+                if score > highest_score:
+                    highest_score = score
+
+            # Create resulted Impact
+            highest_impact = convert_cvss_score_to_impact(highest_score)
+
+            return cvss_data, highest_impact
 
         def get_cwes(data: dict) -> str:
             # Collect all problem types from CNA and ADP containers
@@ -332,11 +346,13 @@ class CVEorgCollector(Collector):
                 return published if published.endswith("Z") else f"{published}Z"
             return None
 
+        cvss_scores, impact = get_cvss_and_impact(content)
         return {
             "comment_zero": get_comment_zero(content),
             "cve_id": content["cveMetadata"]["cveId"],
-            "cvss_scores": get_cvss(content),
+            "cvss_scores": cvss_scores,
             "cwe_id": get_cwes(content),
+            "impact": impact,
             "references": get_refs(content),
             "source": Snippet.Source.CVEORG,
             "title": get_title(content),

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -1,11 +1,13 @@
 import json
 import re
+from decimal import Decimal
 from io import BytesIO
 from typing import Union
 from zipfile import ZipFile
 
 import requests
 from celery.utils.log import get_task_logger
+from cvss import CVSS2, CVSS3, CVSS4
 from django.conf import settings
 from django.db import transaction
 from django.utils import dateparse, timezone
@@ -13,7 +15,7 @@ from django.utils import dateparse, timezone
 from apps.taskman.constants import JIRA_AUTH_TOKEN
 from collectors.constants import SNIPPET_CREATION_ENABLED, SNIPPET_CREATION_START_DATE
 from collectors.framework.models import Collector
-from collectors.utils import handle_urls
+from collectors.utils import convert_cvss_score_to_impact, handle_urls
 from osidb.core import set_user_acls
 from osidb.dmodels.snippet import Snippet
 from osidb.models import FlawCVSS, FlawReference
@@ -72,6 +74,8 @@ class OSVCollector(Collector):
         "CVSS_V3": FlawCVSS.CVSSVersion.VERSION3,
         "CVSS_V4": FlawCVSS.CVSSVersion.VERSION4,
     }
+
+    CVSS_TO_CVSSLIB = {"CVSS_V2": CVSS2, "CVSS_V3": CVSS3, "CVSS_V4": CVSS4}
 
     def __init__(self):
         """initiate collector"""
@@ -261,23 +265,33 @@ class OSVCollector(Collector):
             #  https://ossf.github.io/osv-schema/#summary-details-fields
             return data.get("summary", "From OSV collector")
 
-        def get_cvss(data: dict) -> list:
+        def get_cvss_and_impact(data: dict) -> tuple[list, str]:
             # https://ossf.github.io/osv-schema/#severity-field
+
+            # Create resulted CVSS and get the highest score for Impact calculation
             cvss_data = []
+            highest_score = Decimal("0.0")
             for cvss in data.get("severity", []):
                 if not cvss["type"] in self.CVSS_TO_FLAWCVSS:
                     # Skip unsupported score types
                     continue
+                vector = cvss["score"]
+                score = self.CVSS_TO_CVSSLIB[cvss["type"]](vector).base_score
                 cvss_data.append(
                     {
                         "issuer": FlawCVSS.CVSSIssuer.OSV,
                         "version": self.CVSS_TO_FLAWCVSS[cvss["type"]],
-                        # OSV "score" attribute is really a vector string
-                        "vector": cvss["score"],
+                        "vector": vector,
                         # Actual score is generated automatically when FlawCVSS is saved
                     }
                 )
-            return cvss_data
+                if score > highest_score:
+                    highest_score = score
+
+            # Create resulted Impact
+            highest_impact = convert_cvss_score_to_impact(highest_score)
+
+            return cvss_data, highest_impact
 
         def get_cwes(data: dict) -> str:
             #  https://ossf.github.io/osv-schema/#database_specific-field
@@ -292,11 +306,13 @@ class OSVCollector(Collector):
             else:
                 return ""
 
+        cvss_scores, impact = get_cvss_and_impact(osv_vuln)
         content = {
             "comment_zero": get_comment_zero(osv_vuln),
             "title": get_title(osv_vuln),
-            "cvss_scores": get_cvss(osv_vuln),
+            "cvss_scores": cvss_scores,
             "cwe_id": get_cwes(osv_vuln),
+            "impact": impact,
             "references": get_refs(osv_vuln),
             "source": Snippet.Source.OSV,
             "unembargo_dt": osv_vuln.get("published"),

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -70,6 +70,7 @@ class OSVCollector(Collector):
     CVSS_TO_FLAWCVSS = {
         "CVSS_V2": FlawCVSS.CVSSVersion.VERSION2,
         "CVSS_V3": FlawCVSS.CVSSVersion.VERSION3,
+        "CVSS_V4": FlawCVSS.CVSSVersion.VERSION4,
     }
 
     def __init__(self):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Introduce moderate tracker streams pre-selection (OSIDB-3346)
 - Introduce minor and 0-day incident types (OSIDB-3390)
+- Collect CVSSv4 in OSV collector (OSIDB-3487)
+- Set Impact for collector flaws based on CVSS severity (OSIDB-3487)
 
 ### Fixed
 - Rework and complete the tracker stream pre-selection module to fix it

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -524,6 +524,7 @@ class SnippetFactory(factory.django.DjangoModelFactory):
             ],
             "cwe_id": "CWE-110",
             "comment_zero": "some comment zero",
+            "impact": Impact.IMPORTANT,
             "references": [
                 {"url": self.url, "type": FlawReference.FlawReferenceType.SOURCE}
             ],

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -5,7 +5,7 @@ import pytest
 from apps.workflows.models import Workflow
 from apps.workflows.workflow import WorkflowFramework, WorkflowModel
 from osidb.dmodels.snippet import Snippet
-from osidb.models import Flaw, FlawCVSS, FlawReference
+from osidb.models import Flaw, FlawCVSS, FlawReference, Impact
 from osidb.tests.factories import FlawFactory, SnippetFactory
 
 pytestmark = pytest.mark.unit
@@ -63,6 +63,7 @@ class TestSnippet:
         assert flaw.cvss_scores.count() == 1
         assert flaw.cwe_id == content["cwe_id"]
         assert flaw.comment_zero == content["comment_zero"]
+        assert flaw.impact == Impact.IMPORTANT
         # flaw is newly created, so meta_attr contains custom data
         assert flaw.meta_attr == {"external_ids": json.dumps([content["cve_id"]])}
         assert flaw.references.count() == 1


### PR DESCRIPTION
This PR reworks and extends the CVSS section for collector flaws to be able to calculate the resulting impact. The impact is created based on the highest CVSS score. The PR also updates the OSV collector to collect CVSSv4.

Closes OSIDB-3487