### PR TITLE
OSIDB-3589: Handle ValidationError on tracker filing

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update delegated resolution mapping so low impact won't fix
   changes to fix deferred (OSIDB-3575)
 
+### Fixed
+- ValidationError constraint “unique_external_system_id” during tracker filing (OSIDB-3589)
+
 ## [4.4.1] - 2024-10-17
 ### Added
 - Auto-reset CVSS validation flag on NVD CVSS removal (OSIDB-3407)

--- a/osidb/models/tracker.py
+++ b/osidb/models/tracker.py
@@ -227,11 +227,14 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         else:
             try:
                 super().save(*args, **kwargs)
-            except IntegrityError as e:
+            except (IntegrityError, ValidationError) as e:
                 exc_msg = str(e)
                 if (
-                    "duplicate key value violates unique constraint" in exc_msg
-                    and "osidb_tracker_type_external_system_id" in exc_msg
+                    (
+                        "duplicate key value violates unique constraint" in exc_msg
+                        and "osidb_tracker_type_external_system_id" in exc_msg
+                    )
+                    or "Constraint “unique_external_system_id” is violated." in exc_msg
                 ):
                     # Tracker collector collected this tracker before the whole saving process finished
                     # in the OSIDB, skip the saving and log it


### PR DESCRIPTION
With the update of Django 4.2 constraints now run as part of the  model validation, so we need to handle `ValidationError` 

Closes OSIDB-3589