### PR TITLE
Fix some of warnings and prevent new ones

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -354,7 +354,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1344,
+        "line_number": 1335,
         "is_secret": false
       }
     ],
@@ -394,7 +394,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_update_trackers.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 87,
         "is_secret": false
       }
     ],
@@ -467,5 +467,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-24T15:27:17Z"
+  "generated_at": "2024-10-31T12:11:24Z"
 }

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -1,8 +1,9 @@
 """
 tracker common functionality test cases
 """
+from datetime import datetime, timezone
+
 import pytest
-from django.utils import timezone
 
 from apps.trackers.common import TrackerQueryBuilder
 from osidb.models import Affect, Flaw, Tracker
@@ -467,7 +468,7 @@ class TestTrackerQueryBuilderDescription:
                     ps_component="large-component",
                     # created datetime defines the query result
                     # ordering which is later reflected in description
-                    created_dt=timezone.datetime(2000 + idx, 1, 1, tzinfo=timezone.utc),
+                    created_dt=datetime(2000 + idx, 1, 1, tzinfo=timezone.utc),
                 )
             )
 

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -3,10 +3,11 @@ Bugzilla specific tracker test cases
 """
 
 import json
+from datetime import datetime, timezone
 from typing import Any, Dict
 
 import pytest
-from django.utils.timezone import datetime, make_aware, utc
+from django.utils.timezone import make_aware
 
 from apps.sla.tests.test_framework import load_sla_policies
 from apps.trackers.exceptions import (
@@ -2038,7 +2039,7 @@ class TestTrackerJiraQueryBuilder:
             title="some description",
             source="REDHAT",
             cwe_id="CWE-2",
-            created_dt=datetime(2024, 10, 1, tzinfo=utc),
+            created_dt=datetime(2024, 10, 1, tzinfo=timezone.utc),
         )
         flwcvss2 = FlawCVSSFactory(flaw=flaw2, issuer=FlawCVSS.CVSSIssuer.REDHAT)
         affect2 = AffectFactory(
@@ -2059,7 +2060,7 @@ class TestTrackerJiraQueryBuilder:
             title="some description",
             source="REDHAT",
             cwe_id="CWE-3",
-            created_dt=datetime(2024, 9, 1, tzinfo=utc),
+            created_dt=datetime(2024, 9, 1, tzinfo=timezone.utc),
         )
         flwcvss3 = FlawCVSSFactory(flaw=flaw3, issuer=FlawCVSS.CVSSIssuer.REDHAT)
         affect3 = AffectFactory(
@@ -2078,7 +2079,7 @@ class TestTrackerJiraQueryBuilder:
             title="some description",
             source="REDHAT",
             cwe_id="CWE-4",
-            created_dt=datetime(2024, 10, 2, tzinfo=utc),
+            created_dt=datetime(2024, 10, 2, tzinfo=timezone.utc),
         )
         flwcvss4 = FlawCVSSFactory(flaw=flaw4, issuer=FlawCVSS.CVSSIssuer.REDHAT)
         affect4 = AffectFactory(

--- a/collectors/bzimport/tests/test_collectors.py
+++ b/collectors/bzimport/tests/test_collectors.py
@@ -1,8 +1,7 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 from django.db.utils import IntegrityError
-from django.utils import timezone
 
 from apps.bbsync.models import BugzillaComponent, BugzillaProduct
 from collectors.bzimport.collectors import BugzillaQuerier, MetadataCollector
@@ -84,7 +83,7 @@ class TestBZImportCollector:
             assert period_start < period_end
 
             period_start = period_end
-            if period_start > timezone.now():
+            if period_start > datetime.now().replace(tzinfo=timezone.utc):
                 break
 
     def test_end_period_heuristic_migrations(self, flaw_collector):
@@ -310,7 +309,7 @@ class TestBugzillaTrackerCollector:
             ps_update_stream=ps_update_stream.name,
             type=Tracker.TrackerType.BUGZILLA,
             embargoed=False,
-            updated_dt=timezone.datetime.strptime("1970-01-01T00:00:00Z", BZ_DT_FMT),
+            updated_dt=datetime.strptime("1970-01-01T00:00:00Z", BZ_DT_FMT),
         )
         # make sure the links are there
         tracker = Tracker.objects.first()

--- a/collectors/errata/tests/test_core.py
+++ b/collectors/errata/tests/test_core.py
@@ -1,5 +1,6 @@
+from datetime import datetime, timezone
+
 import pytest
-from django.utils import timezone
 
 from collectors.framework.models import CollectorMetadata
 from osidb.models import Affect, Erratum, Tracker
@@ -37,19 +38,19 @@ class TestErrataToolCollection:
         "bz_updated,jira_updated,expected_end",
         [
             (
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
             ),
             (
-                timezone.datetime(2021, 1, 1, tzinfo=timezone.utc),
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2021, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
             ),
             (
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
-                timezone.datetime(2021, 1, 1, tzinfo=timezone.utc),
-                timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
+                datetime(2021, 1, 1, tzinfo=timezone.utc),
+                datetime(2020, 1, 1, tzinfo=timezone.utc),
             ),
         ],
     )
@@ -153,13 +154,13 @@ class TestErrataToolCollection:
         assert Erratum.objects.count() == 1
         # Which is linked to two Bugzilla trackers, the same as above
         assert Erratum.objects.first().trackers.count() == 2
-        assert Erratum.objects.first().created_dt == timezone.datetime(
+        assert Erratum.objects.first().created_dt == datetime(
             2023, 1, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().shipped_dt == timezone.datetime(
+        assert Erratum.objects.first().shipped_dt == datetime(
             2023, 2, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().updated_dt == timezone.datetime(
+        assert Erratum.objects.first().updated_dt == datetime(
             2023, 3, 8, 0, 41, 10, tzinfo=timezone.utc
         )
 
@@ -287,13 +288,13 @@ class TestErrataToolCollection:
         assert Erratum.objects.count() == 1
         # Which is linked to one Jira tracker, the same as above
         assert Erratum.objects.first().trackers.count() == 1
-        assert Erratum.objects.first().created_dt == timezone.datetime(
+        assert Erratum.objects.first().created_dt == datetime(
             2023, 1, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().shipped_dt == timezone.datetime(
+        assert Erratum.objects.first().shipped_dt == datetime(
             2023, 2, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().updated_dt == timezone.datetime(
+        assert Erratum.objects.first().updated_dt == datetime(
             2023, 3, 8, 0, 41, 10, tzinfo=timezone.utc
         )
 
@@ -341,13 +342,13 @@ class TestErrataToolCollection:
         assert Erratum.objects.count() == 1
         # Which is not linked to any trackers
         assert Erratum.objects.first().trackers.count() == 0
-        assert Erratum.objects.first().created_dt == timezone.datetime(
+        assert Erratum.objects.first().created_dt == datetime(
             2023, 1, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().shipped_dt == timezone.datetime(
+        assert Erratum.objects.first().shipped_dt == datetime(
             2023, 2, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().updated_dt == timezone.datetime(
+        assert Erratum.objects.first().updated_dt == datetime(
             2023, 3, 8, 0, 41, 10, tzinfo=timezone.utc
         )
 
@@ -395,13 +396,13 @@ class TestErrataToolCollection:
         # One erratum was created
         assert Erratum.objects.count() == 1
         assert Erratum.objects.first().advisory_name == f"{sample_erratum_name}-01"
-        assert Erratum.objects.first().created_dt == timezone.datetime(
+        assert Erratum.objects.first().created_dt == datetime(
             2023, 1, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().shipped_dt == timezone.datetime(
+        assert Erratum.objects.first().shipped_dt == datetime(
             2023, 2, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().updated_dt == timezone.datetime(
+        assert Erratum.objects.first().updated_dt == datetime(
             2023, 3, 8, 0, 41, 10, tzinfo=timezone.utc
         )
 
@@ -420,12 +421,12 @@ class TestErrataToolCollection:
         # Erratum is updated
         assert Erratum.objects.count() == 1
         assert Erratum.objects.first().advisory_name == f"{sample_erratum_name}-02"
-        assert Erratum.objects.first().created_dt == timezone.datetime(
+        assert Erratum.objects.first().created_dt == datetime(
             2023, 1, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().shipped_dt == timezone.datetime(
+        assert Erratum.objects.first().shipped_dt == datetime(
             2023, 3, 8, 0, 41, 10, tzinfo=timezone.utc
         )
-        assert Erratum.objects.first().updated_dt == timezone.datetime(
+        assert Erratum.objects.first().updated_dt == datetime(
             2023, 5, 8, 0, 41, 10, tzinfo=timezone.utc
         )

--- a/collectors/jiraffe/tests/test_core.py
+++ b/collectors/jiraffe/tests/test_core.py
@@ -1,5 +1,6 @@
+from datetime import datetime, timezone
+
 import pytest
-from django.utils import timezone
 from jira import Issue
 
 from collectors.jiraffe.core import JiraQuerier
@@ -50,8 +51,8 @@ class TestJiraQuerier:
         """
         test that getting the Jira issues in the give period works
         """
-        from_dt = timezone.datetime(2014, 6, 16, 0, 0, 0, tzinfo=timezone.utc)
-        till_dt = timezone.datetime(2014, 9, 19, 0, 0, 0, tzinfo=timezone.utc)
+        from_dt = datetime(2014, 6, 16, 0, 0, 0, tzinfo=timezone.utc)
+        till_dt = datetime(2014, 9, 19, 0, 0, 0, tzinfo=timezone.utc)
         trackers = JiraQuerier().get_tracker_period(from_dt, till_dt)
 
         assert len(trackers) == 5
@@ -70,8 +71,8 @@ class TestJiraQuerier:
         test that tracker quering counts for both Bug and Vulnerability
         issue type
         """
