### PR TITLE
preserve nist flag on score adoption

### DIFF
--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -284,11 +284,13 @@ class NVDCollector(Collector, NVDQuerier):
                     flaw.cvss_scores.filter(issuer=FlawCVSS.CVSSIssuer.NIST).filter(
                         version=version
                     ).delete()
-                    # remove also any potential NIST CVSS validation flag in case
-                    # the removed score is v3 which undergoes the feedback loop
+                    # also any existing NIST CVSS validation flag should be set to approved
+                    # when the removed score is v3 as it successfully completes the feedback loop
                     if version == FlawCVSS.CVSSVersion.VERSION3:
-                        Flaw.objects.filter(uuid=flaw.uuid).update(
-                            nist_cvss_validation=Flaw.FlawNistCvssValidation.NOVALUE
+                        Flaw.objects.filter(uuid=flaw.uuid).exclude(
+                            nist_cvss_validation=""  # when no flag then do not set any
+                        ).update(
+                            nist_cvss_validation=Flaw.FlawNistCvssValidation.APPROVED
                         )
                     continue
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Publish internal flaws only when the triage is completed (OSIDB-3669)
+- Adjust the NIST flag instead of removing on NIST score deletion
+  and relieve the NIST flag validation to account for it (OSIDB-3672)
 
 ## [4.5.4] - 2024-11-06
 ### Changed

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -394,7 +394,7 @@ class Flaw(
     def _validate_cvss_scores_and_nist_cvss_validation(self, **kwargs):
         """
         Checks that if nist_cvss_validation is set, then both NIST CVSSv3 and RH CVSSv3
-        scores need to be present.
+        scores need to be present unless NIST fully accepted our score and deleted theirs.
         """
         from .cvss import FlawCVSS
 
@@ -409,6 +409,10 @@ class Flaw(
         ).first()
 
         if self.nist_cvss_validation and not (nist_cvss and rh_cvss):
+            # it may happen that NIST accepts our score and deletes theirs and
+            # then having a record in the sense of an approved flag makes sense
+            if self.nist_cvss_validation == self.FlawNistCvssValidation.APPROVED:
+                return
             raise ValidationError(
                 "nist_cvss_validation can only be set if a flaw has both "
                 "NIST CVSSv3 and RH CVSSv3 scores assigned.",

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1014,6 +1014,7 @@ class TestFlawValidators:
             (Flaw.FlawNistCvssValidation.REQUESTED, False, True, True),
             (Flaw.FlawNistCvssValidation.REJECTED, False, False, True),
             (Flaw.FlawNistCvssValidation.APPROVED, True, True, False),
+            (Flaw.FlawNistCvssValidation.APPROVED, False, True, False),
             (Flaw.FlawNistCvssValidation.NOVALUE, False, True, False),
         ],
     )


### PR DESCRIPTION
... instead of removing it. Let us adjust the flag accordingly and relieve the related validation.

Closes OSIDB-3672