### PR TITLE
Add upstream references to Jira trackers on creation

### DIFF
--- a/apps/taskman/service.py
+++ b/apps/taskman/service.py
@@ -265,3 +265,19 @@ class JiraTaskmanQuerier(JiraQuerier):
         query_list = self.query_tasks(query_list)
         query_list = self.query_updated(query_list, updated_after, updated_before)
         return self.run_query(query_list)
+
+    def add_link(self, issue_key, url, title):
+        """Add a remote link to a task."""
+        try:
+            data = {"url": url, "title": title}
+            link = self.jira_conn.add_simple_link(issue_key, data)
+            return Response(data=link.raw, status=201)
+        except JIRAError as e:
+            response_content = safe_get_response_content(e.response)
+            logger.error(
+                (
+                    f"Jira error when creating external link. Status code {e.status_code}, "
+                    f"Jira response {response_content}",
+                )
+            )
+            return Response(data=response_content, status=e.status_code)

--- a/apps/taskman/service.py
+++ b/apps/taskman/service.py
@@ -212,39 +212,6 @@ class JiraTaskmanQuerier(JiraQuerier):
 
         return data
 
-    def create_comment(self, issue_key: str, body: str):
-        """Add a comment in a task"""
-        try:
-            comment = self.jira_conn.add_comment(issue_key, body)
-            return Response(data=comment.raw, status=201)
-        except JIRAError as e:
-
-            response_content = safe_get_response_content(e.response)
-            logger.error(
-                (
-                    f"Jira error when creating Task comment. Status code {e.status_code}, "
-                    f"Jira response {response_content}",
-                )
-            )
-            return Response(data=response_content, status=e.status_code)
-
-    def update_comment(self, issue_key, comment_id, body: str):
-        """Edit a comment in a task"""
-        try:
-            comment = self.jira_conn.comment(issue=issue_key, comment=comment_id)
-            comment.update(body=body)
-            return Response(data=comment.raw, status=200)
-        except JIRAError as e:
-
-            response_content = safe_get_response_content(e.response)
-            logger.error(
-                (
-                    f"Jira error when updating Task comment. Status code {e.status_code}, "
-                    f"Jira response {response_content}",
-                )
-            )
-            return Response(data=response_content, status=e.status_code)
-
     def query_tasks(
         self, query_list: List[Tuple[str, str, str]]
     ) -> List[Tuple[str, str, str]]:
@@ -265,19 +232,3 @@ class JiraTaskmanQuerier(JiraQuerier):
         query_list = self.query_tasks(query_list)
         query_list = self.query_updated(query_list, updated_after, updated_before)
         return self.run_query(query_list)
-
-    def add_link(self, issue_key, url, title):
-        """Add a remote link to a task."""
-        try:
-            data = {"url": url, "title": title}
-            link = self.jira_conn.add_simple_link(issue_key, data)
-            return Response(data=link.raw, status=201)
-        except JIRAError as e:
-            response_content = safe_get_response_content(e.response)
-            logger.error(
-                (
-                    f"Jira error when creating external link. Status code {e.status_code}, "
-                    f"Jira response {response_content}",
-                )
-            )
-            return Response(data=response_content, status=e.status_code)