-        from_dt = timezone.datetime(2024, 9, 30, 14, 0, 0, tzinfo=timezone.utc)
-        before_dt = timezone.datetime(2024, 10, 1, 0, 0, 0, tzinfo=timezone.utc)
+        from_dt = datetime(2024, 9, 30, 14, 0, 0, tzinfo=timezone.utc)
+        before_dt = datetime(2024, 10, 1, 0, 0, 0, tzinfo=timezone.utc)
 
         jq = JiraQuerier()
         query_list = []

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -1,5 +1,6 @@
+from datetime import datetime, timezone
+
 import pytest
-from django.utils import timezone
 
 from collectors.framework.models import CollectorMetadata
 from collectors.nvd.collectors import NVDCollector
@@ -24,14 +25,12 @@ class TestNVDCollector:
         # https://services.nvd.nist.gov/rest/json/cves/2.0/?lastModStartDate=2010-01-01T00:00:00&lastModEndDate=2010-04-11T00:00:00
 
         nvdc = NVDCollector()
-        nvdc.metadata.updated_until_dt = timezone.datetime(
-            2010, 1, 1, 0, 0, tzinfo=timezone.utc
-        )
+        nvdc.metadata.updated_until_dt = datetime(2010, 1, 1, 0, 0, tzinfo=timezone.utc)
 
         # test that the batch is correctly selected
         batch, period_end = nvdc.get_batch()
         assert len(batch) == 296
