### PR TITLE
Update UBI image and vulnerable deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi:8.9
+FROM registry.redhat.io/ubi9/ubi:9.4
 
 LABEL summary="OSIDB" \
       maintainer="Product Security DevOps <prodsec-dev@redhat.com>"
@@ -37,9 +37,9 @@ RUN dnf --nodocs --setopt install_weak_deps=false -y install \
         openssl-devel \
         postgresql-devel \
         procps-ng \
-        python39-devel \
-        python39-pip \
-        python39-wheel \
+        python3-devel \
+        python3-pip \
+        python3-wheel \
         redhat-rpm-config \
         which \
     && dnf --nodocs --setopt install_weak_deps=false -y upgrade --security \
@@ -49,7 +49,7 @@ RUN dnf --nodocs --setopt install_weak_deps=false -y install \
 # This makes podman cache this (lengthy) step as long as requirements.txt stays unchanged.
 # Without this, any change in src/ would make pip install run again.
 COPY ./requirements.txt /opt/app-root/src/requirements.txt
-RUN pip3 install -r /opt/app-root/src/requirements.txt && \
+RUN pip3 install --no-deps -r /opt/app-root/src/requirements.txt && \
     rm -f /opt/app-root/src/requirements.txt
 COPY . /opt/app-root/src
 

--- a/devel-requirements.txt
+++ b/devel-requirements.txt
@@ -10,13 +10,6 @@ asgiref==3.8.1 \
     # via
     #   -c requirements.txt
     #   django
-attrs==21.2.0 \
-    --hash=sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1 \
-    --hash=sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb
-    # via
-    #   -c requirements.txt
-    #   pytest
-    #   pytest-recording
 backports-entry-points-selectable==1.1.1 \
     --hash=sha256:7fceed9532a7aa2bd888654a7314f864a3c16a4e710b34a58cfc0f08114c663b \
     --hash=sha256:914b21a479fde881635f7af5adc7f6e38d6b274be32269070c53b698c60d5386
@@ -147,6 +140,10 @@ djangorestframework-stubs==1.4.0 \
     --hash=sha256:037f0582b1e6c79366b6a839da861474d59210c4bfa1d36291545cb6ede6a0da \
     --hash=sha256:f6ed5fb19c12aa752288ddc6ad28d4ca7c81681ca7f28a19aba9064b2a69489c
     # via -r devel-requirements.in
+exceptiongroup==1.2.2 \
+    --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
+    --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
+    # via pytest
 execnet==1.9.0 \
     --hash=sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5 \
     --hash=sha256:a295f7cc774947aac58dde7fdc85f4aa00c42adf5d8f5468fc630c1acf30a142
@@ -177,9 +174,9 @@ identify==2.4.0 \
     --hash=sha256:a33ae873287e81651c7800ca309dc1f84679b763c9c8b30680e16fbfa82f0107 \
     --hash=sha256:eba31ca80258de6bb51453084bff4a923187cd2193b9c13710f2516ab30732cc
     # via pre-commit
-idna==3.3 \
-    --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
-    --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
+idna==3.10 \
+    --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
+    --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
     # via
     #   -c requirements.txt
     #   requests
@@ -504,10 +501,7 @@ pre-commit==2.16.0 \
 py==1.11.0 \
     --hash=sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719 \
     --hash=sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378
-    # via
-    #   pytest
-    #   pytest-forked
-    #   tox
+    # via tox
 pyasn1==0.4.8 \
     --hash=sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d \
     --hash=sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba
@@ -525,43 +519,39 @@ pyproject-hooks==1.0.0 \
     --hash=sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8 \
     --hash=sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5
     # via build
-pytest==6.2.5 \
-    --hash=sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89 \
-    --hash=sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134
+pytest==7.4.4 \
+    --hash=sha256:2cf0005922c6ace4a3e2ec8b4080eb0d9753fdc93107415332f50ce9e7994280 \
+    --hash=sha256:b090cdf5ed60bf4c45261be03239c2c1c22df034fbffe691abe93cd80cea01d8
     # via
     #   -r devel-requirements.in
     #   pytest-cov
     #   pytest-django
-    #   pytest-forked
     #   pytest-recording
     #   pytest-sugar
     #   pytest-xdist
-pytest-cov==3.0.0 \
-    --hash=sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6 \
-    --hash=sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470
+pytest-cov==5.0.0 \
+    --hash=sha256:4f0764a1219df53214206bf1feea4633c3b558a2925c8b59f144f682861ce652 \
+    --hash=sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857
     # via -r devel-requirements.in
