### PR TITLE
Properly save updated flaw in NVD collector

### DIFF
--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -324,9 +324,11 @@ class NVDCollector(Collector, NVDQuerier):
                 if original_cvss != new_cvss:
                     # set impact if it was empty because a validation requires it
                     if not flaw.impact:
-                        flaw.impact = self.calculate_highest_impact(
+                        impact = self.calculate_highest_impact(
                             [new_cvss2_score, new_cvss3_score, new_cvss4_score]
                         )
+                        Flaw.objects.filter(uuid=flaw.uuid).update(impact=impact)
+                        flaw.refresh_from_db()
                     # perform either update or create
                     cvss_score = FlawCVSS.objects.create_cvss(
                         flaw,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Properly save updated flaw in NVD collector (OSIDB-3661)
 
 ## [4.5.5] - 2024-11-07
 ### Changed


### PR DESCRIPTION
This PR fixes the bug introduced in #821. The flaw impact was updated before saving a CVSS score, but the flaw itself was not saved.

Fixes OSIDB-3661