-        assert period_end == timezone.datetime(2010, 4, 11, 0, 0, tzinfo=timezone.utc)
+        assert period_end == datetime(2010, 4, 11, 0, 0, tzinfo=timezone.utc)
 
         # test that the batch collection works
         # randomly select a few flaws - not all 296
@@ -103,9 +102,9 @@ class TestNVDCollector:
 
         # let us define a time of last collection
         # and one timestamp before and one after
-        before_collector_run = timezone.datetime(2022, 1, 1, 0, 0, tzinfo=timezone.utc)
-        last_collector_run = timezone.datetime(2022, 2, 1, 0, 0, tzinfo=timezone.utc)
-        after_collector_run = timezone.datetime(2022, 3, 1, 0, 0, tzinfo=timezone.utc)
+        before_collector_run = datetime(2022, 1, 1, 0, 0, tzinfo=timezone.utc)
+        last_collector_run = datetime(2022, 2, 1, 0, 0, tzinfo=timezone.utc)
+        after_collector_run = datetime(2022, 3, 1, 0, 0, tzinfo=timezone.utc)
 
         FlawFactory(cve_id=cve1, updated_dt=before_collector_run)
         FlawFactory(cve_id=cve2, updated_dt=after_collector_run)

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -1,7 +1,7 @@
 import json