--- a/apps/taskman/tests/cassettes/test_service/TestTaskmanService.test_add_link.yaml
+++ b/apps/taskman/tests/cassettes/test_service/TestTaskmanService.test_add_link.yaml
@@ -1,0 +1,924 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.0
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
+        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
+        "Having the permission allows to select other user as automation rule actor",
+        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
+        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
+        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
+        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
+        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
+        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
+        "type": "PROJECT", "description": "Ability to move issues between projects
+        or between workflows of the same project (if applicable). Note the user can
+        only move issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 27 Jun 2024 18:00:01 GMT
+      Expires:
+      - Thu, 27 Jun 2024 18:00:01 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '16299'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 1080x164455x1
+      x-asessionid:
+      - 5tt9l1
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.4e24c317.1719511201.2282bf0c
+      x-rh-edge-request-id:
+      - 2282bf0c
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issuetype
+  response:
+    body:
+      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
+        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
+        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
+        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
+        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
+        by Jira Software - do not edit or delete. Issue type for a big user story
+        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
+        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=57660&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":57660},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=57661&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":57661},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
+        large product/portfolio goal or focus area that has clear start and completion
+        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
+        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
+        objective focused on a measurable outcome. May be in support of larger strategic
+        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
+        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
+        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
+        enhancement to or refactoring of existing functionality that is not configurable
+        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
+        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
+        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
+        to track RCA work with specific custom fields defined by the QE Closed Loop
+        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
+        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
+        one-off patch related to a customer support case, provided by Support and
+        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
+        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
+        improvement or enhancement to an existing feature or task. Includes patches
+        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
+        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
+        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
+        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
+        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
+        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
+        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
+        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
+        task tracking an update to a bundled component or revision of component upstream
+        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
+        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
+        or a well-defined set of functionality that delivers business value. Features
+        can include additions or changes to existing functionality. Features can easily
+        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
+        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
+        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
+        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
+        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
+        for conducting internal reviews of our products and process with 3rd party
+        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
+        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
+        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
+        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
+        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
+        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
+        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
+        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
+        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
+        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
+        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
+        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
+        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
+        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
+        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
+        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
+        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
+        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
+        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
+        to represent an interrupt request identifying a problem that must be addressed,
+        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
+        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
+        request for change, often with an approval step at the beginning to confirm
+        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
+        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
+        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
+        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
+        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
+        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
+        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
+        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
+        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
+        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
+        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
+        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
+        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
+        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
+        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
+        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
+        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
+        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
+        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
+        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
+        for grouping release operations, typically to identify milestones associated
+        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
+        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
+        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
+        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
+        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
+        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
+        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
+        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
+        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
+        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
+        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
+        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
+        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
+        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
+        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
+        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
+        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
+        strategic focus area typically defined by leadership teams to achieve organizational
+        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
+        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
+        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
+        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
+        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 24 Oct 2024 16:11:59 GMT
+      Expires:
+      - Thu, 24 Oct 2024 16:11:59 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '24569'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 971x637287x2
+      x-asessionid:
+      - 174z35c
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1729786318.c674e0
+      x-rh-edge-request-id:
+      - c674e0
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/project/OSIM
+  response:
+    body:
+      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
+        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
+        Response team as a task repository, managing the workflow in PSIR and integrating
+        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
+        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
+        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
+        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
+        "Represents a small unit of work that is not end-user facing.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
+        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
+        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
+        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
+        "id": "1", "description": "A problem that impairs or prevents the functions
+        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
+        "id": "16", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a big user story that needs to be broken down.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
+        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
+        "id": "11406", "description": "Expresses areas of concern for a project or
+        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
+        "name": "Risk", "subtask": false, "avatarId": 13268}, {"self": "https://example.com/rest/api/2/issuetype/12206",
+        "id": "12206", "description": "", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=57660&avatarType=issuetype",
+        "name": "Weakness", "subtask": false, "avatarId": 57660}, {"self": "https://example.com/rest/api/2/issuetype/12207",
+        "id": "12207", "description": "", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=57661&avatarType=issuetype",
+        "name": "Vulnerability", "subtask": false, "avatarId": 57661}], "assigneeType":
+        "UNASSIGNED", "versions": [], "name": "Open Security Issue Manager", "roles":
+        {"Scrum master": "https://example.com/rest/api/2/project/12337520/role/10540",
+        "Service Desk Team": "https://example.com/rest/api/2/project/12337520/role/11241",
+        "Developers": "https://example.com/rest/api/2/project/12337520/role/10001",
+        "Service Desk Customers": "https://example.com/rest/api/2/project/12337520/role/11240",
+        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
+        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
+        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
+        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
+        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
+        "projectTypeKey": "software", "archived": false}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 24 Oct 2024 16:11:59 GMT
+      Expires:
+      - Thu, 24 Oct 2024 16:11:59 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '4742'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 971x637288x2
+      x-asessionid:
+      - 1i76kgc
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1729786319.c67530
+      x-rh-edge-request-id:
+      - c67530
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2020-10000 kernel: some description", "description": "Comment zero for
+      CVE-2020-10000", "labels": ["flawuuid:b47f7912-7011-463a-b861-6d7dca13aa3c",
+      "impact:MODERATE", "CVE-2020-10000"], "priority": {"name": "Normal"}, "assignee":
+      {"name": ""}}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '330'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16298112", "key": "OSIM-11643", "self": "https://example.com/rest/api/2/issue/16298112"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 24 Oct 2024 16:12:08 GMT
+      Expires:
+      - Thu, 24 Oct 2024 16:12:08 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 971x637290x2
+      x-asessionid:
+      - z03r0y
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1729786319.c67552
+      x-rh-edge-request-id:
+      - c67552
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-11643
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16298112", "self": "https://example.com/rest/api/2/issue/16298112",
+        "key": "OSIM-11643", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1ea8c176[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3c93a906[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1c7015bb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3d0a54aa[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6f8936d4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@75616eaf[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@69207075[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@660c6ff[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@20796f71[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5e1369c7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@345a19a8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@340d66e2[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10200",
+        "iconUrl": "https://example.com/images/icons/priorities/medium.svg", "name":
+        "Normal", "id": "10200"}, "labels": ["CVE-2020-10000", "flawuuid:b47f7912-7011-463a-b861-6d7dca13aa3c",
+        "impact:MODERATE"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=rh-ee-dmonzoni",
+        "name": "rh-ee-dmonzoni", "key": "JIRAUSER227953", "emailAddress": "dmonzoni+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER227953&avatarId=52988",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER227953&avatarId=52988",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER227953&avatarId=52988",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER227953&avatarId=52988"},
+        "displayName": "Daniel Monzonis", "active": true, "timeZone": "Europe/Madrid"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=rh-ee-dmonzoni",
+        "name": "rh-ee-dmonzoni", "key": "JIRAUSER227953", "emailAddress": "dmonzoni+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER227953&avatarId=52988",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER227953&avatarId=52988",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER227953&avatarId=52988",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER227953&avatarId=52988"},
+        "displayName": "Daniel Monzonis", "active": true, "timeZone": "Europe/Madrid"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-11643/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-11643/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-10-24T16:12:00.072+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-10-24T16:12:00.072+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i1zicv:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 24 Oct 2024 16:12:09 GMT
+      Expires:
+      - Thu, 24 Oct 2024 16:12:09 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '9617'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 972x637329x2
+      x-asessionid:
+      - 14xr9z
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1729786328.c67b1a
+      x-rh-edge-request-id:
+      - c67b1a
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"object": {"url": "https://www.redhat.com", "title": "Red Hat Webpage"}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '73'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue/OSIM-11643/remotelink
+  response:
+    body:
+      string: '{"id": 1757810, "self": "https://example.com/rest/api/2/issue/OSIM-11643/remotelink/1757810"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 24 Oct 2024 16:12:11 GMT
+      Expires:
+      - Thu, 24 Oct 2024 16:12:11 GMT
+      Location:
+      - https://example.com/rest/api/2/issue/OSIM-11643/remotelink/1757810
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '102'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 972x637332x2
+      x-asessionid:
+      - 116jji2
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.7df06e68.1729786329.c67bd4
+      x-rh-edge-request-id:
+      - c67bd4
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+version: 1

--- a/apps/taskman/tests/test_service.py
+++ b/apps/taskman/tests/test_service.py
@@ -98,3 +98,20 @@ class TestTaskmanService(object):
             "Edited comment",
         )
         assert response3.status_code == 200
+
+    @pytest.mark.vcr
+    def test_add_link(self, user_token):
+        """
+        Test that service is able to create remote links in Jira issues.
+        """
+        flaw = FlawFactory(embargoed=False, uuid="b47f7912-7011-463a-b861-6d7dca13aa3c")
+        AffectFactory(flaw=flaw)
+        taskman = JiraTaskmanQuerier(token=user_token)
+
+        response1 = taskman.create_or_update_task(flaw=flaw)
+        assert response1.status_code == 201
+
+        response2 = taskman.add_link(
+            response1.data["key"], "https://www.redhat.com", "Red Hat Webpage"
+        )
+        assert response2.status_code == 201

--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -72,6 +72,14 @@ class TrackerJiraSaver(JiraQuerier):
                 issue_key=issue.key,
                 body=comment,
             )
+        # Add upstream links only on tracker creation
+        for reference in tracker.upstream_references:
+            JiraTaskmanQuerier(token=self._jira_token).add_link(
+                issue_key=issue.key,
+                url=reference.url,
+                title=reference.description,
+            )
+
         return tracker
 
     def update(self, tracker):

--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -4,7 +4,6 @@ Jira tracker query module
 import json
 import logging
 
-from apps.taskman.service import JiraTaskmanQuerier
 from apps.trackers.exceptions import BTSException
 from collectors.jiraffe.core import JiraQuerier
 
@@ -68,13 +67,13 @@ class TrackerJiraSaver(JiraQuerier):
         issue = self.jira_conn.create_issue(fields=query["fields"], prefetch=True)
         tracker.external_system_id = issue.key
         if comment:
-            JiraTaskmanQuerier(token=self._jira_token).create_comment(
+            self.create_comment(
                 issue_key=issue.key,
                 body=comment,
             )
         # Add upstream links only on tracker creation
         for reference in tracker.upstream_references:
-            JiraTaskmanQuerier(token=self._jira_token).add_link(
+            self.add_link(
                 issue_key=issue.key,
                 url=reference.url,
                 title=reference.description,

--- a/collectors/jiraffe/core.py
+++ b/collectors/jiraffe/core.py
@@ -5,6 +5,9 @@ from celery.utils.log import get_task_logger
 from django.utils import timezone
 from jira import JIRA, Issue
 from jira.exceptions import JIRAError
+from rest_framework.response import Response
+
+from osidb.helpers import safe_get_response_content
 
 from .constants import JIRA_DT_FMT, JIRA_MAX_CONNECTION_AGE, JIRA_SERVER, JIRA_TOKEN
 from .exceptions import NonRecoverableJiraffeException
@@ -184,6 +187,55 @@ class JiraQuerier(JiraConnector):
                 )
             # re-raise otherwise
             raise e
+
+    def create_comment(self, issue_key: str, body: str) -> Response:
+        """Add a comment in a Jira issue."""
+        try:
+            comment = self.jira_conn.add_comment(issue_key, body)
+            return Response(data=comment.raw, status=201)
+        except JIRAError as e:
+
+            response_content = safe_get_response_content(e.response)
+            logger.error(
+                (
+                    f"Jira error when creating comment. Status code {e.status_code}, "
+                    f"Jira response {response_content}",
+                )
+            )
+            return Response(data=response_content, status=e.status_code)
+
+    def update_comment(self, issue_key, comment_id, body: str) -> Response:
+        """Edit a comment in a Jira issue."""
+        try:
+            comment = self.jira_conn.comment(issue=issue_key, comment=comment_id)
+            comment.update(body=body)
+            return Response(data=comment.raw, status=200)
+        except JIRAError as e:
+
+            response_content = safe_get_response_content(e.response)
+            logger.error(
+                (
+                    f"Jira error when updating comment. Status code {e.status_code}, "
+                    f"Jira response {response_content}",
+                )
+            )
+            return Response(data=response_content, status=e.status_code)
+
+    def add_link(self, issue_key, url, title) -> Response:
+        """Add a remote link to a task."""
+        try:
+            data = {"url": url, "title": title}
+            link = self.jira_conn.add_simple_link(issue_key, data)
+            return Response(data=link.raw, status=201)
+        except JIRAError as e:
+            response_content = safe_get_response_content(e.response)
+            logger.error(
+                (
+                    f"Jira error when creating external link. Status code {e.status_code}, "
+                    f"Jira response {response_content}",
+                )
+            )
+            return Response(data=response_content, status=e.status_code)
 
     #######################
     # MULTI ISSUE QUERIES #

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Add upstream references to Jira trackers on creation (OSIDB-3148)
 
 ## [4.5.1] - 2024-10-23
 ### Added

--- a/osidb/models/tracker.py
+++ b/osidb/models/tracker.py
@@ -496,6 +496,17 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
             is not None
         )
 
+    @property
+    def upstream_references(self):
+        """Get a list of upstream references related to this tracker."""
+        from osidb.models.flaw.flaw import Flaw
+        from osidb.models.flaw.reference import FlawReference
+
+        flaws = Flaw.objects.filter(affects__trackers=self)
+        return FlawReference.objects.filter(
+            flaw__in=flaws, type=FlawReference.FlawReferenceType.UPSTREAM
+        )
+
     bz_download_manager = models.ForeignKey(
         BZTrackerDownloadManager, null=True, blank=True, on_delete=models.CASCADE
     )


### PR DESCRIPTION
When filing a tracker, the related upstream links (flaw references that are of type UPSTREAM for any related flaws) will be added as remote links in the Jira issue.

Closes OSIDB-3148.