### PR TITLE
do not add private tracker CC to flaws

### DIFF
--- a/apps/bbsync/tests/test_cc.py
+++ b/apps/bbsync/tests/test_cc.py
@@ -505,6 +505,29 @@ class TestAffectCCBuilder:
         assert add_cc == expected_cc
         assert not remove_cc
 
+    def test_private_tracker_cc(self):
+        """
+        test that PS module private tracker CCs are correctly added
+        """
+        flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+        private_tracker_cc = ["me@redhat.com", "you@redhat.com"]
+        PsModuleFactory(
+            name=affect.ps_module,
+            private_trackers_allowed=True,
+            private_tracker_cc=private_tracker_cc,
+        )
+
+        # no private tracker CC is expected for the flaw
+        assert not AffectCCBuilder(affect, flaw.embargoed, destination="flaw").cc
+        assert sorted(
+            AffectCCBuilder(affect, flaw.embargoed, destination="tracker").cc
+        ) == ["me@redhat.com", "you@redhat.com"]
+
     @pytest.mark.parametrize(
         "ps_component,component_overrides,component_cc",
         [

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Check title for keywords in CVEorg collector (OSIDB-3545)
 - Restrict tracker file offer by ProdSec support instead of general one (OSIDB-3559)
 
+### Fixed
+- Do not add private tracker CC to flaws (OSIDB-3558)
+
 ## [4.4.0] - 2024-10-11
 ### Added
 - Introduce moderate tracker streams pre-selection (OSIDB-3346)


### PR DESCRIPTION
The solution is not to great as it adds a layer to the CC builders of recognizing where the CC list is going to be put which is an extra complexity I would rather avoid. However, I do not see a way around as there is literary a different behavior for the flaws and trackers with regard of the private tracker CC.

Closes OSIDB-3558