-pytest-django==4.4.0 \
-    --hash=sha256:65783e78382456528bd9d79a35843adde9e6a47347b20464eb2c885cb0f1f606 \
-    --hash=sha256:b5171e3798bf7e3fc5ea7072fe87324db67a4dd9f1192b037fed4cc3c1b7f455
+pytest-django==4.9.0 \
+    --hash=sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99 \
+    --hash=sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314
     # via -r devel-requirements.in
-pytest-forked==1.3.0 \
-    --hash=sha256:6aa9ac7e00ad1a539c41bec6d21011332de671e938c7637378ec9710204e37ca \
-    --hash=sha256:dc4147784048e70ef5d437951728825a131b81714b398d5d52f17c7c144d8815
-    # via pytest-xdist
-pytest-recording==0.12.0 \
-    --hash=sha256:9039bf488f80c016055ffd039a91e33b1e89f3ee2ee0005c0bbce298fd417ee1 \
-    --hash=sha256:a94b000640fe5d05b34fa9e25dca1671dd7f21195502c5f4d2f600c31dc14f7e
+pytest-recording==0.13.2 \
+    --hash=sha256:000c3babbb466681457fd65b723427c1779a0c6c17d9e381c3142a701e124877 \
+    --hash=sha256:3820fe5743d1ac46e807989e11d073cb776a60bdc544cf43ebca454051b22d13
     # via -r devel-requirements.in
-pytest-spec==3.2.0 \
-    --hash=sha256:128dd1e133c72d6a18b28ed96d0af0fc43aece8f796ebcfcd81c850f0094b62e \
-    --hash=sha256:4af154588195f4bb6c62d6ca030a20218db7d80b675a08897d9a99239ea3d087
+pytest-spec==4.0.0 \
+    --hash=sha256:5d85ed29d9240722dfe778bed80022b917154c8200020864a61bfa65f138f70a \
+    --hash=sha256:71c9985e97d090a69b1f1b7adb64e7a208fb1ac42432ce9566c32cdd6b44c1ad
     # via -r devel-requirements.in
-pytest-sugar==0.9.4 \
-    --hash=sha256:b1b2186b0a72aada6859bea2a5764145e3aaa2c1cfbb23c3a19b5f7b697563d3
+pytest-sugar==0.9.6 \
+    --hash=sha256:30e5225ed2b3cc988a8a672f8bda0fc37bcd92d62e9273937f061112b3f2186d \
+    --hash=sha256:c4793495f3c32e114f0f5416290946c316eb96ad5a3684dcdadda9267e59b2b8
     # via -r devel-requirements.in
-pytest-xdist==2.4.0 \
-    --hash=sha256:7b61ebb46997a0820a263553179d6d1e25a8c50d8a8620cd1aa1e20e3be99168 \
-    --hash=sha256:89b330316f7fc475f999c81b577c2b926c9569f3d397ae432c0c2e2496d61ff9
+pytest-xdist==3.5.0 \
+    --hash=sha256:cbb36f3d67e0c478baa57fa4edc8843887e0f6cfc42d677530a36d7472b32d8a \
+    --hash=sha256:d075629c7e00b611df89f490a5063944bee7a4362a5ff11c7cc7824a03dfce24
     # via -r devel-requirements.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
@@ -615,9 +605,9 @@ pyyaml==6.0 \
     #   kubernetes
     #   pre-commit
     #   vcrpy
-requests==2.32.0 \
-    --hash=sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5 \
-    --hash=sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8
+requests==2.32.3 \
+    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
+    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
     #   -c requirements.txt
     #   coreapi
@@ -670,7 +660,6 @@ six==1.16.0 \
     #   google-auth
     #   kubernetes
     #   openshift
-    #   pytest-spec
     #   python-dateutil
     #   tox
     #   vcrpy
@@ -693,7 +682,6 @@ toml==0.10.2 \
     --hash=sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f
     # via
     #   pre-commit
-    #   pytest
     #   tox
 tomli==1.2.2 \
     --hash=sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee \
@@ -705,10 +693,15 @@ tomli==1.2.2 \
     #   mypy
     #   pip-tools
     #   pyproject-hooks