+from datetime import datetime, timezone
 
 import pytest
-from django.utils.timezone import datetime, utc
 from jira.exceptions import JIRAError
 
 from apps.taskman.service import JiraTaskmanQuerier
@@ -108,7 +108,7 @@ class TestOSVCollector:
         """
         osvc = OSVCollector()
         osvc.snippet_creation_enabled = True
-        osvc.snippet_creation_start_date = datetime(2024, 1, 1, tzinfo=utc)
+        osvc.snippet_creation_start_date = datetime(2024, 1, 1, tzinfo=timezone.utc)
         osvc.collect(osv_id="GHSA-3hwm-922r-47hw")
 
         assert Snippet.objects.count() == 0

--- a/osidb/models/tests/test_ps_module.py
+++ b/osidb/models/tests/test_ps_module.py
@@ -1,37 +1,38 @@
+from datetime import datetime, timezone
+
 import pytest
-from django.utils import timezone
 from freezegun import freeze_time
 
 from osidb.models import PsModule
 
 
 class TestPsModule:
-    @freeze_time(timezone.datetime(2020, 10, 20, tzinfo=timezone.utc))
+    @freeze_time(datetime(2020, 10, 20, tzinfo=timezone.utc))
     @pytest.mark.parametrize(
         "supported_from,supported_until,is_prodsec_supported",
         [
             (
-                timezone.datetime(2020, 10, 10, tzinfo=timezone.utc),
-                timezone.datetime(2020, 10, 30, tzinfo=timezone.utc),
+                datetime(2020, 10, 10, tzinfo=timezone.utc),
+                datetime(2020, 10, 30, tzinfo=timezone.utc),
                 True,
             ),
             (
-                timezone.datetime(2020, 10, 10, tzinfo=timezone.utc),
-                timezone.datetime(2020, 10, 10, tzinfo=timezone.utc),
+                datetime(2020, 10, 10, tzinfo=timezone.utc),
+                datetime(2020, 10, 10, tzinfo=timezone.utc),
                 False,
             ),
             (
-                timezone.datetime(2020, 10, 30, tzinfo=timezone.utc),
-                timezone.datetime(2020, 10, 30, tzinfo=timezone.utc),
+                datetime(2020, 10, 30, tzinfo=timezone.utc),
+                datetime(2020, 10, 30, tzinfo=timezone.utc),
                 True,  # support start in the future should not restrict ProdSec support
             ),
             (
                 None,
-                timezone.datetime(2020, 10, 30, tzinfo=timezone.utc),
+                datetime(2020, 10, 30, tzinfo=timezone.utc),
                 True,
             ),
             (
-                timezone.datetime(2020, 10, 10, tzinfo=timezone.utc),
+                datetime(2020, 10, 10, tzinfo=timezone.utc),
                 None,
                 True,
             ),

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -1,10 +1,9 @@
-from datetime import timedelta
+from datetime import timedelta, timezone
 from typing import Set, Union
 
 import pghistory
 import pytest
 from django.conf import settings
-from django.utils import timezone
 from django.utils.timezone import datetime, make_aware
 from freezegun import freeze_time
 from rest_framework import status
@@ -374,9 +373,7 @@ class TestEndpointsFlaws:
         with freeze_time(future_dt):
             tracker.external_system_id = "foo"
             tracker.save()
-        assert tracker.updated_dt == future_dt.astimezone(
-            timezone.get_current_timezone()
-        )
+        assert tracker.updated_dt == future_dt.astimezone(timezone.utc)
 
         # we should get a result now
         response = auth_client().get(f"{test_api_uri}/flaws?changed_after={future_dt}")
@@ -400,9 +397,7 @@ class TestEndpointsFlaws:
         with freeze_time(future_dt):
             affect.ps_component = "foo"
             affect.save()
-        assert affect.updated_dt == future_dt.astimezone(
-            timezone.get_current_timezone()
-        )
+        assert affect.updated_dt == future_dt.astimezone(timezone.utc)
 
         response = auth_client().get(f"{test_api_uri}/flaws?changed_after={future_dt}")
         assert response.status_code == 200
@@ -427,9 +422,7 @@ class TestEndpointsFlaws:
             with freeze_time(future_dt):
                 affect.ps_component = "foo"
                 affect.save()
-            assert affect.updated_dt == future_dt.astimezone(
-                timezone.get_current_timezone()
-            )
+            assert affect.updated_dt == future_dt.astimezone(timezone.utc)
 
         response = auth_client().get(f"{test_api_uri}/flaws?changed_after={future_dt}")
         assert response.status_code == 200
@@ -476,7 +469,7 @@ class TestEndpointsFlaws:
         with freeze_time(past_dt):
             tracker.external_system_id = "foo"
             tracker.save()
-        assert tracker.updated_dt == past_dt.astimezone(timezone.get_current_timezone())
+        assert tracker.updated_dt == past_dt.astimezone(timezone.utc)
 
         # we should get a result now
         response = auth_client().get(
@@ -510,7 +503,7 @@ class TestEndpointsFlaws:
         with freeze_time(past_dt):
             affect.ps_component = "foo"
             affect.save()
-        assert affect.updated_dt == past_dt.astimezone(timezone.get_current_timezone())
+        assert affect.updated_dt == past_dt.astimezone(timezone.utc)
 
         response = auth_client().get(
             f"{test_api_uri}/flaws?changed_before={past_dt.strftime('%Y-%m-%dT%H:%M:%SZ')}"
@@ -574,9 +567,7 @@ class TestEndpointsFlaws:
             with freeze_time(past_dt):
                 tracker.resolution = "foo"
                 tracker.save()
-            assert tracker.updated_dt == past_dt.astimezone(
-                timezone.get_current_timezone()
-            )
+            assert tracker.updated_dt == past_dt.astimezone(timezone.utc)
 
         # we should get a result now
         response = auth_client().get(

--- a/osidb/tests/endpoints/flaws/test_unembargo.py
+++ b/osidb/tests/endpoints/flaws/test_unembargo.py
@@ -1,7 +1,7 @@
+from datetime import datetime, timezone
 from itertools import chain
 
 import pytest
-from django.utils import timezone
 from freezegun import freeze_time
 from rest_framework import status
 
@@ -39,14 +39,14 @@ class TestEndpointsFlawsUnembargo:
     result from /flaws endpoint PUT calls
     """
 
