### PR TITLE
Ignore invalid CVSS from OSV collector

### DIFF
--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -289,7 +289,12 @@ class OSVCollector(Collector):
                     # Skip unsupported score types
                     continue
                 vector = cvss["score"]
-                score = self.CVSS_TO_CVSSLIB[cvss["type"]](vector).base_score
+                try:
+                    score = self.CVSS_TO_CVSSLIB[cvss["type"]](vector).base_score
+                except Exception as exc:
+                    logger.error(f"Failed to proces CVSS for {cvss}. Error: {exc}.")
+                    # TODO: Ignore invalid CVSS from OSV until the data issue gets fixed
+                    continue
                 cvss_data.append(
                     {
                         "issuer": FlawCVSS.CVSSIssuer.OSV,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix conversion of CVSS severity to impact (OSIDB-3661)
+- Ignore invalid CVSS from OSV collector (OSIDB-3663)
 
 ## [4.5.3] - 2024-11-05
 ### Added


### PR DESCRIPTION
This PR temporarily updates exception handling when encountering invalid CVSS data from OSV like `{'type': 'CVSS_V4', 'score':'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:H/A:N'}`. This case is now only logged but does not block the OSV collector from running. Once the data gets fixed in OSV, the change will be removed.

Fixes OSIDB-3663