-tox==3.24.4 \
-    --hash=sha256:5e274227a53dc9ef856767c21867377ba395992549f02ce55eb549f9fb9a8d10 \
-    --hash=sha256:c30b57fa2477f1fb7c36aa1d83292d5c2336cd0018119e1b1c17340e2c2708ca
+    #   pytest
+tox==3.25.1 \
+    --hash=sha256:c138327815f53bc6da4fe56baec5f25f00622ae69ef3fe4e1e385720e22486f9 \
+    --hash=sha256:c38e15f4733683a9cc0129fba078633e07eb0961f550a010ada879e95fb32632
     # via -r devel-requirements.in
+types-markdown==3.7.0.20240822 \
+    --hash=sha256:183557c9f4f865bdefd8f5f96a38145c31819271cde111d35557c3bd2069e78d \
+    --hash=sha256:bec91c410aaf2470ffdb103e38438fbcc53689b00133f19e64869eb138432ad7
+    # via djangorestframework-stubs
 types-pytz==2021.3.6 \
     --hash=sha256:6805c72d51118923c5bf98633c39593d5b464d2ab49a803440e2d7ab6b8920df \
     --hash=sha256:74547fd90d8d8ab4f1eedf3a344a7d186d97486973895f81221a712e1e2cd993
@@ -716,7 +709,17 @@ types-pytz==2021.3.6 \
 types-pyyaml==6.0.5 \
     --hash=sha256:2fd21310870addfd51db621ad9f3b373f33ee3cbb81681d70ef578760bd22d35 \
     --hash=sha256:464e050914f3d1d83a8c038e1cf46da5cb96b7cd02eaa096bcaa03675edd8a2e
-    # via django-stubs
+    # via
+    #   django-stubs
+    #   djangorestframework-stubs
+types-requests==2.31.0.6 \
+    --hash=sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9 \
+    --hash=sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0
+    # via djangorestframework-stubs
+types-urllib3==1.26.25.14 \
+    --hash=sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f \
+    --hash=sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e
+    # via types-requests
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/requirements.txt
+++ b/requirements.txt
@@ -429,9 +429,9 @@ humanize==3.14.0 \
     --hash=sha256:32bcf712ac98ff5e73627a9d31e1ba5650619008d6d13543b5d53b48e8ab8d43 \
     --hash=sha256:60dd8c952b1df1ad83f0903844dec50a34ba7a04eea22a6b14204ffb62dbb0a4
     # via flower
-idna==3.3 \
-    --hash=sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff \
-    --hash=sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d
+idna==3.10 \
+    --hash=sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9 \
+    --hash=sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3
     # via requests
 importlib-metadata==4.8.2 \
     --hash=sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100 \
@@ -633,9 +633,9 @@ redis[hiredis]==4.5.4 \
     #   -r requirements.in
     #   celery-redbeat
     #   rhubarb
-requests==2.32.0 \
-    --hash=sha256:f2c3881dddb70d056c5bd7600a4fae312b2a300e39be6a118d30b90bd27262b5 \
-    --hash=sha256:fa5490319474c82ef1d2c9bc459d3652e3ae4ef4c4ebdd18a21145a47ca4b6b8
+requests==2.32.3 \
+    --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
+    --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
     #   -r requirements.in
     #   jira

--- a/test.Dockerfile
+++ b/test.Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.9
+FROM registry.access.redhat.com/ubi9/ubi:9.4
 
 LABEL summary="OSIDB testrunner" \
       maintainer="Product Security DevOps <prodsec-dev@redhat.com>"
@@ -28,9 +28,9 @@ RUN dnf --nodocs --setopt install_weak_deps=false -y install \
         make \
         openldap-devel \
         openssl-devel \
-        python39-devel \
-        python39-pip \
-        python39-wheel \
+        python3-devel \
+        python3-pip \
+        python3-wheel \
         redhat-rpm-config \
         which \
     && dnf --nodocs --setopt install_weak_deps=false -y upgrade --security \
@@ -40,6 +40,6 @@ RUN dnf --nodocs --setopt install_weak_deps=false -y install \
 # This makes podman cache this (lengthy) step as long as devel-requirements.txt stays unchanged.
 # Without this, any change in src/ would make pip install run again.
 COPY ./devel-requirements.txt /opt/app-root/src/devel-requirements.txt
-RUN pip3 install -r /opt/app-root/src/devel-requirements.txt && \
+RUN pip3 install --no-deps -r /opt/app-root/src/devel-requirements.txt && \
     rm -f /opt/app-root/src/devel-requirements.txt
 COPY . /opt/app-root/src


### PR DESCRIPTION
Update the version of the UBI image that the osidb-service pod is based on, as well as some dependencies which contain vulnerabilities.

Related to OSIDB-3326.