### PR TITLE
OSIDB-3581: Validate zero cvss score for flaws without impact

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,7 +162,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 94,
+        "line_number": 95,
         "is_secret": false
       }
     ],
@@ -467,5 +467,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-31T12:11:24Z"
+  "generated_at": "2024-11-04T10:36:13Z"
 }

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -16,6 +16,7 @@ from osidb.models import (
     FlawAcknowledgment,
     FlawCVSS,
     FlawReference,
+    Impact,
     Snippet,
     Tracker,
 )
@@ -914,6 +915,7 @@ class TestFlawDraftBBSyncIntegration:
             ],
             "source": source,
             "title": f"From {source} collector",
+            "impact": Impact.LOW,
             f"published_in_{source.lower()}": "2024-01-21T16:29:00.393Z",
         }
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add upstream references to Jira trackers on creation (OSIDB-3148)
 - Change ACL mixin serializer to support internal ACLs (OSIDB-3578)
 - Make product definitions collector atomic (OSIDB-3590)
+- Validate that the CVSSv3 score is zero for flaws with impact "None" (OSIDB-3581)
 
 ## [4.5.2] - 2024-10-24
 ### Changed

--- a/osidb/models/flaw/cvss.py
+++ b/osidb/models/flaw/cvss.py
@@ -1,5 +1,7 @@
+from decimal import Decimal
+
 from django.contrib.postgres.indexes import GinIndex
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
 
 from osidb.mixins import ACLMixinManager, TrackingMixin, TrackingMixinManager
@@ -40,3 +42,9 @@ class FlawCVSS(CVSS):
         indexes = TrackingMixin.Meta.indexes + [
             GinIndex(fields=["acl_read"]),
         ]
+
+    def _validate_empty_impact_and_cvss_score(self, **kwargs):
+        if not self.flaw.impact and self.cvss_object.base_score != Decimal("0.0"):
+            raise ValidationError(
+                {"cvss_score": ["CVSS score must be 0.0 for flaws with no impact"]}
+            )

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -429,6 +429,21 @@ class Flaw(
                 **kwargs,
             )
 
+    def _validate_empty_impact_and_cvss_score(self, **kwargs):
+        """
+        Checks that if impact is None, CVSSv3 score must be zero.
+        """
+        from .cvss import FlawCVSS
+
+        rh_cvss3 = self.cvss_scores.filter(
+            version=FlawCVSS.CVSSVersion.VERSION3, issuer=FlawCVSS.CVSSIssuer.REDHAT
+        ).first()
+
+        if not self.impact and rh_cvss3 and rh_cvss3.score != Decimal("0.0"):
+            raise ValidationError(
+                {"impact": ["Impact is set to None but CVSSv3 score is not zero."]}
+            )
+
     def _validate_cve_description_and_requires_cve_description(self, **kwargs):
         """
         Checks that if cve_description is missing, then requires_cve_description must not have


### PR DESCRIPTION
Added validation to the `Flaw` Model and the `FlawCVSSSerializer` to check that if the flaw has impact `''`, the CVSS score **must** be 0.

I had to add the validation to the serializer as adding it to the Model was using the value already on the database instead of the one that comes from the request.

Closes OSIDB-3581