### PR TITLE
Adjust delays in CVEorg and OSV collectors

### DIFF
--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -197,7 +197,8 @@ class CVEorgCollector(Collector):
                             if new_flaw:
                                 new_flaws.append(content["cve_id"])
                         # introduce a small delay after each transaction to not hit the Jira rate limit
-                        sleep(1)
+                        if new_flaw:
+                            sleep(1)
                     except Exception as exc:
                         message = f"Failed to save snippet and flaw for {content['cve_id']}. Error: {exc}."
                         logger.error(message)

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -167,7 +167,8 @@ class OSVCollector(Collector):
                             new_snippets.extend(created_snippets)
                             new_flaws.extend(created_flaws)
                         # introduce a small delay after each transaction to not hit the Jira rate limit
-                        sleep(1)
+                        if created_flaws:
+                            sleep(1)
                     except Exception as exc:
                         message = f"Failed to save snippet and flaw for {osv_id}. Error: {exc}."
                         logger.error(message)


### PR DESCRIPTION
This PR adjusts delays in CVEorg and OSV collectors to wait only in a case when a flaw is created.