-    @freeze_time(timezone.datetime(2020, 10, 10, tzinfo=timezone.utc))
+    @freeze_time(datetime(2020, 10, 10, tzinfo=timezone.utc))
     def test_minimal(self, auth_client, test_api_uri):
         """
         test that a minimal flaw context can be correctly unembargoed
         """
         flaw = FlawFactory(
             embargoed=True,
-            unembargo_dt=timezone.datetime(2030, 10, 10, tzinfo=timezone.utc),
+            unembargo_dt=datetime(2030, 10, 10, tzinfo=timezone.utc),
         )
         ps_module = PsModuleFactory()
         AffectFactory(
@@ -59,7 +59,7 @@ class TestEndpointsFlawsUnembargo:
         assert Affect.objects.first().is_embargoed
         assert Flaw.objects.first().is_embargoed
 
-        with freeze_time(timezone.datetime(2030, 10, 10, tzinfo=timezone.utc)):
+        with freeze_time(datetime(2030, 10, 10, tzinfo=timezone.utc)):
             flaw_data = {
                 "comment_zero": flaw.comment_zero,
                 "embargoed": False,
@@ -78,14 +78,14 @@ class TestEndpointsFlawsUnembargo:
             assert not Affect.objects.first().is_embargoed
             assert not Flaw.objects.first().is_embargoed
 
-    @freeze_time(timezone.datetime(2020, 10, 10, tzinfo=timezone.utc))
+    @freeze_time(datetime(2020, 10, 10, tzinfo=timezone.utc))
     def test_complex(self, auth_client, test_api_uri):
         """
         test that a complex flaw context can be correctly unembargoed
         """
         flaw = FlawFactory(
             embargoed=True,
-            unembargo_dt=timezone.datetime(2030, 10, 10, tzinfo=timezone.utc),
+            unembargo_dt=datetime(2030, 10, 10, tzinfo=timezone.utc),
         )
         FlawAcknowledgmentFactory(flaw=flaw, affiliation="Corp1")
         FlawAcknowledgmentFactory(flaw=flaw, affiliation="Corp2")
@@ -145,7 +145,7 @@ class TestEndpointsFlawsUnembargo:
             )
         )
 
