### PR TITLE
publish internal flaws only when the triage is completed

### DIFF
--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -318,9 +318,11 @@ class WorkflowModel(models.Model):
         return WorkflowFramework().jira_status(self)
 
     def adjust_acls(self, save=True):
-        # Only new and rejected state can have internal ACLs
+        # a flaw can have internal ACLs before the triage is
+        # completed or if it was rejected during the triage
         internal_supported = [
             WorkflowModel.WorkflowState.NEW,
+            WorkflowModel.WorkflowState.TRIAGE,
             WorkflowModel.WorkflowState.REJECTED,
         ]
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Publish internal flaws only when the triage is completed (OSIDB-3669)
 
 ## [4.5.4] - 2024-11-06
 ### Changed


### PR DESCRIPTION
to prevent sending notification and creating CVE page too early

Closes OSIDB-3669