### PR TITLE
OSIDB-3573: Update `updated_dt` field on QuerySet .update() method

### DIFF
--- a/apps/exploits/query_sets.py
+++ b/apps/exploits/query_sets.py
@@ -1,9 +1,11 @@
 from django.db import models
 
+from osidb.query_sets import CustomQuerySetUpdatedDt
+
 from .constants import FIXED_AND_UNFIXABLE_TRACKER_RESOLUTIONS, UNSUPPORTED_PRODUCTS
 
 
-class AffectQuerySetExploitExtension(models.QuerySet):
+class AffectQuerySetExploitExtension(CustomQuerySetUpdatedDt):
     """
     Additional Affect queries needed for exploit reports.
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Update field `updated_dt` on queryset update (OSIDB-3573)
 
 ## [4.5.6] - 2024-11-08
 ### Fixed

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -21,6 +21,7 @@ from osidb.mixins import (
     TrackingMixin,
     TrackingMixinManager,
 )
+from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .abstract import CVSS, Impact
 from .flaw.flaw import Flaw
@@ -595,7 +596,7 @@ class AffectCVSS(CVSS):
         Affect, on_delete=models.CASCADE, blank=True, related_name="cvss_scores"
     )
 
-    objects = AffectCVSSManager()
+    objects = AffectCVSSManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     class Meta:
         constraints = [

--- a/osidb/models/erratum.py
+++ b/osidb/models/erratum.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from osidb.mixins import TrackingMixin, TrackingMixinManager
+from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .tracker import Tracker
 
@@ -46,7 +47,7 @@ class Erratum(TrackingMixin):
     # But all errata report the same Bugzilla / Jira tracker as "fixed"
     trackers = models.ManyToManyField(Tracker, related_name="errata")
 
-    objects = ErratumManager()
+    objects = ErratumManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     class Meta:
         verbose_name = "Erratum"

--- a/osidb/models/flaw/acknowledgment.py
+++ b/osidb/models/flaw/acknowledgment.py
@@ -12,6 +12,7 @@ from osidb.mixins import (
     TrackingMixin,
     TrackingMixinManager,
 )
+from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .flaw import Flaw
 from .source import FlawSource
@@ -67,7 +68,7 @@ class FlawAcknowledgment(AlertMixin, ACLMixin, BugzillaSyncMixin, TrackingMixin)
         Flaw, on_delete=models.CASCADE, related_name="acknowledgments"
     )
 
-    objects = FlawAcknowledgmentManager()
+    objects = FlawAcknowledgmentManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     class Meta:
         """define meta"""

--- a/osidb/models/flaw/cvss.py
+++ b/osidb/models/flaw/cvss.py
@@ -6,6 +6,7 @@ from django.db import models
 
 from osidb.mixins import ACLMixinManager, TrackingMixin, TrackingMixinManager
 from osidb.models.abstract import CVSS
+from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .flaw import Flaw
 
@@ -31,7 +32,7 @@ class FlawCVSS(CVSS):
         Flaw, on_delete=models.CASCADE, blank=True, related_name="cvss_scores"
     )
 
-    objects = FlawCVSSManager()
+    objects = FlawCVSSManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     class Meta:
         constraints = [

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -31,6 +31,7 @@ from osidb.mixins import (
     TrackingMixinManager,
 )
 from osidb.models import FlawSource, Impact, PsModule, SpecialConsiderationPackage
+from osidb.query_sets import CustomQuerySetUpdatedDt
 from osidb.sync_manager import (
     BZSyncManager,
     FlawDownloadManager,
@@ -902,7 +903,7 @@ class Flaw(
         """return osidb api url"""
         return f"/api/{OSIDB_API_VERSION}/{self.uuid}"
 
-    objects = FlawManager()
+    objects = FlawManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     def get_affect(self, ps_module, ps_component):
         """return related affect by PS module and PS component"""

--- a/osidb/models/flaw/reference.py
+++ b/osidb/models/flaw/reference.py
@@ -11,6 +11,7 @@ from osidb.mixins import (
     TrackingMixin,
     TrackingMixinManager,
 )
+from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .flaw import Flaw
 
@@ -85,7 +86,7 @@ class FlawReference(AlertMixin, ACLMixin, TrackingMixin):
     # one flaw can have many references
     flaw = models.ForeignKey(Flaw, on_delete=models.CASCADE, related_name="references")
 
-    objects = FlawReferenceManager()
+    objects = FlawReferenceManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     class Meta:
         """define meta"""

--- a/osidb/models/package_versions.py
+++ b/osidb/models/package_versions.py
@@ -13,6 +13,7 @@ from osidb.mixins import (
     TrackingMixin,
     TrackingMixinManager,
 )
+from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .flaw.flaw import Flaw
 
@@ -144,7 +145,7 @@ class Package(AlertMixin, ACLMixin, BugzillaSyncMixin, TrackingMixin):
 
     package = models.CharField(max_length=2048)
 
-    objects = PackageManager()
+    objects = PackageManager.from_queryset(CustomQuerySetUpdatedDt)()
 
     def bzsync(self, *args, bz_api_key, **kwargs):
         """

--- a/osidb/query_sets.py
+++ b/osidb/query_sets.py
@@ -1,0 +1,13 @@
+from django.db import models
+from django.utils import timezone
+
+
+class CustomQuerySetUpdatedDt(models.QuerySet):
+    """Extend QuerySet to inject updated_dt on update"""
+
+    def update(self, **kwargs):
+        if getattr(self.model, "updated_dt", False):
+            if "updated_dt" not in kwargs:
+                kwargs["updated_dt"] = timezone.now().replace(microsecond=0)
+
+        return super().update(**kwargs)