-        with freeze_time(timezone.datetime(2030, 10, 10, tzinfo=timezone.utc)):
+        with freeze_time(datetime(2030, 10, 10, tzinfo=timezone.utc)):
             flaw_data = {
                 "comment_zero": flaw.comment_zero,
                 "embargoed": False,
@@ -176,7 +176,7 @@ class TestEndpointsFlawsUnembargo:
                 )
             )
 
-    @freeze_time(timezone.datetime(2020, 10, 10, tzinfo=timezone.utc))
+    @freeze_time(datetime(2020, 10, 10, tzinfo=timezone.utc))
     def test_combined(self, auth_client, test_api_uri):
         """
         test that a combined flaw context of multiple flaws can be correctly unembargoed
@@ -184,7 +184,7 @@ class TestEndpointsFlawsUnembargo:
         ps_module = PsModuleFactory()
         flaw1 = FlawFactory(
             embargoed=True,
-            unembargo_dt=timezone.datetime(2030, 10, 10, tzinfo=timezone.utc),
+            unembargo_dt=datetime(2030, 10, 10, tzinfo=timezone.utc),
         )
         affect1 = AffectFactory(
             flaw=flaw1,
@@ -194,7 +194,7 @@ class TestEndpointsFlawsUnembargo:
         )
         flaw2 = FlawFactory(
             embargoed=flaw1.embargoed,
-            unembargo_dt=timezone.datetime(2040, 10, 10, tzinfo=timezone.utc),
+            unembargo_dt=datetime(2040, 10, 10, tzinfo=timezone.utc),
         )
         affect2 = AffectFactory(
             flaw=flaw2,
@@ -215,7 +215,7 @@ class TestEndpointsFlawsUnembargo:
         assert all(instance.is_embargoed for instance in Flaw.objects.all())
         assert all(instance.is_embargoed for instance in Tracker.objects.all())
 
-        with freeze_time(timezone.datetime(2030, 10, 10, tzinfo=timezone.utc)):
+        with freeze_time(datetime(2030, 10, 10, tzinfo=timezone.utc)):
             flaw_data = {
                 "comment_zero": flaw1.comment_zero,
                 "embargoed": False,
@@ -237,7 +237,7 @@ class TestEndpointsFlawsUnembargo:
             assert Affect.objects.get(uuid=affect2.uuid).is_embargoed
             assert all(instance.is_embargoed for instance in Tracker.objects.all())
 
-        with freeze_time(timezone.datetime(2040, 10, 10, tzinfo=timezone.utc)):
+        with freeze_time(datetime(2040, 10, 10, tzinfo=timezone.utc)):
             flaw_data = {
                 "comment_zero": flaw2.comment_zero,
                 "embargoed": False,

--- a/osidb/tests/endpoints/flaws/test_update_trackers.py
+++ b/osidb/tests/endpoints/flaws/test_update_trackers.py
@@ -1,8 +1,7 @@
+from datetime import datetime, timezone
 from unittest.mock import patch
 
 import pytest
-from django.utils import timezone
-from django.utils.timezone import datetime
 from rest_framework import status
 
 from osidb.models import Affect, Tracker

--- a/osidb/tests/test_audit.py
+++ b/osidb/tests/test_audit.py
@@ -1,9 +1,9 @@
 import uuid
+from datetime import datetime, timezone
 
 import pghistory
 import pytest
 from django.db import transaction
-from django.utils import timezone
 
 from osidb.core import set_user_acls
 from osidb.models import Affect, Flaw, FlawSource, Impact
@@ -40,14 +40,14 @@ class TestAuditFlaw:
             bz_id="12345",
             cwe_id="CWE-1",
             title="first",
-            unembargo_dt=timezone.datetime(2020, 1, 1, tzinfo=timezone.utc),
+            unembargo_dt=datetime(2020, 1, 1, tzinfo=timezone.utc),
             comment_zero="description",
             impact=Impact.LOW,
             components=["curl"],
             source=FlawSource.INTERNET,
             acl_read=self.acl_read,
             acl_write=self.acl_write,
-            reported_dt=timezone.now(),
+            reported_dt=datetime.now().replace(tzinfo=timezone.utc),
         )
         flaw1.save()
         affect1 = AffectFactory(flaw=flaw1)

--- a/osidb/tests/test_factories.py
+++ b/osidb/tests/test_factories.py
@@ -1,8 +1,9 @@
 """
 tests related to the test factories
 """
+from datetime import datetime, timezone
+
 import pytest
-from django.utils import timezone
 
 from osidb.models import Affect, Tracker
 from osidb.tests.factories import (
@@ -42,9 +43,5 @@ class TestTrackerFactory:
             created_dt="2000-10-10T00:00:00Z",
             updated_dt="2000-10-10T00:00:00Z",
         )
-        assert tracker.created_dt == timezone.datetime(
-            2000, 10, 10, tzinfo=timezone.utc
-        )
-        assert tracker.updated_dt == timezone.datetime(
-            2000, 10, 10, tzinfo=timezone.utc
-        )
+        assert tracker.created_dt == datetime(2000, 10, 10, tzinfo=timezone.utc)
+        assert tracker.updated_dt == datetime(2000, 10, 10, tzinfo=timezone.utc)

--- a/pytest.ini
+++ b/pytest.ini
@@ -12,5 +12,8 @@ markers =
 
 filterwarnings =
     error
-    default::django.utils.deprecation.RemovedInDjango50Warning
+    # TODO: solve RemovedInDjango50Warning before updating to Django 5
+    # lines below ensure that no new warnings will be introduced in the code (only the existing ones are allowed)
+    default:.*USE_L10N.*:django.utils.deprecation.RemovedInDjango50Warning
+    default:.*QuerySet.iterator().*:django.utils.deprecation.RemovedInDjango50Warning
     default:.*accessing deprecated field.*:DeprecationWarning


### PR DESCRIPTION
This PR fixes warnings regarding `django.utils.timezone.utc` being deprecated and ensures that no new warnings will be introduced in the code (only the already present warnings are allowed).