### PR TITLE
OSIDB-3588: Implement resolution steps for duplicate tracker validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Implement resolution steps for duplicate tracker validation (OSIDB-3588)
+
 ### Changed
 - Add upstream references to Jira trackers on creation (OSIDB-3148)
 - Change ACL mixin serializer to support internal ACLs (OSIDB-3578)

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -806,6 +806,7 @@ class AlertMixin(ValidateMixin):
                         name=validation_name,
                         description=e.message,
                         alert_type=Alert.AlertType.ERROR,
+                        **(e.params or {}),
                     )
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
- Added the external system id of the duplicated trackers to the error message so it is easier to identify in cases with multiple affects/trackers.
- Modified the alert creation to accept the `params` field of the `ValidationError` as `kwargs`, to pass additional parameters.
- Added some resolution steps to `_validate_tracker_duplicate`

Closes OSIDB-3588