--- a/osidb/tests/test_querysets.py
+++ b/osidb/tests/test_querysets.py
@@ -1,0 +1,69 @@
+import pytest
+from freezegun import freeze_time
+
+from osidb.models import Affect, Flaw, FlawCVSS
+from osidb.tests.factories import AffectFactory, FlawCVSSFactory, FlawFactory
+
+from .test_flaw import tzdatetime
+
+pytestmark = pytest.mark.unit
+
+
+class TestCustomQuerySet:
+    @pytest.mark.parametrize(
+        "model, factory, fields",
+        [
+            (
+                Affect,
+                AffectFactory,
+                {"affectedness": Affect.AffectAffectedness.NOTAFFECTED},
+            ),
+            (Flaw, FlawFactory, {"title": "new title"}),
+            (FlawCVSS, FlawCVSSFactory, {"version": FlawCVSS.CVSSVersion.VERSION3}),
+        ],
+    )
+    def test_inject_updated_dt(self, model, factory, fields):
+        """Test that updated_dt field is injected into the queryset if not present"""
+        model_instance = factory()
+
+        with freeze_time(tzdatetime(2024, 11, 8, 12, 0, 0)):
+            update_count = model.objects.filter(uuid=model_instance.uuid).update(
+                **fields
+            )
+
+        model_instance.refresh_from_db()
+
+        assert update_count == 1
+        assert (
+            getattr(model_instance, list(fields.keys())[0]) == list(fields.values())[0]
+        )
+        assert model_instance.updated_dt == tzdatetime(2024, 11, 8, 12, 0, 0)
+
+    @pytest.mark.parametrize(
+        "model, factory, fields",
+        [
+            (
+                Affect,
+                AffectFactory,
+                {"affectedness": Affect.AffectAffectedness.NOTAFFECTED},
+            ),
+            (Flaw, FlawFactory, {"title": "new title"}),
+            (FlawCVSS, FlawCVSSFactory, {"version": FlawCVSS.CVSSVersion.VERSION3}),
+        ],
+    )
+    def test_no_inject_updated_dt(self, model, factory, fields):
+        """Test that updated_dt field is not injected into the queryset if present"""
+        model_instance = factory()
+
+        with freeze_time(tzdatetime(2024, 11, 8, 12, 0, 0)):
+            update_count = model.objects.filter(uuid=model_instance.uuid).update(
+                **fields, updated_dt=tzdatetime(2024, 11, 9, 13, 0, 0)
+            )
+
+        model_instance.refresh_from_db()
+
+        assert update_count == 1
+        assert (
+            getattr(model_instance, list(fields.keys())[0]) == list(fields.values())[0]
+        )
+        assert model_instance.updated_dt == tzdatetime(2024, 11, 9, 13, 0, 0)


### PR DESCRIPTION
This pull request introduces a new custom queryset class `CustomQuerySetUpdatedDt` to ensure the `updated_dt` field is automatically updated whenever a queryset update occurs. Additionally, it updates various models to use this new queryset class and adds tests to verify the functionality.

### Introduction of `CustomQuerySetUpdatedDt`:

* [`osidb/query_sets.py`](diffhunk://#diff-08f54f0a22f87ea409168fc397127756fdc51eca0d7e42f330f4f5fb8590ff2bR1-R13): Added a new class `CustomQuerySetUpdatedDt` that extends `models.QuerySet` to inject the `updated_dt` field on update if it is not already present.

### Model updates to use `CustomQuerySetUpdatedDt`:

* [`osidb/models/affect.py`](diffhunk://#diff-7fef8f70733e33b9dabbe4e794e909da7176cf2118ebab5ab8739e298f93f793L598-R599): Updated `AffectCVSS` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/erratum.py`](diffhunk://#diff-0e2c0445036d1688c54542693ce66ba6bf2203ebc58868ddd9694cba2b67e017L49-R50): Updated `Erratum` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/flaw/acknowledgment.py`](diffhunk://#diff-f40fce6c16f6ee7aef3686ccb9eea37318af4350160bb8e7037f3046d296fa05L70-R71): Updated `FlawAcknowledgment` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/flaw/cvss.py`](diffhunk://#diff-e9b54ddaeb2eaf645948dfecd569abbdf7ec850e55cc1754e66a4e463fed9d68L34-R35): Updated `FlawCVSS` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/flaw/flaw.py`](diffhunk://#diff-b8b91c2f912f29b4d2203a3a55120a53126e3a7f61af03b840400a974e8b25a5L905-R906): Updated `Flaw` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/flaw/reference.py`](diffhunk://#diff-45ca19debfc4cdab697ab87327cfda1c3bc890a50ad06b17b5316995bc2a7748L88-R89): Updated `FlawReference` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/package_versions.py`](diffhunk://#diff-82ffbdef873f86db0307762e46f1c183335867322aea4acc895beb74b82b1160L147-R148): Updated `Package` to use `CustomQuerySetUpdatedDt` in its manager.
* [`osidb/models/tracker.py`](diffhunk://#diff-00cb6f74260fb2544f32387fde9aad2da9f6124852100b58b25d6b34453dbbe8L132-R133): Updated `Tracker` to use `CustomQuerySetUpdatedDt` in its manager.

Closes OSIDB-3573

---
These are the places where we were triggering a QuerySet update without updating the `updated_dt` field:

https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/apps/bbsync/save.py#L68-L70
https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/apps/bbsync/save.py#L127-L129
https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/osidb/signals.py#L134-L136
https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/osidb/signals.py#L154-L156
https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/collectors/nvd/collectors.py#L317-L321
https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/osidb/sync_manager.py#L335
https://github.com/RedHatProductSecurity/osidb/blob/7b7aa58ae0e7ac63b1d88ef0c3cc1fa4bf660141/osidb/sync_manager.py#L862-L864