### PR TITLE
fix internal acls during serializer update

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Add upstream references to Jira trackers on creation (OSIDB-3148)
+- Change ACL mixin serializer to support internal ACLs (OSIDB-3578)
 
 ## [4.5.2] - 2024-10-24
 ### Changed

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -435,7 +435,14 @@ class ACLMixinSerializer(serializers.ModelSerializer):
         return super().create(validated_data)
 
     def update(self, instance, validated_data):
-        validated_data = self.embargoed2acls(validated_data)
+        # defaults to keep current ACLs
+        validated_data["acl_read"] = instance.acl_read
+        validated_data["acl_write"] = instance.acl_write
+
+        if instance.is_public or instance.is_embargoed:
+            # only allow manual ACL changes between embargoed and public
+            validated_data = self.embargoed2acls(validated_data)
+
         return super().update(instance, validated_data)
 
 


### PR DESCRIPTION
This PR changes `ACLMixinSerializer` in order to support other ACLs other than embargoed and public.

Closes OSIDB-3578.