### PR TITLE
Osidb 3492

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -162,7 +162,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 88,
+        "line_number": 873,
         "is_secret": false
       }
     ],
@@ -176,13 +176,13 @@
         "is_secret": false
       }
     ],
-    "apps/trackers/tests/test_integration.py": [
+    "apps/taskman/tests/test_flaw_model_integration.py": [
       {
         "type": "Secret Keyword",
-        "filename": "apps/trackers/tests/test_integration.py",
+        "filename": "apps/taskman/tests/test_flaw_model_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 236,
+        "line_number": 156,
         "is_secret": false
       }
     ],
@@ -193,6 +193,16 @@
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
         "line_number": 70,
+        "is_secret": false
+      }
+    ],
+    "apps/workflows/tests/test_endpoints.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "apps/workflows/tests/test_endpoints.py",
+        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
+        "is_verified": false,
+        "line_number": 294,
         "is_secret": false
       }
     ],
@@ -428,16 +438,6 @@
         "is_secret": false
       }
     ],
-    "osidb/tests/test_mixins.py": [
-      {
-        "type": "Secret Keyword",
-        "filename": "osidb/tests/test_mixins.py",
-        "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
-        "is_verified": false,
-        "line_number": 775,
-        "is_secret": false
-      }
-    ],
     "perf/main.py": [
       {
         "type": "Secret Keyword",
@@ -467,5 +467,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-12T15:56:30Z"
+  "generated_at": "2024-11-19T12:20:04Z"
 }

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -879,7 +879,7 @@ class TestBBSyncSaveIntegration:
     test the integration of BBSync with the model save machinery
     """
 
-    def test_bz_id(self, monkeypatch):
+    def test_bz_id(self):
         """
         test preventing regression in the Bugzilla ID sync
 

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -60,7 +60,14 @@ class TestBBSyncIntegration:
         ]
 
     @pytest.mark.vcr
-    def test_flaw_create(self, auth_client, test_api_uri, enable_bz_async_sync):
+    def test_flaw_create(
+        self,
+        auth_client,
+        test_api_uri,
+        bugzilla_token,
+        jira_token,
+        enable_bz_async_sync,
+    ):
         """
         test creating a flaw with Bugzilla two-way sync
         """
@@ -85,8 +92,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
         body = response.json()
@@ -116,7 +123,7 @@ class TestBBSyncIntegration:
 
         # Simulating what BZSyncManager would do when executed by Celery
         # part 2/2
-        flaw._perform_bzsync(bz_api_key="SECRET")
+        flaw._perform_bzsync(bz_api_key=bugzilla_token)
 
         # The sync should send data to BZ and save the bz_id to the DB
         assert (
@@ -140,7 +147,7 @@ class TestBBSyncIntegration:
         assert response.json()["mitigation"] == "mitigation"
 
     @pytest.mark.vcr
-    def test_flaw_update(self, auth_client, test_api_uri):
+    def test_flaw_update(self, auth_client, bugzilla_token, jira_token, test_api_uri):
         """
         test updating a flaw with Bugzilla two-way sync
         """
@@ -175,8 +182,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -185,7 +192,9 @@ class TestBBSyncIntegration:
         assert response.json()["title"] == "Bar"
 
     @pytest.mark.vcr
-    def test_flaw_update_add_cve(self, auth_client, test_api_uri):
+    def test_flaw_update_add_cve(
+        self, auth_client, bugzilla_token, jira_token, test_api_uri
+    ):
         """
         test adding a CVE to an existing CVE-less flaw
         """
@@ -227,8 +236,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -237,7 +246,9 @@ class TestBBSyncIntegration:
         assert response.json()["cve_id"] == "CVE-2000-3000"
 
     @pytest.mark.vcr
-    def test_flaw_update_remove_cve(self, auth_client, test_api_uri):
+    def test_flaw_update_remove_cve(
+        self, auth_client, bugzilla_token, jira_token, test_api_uri
+    ):
         """
         test removing of a CVE from a flaw
         """
@@ -279,8 +290,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -289,7 +300,9 @@ class TestBBSyncIntegration:
         assert response.json()["cve_id"] is None
 
     @pytest.mark.vcr
-    def test_flaw_update_modify_cve(self, auth_client, test_api_uri):
+    def test_flaw_update_modify_cve(
+        self, auth_client, bugzilla_token, jira_token, test_api_uri
+    ):
         """
         Test modifying the CVE of an existing flaw which already had a CVE.
         """
@@ -333,8 +346,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -343,7 +356,9 @@ class TestBBSyncIntegration:
         assert response.json()["cve_id"] == "CVE-2024-666666"
 
     @pytest.mark.vcr
-    def test_flaw_update_remove_unembargo_dt(self, auth_client, test_api_uri):
+    def test_flaw_update_remove_unembargo_dt(
+        self, auth_client, bugzilla_token, test_api_uri
+    ):
         """
         test removing unembargo_dt from an embargoed flaw
         """
@@ -388,7 +403,7 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
         )
         assert response.status_code == 200
 
@@ -397,7 +412,7 @@ class TestBBSyncIntegration:
         assert response.json()["unembargo_dt"] is None
 
     @pytest.mark.vcr
-    def test_flaw_unembargo(self, auth_client, test_api_uri):
+    def test_flaw_unembargo(self, auth_client, bugzilla_token, test_api_uri):
         """
         test flaw unembargo with Bugzilla two-way sync
         """
@@ -447,7 +462,7 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
         )
         assert response.status_code == 200
         assert not Affect.objects.get(uuid=affect.uuid).is_embargoed
@@ -457,8 +472,10 @@ class TestBBSyncIntegration:
     def test_flaw_unembargo_complex(
         self,
         auth_client,
+        bugzilla_token,
         enable_bz_sync,
         enable_jira_tracker_sync,
+        jira_token,
         test_api_uri,
     ):
         """
@@ -617,8 +634,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -636,7 +653,7 @@ class TestBBSyncIntegration:
         assert not Tracker.objects.get(uuid=tracker2.uuid).is_embargoed
 
     @pytest.mark.vcr
-    def test_affect_create(self, auth_client, test_api_uri):
+    def test_affect_create(self, auth_client, bugzilla_token, test_api_uri):
         """
         test creating a flaw affect with Bugzilla two-way sync
         """
@@ -666,7 +683,7 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/affects",
             affect_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
         )
         assert response.status_code == 201
         body = response.json()
@@ -680,7 +697,7 @@ class TestBBSyncIntegration:
         assert response.json()["resolution"] == "DELEGATED"
 
     @pytest.mark.vcr
-    def test_affect_update(self, auth_client, test_api_uri):
+    def test_affect_update(self, auth_client, bugzilla_token, jira_token, test_api_uri):
         """
         test updating a flaw affect with Bugzilla two-way sync
         """
@@ -718,8 +735,8 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/affects/{affect.uuid}",
             affect_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -731,7 +748,7 @@ class TestBBSyncIntegration:
         assert response.json()["resolution"] == "WONTFIX"
 
     @pytest.mark.vcr
-    def test_affect_delete(self, auth_client, test_api_uri):
+    def test_affect_delete(self, auth_client, bugzilla_token, test_api_uri):
         """
         test deleting a flaw affect with Bugzilla two-way sync
         """
@@ -765,7 +782,7 @@ class TestBBSyncIntegration:
         response = auth_client().delete(
             f"{test_api_uri}/affects/{affect.uuid}",
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
         )
         assert response.status_code == 200
 
@@ -775,7 +792,7 @@ class TestBBSyncIntegration:
     @pytest.mark.vcr(
         vcr_cassette_name="cassettes/TestBBSyncIntegration.test_flaw_create.yaml"
     )
-    def test_flaw_validations(self, auth_client, test_api_uri):
+    def test_flaw_validations(self, auth_client, bugzilla_token, test_api_uri):
         """
         test that flaw validations are not bypassed when syncing to Bugzilla
         """
@@ -791,7 +808,7 @@ class TestBBSyncIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
         )
         assert response.status_code == 400
         assert "Components value is required" in str(response.content)
@@ -915,6 +932,7 @@ class TestFlawDraftBBSyncIntegration:
         self,
         internal_read_groups,
         internal_write_groups,
+        jira_token,
         source,
         cve_id,
         ext_id,
@@ -952,7 +970,7 @@ class TestFlawDraftBBSyncIntegration:
         snippet = SnippetFactory(
             source=source, ext_id=ext_id, cve_id=cve_id, content=content
         )
-        flaw = snippet.convert_snippet_to_flaw(jira_token="SECRET")  # nosec
+        flaw = snippet.convert_snippet_to_flaw(jira_token=jira_token)
 
         assert Flaw.objects.all().count() == 1
         assert Flaw.objects.all()[0] == flaw

--- a/apps/taskman/tests/conftest.py
+++ b/apps/taskman/tests/conftest.py
@@ -2,7 +2,7 @@ import uuid
 
 import pytest
 from django.conf import settings
-from taskman.constants import JIRA_AUTH_TOKEN, TASKMAN_API_VERSION
+from taskman.constants import TASKMAN_API_VERSION
 
 from osidb.constants import OSIDB_API_VERSION
 
@@ -23,16 +23,6 @@ def use_debug(settings):
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
-
-
-@pytest.fixture
-def user_token():
-    return JIRA_AUTH_TOKEN if JIRA_AUTH_TOKEN else "USER_JIRA_TOKEN"
-
-
-@pytest.fixture
-def bz_api_key():
-    return "USER_BZ_API_KEY"
 
 
 @pytest.fixture

--- a/apps/taskman/tests/test_service.py
+++ b/apps/taskman/tests/test_service.py
@@ -16,15 +16,15 @@ pytestmark = pytest.mark.unit
 
 
 class TestTaskmanService(object):
-    def test_jira_connection(self, user_token):
+    def test_jira_connection(self):
         """
         Test that taskman is able to instantiate a Jira connection object
         """
-        assert JiraTaskmanQuerier(token=user_token).jira_conn
+        assert JiraTaskmanQuerier(token="SECRET").jira_conn  # nosec
 
     @pytest.mark.vcr
     @pytest.mark.enable_signals
-    def test_create_or_update_task(self, user_token):
+    def test_create_or_update_task(self, jira_token):
         """
         Test that service is able to create and update regular fields, team, assignment and status
         """
@@ -35,7 +35,7 @@ class TestTaskmanService(object):
             workflow_state=WorkflowModel.WorkflowState.NEW,
         )
         AffectFactory(flaw=flaw)
-        taskman = JiraTaskmanQuerier(token=user_token)
+        taskman = JiraTaskmanQuerier(token=jira_token)
 
         response1 = taskman.create_or_update_task(flaw=flaw)
         assert response1.status_code == 201
@@ -77,14 +77,14 @@ class TestTaskmanService(object):
         assert not issue["fields"]["assignee"]
 
     @pytest.mark.vcr
-    def test_comments(self, user_token):
+    def test_comments(self, jira_token):
         """
         Test that service is able to create comment in Jira
         """
         # Remove randomness to reuse VCR every possible time
         flaw = FlawFactory(embargoed=False, uuid="99cce9ba-829d-4933-b4c1-44533d819e77")
         AffectFactory(flaw=flaw)
-        taskman = JiraTaskmanQuerier(token=user_token)
+        taskman = JiraTaskmanQuerier(token=jira_token)
 
         response1 = taskman.create_or_update_task(flaw=flaw)
         assert response1.status_code == 201
@@ -93,13 +93,13 @@ class TestTaskmanService(object):
         assert response2.status_code == 201
 
     @pytest.mark.vcr
-    def test_add_link(self, user_token):
+    def test_add_link(self, jira_token):
         """
         Test that service is able to create remote links in Jira issues.
         """
         flaw = FlawFactory(embargoed=False, uuid="b47f7912-7011-463a-b861-6d7dca13aa3c")
         AffectFactory(flaw=flaw)
-        taskman = JiraTaskmanQuerier(token=user_token)
+        taskman = JiraTaskmanQuerier(token=jira_token)
 
         response1 = taskman.create_or_update_task(flaw=flaw)
         assert response1.status_code == 201

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_create_update_jira_vulnerability_issuetype.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerAPI.test_tracker_create_update_jira_vulnerability_issuetype.yaml
@@ -1,13 +1,11 @@
 interactions:
 - request:
-    body: '{"fields": {"issuetype": {"name": "Vulnerability"}, "project": {"key":
-      "OCPBUGS"}, "components": [{"name": "Security"}], "description": "Security Tracking
-      Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~",
-      "labels": ["Security", "SecurityTracking", "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42",
-      "pscomponent:Security"], "summary": "Security: Foo [openshift-4.8.z]", "customfield_12324940":
-      {"value": "Critical"}, "customfield_12324746": {"value": "Red Hat"}, "customfield_12324747":
-      "CWE-1", "customfield_12324752": "Security", "customfield_12324751": "curl",
-      "customfield_12324750": {"value": "False"}, "customfield_12324753": []}}'
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "components":
+      [{"name": "kernel / Other"}], "priority": {"name": "Critical"}, "description":
+      "Public Security Tracking Issue\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~\n\nReproducers,
+      if any, will remain confidential and never be made public, unless done so by
+      the security team.", "labels": ["Security", "SecurityTracking", "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42",
+      "pscomponent:kernel"], "summary": "kernel: Foo [rhel-8]", "security": null}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -18,29 +16,29 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '706'
+      - '557'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16288116", "key": "OCPBUGS-41925", "self": "https://example.com/rest/api/2/issue/16288116"}'
+      string: '{"id": "16309329", "key": "RHEL-59490", "self": "https://example.com/rest/api/2/issue/16309329"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - keep-alive
+      - close
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 26 Sep 2024 16:17:35 GMT
+      - Tue, 19 Nov 2024 11:19:56 GMT
       Expires:
-      - Thu, 26 Sep 2024 16:17:35 GMT
+      - Tue, 19 Nov 2024 11:19:56 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -53,7 +51,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '106'
+      - '103'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -61,9 +59,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 977x785165x10
+      - 679x339938x1
       x-asessionid:
-      - 1xd80ae
+      - jrk5wz
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -75,9 +73,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1727367453.7b26120
+      - 0.8f68dc17.1732015186.3f93972d
       x-rh-edge-request-id:
-      - 7b26120
+      - 3f93972d
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -99,130 +97,177 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OCPBUGS-41925
+    uri: https://example.com/rest/api/2/issue/RHEL-59490
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16288116", "self": "https://example.com/rest/api/2/issue/16288116",
-        "key": "OCPBUGS-41925", "fields": {"customfield_12322244": null, "customfield_12324940":
-        {"self": "https://example.com/rest/api/2/customFieldOption/40250", "value":
-        "Critical", "id": "40250", "disabled": false}, "customfield_12324540": "0.0",
-        "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5c762075[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@58b30c37[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16309329", "self": "https://example.com/rest/api/2/issue/16309329",
+        "key": "RHEL-59490", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4cd8d5ea[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@358263c7[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@d9be13a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4d89960a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a2190dc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@72dc3c77[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@201c9127[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@21246ae8[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2785b960[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@34290663[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70782c68[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@72097ba5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@32498be5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@14f34a30[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a861217[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@315d5955[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f35ea38[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@41198b24[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5b152fba[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@59527c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@60dd1c65[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6d90ebf1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
-        null, "customfield_12319640": null, "customfield_12313140": null, "priority":
-        {"self": "https://example.com/rest/api/2/priority/10300", "iconUrl": "https://example.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["Security", "SecurityTracking",
-        "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:Security"],
-        "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions": [],
-        "issuelinks": [], "assignee": {"self": "https://example.com/rest/api/2/user?username=rh-ee-bleanhar",
-        "name": "rh-ee-bleanhar", "key": "bleanhar", "emailAddress": "bleanhar@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=48",
-        "24x24": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=24",
-        "16x16": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=16",
-        "32x32": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=32"},
-        "displayName": "Brenton Leanhardt", "active": true, "timeZone": "America/New_York"},
-        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
-        "https://example.com/rest/api/2/status/10016", "description": "Initial creation
-        status. Implies nothing yet and should be very short lived; also can be a
-        Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "customfield_12317334": null, "customfield_12318148": null, "customfield_12315950":
+        null, "customfield_12310940": null, "customfield_12321440": null, "lastViewed":
+        null, "customfield_12321040": null, "customfield_12317340": null, "customfield_12323341":
+        null, "customfield_12317341": null, "customfield_12319640": null, "customfield_12317342":
+        null, "customfield_12313140": null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:kernel"], "customfield_12311641":
+        null, "customfield_12311240": null, "aggregatetimeoriginalestimate": null,
+        "timeestimate": null, "versions": [], "customfield_12317343": null, "issuelinks":
+        [], "customfield_12317345": null, "customfield_12325240": null, "assignee":
+        {"self": "https://example.com/rest/api/2/user?username=kernel-mgr", "name":
+        "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [{"self": "https://example.com/rest/api/2/component/12367903", "id": "12367903",
-        "name": "Security", "description": "Embargoed security issues"}], "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12317313":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
-        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
-        "reporter": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "creator":
+        {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
         "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
-        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=xiyuan%40redhat.com",
-        "name": "xiyuan@redhat.com", "key": "xiaojiey", "emailAddress": "xiyuan@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=29962",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=29962",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=29962",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=29962"},
-        "displayName": "Xiaojie Yuan", "active": true, "timeZone": "Asia/Shanghai"},
-        "customfield_12313240": null, "customfield_12319742": null, "progress": {"progress":
-        0, "total": 0}, "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/votes",
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59490/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12324344":
-        null, "customfield_12325158": null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/12207",
-        "id": "12207", "description": "", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=57661&avatarType=issuetype",
-        "name": "Vulnerability", "subtask": false, "avatarId": 57661}, "customfield_12324343":
-        null, "customfield_12325157": null, "customfield_12324345": null, "customfield_12325159":
-        null, "customfield_12322040": null, "customfield_12318341": null, "customfield_12324340":
-        null, "customfield_12325154": null, "customfield_12325153": null, "customfield_12325156":
-        null, "timespent": null, "customfield_12325155": null, "customfield_12320940":
-        null, "customfield_12324748": null, "customfield_12324747": "CWE-1", "project":
-        {"self": "https://example.com/rest/api/2/project/12332330", "id": "12332330",
-        "key": "OCPBUGS", "name": "OpenShift Bugs", "projectTypeKey": "software",
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?avatarId=17263",
-        "24x24": "https://example.com/secure/projectavatar?size=small&avatarId=17263",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&avatarId=17263",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&avatarId=17263"}},
-        "customfield_12324749": null, "customfield_12320944": null, "aggregatetimespent":
-        null, "customfield_12324746": {"self": "https://example.com/rest/api/2/customFieldOption/39375",
-        "value": "Red Hat", "id": "39375", "disabled": false}, "customfield_12310220":
-        null, "customfield_12310183": null, "resolutiondate": null, "customfield_12325150":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
         null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
         null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
-        null, "customfield_12324751": "curl", "customfield_12319040": null, "customfield_12324750":
-        {"self": "https://example.com/rest/api/2/customFieldOption/39386", "value":
-        "False", "id": "39386", "disabled": false}, "customfield_12325047": null,
-        "watches": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/watchers",
-        "watchCount": 0, "isWatching": false}, "customfield_12319285": null, "customfield_12324753":
-        null, "customfield_12324752": "Security", "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-09-26T16:17:33.507+0000",
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59490/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-19T11:19:47.970+0000",
         "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
-        null, "customfield_12324754": null, "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-09-26T16:17:33.507+0000", "customfield_12311840": null, "customfield_12322143":
-        null, "customfield_12322140": null, "customfield_12317351": null, "customfield_12316142":
-        null, "customfield_12322141": null, "customfield_12322142": null, "timeoriginalestimate":
-        null, "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~",
-        "timetracking": {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2024-11-19T11:19:56.128+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Public Security Tracking
+        Issue\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~\n\nReproducers,
+        if any, will remain confidential and never be made public, unless done so
+        by the security team.", "customfield_12322148": null, "timetracking": {},
+        "security": {"self": "https://example.com/rest/api/2/securitylevel/11694",
+        "id": "11694", "description": "Restricts access to Red Hat employees who are
+        approved to view product development information", "name": "Red Hat Engineering
+        Authorized"}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Security:
-        Foo [openshift-4.8.z]", "customfield_12323640": null, "customfield_12325147":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "kernel: Foo [rhel-8]", "customfield_12323640": null, "customfield_12325147":
         null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
         null, "customfield_12317360": null, "customfield_12323641": null, "customfield_12325148":
-        null, "customfield_12319540": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "customfield_12319940": null, "customfield_12319269": null, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141":
-        null, "customfield_12317247": null, "customfield_12325140": null, "customfield_12317248":
-        null, "customfield_12310213": null, "customfield_12311940": "2|i1xxfr:"}}'
+        null, "customfield_12325143": null, "customfield_12318450": null, "customfield_12325142":
+        null, "customfield_12323242": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12313040": null, "customfield_12323649": null, "customfield_12321740":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "customfield_12319940": null, "customfield_12319269":
+        null, "customfield_12317366": null, "comment": {"comments": [{"self": "https://example.com/rest/api/2/issue/16309329/comment/25579769",
+        "id": "25579769", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2024-11-19T11:19:56.128+0000",
+        "updated": "2024-11-19T11:19:56.128+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i219v3:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -231,9 +276,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 26 Sep 2024 16:17:35 GMT
+      - Tue, 19 Nov 2024 11:20:02 GMT
       Expires:
-      - Thu, 26 Sep 2024 16:17:35 GMT
+      - Tue, 19 Nov 2024 11:20:02 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -246,7 +291,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '12280'
+      - '16242'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -254,9 +299,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 977x785167x11
+      - 680x339947x1
       x-asessionid:
-      - 6w7pw6
+      - 1d66rm6
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -268,9 +313,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1727367455.7b27f20
+      - 0.8f68dc17.1732015201.3f9444fd
       x-rh-edge-request-id:
-      - 7b27f20
+      - 3f9444fd
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -292,130 +337,177 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OCPBUGS-41925
+    uri: https://example.com/rest/api/2/issue/RHEL-59490
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16288116", "self": "https://example.com/rest/api/2/issue/16288116",
-        "key": "OCPBUGS-41925", "fields": {"customfield_12322244": null, "customfield_12324940":
-        {"self": "https://example.com/rest/api/2/customFieldOption/40250", "value":
-        "Critical", "id": "40250", "disabled": false}, "customfield_12324540": "0.0",
-        "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@23fa6eeb[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2e75f870[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16309329", "self": "https://example.com/rest/api/2/issue/16309329",
+        "key": "RHEL-59490", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@9698de1[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10a6013f[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@57c31e46[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@5674cab6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a0ba743[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@786cd6af[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3792d6ca[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@47c38bf4[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@30850df0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2ec27ce1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@f47cb75[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@54807d42[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ed388[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@20e18543[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@389cd335[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@175c3b7f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61d8488f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4d3f026a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13646583[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@65953353[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@462a835e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7333e5a3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
-        null, "customfield_12319640": null, "customfield_12313140": null, "priority":
-        {"self": "https://example.com/rest/api/2/priority/10300", "iconUrl": "https://example.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["Security", "SecurityTracking",
-        "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:Security"],
-        "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions": [],
-        "issuelinks": [], "assignee": {"self": "https://example.com/rest/api/2/user?username=rh-ee-bleanhar",
-        "name": "rh-ee-bleanhar", "key": "bleanhar", "emailAddress": "bleanhar@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=48",
-        "24x24": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=24",
-        "16x16": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=16",
-        "32x32": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=32"},
-        "displayName": "Brenton Leanhardt", "active": true, "timeZone": "America/New_York"},
-        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
-        "https://example.com/rest/api/2/status/10016", "description": "Initial creation
-        status. Implies nothing yet and should be very short lived; also can be a
-        Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "customfield_12317334": null, "customfield_12318148": null, "customfield_12315950":
+        null, "customfield_12310940": null, "customfield_12321440": null, "lastViewed":
+        null, "customfield_12321040": null, "customfield_12317340": null, "customfield_12323341":
+        null, "customfield_12317341": null, "customfield_12319640": null, "customfield_12317342":
+        null, "customfield_12313140": null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:kernel"], "customfield_12311641":
+        null, "customfield_12311240": null, "aggregatetimeoriginalestimate": null,
+        "timeestimate": null, "versions": [], "customfield_12317343": null, "issuelinks":
+        [], "customfield_12317345": null, "customfield_12325240": null, "assignee":
+        {"self": "https://example.com/rest/api/2/user?username=kernel-mgr", "name":
+        "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [{"self": "https://example.com/rest/api/2/component/12367903", "id": "12367903",
-        "name": "Security", "description": "Embargoed security issues"}], "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12317313":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
-        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
-        "reporter": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "creator":
+        {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
         "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
-        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=xiyuan%40redhat.com",
-        "name": "xiyuan@redhat.com", "key": "xiaojiey", "emailAddress": "xiyuan@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=29962",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=29962",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=29962",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=29962"},
-        "displayName": "Xiaojie Yuan", "active": true, "timeZone": "Asia/Shanghai"},
-        "customfield_12313240": null, "customfield_12319742": null, "progress": {"progress":
-        0, "total": 0}, "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/votes",
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59490/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12324344":
-        null, "customfield_12325158": null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/12207",
-        "id": "12207", "description": "", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=57661&avatarType=issuetype",
-        "name": "Vulnerability", "subtask": false, "avatarId": 57661}, "customfield_12324343":
-        null, "customfield_12325157": null, "customfield_12324345": null, "customfield_12325159":
-        null, "customfield_12322040": null, "customfield_12318341": null, "customfield_12324340":
-        null, "customfield_12325154": null, "customfield_12325153": null, "customfield_12325156":
-        null, "timespent": null, "customfield_12325155": null, "customfield_12320940":
-        null, "customfield_12324748": null, "customfield_12324747": "CWE-1", "project":
-        {"self": "https://example.com/rest/api/2/project/12332330", "id": "12332330",
-        "key": "OCPBUGS", "name": "OpenShift Bugs", "projectTypeKey": "software",
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?avatarId=17263",
-        "24x24": "https://example.com/secure/projectavatar?size=small&avatarId=17263",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&avatarId=17263",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&avatarId=17263"}},
-        "customfield_12324749": null, "customfield_12320944": null, "aggregatetimespent":
-        null, "customfield_12324746": {"self": "https://example.com/rest/api/2/customFieldOption/39375",
-        "value": "Red Hat", "id": "39375", "disabled": false}, "customfield_12310220":
-        null, "customfield_12310183": null, "resolutiondate": null, "customfield_12325150":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
         null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
         null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
-        null, "customfield_12324751": "curl", "customfield_12319040": null, "customfield_12324750":
-        {"self": "https://example.com/rest/api/2/customFieldOption/39386", "value":
-        "False", "id": "39386", "disabled": false}, "customfield_12325047": null,
-        "watches": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/watchers",
-        "watchCount": 0, "isWatching": false}, "customfield_12319285": null, "customfield_12324753":
-        null, "customfield_12324752": "Security", "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-09-26T16:17:33.507+0000",
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59490/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-19T11:19:47.970+0000",
         "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
-        null, "customfield_12324754": null, "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-09-26T16:17:33.507+0000", "customfield_12311840": null, "customfield_12322143":
-        null, "customfield_12322140": null, "customfield_12317351": null, "customfield_12316142":
-        null, "customfield_12322141": null, "customfield_12322142": null, "timeoriginalestimate":
-        null, "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~",
-        "timetracking": {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2024-11-19T11:19:56.128+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Public Security Tracking
+        Issue\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~\n\nReproducers,
+        if any, will remain confidential and never be made public, unless done so
+        by the security team.", "customfield_12322148": null, "timetracking": {},
+        "security": {"self": "https://example.com/rest/api/2/securitylevel/11694",
+        "id": "11694", "description": "Restricts access to Red Hat employees who are
+        approved to view product development information", "name": "Red Hat Engineering
+        Authorized"}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
         "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Security:
-        Foo [openshift-4.8.z]", "customfield_12323640": null, "customfield_12325147":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "kernel: Foo [rhel-8]", "customfield_12323640": null, "customfield_12325147":
         null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
         null, "customfield_12317360": null, "customfield_12323641": null, "customfield_12325148":
-        null, "customfield_12319540": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "customfield_12319940": null, "customfield_12319269": null, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141":
-        null, "customfield_12317247": null, "customfield_12325140": null, "customfield_12317248":
-        null, "customfield_12310213": null, "customfield_12311940": "2|i1xxfr:"}}'
+        null, "customfield_12325143": null, "customfield_12318450": null, "customfield_12325142":
+        null, "customfield_12323242": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12313040": null, "customfield_12323649": null, "customfield_12321740":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "customfield_12319940": null, "customfield_12319269":
+        null, "customfield_12317366": null, "comment": {"comments": [{"self": "https://example.com/rest/api/2/issue/16309329/comment/25579769",
+        "id": "25579769", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2024-11-19T11:19:56.128+0000",
+        "updated": "2024-11-19T11:19:56.128+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i219v3:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -424,9 +516,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 26 Sep 2024 16:17:36 GMT
+      - Tue, 19 Nov 2024 11:20:03 GMT
       Expires:
-      - Thu, 26 Sep 2024 16:17:36 GMT
+      - Tue, 19 Nov 2024 11:20:03 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -439,7 +531,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '12281'
+      - '16241'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -447,9 +539,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 977x785168x11
+      - 680x339948x1
       x-asessionid:
-      - glntvb
+      - vfl2g5
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -461,9 +553,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.dfb1060.1727367455.939f3db
+      - 0.8f68dc17.1732015202.3f944f80
       x-rh-edge-request-id:
-      - 939f3db
+      - 3f944f80
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -472,209 +564,13 @@ interactions:
       code: 200
       message: OK
 - request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OCPBUGS-41925
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16288116", "self": "https://example.com/rest/api/2/issue/16288116",
-        "key": "OCPBUGS-41925", "fields": {"customfield_12322244": null, "customfield_12324940":
-        {"self": "https://example.com/rest/api/2/customFieldOption/40250", "value":
-        "Critical", "id": "40250", "disabled": false}, "customfield_12324540": "0.0",
-        "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@601c625a[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@30b7a97c[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@55d24d35[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@58a3f2ba[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@40db8dd4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@69755902[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2e090afc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@69f80ba5[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@75519e63[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@362f6482[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5097c651[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@799b4ac5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
-        null, "customfield_12319640": null, "customfield_12313140": null, "priority":
-        {"self": "https://example.com/rest/api/2/priority/10300", "iconUrl": "https://example.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["Security", "SecurityTracking",
-        "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:Security"],
-        "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions": [],
-        "issuelinks": [], "assignee": {"self": "https://example.com/rest/api/2/user?username=rh-ee-bleanhar",
-        "name": "rh-ee-bleanhar", "key": "bleanhar", "emailAddress": "bleanhar@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=48",
-        "24x24": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=24",
-        "16x16": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=16",
-        "32x32": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=32"},
-        "displayName": "Brenton Leanhardt", "active": true, "timeZone": "America/New_York"},
-        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
-        "https://example.com/rest/api/2/status/10016", "description": "Initial creation
-        status. Implies nothing yet and should be very short lived; also can be a
-        Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [{"self": "https://example.com/rest/api/2/component/12367903", "id": "12367903",
-        "name": "Security", "description": "Embargoed security issues"}], "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "customfield_12320842":
-        null, "customfield_12310243": null, "aggregatetimeestimate": null, "customfield_12317313":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
-        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
-        "reporter": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
-        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=xiyuan%40redhat.com",
-        "name": "xiyuan@redhat.com", "key": "xiaojiey", "emailAddress": "xiyuan@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=29962",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=29962",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=29962",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=29962"},
-        "displayName": "Xiaojie Yuan", "active": true, "timeZone": "Asia/Shanghai"},
-        "customfield_12313240": null, "customfield_12319742": null, "progress": {"progress":
-        0, "total": 0}, "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12324344":
-        null, "customfield_12325158": null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/12207",
-        "id": "12207", "description": "", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=57661&avatarType=issuetype",
-        "name": "Vulnerability", "subtask": false, "avatarId": 57661}, "customfield_12324343":
-        null, "customfield_12325157": null, "customfield_12324345": null, "customfield_12325159":
-        null, "customfield_12322040": null, "customfield_12318341": null, "customfield_12324340":
-        null, "customfield_12325154": null, "customfield_12325153": null, "customfield_12325156":
-        null, "timespent": null, "customfield_12325155": null, "customfield_12320940":
-        null, "customfield_12324748": null, "customfield_12324747": "CWE-1", "project":
-        {"self": "https://example.com/rest/api/2/project/12332330", "id": "12332330",
-        "key": "OCPBUGS", "name": "OpenShift Bugs", "projectTypeKey": "software",
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?avatarId=17263",
-        "24x24": "https://example.com/secure/projectavatar?size=small&avatarId=17263",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&avatarId=17263",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&avatarId=17263"}},
-        "customfield_12324749": null, "customfield_12320944": null, "aggregatetimespent":
-        null, "customfield_12324746": {"self": "https://example.com/rest/api/2/customFieldOption/39375",
-        "value": "Red Hat", "id": "39375", "disabled": false}, "customfield_12310220":
-        null, "customfield_12310183": null, "resolutiondate": null, "customfield_12325150":
-        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
-        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
-        null, "customfield_12324751": "curl", "customfield_12319040": null, "customfield_12324750":
-        {"self": "https://example.com/rest/api/2/customFieldOption/39386", "value":
-        "False", "id": "39386", "disabled": false}, "customfield_12325047": null,
-        "watches": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/watchers",
-        "watchCount": 0, "isWatching": false}, "customfield_12319285": null, "customfield_12324753":
-        null, "customfield_12324752": "Security", "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-09-26T16:17:33.507+0000",
-        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
-        null, "customfield_12324754": null, "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-09-26T16:17:33.507+0000", "customfield_12311840": null, "customfield_12322143":
-        null, "customfield_12322140": null, "customfield_12317351": null, "customfield_12316142":
-        null, "customfield_12322141": null, "customfield_12322142": null, "timeoriginalestimate":
-        null, "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~",
-        "timetracking": {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Security:
-        Foo [openshift-4.8.z]", "customfield_12323640": null, "customfield_12325147":
-        null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
-        null, "customfield_12317360": null, "customfield_12323641": null, "customfield_12325148":
-        null, "customfield_12319540": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "customfield_12319940": null, "customfield_12319269": null, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141":
-        null, "customfield_12317247": null, "customfield_12325140": null, "customfield_12317248":
-        null, "customfield_12310213": null, "customfield_12311940": "2|i1xxfr:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Thu, 26 Sep 2024 16:17:36 GMT
-      Expires:
-      - Thu, 26 Sep 2024 16:17:36 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '12282'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 977x947975x2
-      x-asessionid:
-      - 1pwtxn5
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.18fb1060.1727367456.7b28bf6
-      x-rh-edge-request-id:
-      - 7b28bf6
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"issuetype": {"name": "Vulnerability"}, "project": {"key":
-      "OCPBUGS"}, "components": [{"name": "openshift-apiserver"}], "description":
-      "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~",
-      "labels": ["Security", "SecurityTracking", "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42",
-      "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:openshift-apiserver"],
-      "summary": "openshift-apiserver: Foo [openshift-4.10.z]", "customfield_12324940":
-      {"value": "Critical"}, "customfield_12324746": {"value": "Red Hat"}, "customfield_12324747":
-      "CWE-1", "customfield_12324752": "openshift-apiserver", "customfield_12324751":
-      "curl", "customfield_12324750": {"value": "False"}, "customfield_12324753":
-      []}, "key": "OCPBUGS-41925"}'
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "components":
+      [{"name": "kernel-rt / Other"}], "priority": {"name": "Critical"}, "description":
+      "Public Security Tracking Issue\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~\n\nReproducers,
+      if any, will remain confidential and never be made public, unless done so by
+      the security team.", "labels": ["Security", "SecurityTracking", "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42",
+      "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:kernel-rt"], "summary":
+      "kernel-rt: Foo [rhel-8.10.z]", "security": null}, "key": "RHEL-59490"}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -685,15 +581,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '824'
+      - '641'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OCPBUGS-41925
+    uri: https://example.com/rest/api/2/issue/RHEL-59490
   response:
     body:
       string: ''
@@ -705,9 +601,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Thu, 26 Sep 2024 16:17:37 GMT
+      - Tue, 19 Nov 2024 11:20:05 GMT
       Expires:
-      - Thu, 26 Sep 2024 16:17:37 GMT
+      - Tue, 19 Nov 2024 11:20:05 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -716,202 +612,6 @@ interactions:
       - '5'
       X-RateLimit-Remaining:
       - '4'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 977x947976x2
-      x-asessionid:
-      - uhmkiz
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.dfb1060.1727367456.939f7fb
-      x-rh-edge-request-id:
-      - 939f7fb
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OCPBUGS-41925
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16288116", "self": "https://example.com/rest/api/2/issue/16288116",
-        "key": "OCPBUGS-41925", "fields": {"customfield_12322244": null, "customfield_12324940":
-        {"self": "https://example.com/rest/api/2/customFieldOption/40250", "value":
-        "Critical", "id": "40250", "disabled": false}, "customfield_12324540": "0.0",
-        "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@63176446[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3602fdea[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6beee757[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4a22ba6d[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@543b8315[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7b96b39f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67de27e5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@38f008a1[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@305b1781[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7e1f505e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6868b177[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@50e519db[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
-        null, "customfield_12319640": null, "customfield_12313140": null, "priority":
-        {"self": "https://example.com/rest/api/2/priority/10300", "iconUrl": "https://example.com/images/icons/priorities/trivial.svg",
-        "name": "Undefined", "id": "10300"}, "labels": ["Security", "SecurityTracking",
-        "flawuuid:9143582e-8711-4e69-ba6a-b3ead61fbb42", "pscomponent:openshift-apiserver"],
-        "aggregatetimeoriginalestimate": null, "timeestimate": null, "versions": [],
-        "issuelinks": [], "assignee": {"self": "https://example.com/rest/api/2/user?username=rh-ee-bleanhar",
-        "name": "rh-ee-bleanhar", "key": "bleanhar", "emailAddress": "bleanhar@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=48",
-        "24x24": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=24",
-        "16x16": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=16",
-        "32x32": "https://example.com/avatar/43b9a63c0e743cfc2174ac195be1b106?d=mm&s=32"},
-        "displayName": "Brenton Leanhardt", "active": true, "timeZone": "America/New_York"},
-        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
-        "https://example.com/rest/api/2/status/10016", "description": "Initial creation
-        status. Implies nothing yet and should be very short lived; also can be a
-        Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [{"self": "https://example.com/rest/api/2/component/12367887", "id": "12367887",
-        "name": "openshift-apiserver", "description": "OpenShift API Server, OpenShift
-        API Server Operator, Admission for OpenShift v4 (include Image, Build and
-        DeploymentConfig APIs)"}], "customfield_12314040": null, "customfield_12320844":
-        null, "archiveddate": null, "customfield_12320842": null, "customfield_12310243":
-        null, "aggregatetimeestimate": null, "customfield_12317313": null, "creator":
-        {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
-        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
-        "reporter": {"self": "https://example.com/rest/api/2/user?username=jsvoboda%40redhat.com",
-        "name": "jsvoboda@redhat.com", "key": "jsvoboda", "emailAddress": "jsvoboda+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jsvoboda&avatarId=44675",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jsvoboda&avatarId=44675",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jsvoboda&avatarId=44675",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jsvoboda&avatarId=44675"},
-        "displayName": "Jakub Svoboda", "active": true, "timeZone": "Europe/Prague"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
-        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=xiyuan%40redhat.com",
-        "name": "xiyuan@redhat.com", "key": "xiaojiey", "emailAddress": "xiyuan@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=29962",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=29962",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=29962",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=29962"},
-        "displayName": "Xiaojie Yuan", "active": true, "timeZone": "Asia/Shanghai"},
-        "customfield_12313240": null, "customfield_12319742": null, "progress": {"progress":
-        0, "total": 0}, "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12324344":
-        null, "customfield_12325158": null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/12207",
-        "id": "12207", "description": "", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=57661&avatarType=issuetype",
-        "name": "Vulnerability", "subtask": false, "avatarId": 57661}, "customfield_12324343":
-        null, "customfield_12325157": null, "customfield_12324345": null, "customfield_12325159":
-        null, "customfield_12322040": null, "customfield_12318341": null, "customfield_12324340":
-        null, "customfield_12325154": null, "customfield_12325153": null, "customfield_12325156":
-        null, "timespent": null, "customfield_12325155": null, "customfield_12320940":
-        null, "customfield_12324748": null, "customfield_12324747": "CWE-1", "project":
-        {"self": "https://example.com/rest/api/2/project/12332330", "id": "12332330",
-        "key": "OCPBUGS", "name": "OpenShift Bugs", "projectTypeKey": "software",
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?avatarId=17263",
-        "24x24": "https://example.com/secure/projectavatar?size=small&avatarId=17263",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&avatarId=17263",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&avatarId=17263"}},
-        "customfield_12324749": null, "customfield_12320944": null, "aggregatetimespent":
-        null, "customfield_12324746": {"self": "https://example.com/rest/api/2/customFieldOption/39375",
-        "value": "Red Hat", "id": "39375", "disabled": false}, "customfield_12310220":
-        null, "customfield_12310183": null, "resolutiondate": null, "customfield_12325150":
-        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
-        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
-        null, "customfield_12324751": "curl", "customfield_12319040": null, "customfield_12324750":
-        {"self": "https://example.com/rest/api/2/customFieldOption/39386", "value":
-        "False", "id": "39386", "disabled": false}, "customfield_12325047": null,
-        "watches": {"self": "https://example.com/rest/api/2/issue/OCPBUGS-41925/watchers",
-        "watchCount": 0, "isWatching": false}, "customfield_12319285": null, "customfield_12324753":
-        null, "customfield_12324752": "openshift-apiserver", "customfield_12325044":
-        null, "customfield_12325043": null, "customfield_12325046": null, "created":
-        "2024-09-26T16:17:33.507+0000", "customfield_12321240": null, "customfield_12325045":
-        null, "customfield_12323940": null, "customfield_12324754": null, "customfield_12320947":
-        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
-        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-09-26T16:17:37.200+0000", "customfield_12311840": null, "customfield_12322143":
-        null, "customfield_12322140": null, "customfield_12317351": null, "customfield_12316142":
-        null, "customfield_12322141": null, "customfield_12322142": null, "timeoriginalestimate":
-        null, "description": "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\nFoo\nhttps://example.com/show_bug.cgi?id=None\n\ntest\n\n~~~",
-        "timetracking": {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "openshift-apiserver:
-        Foo [openshift-4.10.z]", "customfield_12323640": null, "customfield_12325147":
-        null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
-        null, "customfield_12317360": null, "customfield_12323641": null, "customfield_12325148":
-        null, "customfield_12319540": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "customfield_12319940": null, "customfield_12319269": null, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141":
-        null, "customfield_12317247": null, "customfield_12325140": null, "customfield_12317248":
-        null, "customfield_12310213": null, "customfield_12311940": "2|i1xxfr:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Thu, 26 Sep 2024 16:17:38 GMT
-      Expires:
-      - Thu, 26 Sep 2024 16:17:38 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '12430'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -919,9 +619,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 977x785194x11
+      - 680x339949x1
       x-asessionid:
-      - o0dw3u
+      - 11ajwbm
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -933,14 +633,14 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1727367457.7b2a12c
+      - 0.8468dc17.1732015204.2fbcfa02
       x-rh-edge-request-id:
-      - 7b2a12c
+      - 2fbcfa02
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
+      code: 204
+      message: No Content
 version: 1

--- a/apps/trackers/tests/cassettes/test_integration/TestTrackerSaver.test_tracker_update_bugzilla.yaml
+++ b/apps/trackers/tests/cassettes/test_integration/TestTrackerSaver.test_tracker_update_bugzilla.yaml
@@ -11,12 +11,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh100"}'
+      string: '{"version": "5.0.4.rh102"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:42 GMT
+      - Wed, 13 Nov 2024 12:59:26 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -41,9 +41,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1723494642.3b291e9
+      - 0.d369dc17.1731502765.2ea6e066
       x-rh-edge-request-id:
-      - 3b291e9
+      - 2ea6e066
     status:
       code: 200
       message: OK
@@ -59,13 +59,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "id": 1, "can_login":
-        true, "real_name": "Need Real Name", "email": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"can_login": true, "real_name": "Need Real Name", "id":
+        1, "email": "aander07@packetmaster.com", "name": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -80,7 +80,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:43 GMT
+      - Wed, 13 Nov 2024 12:59:26 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -90,9 +90,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1723494642.3b2925c
+      - 0.d369dc17.1731502766.2ea6e0b6
       x-rh-edge-request-id:
-      - 3b2925c
+      - 2ea6e0b6
     status:
       code: 200
       message: OK
@@ -108,13 +108,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/bug/2291491?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&include_fields=id&include_fields=last_change_time
   response:
     body:
-      string: '{"faults": [], "bugs": [{"id": 2291491, "data_category": "Engineering",
-        "last_change_time": "2024-08-12T20:26:54Z"}]}'
+      string: '{"bugs": [{"last_change_time": "2024-11-13T12:56:45Z", "data_category":
+        "Engineering", "id": 2291491}], "faults": []}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -129,7 +129,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:44 GMT
+      - Wed, 13 Nov 2024 12:59:27 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -139,19 +139,19 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1723494643.3b29425
+      - 0.d369dc17.1731502766.2ea6e36a
       x-rh-edge-request-id:
-      - 3b29425
+      - 2ea6e36a
     status:
       code: 200
       message: OK
 - request:
     body: '{"product": "Red Hat Certification Program", "version": "1.0", "priority":
-      "medium", "severity": "medium", "blocks": {"add": ["2217733"], "remove": []},
-      "component": "redhat-certification", "groups": {"add": ["devel"], "remove":
-      []}, "keywords": {"add": ["Security", "SecurityTracking"]}, "summary": "CVE-2020-10000
-      openssl: CVE-2020-10000 kernel: some description [rhcertification-6]", "whiteboard":
-      "{\"flaws\": [\"faa02077-2b32-41cc-9e4a-659b577e6dc6\"]}", "ids": ["2291491"]}'
+      "low", "severity": "low", "blocks": {"add": ["2217733"], "remove": []}, "component":
+      "redhat-certification", "groups": {"add": ["devel"], "remove": []}, "keywords":
+      {"add": ["Security", "SecurityTracking"]}, "summary": "CVE-2020-10000 redhat-certification:
+      CVE-2020-10000 kernel: some description [rhcertification-8]", "whiteboard":
+      "{\"flaws\": [\"8328fe68-0804-4acf-a812-6dbee1b0d3ec\"]}", "ids": ["2291491"]}'
     headers:
       Accept:
       - '*/*'
@@ -160,20 +160,20 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '479'
+      - '486'
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: PUT
     uri: https://example.com/rest/bug/2291491
   response:
     body:
-      string: '{"bugs": [{"changes": {"whiteboard": {"removed": "{\"flaws\": [\"bc317295-21c6-44db-bf8a-b92df55fba10\"]}",
-        "added": "{\"flaws\": [\"faa02077-2b32-41cc-9e4a-659b577e6dc6\"]}"}, "priority":
-        {"removed": "urgent", "added": "medium"}, "severity": {"removed": "urgent",
-        "added": "medium"}}, "last_change_time": "2024-08-12T20:30:45Z", "alias":
-        [], "id": 2291491}]}'
+      string: '{"bugs": [{"id": 2291491, "changes": {"whiteboard": {"added": "{\"flaws\":
+        [\"8328fe68-0804-4acf-a812-6dbee1b0d3ec\"]}", "removed": "{\"flaws\": [\"28a8e7a5-3067-43eb-9974-c042d4a84191\"]}"},
+        "priority": {"added": "low", "removed": "urgent"}, "severity": {"added": "low",
+        "removed": "urgent"}, "blocks": {"removed": "", "added": "2217733"}}, "alias":
+        [], "last_change_time": "2024-11-13T12:59:28Z"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -184,11 +184,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '337'
+      - '373'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:45 GMT
+      - Wed, 13 Nov 2024 12:59:36 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -198,9 +198,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.7df06e68.1723494644.3b295ba
+      - 0.d369dc17.1731502767.2ea6e63e
       x-rh-edge-request-id:
-      - 3b295ba
+      - 2ea6e63e
     status:
       code: 200
       message: OK
@@ -216,12 +216,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh100"}'
+      string: '{"version": "5.0.4.rh102"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -236,7 +236,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:46 GMT
+      - Wed, 13 Nov 2024 12:59:37 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -246,9 +246,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1723494646.16b85a67
+      - 0.d369dc17.1731502776.2ea71856
       x-rh-edge-request-id:
-      - 16b85a67
+      - 2ea71856
     status:
       code: 200
       message: OK
@@ -264,13 +264,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"real_name": "Need Real Name", "email": "aander07@packetmaster.com",
-        "can_login": true, "id": 1, "name": "aander07@packetmaster.com"}]}'
+      string: '{"users": [{"can_login": true, "real_name": "Need Real Name", "email":
+        "aander07@packetmaster.com", "id": 1, "name": "aander07@packetmaster.com"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -285,7 +285,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:47 GMT
+      - Wed, 13 Nov 2024 12:59:37 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -295,9 +295,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1723494646.16b85b12
+      - 0.d369dc17.1731502777.2ea718b9
       x-rh-edge-request-id:
-      - 16b85b12
+      - 2ea718b9
     status:
       code: 200
       message: OK
@@ -313,52 +313,54 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/bug/2291491?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
   response:
     body:
-      string: '{"faults": [], "bugs": [{"cf_pgm_internal": "", "flags": [{"setter":
-        "bugzilla@redhat.com", "status": "-", "name": "requires_doc_text", "id": 6115848,
-        "is_active": 1, "type_id": 415, "modification_date": "2024-06-13T14:25:38Z",
-        "creation_date": "2024-06-13T14:25:38Z"}], "cf_target_upstream_version": "",
-        "cf_last_closed": null, "resolution": "", "status": "NEW", "docs_contact":
-        "", "cf_verified": [], "platform": "Unspecified", "keywords": ["Security",
-        "SecurityTracking"], "is_open": true, "creator_detail": {"partner": false,
-        "email": "osoukup@redhat.com", "insider": true, "id": 412888, "real_name":
-        "Ondrej Soukup", "name": "osoukup@redhat.com", "active": true}, "cf_clone_of":
-        null, "comments": [{"creator_id": 412888, "private_groups": [], "id": 18018087,
-        "time": "2024-06-13T14:25:38Z", "text": "rhcertification-6 tracking bug for
-        openssl: see the bugs linked in the \"Blocks\" field of this bug for full
-        details of the security issue(s).\n\nThis bug is never intended to be made
-        public, please put any public notes in the blocked bugs.", "creation_time":
-        "2024-06-13T14:25:38Z", "attachment_id": null, "bug_id": 2291491, "tags":
-        [], "is_private": false, "count": 0, "creator": "osoukup@redhat.com"}], "is_cc_accessible":
-        true, "depends_on": [], "classification": "Red Hat", "creator": "osoukup@redhat.com",
-        "cf_release_notes": "", "cf_internal_whiteboard": "", "cf_devel_whiteboard":
-        "", "target_release": ["---"], "component": ["redhat-certification"], "op_sys":
-        "Unspecified", "deadline": "2024-07-23", "external_bugs": [], "sub_components":
-        {}, "url": "", "cf_doc_type": "No Doc Update", "version": ["1.0"], "id": 2291491,
-        "summary": "CVE-2020-10000 openssl: CVE-2020-10000 kernel: some description
-        [rhcertification-6]", "qa_contact": "rhcert-qe@redhat.com", "whiteboard":
-        "{\"flaws\": [\"faa02077-2b32-41cc-9e4a-659b577e6dc6\"]}", "alias": [], "groups":
-        ["devel"], "last_change_time": "2024-08-12T20:30:45Z", "priority": "medium",
-        "product": "Red Hat Certification Program", "qa_contact_detail": {"insider":
-        false, "id": 408554, "email": "rhcert-qe@redhat.com", "real_name": "rhcert
-        qe", "partner": false, "active": false, "name": "rhcert-qe@redhat.com"}, "remaining_time":
-        0, "blocks": [2217733], "actual_time": 0, "data_category": "Engineering",
-        "cc": [], "tags": [], "severity": "medium", "cf_build_id": "", "is_confirmed":
-        true, "cf_pm_score": "0", "estimated_time": 0, "cf_partner": [], "cf_environment":
-        "", "cf_fixed_in": "", "creation_time": "2024-06-13T14:25:38Z", "cf_conditional_nak":
-        [], "cf_qa_whiteboard": "", "description": "rhcertification-6 tracking bug
-        for openssl: see the bugs linked in the \"Blocks\" field of this bug for full
-        details of the security issue(s).\n\nThis bug is never intended to be made
-        public, please put any public notes in the blocked bugs.", "assigned_to_detail":
-        {"partner": false, "email": "jweng@redhat.com", "insider": true, "id": 283338,
-        "real_name": "Jianwei Weng", "name": "jweng@redhat.com", "active": true},
-        "target_milestone": "---", "cf_embargoed": null, "cf_major_incident": null,
-        "cf_cust_facing": "---", "is_creator_accessible": true, "cc_detail": [], "assigned_to":
-        "jweng@redhat.com", "dupe_of": null, "cf_qe_conditional_nak": []}]}'
+      string: '{"faults": [], "bugs": [{"deadline": "2024-07-23", "data_category":
+        "Engineering", "classification": "Red Hat", "description": "rhcertification-6
+        tracking bug for openssl: see the bugs linked in the \"Blocks\" field of this
+        bug for full details of the security issue(s).\n\nThis bug is never intended
+        to be made public, please put any public notes in the blocked bugs.", "assigned_to":
+        "jweng@redhat.com", "cf_qa_whiteboard": "", "actual_time": 0, "resolution":
+        "", "product": "Red Hat Certification Program", "creator": "osoukup@redhat.com",
+        "groups": ["devel"], "cf_partner": [], "platform": "Unspecified", "op_sys":
+        "Unspecified", "blocks": [2217733], "cf_devel_whiteboard": "", "cf_fixed_in":
+        "", "cf_qe_conditional_nak": [], "is_creator_accessible": true, "cf_target_upstream_version":
+        "", "depends_on": [], "cf_build_id": "", "external_bugs": [], "cf_clone_of":
+        null, "alias": [], "url": "", "dupe_of": null, "cf_major_incident": null,
+        "cf_conditional_nak": [], "target_milestone": "---", "cf_verified": [], "assigned_to_detail":
+        {"insider": true, "real_name": "Jianwei Weng", "id": 283338, "email": "jweng@redhat.com",
+        "partner": false, "name": "jweng@redhat.com", "active": true}, "docs_contact":
+        "", "component": ["redhat-certification"], "priority": "low", "cc_detail":
+        [{"active": true, "name": "conrado@redhat.com", "partner": false, "email":
+        "conrado@redhat.com", "real_name": "Conrado Costa", "id": 482384, "insider":
+        true}], "cf_release_notes": "", "is_open": true, "cf_environment": "", "version":
+        ["1.0"], "qa_contact": "rhcert-qe@redhat.com", "creation_time": "2024-06-13T14:25:38Z",
+        "cf_pgm_internal": "", "is_cc_accessible": true, "target_release": ["---"],
+        "cf_pm_score": "0", "id": 2291491, "qa_contact_detail": {"active": false,
+        "name": "rhcert-qe@redhat.com", "partner": false, "email": "rhcert-qe@redhat.com",
+        "real_name": "rhcert qe", "id": 408554, "insider": false}, "estimated_time":
+        0, "severity": "low", "tags": [], "summary": "CVE-2020-10000 redhat-certification:
+        CVE-2020-10000 kernel: some description [rhcertification-8]", "whiteboard":
+        "{\"flaws\": [\"8328fe68-0804-4acf-a812-6dbee1b0d3ec\"]}", "remaining_time":
+        0, "cf_embargoed": null, "cc": ["conrado@redhat.com"], "creator_detail": {"insider":
+        true, "real_name": "Ondrej Soukup", "id": 412888, "email": "osoukup@redhat.com",
+        "partner": false, "name": "osoukup@redhat.com", "active": true}, "keywords":
+        ["Security", "SecurityTracking"], "cf_last_closed": null, "flags": [{"id":
+        6115848, "creation_date": "2024-06-13T14:25:38Z", "name": "requires_doc_text",
+        "status": "-", "setter": "bugzilla@redhat.com", "is_active": 1, "modification_date":
+        "2024-06-13T14:25:38Z", "type_id": 415}], "comments": [{"id": 18018087, "creation_time":
+        "2024-06-13T14:25:38Z", "creator": "osoukup@redhat.com", "count": 0, "tags":
+        [], "is_private": false, "bug_id": 2291491, "text": "rhcertification-6 tracking
+        bug for openssl: see the bugs linked in the \"Blocks\" field of this bug for
+        full details of the security issue(s).\n\nThis bug is never intended to be
+        made public, please put any public notes in the blocked bugs.", "time": "2024-06-13T14:25:38Z",
+        "attachment_id": null, "creator_id": 412888, "private_groups": []}], "sub_components":
+        {}, "cf_cust_facing": "---", "cf_internal_whiteboard": "", "cf_doc_type":
+        "No Doc Update", "last_change_time": "2024-11-13T12:59:28Z", "is_confirmed":
+        true, "status": "NEW"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -371,7 +373,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Mon, 12 Aug 2024 20:30:48 GMT
+      - Wed, 13 Nov 2024 12:59:38 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       Vary:
@@ -381,13 +383,13 @@ interactions:
       X-xss-protection:
       - 1; mode=block
       content-length:
-      - '3059'
+      - '3229'
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.64f06e68.1723494647.16b85d10
+      - 0.d369dc17.1731502777.2ea71a6f
       x-rh-edge-request-id:
-      - 16b85d10
+      - 2ea71a6f
     status:
       code: 200
       message: OK

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -1,6 +1,5 @@
 import pytest
 
-import apps.trackers.common as common
 from apps.sla.framework import SLAPolicy
 from apps.trackers.constants import TRACKERS_API_VERSION
 
@@ -24,11 +23,8 @@ def enable_db_access_for_all_tests(db) -> None:
 
 
 @pytest.fixture(autouse=True)
-def pin_envs(enable_jira_task_sync, enable_bz_async_sync, monkeypatch) -> None:
-    """
-    the tests should be immune to what .env you build the testrunner with
-    """
-    monkeypatch.setattr(common, "BZ_URL", "https://example.com")
+def auto_enable_sync(enable_jira_task_sync, enable_bz_async_sync) -> None:
+    pass
 
 
 @pytest.fixture

--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -32,16 +32,6 @@ def pin_envs(enable_jira_task_sync, enable_bz_async_sync, monkeypatch) -> None:
 
 
 @pytest.fixture
-def jira_test_url() -> str:
-    return "https://issues.stage.redhat.com"
-
-
-@pytest.fixture
-def user_token() -> str:
-    return "USER_JIRA_TOKEN"
-
-
-@pytest.fixture
 def stage_jira_project() -> str:
     return "OSIM"
 

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -485,7 +485,7 @@ class TestTrackerQueryBuilderDescription:
         if flaw_count == 1:
             assert tqb.description == (
                 "More information about this security flaw is available in the following bug:\n\n"
-                "https://example.com/show_bug.cgi?id=0\n\n"
+                "https://bugzilla.redhat.com/show_bug.cgi?id=0\n\n"
                 "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
                 "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
                 "affects their package, before starting the update process."
@@ -493,8 +493,8 @@ class TestTrackerQueryBuilderDescription:
         elif flaw_count == 2:
             assert tqb.description == (
                 "More information about these security flaws is available in the following bugs:\n\n"
-                "https://example.com/show_bug.cgi?id=0\n"
-                "https://example.com/show_bug.cgi?id=1\n\n"
+                "https://bugzilla.redhat.com/show_bug.cgi?id=0\n"
+                "https://bugzilla.redhat.com/show_bug.cgi?id=1\n\n"
                 "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
                 "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
                 "affects their package, before starting the update process."
@@ -503,9 +503,9 @@ class TestTrackerQueryBuilderDescription:
             assert tqb.description == (
                 (
                     "More information about these security flaws is available in the following bugs:\n\n"
-                    "https://example.com/show_bug.cgi?id=0\n"
-                    "https://example.com/show_bug.cgi?id=1\n"
-                    "https://example.com/show_bug.cgi?id=2\n\n"
+                    "https://bugzilla.redhat.com/show_bug.cgi?id=0\n"
+                    "https://bugzilla.redhat.com/show_bug.cgi?id=1\n"
+                    "https://bugzilla.redhat.com/show_bug.cgi?id=2\n\n"
                     "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
                     "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
                     "affects their package, before starting the update process."
@@ -557,7 +557,7 @@ class TestTrackerQueryBuilderDescription:
             "Flaw:\n"
             "-----\n\n"
             "serious flaw\n"
-            "https://example.com/show_bug.cgi?id=12345\n\n"
+            "https://bugzilla.redhat.com/show_bug.cgi?id=12345\n\n"
             "this flaw is very hard to fix\n\n"
             "~~~"
         )
@@ -609,7 +609,7 @@ class TestTrackerQueryBuilderDescription:
             "Flaw:\n"
             "-----\n\n"
             "serious flaw\n"
-            "https://example.com/show_bug.cgi?id=12345\n\n"
+            "https://bugzilla.redhat.com/show_bug.cgi?id=12345\n\n"
             "this flaw is very hard to fix\n\n"
             "~~~"
         )

--- a/apps/trackers/tests/test_file_offer.py
+++ b/apps/trackers/tests/test_file_offer.py
@@ -65,7 +65,6 @@ class TestTrackerSuggestions:
         affectedness,
         resolution,
         is_valid,
-        user_token,
         auth_client,
         test_app_api_uri,
     ):
@@ -90,7 +89,7 @@ class TestTrackerSuggestions:
             active_to_ps_module=ps_module_regular,
         )
 
-        headers = {"HTTP_JiraAuthentication": user_token}
+        headers = {"HTTP_JiraAuthentication": "SECRET"}
         response = auth_client().post(
             f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw.uuid]},
@@ -111,9 +110,7 @@ class TestTrackerSuggestions:
             assert res["not_applicable"][0]["uuid"] == str(affect.uuid)
             assert len(res["modules_components"]) == 0
 
-    def test_trackers_file_offer_embargoed(
-        self, user_token, auth_client, test_app_api_uri
-    ):
+    def test_trackers_file_offer_embargoed(self, auth_client, test_app_api_uri):
         """
         Test auto tracker auto filing defined in product
         definition rules related to embargo status
@@ -155,7 +152,7 @@ class TestTrackerSuggestions:
             ps_module="public-only-module",
         )
 
-        headers = {"HTTP_JiraAuthentication": user_token}
+        headers = {"HTTP_JiraAuthentication": "SECRET"}
         response = auth_client().post(
             f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw.uuid, flaw_embargoed.uuid]},
@@ -201,7 +198,6 @@ class TestTrackerSuggestions:
         self,
         auth_client,
         test_app_api_uri,
-        user_token,
         affectedness,
         resolution,
         should_suggest,
@@ -244,7 +240,7 @@ class TestTrackerSuggestions:
             unacked_to_ps_module=ps_module,
         ).save()
 
-        headers = {"HTTP_JiraAuthentication": user_token}
+        headers = {"HTTP_JiraAuthentication": "SECRET"}
         response = auth_client().post(
             f"{test_app_api_uri}/file",
             data={"flaw_uuids": [flaw.uuid]},

--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -30,7 +30,7 @@ pytestmark = pytest.mark.integration
 
 class TestTrackerSaver:
     @pytest.mark.vcr
-    def test_tracker_create_bugzilla(self):
+    def test_tracker_create_bugzilla(self, bugzilla_token):
         """
         test basic Bugzilla tracker creation
         """
@@ -78,7 +78,7 @@ class TestTrackerSaver:
         assert tracker.bz_id is None
 
         # 2) create tracker in OSIDB and Bugzilla
-        ts = TrackerSaver(tracker, bz_api_key="SECRET")
+        ts = TrackerSaver(tracker, bz_api_key=bugzilla_token)
         created_tracker = ts.save()
         assert created_tracker.bz_id
         assert created_tracker.uuid == tracker.uuid
@@ -105,7 +105,7 @@ class TestTrackerSaver:
         assert not loaded_tracker.alerts.exists()
 
     @pytest.mark.vcr
-    def test_tracker_update_bugzilla(self):
+    def test_tracker_update_bugzilla(self, bugzilla_token):
         """
         test basic Bugzilla tracker update
         """
@@ -158,7 +158,7 @@ class TestTrackerSaver:
         )
         assert tracker.bz_id == tracker_id
         # 3) update tracker in OSIDB and Bugzilla
-        ts = TrackerSaver(tracker, bz_api_key="SECRET")
+        ts = TrackerSaver(tracker, bz_api_key=bugzilla_token)
         updated_tracker = ts.save()
         assert updated_tracker.bz_id == tracker_id
         assert updated_tracker.uuid == tracker.uuid
@@ -190,7 +190,9 @@ class TestTrackerSaver:
 
 class TestTrackerAPI:
     @pytest.mark.vcr
-    def test_tracker_create_bugzilla(self, auth_client, enable_bz_sync, test_api_uri):
+    def test_tracker_create_bugzilla(
+        self, auth_client, bugzilla_token, enable_bz_sync, jira_token, test_api_uri
+    ):
         """
         test the whole stack Bugzilla tracker creation
         starting on the API and ending in Bugzilla
@@ -233,8 +235,8 @@ class TestTrackerAPI:
             f"{test_api_uri}/trackers",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -252,7 +254,9 @@ class TestTrackerAPI:
         assert tracker_json["ps_update_stream"] == "rhcertification-6"
 
     @pytest.mark.vcr
-    def test_tracker_update_bugzilla(self, auth_client, enable_bz_sync, test_api_uri):
+    def test_tracker_update_bugzilla(
+        self, auth_client, bugzilla_token, enable_bz_sync, jira_token, test_api_uri
+    ):
         """
         test the whole stack Bugzilla tracker update
         starting on the API and ending in Bugzilla
@@ -314,8 +318,8 @@ class TestTrackerAPI:
             f"{test_api_uri}/trackers/{tracker.uuid}",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -335,7 +339,13 @@ class TestTrackerAPI:
 
     @pytest.mark.vcr
     def test_tracker_create_jira(
-        self, auth_client, enable_bz_sync, enable_jira_tracker_sync, test_api_uri
+        self,
+        auth_client,
+        bugzilla_token,
+        enable_bz_sync,
+        enable_jira_tracker_sync,
+        jira_token,
+        test_api_uri,
     ):
         """
         test the whole stack Jira tracker creation
@@ -402,8 +412,8 @@ class TestTrackerAPI:
             f"{test_api_uri}/trackers",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -423,7 +433,13 @@ class TestTrackerAPI:
 
     @pytest.mark.vcr
     def test_tracker_update_jira(
-        self, auth_client, enable_bz_sync, enable_jira_tracker_sync, test_api_uri
+        self,
+        auth_client,
+        bugzilla_token,
+        enable_bz_sync,
+        enable_jira_tracker_sync,
+        jira_token,
+        test_api_uri,
     ):
         """
         test the whole stack Jira tracker update
@@ -548,8 +564,8 @@ class TestTrackerAPI:
             f"{test_api_uri}/trackers/{tracker.uuid}",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 
@@ -573,8 +589,10 @@ class TestTrackerAPI:
     def test_tracker_create_update_jira_vulnerability_issuetype(
         self,
         auth_client,
+        bugzilla_token,
         enable_bz_sync,
         enable_jira_tracker_sync,
+        jira_token,
         test_api_uri,
         monkeypatch,
     ):
@@ -738,8 +756,8 @@ class TestTrackerAPI:
             flaw_data,
             format="json",
             # TODO sanitize keys both here and in VCRs
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
 
@@ -784,8 +802,8 @@ class TestTrackerAPI:
             f"{test_api_uri}/trackers",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
 
         assert response.status_code == status.HTTP_201_CREATED
@@ -880,8 +898,8 @@ class TestTrackerAPI:
             f"{test_api_uri}/trackers/{tracker_new.uuid}",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
 

--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -8,45 +8,34 @@ import pytest
 from django.utils import timezone
 from rest_framework import status
 
-from apps.trackers.jira.query import JiraPriority
-from apps.trackers.models import JiraBugIssuetype, JiraProjectFields
 from apps.trackers.save import TrackerSaver
-from apps.trackers.tests.factories import JiraProjectFieldsFactory
 from collectors.bzimport.collectors import BugzillaTrackerCollector
 from collectors.bzimport.constants import BZ_DT_FMT
 from collectors.jiraffe.collectors import JiraTrackerCollector
-from osidb.models import Affect, Flaw, Impact, Tracker
+from osidb.models import Affect, Flaw, Impact, PsUpdateStream, Tracker
 from osidb.sync_manager import BZTrackerLinkManager, JiraTrackerLinkManager
-from osidb.tests.factories import (
-    AffectFactory,
-    FlawFactory,
-    PsModuleFactory,
-    PsUpdateStreamFactory,
-    TrackerFactory,
-)
+from osidb.tests.factories import AffectFactory, FlawFactory, TrackerFactory
 
 pytestmark = pytest.mark.integration
 
 
 class TestTrackerSaver:
     @pytest.mark.vcr
-    def test_tracker_create_bugzilla(self, bugzilla_token):
+    def test_tracker_create_bugzilla(
+        self, bugzilla_token, setup_sample_external_resources
+    ):
         """
         test basic Bugzilla tracker creation
         """
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="bugzilla",
-            bts_key="Red Hat Certification Program",
-            bts_groups={"public": ["devel"]},
-            default_component="redhat-certification",
-            name="rhcertification-6",
+        # 1) get valid external data
+        ps_update_stream = (
+            PsUpdateStream.objects.filter(active_to_ps_module__bts_name="bugzilla")
+            .order_by("name")
+            .first()
         )
-        ps_update_stream = PsUpdateStreamFactory(
-            name="rhcertification-6",
-            ps_module=ps_module,
-            version="1.0",
-        )
+        ps_module = ps_update_stream.active_to_ps_module
+
+        # 2) define all the context
         flaw = FlawFactory(
             bz_id="2217733",
             embargoed=False,
@@ -56,7 +45,7 @@ class TestTrackerSaver:
         affect = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="openssl",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
         )
@@ -77,27 +66,27 @@ class TestTrackerSaver:
         )
         assert tracker.bz_id is None
 
-        # 2) create tracker in OSIDB and Bugzilla
+        # 3) create tracker in OSIDB and Bugzilla
         ts = TrackerSaver(tracker, bz_api_key=bugzilla_token)
         created_tracker = ts.save()
         assert created_tracker.bz_id
         assert created_tracker.uuid == tracker.uuid
         created_tracker.save()
 
-        # 3) load tracker from Bugzilla
+        # 4) load tracker from Bugzilla
         btc = BugzillaTrackerCollector()
         btc.sync_tracker(created_tracker.bz_id)
         BZTrackerLinkManager.link_tracker_with_affects(created_tracker.bz_id)
 
-        # 4) get the newly loaded tracker from the DB
+        # 5) get the newly loaded tracker from the DB
         loaded_tracker = Tracker.objects.get(external_system_id=created_tracker.bz_id)
         loaded_tracker.save()  # get rid of Tracker alerts related to missing affect
 
-        # 5) check the correct result of the creation and loading
+        # 6) check the correct result of the creation and loading
         assert loaded_tracker.bz_id == created_tracker.bz_id
         assert not loaded_tracker.embargoed
         assert loaded_tracker.type == Tracker.TrackerType.BUGZILLA
-        assert loaded_tracker.ps_update_stream == "rhcertification-6"
+        assert loaded_tracker.ps_update_stream == ps_update_stream.name
         assert loaded_tracker.status == "NEW"
         assert not loaded_tracker.resolution
         assert loaded_tracker.affects.count() == 1
@@ -105,23 +94,21 @@ class TestTrackerSaver:
         assert not loaded_tracker.alerts.exists()
 
     @pytest.mark.vcr
-    def test_tracker_update_bugzilla(self, bugzilla_token):
+    def test_tracker_update_bugzilla(
+        self, bugzilla_token, setup_sample_external_resources
+    ):
         """
         test basic Bugzilla tracker update
         """
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="bugzilla",
-            bts_key="Red Hat Certification Program",
-            bts_groups={"public": ["devel"]},
-            default_component="redhat-certification",
-            name="rhcertification-6",
+        # 1) get valid external data
+        ps_update_stream = (
+            PsUpdateStream.objects.filter(active_to_ps_module__bts_name="bugzilla")
+            .order_by("name")
+            .first()
         )
-        ps_update_stream = PsUpdateStreamFactory(
-            name="rhcertification-6",
-            ps_module=ps_module,
-            version="1.0",
-        )
+        ps_module = ps_update_stream.active_to_ps_module
+
+        # 2) define all the context
         flaw = FlawFactory(
             bz_id="2217733",
             embargoed=False,
@@ -130,15 +117,15 @@ class TestTrackerSaver:
         affect = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="openssl",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
         )
 
-        # 2) define a tracker model instance
+        # 3) define a tracker model instance
         #    according an exising Bugzilla tracker
         tracker_id = "2291491"
-        updated_dt = "2024-08-12T20:26:54Z"
+        updated_dt = "2024-11-13T12:56:45Z"
         tracker = TrackerFactory(
             affects=[affect],
             bz_id=tracker_id,
@@ -148,7 +135,6 @@ class TestTrackerSaver:
             status="NEW",
             resolution="",
             meta_attr={
-                "blocks": f"[{flaw.bz_id}]",
                 "whiteboard": {"flaws": [flaw.uuid]},
                 "updated_dt": updated_dt,
                 "ps_module": affect.ps_module,
@@ -157,33 +143,35 @@ class TestTrackerSaver:
             updated_dt=timezone.datetime.strptime(updated_dt, BZ_DT_FMT),
         )
         assert tracker.bz_id == tracker_id
-        # 3) update tracker in OSIDB and Bugzilla
+        # 4) update tracker in OSIDB and Bugzilla
         ts = TrackerSaver(tracker, bz_api_key=bugzilla_token)
         updated_tracker = ts.save()
         assert updated_tracker.bz_id == tracker_id
         assert updated_tracker.uuid == tracker.uuid
         updated_tracker.save(auto_timestamps=False)
 
-        # 4) load tracker from Bugzilla
+        # 5) load tracker from Bugzilla
         btc = BugzillaTrackerCollector()
+        btc.bz_querier._bz_api_key = bugzilla_token
+
         btc.sync_tracker(updated_tracker.bz_id)
         BZTrackerLinkManager.link_tracker_with_affects(updated_tracker.bz_id)
 
-        # 5) get the newly loaded tracker from the DB
+        # 6) get the newly loaded tracker from the DB
         loaded_tracker = Tracker.objects.get(external_system_id=tracker_id)
 
-        # 6) check the correct result of the update and loading
+        # 7) check the correct result of the update and loading
         assert loaded_tracker.bz_id == tracker_id
         assert not loaded_tracker.embargoed
         assert loaded_tracker.type == Tracker.TrackerType.BUGZILLA
-        assert loaded_tracker.ps_update_stream == "rhcertification-6"
+        assert loaded_tracker.ps_update_stream == ps_update_stream.name
         assert loaded_tracker.status == "NEW"
         assert not loaded_tracker.resolution
         assert loaded_tracker.affects.count() == 1
         assert loaded_tracker.affects.first() == affect
         assert not loaded_tracker.alerts.exists()
 
-        # 7) check that the update actually happened
+        # 8) check that the update actually happened
         assert "updated_dt" in loaded_tracker.meta_attr
         assert updated_dt != loaded_tracker.meta_attr["updated_dt"]
 
@@ -191,25 +179,27 @@ class TestTrackerSaver:
 class TestTrackerAPI:
     @pytest.mark.vcr
     def test_tracker_create_bugzilla(
-        self, auth_client, bugzilla_token, enable_bz_sync, jira_token, test_api_uri
+        self,
+        auth_client,
+        bugzilla_token,
+        enable_bz_sync,
+        jira_token,
+        setup_sample_external_resources,
+        test_api_uri,
     ):
         """
         test the whole stack Bugzilla tracker creation
         starting on the API and ending in Bugzilla
         """
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="bugzilla",
-            bts_key="Red Hat Certification Program",
-            bts_groups={"public": ["devel"]},
-            default_component="redhat-certification",
-            name="rhcertification-6",
+        # 1) get valid external data
+        ps_update_stream = (
+            PsUpdateStream.objects.filter(active_to_ps_module__bts_name="bugzilla")
+            .order_by("name")
+            .first()
         )
-        ps_update_stream = PsUpdateStreamFactory(
-            name="rhcertification-6",
-            ps_module=ps_module,
-            version="1.0",
-        )
+        ps_module = ps_update_stream.active_to_ps_module
+
+        # 2) define all the context
         flaw = FlawFactory(
             bz_id="2217733",
             cve_id=None,
@@ -220,12 +210,12 @@ class TestTrackerAPI:
         affect = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="openssl",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
         )
 
-        # 2) create tracker in OSIDB and Bugzilla
+        # 3) create tracker in OSIDB and Bugzilla
         tracker_data = {
             "affects": [affect.uuid],
             "embargoed": flaw.embargoed,
@@ -241,44 +231,39 @@ class TestTrackerAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-        # 3) the tracker is not stored to DB as it happens async
+        # 4) the tracker is not stored to DB as it happens async
         #    so check that there is no tracker relic stored
         assert not Tracker.objects.count()
 
-        # 4) so check at least the response
+        # 5) so check at least the response
         #    even though it is not complete
         tracker_json = response.json()
         assert tracker_json["external_system_id"]
         assert not tracker_json["embargoed"]
         assert tracker_json["type"] == Tracker.TrackerType.BUGZILLA
-        assert tracker_json["ps_update_stream"] == "rhcertification-6"
+        assert tracker_json["ps_update_stream"] == ps_update_stream.name
 
     @pytest.mark.vcr
     def test_tracker_update_bugzilla(
-        self, auth_client, bugzilla_token, enable_bz_sync, jira_token, test_api_uri
+        self,
+        auth_client,
+        bugzilla_token,
+        enable_bz_sync,
+        jira_token,
+        setup_sample_external_resources,
+        test_api_uri,
     ):
         """
         test the whole stack Bugzilla tracker update
         starting on the API and ending in Bugzilla
         """
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="bugzilla",
-            bts_key="Red Hat Certification Program",
-            bts_groups={"public": ["devel"]},
-            default_component="redhat-certification",
-            name="rhcertification-6",
-        )
-        ps_update_stream1 = PsUpdateStreamFactory(
-            name="rhcertification-6",
-            ps_module=ps_module,
-            version="1.0",
-        )
-        ps_update_stream2 = PsUpdateStreamFactory(
-            name="rhcertification-6-default",
-            ps_module=ps_module,
-            version="1.0",
-        )
+        # 1) get valid external data
+        ps_update_streams = PsUpdateStream.objects.filter(
+            active_to_ps_module__bts_name="bugzilla"
+        ).order_by("name")
+        ps_module = ps_update_streams.first().active_to_ps_module
+
+        # 2) define all the context
         flaw = FlawFactory(
             bz_id="2217733",
             embargoed=False,
@@ -287,12 +272,12 @@ class TestTrackerAPI:
         affect = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="openssl",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
         )
 
-        # 2) define a tracker model instance
+        # 3) define a tracker model instance
         #    according an exising Bugzilla tracker
         tracker_id = "2291491"
         updated_dt = "2024-06-13T14:29:58Z"
@@ -300,17 +285,17 @@ class TestTrackerAPI:
             affects=[affect],
             bz_id=tracker_id,
             embargoed=flaw.embargoed,
-            ps_update_stream=ps_update_stream1.name,
+            ps_update_stream=ps_update_streams[0].name,
             type=Tracker.TrackerType.BUGZILLA,
             meta_attr={"blocks": '["2217733"]', "updated_dt": updated_dt},
             updated_dt=timezone.datetime.strptime(updated_dt, BZ_DT_FMT),
         )
-
-        # 3) update tracker in OSIDB and Bugzilla
+        print(ps_update_streams[0].name)
+        # 4) update tracker in OSIDB and Bugzilla
         tracker_data = {
             "affects": [affect.uuid],
             "embargoed": flaw.embargoed,
-            "ps_update_stream": ps_update_stream2.name,  # new value
+            "ps_update_stream": ps_update_streams[1].name,  # new value
             "status": "NEW",  # this one is mandatory even though ignored in the backend query for now
             "updated_dt": updated_dt,
         }
@@ -323,18 +308,18 @@ class TestTrackerAPI:
         )
         assert response.status_code == 200
 
-        # 4) the actual update in the database happens async
+        # 5) the actual update in the database happens async
         #    so check at least the correct data in the response
         tracker_json = response.json()
         assert tracker_json["external_system_id"] == tracker_id
         assert not tracker_json["embargoed"]
         assert tracker_json["type"] == Tracker.TrackerType.BUGZILLA
-        assert tracker_json["ps_update_stream"] == ps_update_stream2.name
+        assert tracker_json["ps_update_stream"] == ps_update_streams[1].name
         assert len(tracker_json["affects"]) == 1
         assert tracker_json["affects"][0] == str(affect.uuid)
         assert not tracker_json["alerts"]
 
-        # 5) check that the actual update did not happen
+        # 6) check that the actual update did not happen
         assert updated_dt == tracker_json["updated_dt"]
 
     @pytest.mark.vcr
@@ -345,25 +330,22 @@ class TestTrackerAPI:
         enable_bz_sync,
         enable_jira_tracker_sync,
         jira_token,
+        setup_sample_external_resources,
         test_api_uri,
     ):
         """
         test the whole stack Jira tracker creation
         starting on the API and ending in Jira
         """
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="jboss",
-            bts_key="OSIDB",
-            bts_groups={"public": []},
-            default_component="Security",
-            name="openshift-4",
+        # 1) get valid external data
+        ps_update_stream = (
+            PsUpdateStream.objects.filter(active_to_ps_module__bts_name="jboss")
+            .order_by("name")
+            .first()
         )
-        ps_update_stream = PsUpdateStreamFactory(
-            name="openshift-4.8.z",
-            ps_module=ps_module,
-            version="4.8",
-        )
+        ps_module = ps_update_stream.active_to_ps_module
+
+        # 2) define all the context
         flaw = FlawFactory(
             uuid="675df471-7375-4ba1-9d0f-c178a8a58ae7",
             bz_id="2217733",
@@ -377,32 +359,13 @@ class TestTrackerAPI:
         affect = AffectFactory(
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="openshift",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw.impact,
         )
-        JiraProjectFieldsFactory(
-            project_key="OSIDB",
-            field_id="priority",
-            allowed_values=[JiraPriority.MINOR],
-        )
-        JiraProjectFieldsFactory(
-            project_key=ps_module.bts_key,
-            field_id="security",
-            field_name="Security Level",
-            allowed_values=[
-                "Embargoed Security Issue",
-                "Red Hat Employee",
-                "Red Hat Engineering Authorized",
-                "Red Hat Partner",
-                "Restricted",
-                "Team",
-            ],
-        )
-        JiraBugIssuetype(project=ps_module.bts_key).save()
 
-        # 2) create tracker in OSIDB and Jira
+        # 3) create tracker in OSIDB and Jira
         tracker_data = {
             "affects": [affect.uuid],
             "embargoed": flaw.embargoed,
@@ -418,18 +381,18 @@ class TestTrackerAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-        # 3) the tracker is not stored to DB as it happens async
+        # 4) the tracker is not stored to DB as it happens async
         #    so check that there is no tracker relic stored
         assert not Tracker.objects.count()
 
-        # 4) so check at least the response
+        # 5) so check at least the response
         #    even though it is not complete
         tracker_json = response.json()
         assert tracker_json["external_system_id"]
         assert "OSIDB" in tracker_json["external_system_id"]
         assert not tracker_json["embargoed"]
         assert tracker_json["type"] == Tracker.TrackerType.JIRA
-        assert tracker_json["ps_update_stream"] == "openshift-4.8.z"
+        assert tracker_json["ps_update_stream"] == ps_update_stream.name
 
     @pytest.mark.vcr
     def test_tracker_update_jira(
@@ -439,49 +402,20 @@ class TestTrackerAPI:
         enable_bz_sync,
         enable_jira_tracker_sync,
         jira_token,
+        setup_sample_external_resources,
         test_api_uri,
     ):
         """
         test the whole stack Jira tracker update
         starting on the API and ending in Jira
         """
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="jboss",
-            bts_key="OSIDB",
-            bts_groups={"public": []},
-            default_component="Security",
-            name="openshift-4",
-        )
-        ps_update_stream1 = PsUpdateStreamFactory(
-            name="openshift-4.8.z",
-            ps_module=ps_module,
-            version="4.8",
-        )
-        ps_update_stream2 = PsUpdateStreamFactory(
-            name="openshift-4.9.z",
-            ps_module=ps_module,
-            version="4.9",
-        )
-        JiraProjectFieldsFactory(
-            project_key="OSIDB",
-            field_id="priority",
-            allowed_values=[JiraPriority.MINOR],
-        )
-        JiraProjectFieldsFactory(
-            project_key=ps_module.bts_key,
-            field_id="security",
-            field_name="Security Level",
-            allowed_values=[
-                "Embargoed Security Issue",
-                "Red Hat Employee",
-                "Red Hat Engineering Authorized",
-                "Red Hat Partner",
-                "Restricted",
-                "Team",
-            ],
-        )
-        JiraBugIssuetype(project=ps_module.bts_key).save()
+        # 1) get valid external data
+        ps_update_streams = PsUpdateStream.objects.filter(
+            active_to_ps_module__bts_name="jboss"
+        ).order_by("name")
+        ps_module = ps_update_streams.first().active_to_ps_module
+
+        # 2) define all the context
         # flaw to keep linked
         flaw1 = FlawFactory(
             bz_id="1663908",
@@ -495,7 +429,7 @@ class TestTrackerAPI:
         affect1 = AffectFactory(
             flaw=flaw1,
             ps_module=ps_module.name,
-            ps_component="openshift",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw1.impact,
@@ -513,7 +447,7 @@ class TestTrackerAPI:
         affect2 = AffectFactory(
             flaw=flaw2,
             ps_module=ps_module.name,
-            ps_component="openshift",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw2.impact,
@@ -531,33 +465,33 @@ class TestTrackerAPI:
         affect3 = AffectFactory(
             flaw=flaw3,
             ps_module=ps_module.name,
-            ps_component="openshift",
+            ps_component=ps_module.default_component,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw3.impact,
         )
 
-        # 2) define a tracker model instance
-        #    according an exising Bugzilla tracker
+        # 3) define a tracker model instance
+        #    according an exising Jira tracker
         tracker_id = "OSIDB-920"
         updated_dt = "2024-06-17T12:41:00Z"
         tracker = TrackerFactory(
             affects=[affect1, affect2],
             bz_id=tracker_id,
             embargoed=flaw1.embargoed,
-            ps_update_stream=ps_update_stream1.name,
+            ps_update_stream=ps_update_streams[0].name,
             type=Tracker.TrackerType.JIRA,
             updated_dt=timezone.datetime.strptime(updated_dt, BZ_DT_FMT),
         )
 
-        # 3) update tracker in OSIDB and Bugzilla
+        # 4) update tracker in OSIDB and Jira
         tracker_data = {
             "affects": [
                 affect1.uuid,
                 affect3.uuid,
             ],  # affect2 removed and affect3 added
             "embargoed": flaw1.embargoed,
-            "ps_update_stream": ps_update_stream2.name,  # new value
+            "ps_update_stream": ps_update_streams[2].name,  # new value
             "updated_dt": updated_dt,
         }
         response = auth_client().put(
@@ -569,20 +503,20 @@ class TestTrackerAPI:
         )
         assert response.status_code == 200
 
-        # 4) the actual update in the database happens async
+        # 5) the actual update in the database happens async
         #    so check at least the correct data in the response
         tracker_json = response.json()
         assert tracker_json["external_system_id"] == tracker_id
         assert "OSIDB" in tracker_json["external_system_id"]
         assert not tracker_json["embargoed"]
         assert tracker_json["type"] == Tracker.TrackerType.JIRA
-        assert tracker_json["ps_update_stream"] == ps_update_stream2.name
+        assert tracker_json["ps_update_stream"] == ps_update_streams[2].name
         assert len(tracker_json["affects"]) == 2
         assert str(affect1.uuid) in tracker_json["affects"]
         assert str(affect3.uuid) in tracker_json["affects"]
         assert not tracker_json["alerts"]
 
-        # 5) check that the actual update did not happen
+        # 6) check that the actual update did not happen
         assert updated_dt == tracker_json["updated_dt"]
 
     @pytest.mark.vcr
@@ -593,6 +527,7 @@ class TestTrackerAPI:
         enable_bz_sync,
         enable_jira_tracker_sync,
         jira_token,
+        setup_sample_external_resources,
         test_api_uri,
         monkeypatch,
     ):
@@ -602,115 +537,15 @@ class TestTrackerAPI:
         Tested in just one test so that complex set up is not necessary for the follow-up
         test of tracker update.
         """
+        # 1) get valid external data
+        ps_update_streams = PsUpdateStream.objects.filter(
+            active_to_ps_module__bts_name="jboss"
+        ).order_by("name")
+        ps_module = ps_update_streams.first().active_to_ps_module
+        ps_component1 = setup_sample_external_resources["jboss_components"][0]
+        ps_component2 = setup_sample_external_resources["jboss_components"][1]
 
-        # 1) define all the context
-        ps_module = PsModuleFactory(
-            bts_name="jboss",
-            bts_key="OCPBUGS",
-            bts_groups={"public": []},
-            default_component="Security",
-            name="openshift-4",
-        )
-        ps_update_stream = PsUpdateStreamFactory(
-            name="openshift-4.8.z",
-            ps_module=ps_module,
-            version="4.8",
-        )
-
-        JiraProjectFieldsFactory(
-            project_key="OCPBUGS",
-            field_id="priority",
-            allowed_values=[JiraPriority.MINOR],
-        )
-        JiraProjectFieldsFactory(
-            project_key=ps_module.bts_key,
-            field_id="security",
-            field_name="Security Level",
-            allowed_values=[
-                "Embargoed Security Issue",
-                "Red Hat Employee",
-                "Red Hat Engineering Authorized",
-                "Red Hat Partner",
-                "Restricted",
-                "Team",
-            ],
-        )
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324746",
-            field_name="Source",
-            # Severely pruned for the test
-            allowed_values=["Red Hat", "Upstream"],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324749",
-            field_name="CVE ID",
-            allowed_values=[],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324748",
-            field_name="CVSS Score",
-            allowed_values=[],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324747",
-            field_name="CWE ID",
-            allowed_values=[],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324752",
-            field_name="Downstream Component Name",
-            allowed_values=[],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324751",
-            field_name="Upstream Affected Component",
-            allowed_values=[],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324750",
-            field_name="Embargo Status",
-            allowed_values=["True", "False"],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324753",
-            field_name="Special Handling",
-            allowed_values=[
-                "0-day",
-                "Major Incident",
-                "Minor Incident",
-                "KEV (active exploit case)",
-            ],
-        ).save()
-
-        JiraProjectFields(
-            project_key=ps_module.bts_key,
-            field_id="customfield_12324940",
-            field_name="CVE Severity",
-            allowed_values=[
-                "Critical",
-                "Important",
-                "Moderate",
-                "Low",
-                "An Irrelevant Value To Be Ignored",
-                "None",
-            ],
-        ).save()
+        # 2) define all the context
 
         # Create the flaw for the purpose of the test
         # (this is not part of the test per se, but necessary setup).
@@ -777,7 +612,7 @@ class TestTrackerAPI:
             uuid="7cb199fd-86eb-45eb-aa3a-8fd7ecd32c1d",
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="Security",
+            ps_component=ps_component1,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw.impact,
@@ -792,11 +627,11 @@ class TestTrackerAPI:
         assert Affect.objects.first() == affect
         assert affect.flaw == flaw
 
-        # 2) create tracker in OSIDB and Jira
+        # 3) create tracker in OSIDB and Jira
         tracker_data = {
             "affects": [affect.uuid],
             "embargoed": flaw.embargoed,
-            "ps_update_stream": ps_update_stream.name,
+            "ps_update_stream": ps_update_streams[0].name,
         }
         response = auth_client().post(
             f"{test_api_uri}/trackers",
@@ -808,18 +643,18 @@ class TestTrackerAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-        # 3) the tracker is not stored to DB as it happens async
+        # 4) the tracker is not stored to DB as it happens async
         #    so check that there is no tracker relic stored
         assert not Tracker.objects.count()
 
-        # 4) so check at least the response
+        # 5) so check at least the response
         #    even though it is not complete
         tracker_json = response.json()
         assert tracker_json["external_system_id"]
-        assert "OCPBUGS" in tracker_json["external_system_id"]
+        assert ps_module.bts_key in tracker_json["external_system_id"]
         assert not tracker_json["embargoed"]
         assert tracker_json["type"] == Tracker.TrackerType.JIRA
-        assert tracker_json["ps_update_stream"] == "openshift-4.8.z"
+        assert tracker_json["ps_update_stream"] == ps_update_streams[0].name
 
         # NOTE: Reloading flaw is tested in test_tracker_create_jira.
         #       That test requires the flaw to be set up correctly in the BTS
@@ -828,7 +663,7 @@ class TestTrackerAPI:
         #       The flaw sync works the same for both Bug and Vulnerability
         #       issuetype trackers. No need to test it here.
 
-        # 5) check that the data are the same also when collecting the Tracker
+        # 6) check that the data are the same also when collecting the Tracker
 
         tracker_id = tracker_json["external_system_id"]
 
@@ -848,7 +683,7 @@ class TestTrackerAPI:
         assert tracker_new.external_system_id == tracker_id
         assert not tracker_new.embargoed
         assert tracker_new.type == Tracker.TrackerType.JIRA
-        assert tracker_new.ps_update_stream == "openshift-4.8.z"
+        assert tracker_new.ps_update_stream == ps_update_streams[0].name
         assert tracker_new.status == "New"
         assert not tracker_new.resolution
         labels_new = json.loads(tracker_new.meta_attr["labels"])
@@ -856,9 +691,9 @@ class TestTrackerAPI:
             "Security",
             "SecurityTracking",
             f"flawuuid:{flaw.uuid}",
-            "pscomponent:Security",
+            "pscomponent:" + ps_component1,
         ] == sorted(labels_new)
-        assert tracker_new.meta_attr["jira_issuetype"] == "Vulnerability"
+        assert tracker_new.meta_attr["jira_issuetype"] == "Bug"
 
         # Not linked yet
         assert tracker_new.affects.count() == 0
@@ -870,20 +705,15 @@ class TestTrackerAPI:
         assert tracker_new.affects.first() == affect
         assert not tracker_new.alerts.exists()
 
-        # 6) test tracker update
+        # 7) test tracker update
         affect2 = AffectFactory(
             uuid="8db199fd-86eb-45eb-aa3a-8fd7ecd32c2e",
             flaw=flaw,
             ps_module=ps_module.name,
-            ps_component="openshift-apiserver",
+            ps_component=ps_component2,
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             impact=flaw.impact,
-        )
-        ps_update_stream2 = PsUpdateStreamFactory(
-            name="openshift-4.10.z",
-            ps_module=ps_module,
-            version="4.10",
         )
 
         tracker_data = {
@@ -891,7 +721,7 @@ class TestTrackerAPI:
                 affect2.uuid,
             ],
             "embargoed": flaw.embargoed,
-            "ps_update_stream": ps_update_stream2.name,  # new value
+            "ps_update_stream": ps_update_streams[1].name,  # new value
             "updated_dt": tracker_new.updated_dt,
         }
         response = auth_client().put(
@@ -912,20 +742,20 @@ class TestTrackerAPI:
         assert affect.flaw == flaw
         assert affect2.flaw == flaw
 
-        # 7) the actual update in the database happens async
+        # 8) the actual update in the database happens async
         #    so check at least the correct data in the response
         tracker_json = response.json()
         assert tracker_json["external_system_id"] == tracker_id
         assert tracker_json["external_system_id"] == tracker_new.external_system_id
         assert not tracker_json["embargoed"]
         assert tracker_json["type"] == Tracker.TrackerType.JIRA
-        assert tracker_json["ps_update_stream"] == ps_update_stream2.name
+        assert tracker_json["ps_update_stream"] == ps_update_streams[1].name
         assert len(tracker_json["affects"]) == 1
         assert str(affect.uuid) not in tracker_json["affects"]
         assert str(affect2.uuid) in tracker_json["affects"]
         assert not tracker_json["alerts"]
 
-        # 8) check that the actual update did not happen
+        # 9) check that the actual update did not happen
         assert tracker_new.updated_dt == timezone.datetime.strptime(
             tracker_json["updated_dt"], "%Y-%m-%dT%H:%M:%S.%f%z"
         )

--- a/apps/workflows/tests/conftest.py
+++ b/apps/workflows/tests/conftest.py
@@ -59,11 +59,6 @@ def test_api_uri_osidb(test_scheme_host_osidb, api_version):
 
 
 @pytest.fixture
-def user_token():
-    return "USER_JIRA_TOKEN"
-
-
-@pytest.fixture
 def command_curl():
     """define path to curl"""
     test_curl_path = get_env("TEST_CURL_PATH")

--- a/collectors/cveorg/tests/conftest.py
+++ b/collectors/cveorg/tests/conftest.py
@@ -3,7 +3,6 @@ from pathlib import Path
 import pytest
 from django.utils import timezone
 
-from collectors.cveorg import collectors
 from collectors.cveorg.collectors import CVEorgCollector
 
 
@@ -13,11 +12,8 @@ def enable_db_access_for_all_tests(db):
 
 
 @pytest.fixture(autouse=True)
-def enable_env_vars(enable_jira_task_sync, enable_bz_sync, monkeypatch) -> None:
-    """
-    Set necessary variables when storing flaws to BZ and Jira.
-    """
-    monkeypatch.setattr(collectors, "JIRA_AUTH_TOKEN", "SECRET")
+def auto_enable_sync(enable_jira_task_sync, enable_bz_sync) -> None:
+    pass
 
 
 @pytest.fixture()

--- a/collectors/jiraffe/tests/conftest.py
+++ b/collectors/jiraffe/tests/conftest.py
@@ -4,11 +4,3 @@ import pytest
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
-
-
-@pytest.fixture()
-def pin_envs(monkeypatch) -> None:
-    """
-    the tests should be immune to what .env you build the testrunner with
-    """
-    monkeypatch.setenv("HTTPS_PROXY", "http://squid.corp.redhat.com:3128")

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.unit
 
 class TestJiraTaskCollector:
     @pytest.mark.vcr
-    def test_collect(self, enable_jira_task_sync, jira_token, monkeypatch):
+    def test_collect(self, enable_jira_task_sync, jira_token):
         """
         test the Jira collector run
         """
@@ -82,7 +82,7 @@ class TestJiraTaskCollector:
         assert flaw.workflow_state == "TRIAGE"
 
     @pytest.mark.vcr
-    def test_link_on_cve(self, monkeypatch):
+    def test_link_on_cve(self):
         # some random UUID
         flaw = FlawFactory(cve_id="CVE-2024-34703")
         # this is super-unprobable to happen but based
@@ -370,7 +370,7 @@ class TestMetadataCollector:
     @freeze_time(datetime(2015, 12, 12))
     @pytest.mark.vcr(*BASE_METADATA_COLLECTOR_VCRS)
     @pytest.mark.parametrize("project_key,fields_count", [("RHEL", 120), ("OSIM", 20)])
-    def test_collect_basic(self, pin_envs, project_key, fields_count):
+    def test_collect_basic(self, project_key, fields_count):
         """
         Test that collector is able to get metadata from Jira projects
         """
@@ -465,7 +465,7 @@ class TestMetadataCollector:
         ],
     )
     def test_collect_vulnerability_issuetype(
-        self, pin_envs, project_key, fields_count, vulntype_exists
+        self, project_key, fields_count, vulntype_exists
     ):
         """
         Test that collector is able to get metadata from Jira projects

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -6,8 +6,6 @@ import pytest
 from freezegun import freeze_time
 from jira.exceptions import JIRAError
 
-import collectors.jiraffe.collectors as collectors
-from apps.taskman.constants import JIRA_AUTH_TOKEN
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.trackers.models import JiraProjectFields
 from apps.workflows.workflow import WorkflowModel
@@ -37,13 +35,10 @@ pytestmark = pytest.mark.unit
 
 class TestJiraTaskCollector:
     @pytest.mark.vcr
-    def test_collect(self, enable_jira_task_sync, monkeypatch):
+    def test_collect(self, enable_jira_task_sync, jira_token, monkeypatch):
         """
         test the Jira collector run
         """
-        jira_token = JIRA_AUTH_TOKEN if JIRA_AUTH_TOKEN else "USER_JIRA_TOKEN"
-        monkeypatch.setattr(collectors, "JIRA_TOKEN", jira_token)
-
         collector = JiraTaskCollector()
         jtq = JiraTaskmanQuerier(token=jira_token)
 
@@ -88,8 +83,6 @@ class TestJiraTaskCollector:
 
     @pytest.mark.vcr
     def test_link_on_cve(self, monkeypatch):
-        monkeypatch.setattr(collectors, "JIRA_TOKEN", "SECRET")
-
         # some random UUID
         flaw = FlawFactory(cve_id="CVE-2024-34703")
         # this is super-unprobable to happen but based
@@ -102,12 +95,10 @@ class TestJiraTaskCollector:
         assert Flaw.objects.get(uuid=flaw.uuid).task_key
 
     @pytest.mark.vcr
-    def test_outdated_query(self, enable_jira_task_sync, monkeypatch):
+    def test_outdated_query(self, enable_jira_task_sync, jira_token, monkeypatch):
         """
         test that Jira task collector ignores tasks with outdated timestamp
         """
-        jira_token = JIRA_AUTH_TOKEN if JIRA_AUTH_TOKEN else "USER_JIRA_TOKEN"
-        monkeypatch.setattr(collectors, "JIRA_TOKEN", jira_token)
 
         jtq = JiraTaskmanQuerier(token=jira_token)
 

--- a/collectors/jiraffe/tests/test_convertors.py
+++ b/collectors/jiraffe/tests/test_convertors.py
@@ -255,7 +255,7 @@ class TestJiraTrackerConvertor:
         assert tracker.affects.first() == affect
 
     @pytest.mark.vcr
-    def test_convert_linked_from_tracker_side_flawuuid(self, pin_envs):
+    def test_convert_linked_from_tracker_side_flawuuid(self):
         """
         test that the convertor linking works
         when the link is in tracker flawuuid label

--- a/collectors/osv/tests/conftest.py
+++ b/collectors/osv/tests/conftest.py
@@ -7,7 +7,5 @@ def enable_db_access_for_all_tests(db):
 
 
 @pytest.fixture(autouse=True)
-def enable_env_vars(enable_jira_task_sync, enable_bz_sync, monkeypatch) -> None:
-    from collectors.osv import collectors
-
-    monkeypatch.setattr(collectors, "JIRA_AUTH_TOKEN", "SECRET")
+def auto_enable_sync(enable_jira_task_sync, enable_bz_sync) -> None:
+    pass

--- a/conftest.py
+++ b/conftest.py
@@ -314,8 +314,13 @@ def set_recording_environments(is_recording_vcr, monkeypatch):
     from apps.trackers import common
     from apps.trackers.jira import save as jira_save
     from collectors.bzimport import collectors as bzimport_collector
+    from collectors.bzimport.collectors import BugzillaConnector
+    from collectors.cveorg import collectors as cveorg_collector
+    from collectors.jiraffe import collectors as jira_collector
     from collectors.jiraffe import core as jira_core
     from collectors.jiraffe.core import JiraConnector
+    from collectors.osv import collectors as osv_collector
+    from osidb.models import snippet
 
     # testrunner should not contains environments set in order to make tests independent
     # from envs but VCR needs them so we manually load values where it is needed
@@ -354,3 +359,37 @@ def set_recording_environments(is_recording_vcr, monkeypatch):
 
     monkeypatch.setattr(common, "BZ_URL", bz_url)
     monkeypatch.setattr(bzimport_collector, "BZ_URL", bz_url)
+
+    # replace tokens
+    monkeypatch.setattr(BugzillaConnector, "_bz_api_key", bugzilla_token)
+    monkeypatch.setattr(snippet, "BZ_API_KEY", bugzilla_token)
+    monkeypatch.setattr(bzimport_collector, "BZ_API_KEY", bugzilla_token)
+
+    monkeypatch.setattr(JiraConnector, "_jira_token", jira_token)
+    monkeypatch.setattr(osv_collector, "JIRA_AUTH_TOKEN", jira_token)
+    monkeypatch.setattr(cveorg_collector, "JIRA_AUTH_TOKEN", jira_token)
+    monkeypatch.setattr(jira_collector, "JIRA_TOKEN", jira_token)
+    monkeypatch.setattr(jira_core, "JIRA_TOKEN", jira_token)
+
+
+
+@pytest.fixture
+def bugzilla_token(is_recording_vcr):
+    """
+    return "SECRET" or user env BZIMPORT_BZ_API_KEY in case of VCR rewrite
+    """
+    # testrunner should not contains environments set in order to make tests
+    # independent from envs so we manually load values where it is needed
+    config = dotenv_values(".env")
+    return config.get("BZIMPORT_BZ_API_KEY", "SECRET") if is_recording_vcr else "SECRET"
+
+
+@pytest.fixture
+def jira_token(is_recording_vcr):
+    """
+    return "SECRET" or user env JIRA_AUTH_TOKEN in case of VCR rewrite
+    """
+    # testrunner should not contains environments set in order to make tests
+    # independent from envs so we manually load values where it is needed
+    config = dotenv_values(".env")
+    return config.get("JIRA_AUTH_TOKEN", "SECRET") if is_recording_vcr else "SECRET"

--- a/devel-requirements.in
+++ b/devel-requirements.in
@@ -20,5 +20,6 @@ pytest-recording
 pytest-spec
 pytest-sugar
 pytest-xdist
+python-dotenv
 tox
 vcrpy

--- a/devel-requirements.txt
+++ b/devel-requirements.txt
@@ -561,6 +561,10 @@ python-dateutil==2.8.2 \
     #   faker
     #   freezegun
     #   kubernetes
+python-dotenv==1.0.1 \
+    --hash=sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca \
+    --hash=sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a
+    # via -r devel-requirements.in
 python-string-utils==1.0.0 \
     --hash=sha256:dcf9060b03f07647c0a603408dc8b03f807f3b54a05c6e19eb14460256fac0cb \
     --hash=sha256:f1a88700baf99db1a9b6953f44181ad9ca56623c81e257e6009707e2e7851fa4
@@ -698,10 +702,6 @@ tox==3.25.1 \
     --hash=sha256:c138327815f53bc6da4fe56baec5f25f00622ae69ef3fe4e1e385720e22486f9 \
     --hash=sha256:c38e15f4733683a9cc0129fba078633e07eb0961f550a010ada879e95fb32632
     # via -r devel-requirements.in
-types-markdown==3.7.0.20240822 \
-    --hash=sha256:183557c9f4f865bdefd8f5f96a38145c31819271cde111d35557c3bd2069e78d \
-    --hash=sha256:bec91c410aaf2470ffdb103e38438fbcc53689b00133f19e64869eb138432ad7
-    # via djangorestframework-stubs
 types-pytz==2021.3.6 \
     --hash=sha256:6805c72d51118923c5bf98633c39593d5b464d2ab49a803440e2d7ab6b8920df \
     --hash=sha256:74547fd90d8d8ab4f1eedf3a344a7d186d97486973895f81221a712e1e2cd993
@@ -709,17 +709,7 @@ types-pytz==2021.3.6 \
 types-pyyaml==6.0.5 \
     --hash=sha256:2fd21310870addfd51db621ad9f3b373f33ee3cbb81681d70ef578760bd22d35 \
     --hash=sha256:464e050914f3d1d83a8c038e1cf46da5cb96b7cd02eaa096bcaa03675edd8a2e
-    # via
-    #   django-stubs
-    #   djangorestframework-stubs
-types-requests==2.31.0.6 \
-    --hash=sha256:a2db9cb228a81da8348b49ad6db3f5519452dd20a9c1e1a868c83c5fe88fd1a9 \
-    --hash=sha256:cd74ce3b53c461f1228a9b783929ac73a666658f223e28ed29753771477b3bd0
-    # via djangorestframework-stubs
-types-urllib3==1.26.25.14 \
-    --hash=sha256:229b7f577c951b8c1b92c1bc2b2fdb0b49847bd2af6d1cc2a2e3dd340f3bda8f \
-    --hash=sha256:9683bbb7fb72e32bfe9d2be6e04875fbe1b3eeec3cbb4ea231435aa7fd6b4f0e
-    # via types-requests
+    # via django-stubs
 typing-extensions==4.12.2 \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add history to several other models: AffectCVSS, FlawAcknowledgment, FlawComment,
   FlawCVSS, FlawReference, Snippet and Tracker. (OSIDB-3466)
+- Moved metadata creation during tests to root level conftest and
+  automatically set envs during VCR recording (OSIDB-3492)
 
 ## [4.5.6] - 2024-11-08
 ### Fixed

--- a/osidb/exceptions.py
+++ b/osidb/exceptions.py
@@ -12,3 +12,7 @@ class DataInconsistencyException(OSIDBException):
     """Data Inconsistency Exception"""
 
     http_code = status.HTTP_409_CONFLICT
+
+
+class InvalidTestEnvironmentException(OSIDBException):
+    """Invalid Test Environment Exception"""

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -574,7 +574,6 @@ class TestBugzillaJiraMixinIntegration:
         enable_jira_task_sync,
         enable_jira_tracker_sync,
         jira_token,
-        monkeypatch,
     ):
         """Test that sync occurs using internal OSIDB APIs"""
         self.setup_workflow()

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -569,9 +569,11 @@ class TestBugzillaJiraMixinIntegration:
     @pytest.mark.vcr
     def test_manual_changes(
         self,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
+        jira_token,
         monkeypatch,
     ):
         """Test that sync occurs using internal OSIDB APIs"""
@@ -589,11 +591,10 @@ class TestBugzillaJiraMixinIntegration:
             unembargo_dt=tzdatetime(2000, 1, 1),
         )
 
-        jira_token = "SECRET"
-        bz_token = "SECRET"
-
         flaw.save(
-            jira_token=jira_token, bz_api_key=bz_token, force_synchronous_sync=True
+            jira_token=jira_token,
+            bz_api_key=bugzilla_token,
+            force_synchronous_sync=True,
         )
 
         PsModuleFactory(name="ps-module-0")
@@ -604,14 +605,14 @@ class TestBugzillaJiraMixinIntegration:
         AffectFactory(flaw=flaw, ps_module="ps-module-0")
         flaw = Flaw.objects.get(uuid=flaw.uuid)
 
-        flaw.promote(jira_token=jira_token, bz_api_key=bz_token)
+        flaw.promote(jira_token=jira_token, bz_api_key=bugzilla_token)
         assert flaw.workflow_state == WorkflowModel.WorkflowState.TRIAGE
 
         jtq = JiraTaskmanQuerier(jira_token)
 
         issue = jtq.jira_conn.issue(flaw.task_key).raw
         assert issue["fields"]["status"]["name"] == "Refinement"
-        flaw.reject(jira_token=jira_token, bz_api_key=bz_token)
+        flaw.reject(jira_token=jira_token, bz_api_key=bugzilla_token)
         assert flaw.workflow_state == WorkflowModel.WorkflowState.REJECTED
 
         issue = jtq.jira_conn.issue(flaw.task_key).raw
@@ -622,17 +623,16 @@ class TestBugzillaJiraMixinIntegration:
     @pytest.mark.enable_signals
     def test_api_changes(
         self,
+        auth_client,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
-        auth_client,
+        jira_token,
         test_api_uri,
     ):
         """Test that sync occurs using OSIDB REST API"""
         self.setup_workflow()
-
-        jira_token = "SECRET"
-        bz_token = "SECRET"
 
         flaw_data = {
             "title": "Foo",
@@ -649,7 +649,7 @@ class TestBugzillaJiraMixinIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
 
@@ -667,7 +667,7 @@ class TestBugzillaJiraMixinIntegration:
         response = auth_client().post(
             f"{test_api_uri}/flaws/{created_uuid}/promote",
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
 
@@ -683,7 +683,7 @@ class TestBugzillaJiraMixinIntegration:
             f"{test_api_uri}/flaws/{created_uuid}/reject",
             {"reason": "This is not a bug."},
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
 
@@ -696,10 +696,12 @@ class TestMultiMixinIntegration:
     @pytest.mark.vcr
     def test_tracker_validation(
         self,
+        auth_client,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
-        auth_client,
+        jira_token,
         test_api_uri,
     ):
         """Tests that validations will block for Trackers with all sync enabled"""
@@ -772,8 +774,8 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/trackers",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY="SECRET",
-            HTTP_JIRA_API_KEY="SECRET",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
         )
         assert any(
             "The tracker is associated with a DEFER affect" in error
@@ -786,18 +788,16 @@ class TestMultiMixinIntegration:
     @pytest.mark.vcr
     def test_tracker_validation_bugzilla(
         self,
+        auth_client,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
-        auth_client,
-        test_api_uri,
+        jira_token,
         monkeypatch,
+        test_api_uri,
     ):
         """Test that bugzilla Tracker endpoint only recreates alerts when needed"""
-
-        jira_token = "SECRET"
-        bz_token = "SECRET"
-
         validation_counter = {}
         original_validate = AlertMixin.validate
 
@@ -846,7 +846,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
@@ -868,7 +868,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/affects/bulk",
             affects_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
@@ -885,7 +885,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/trackers",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
@@ -896,17 +896,16 @@ class TestMultiMixinIntegration:
     @pytest.mark.vcr
     def test_tracker_validation_jira(
         self,
+        auth_client,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
-        auth_client,
-        test_api_uri,
+        jira_token,
         monkeypatch,
+        test_api_uri,
     ):
         """Test that jira Tracker endpoint only recreates alerts when needed"""
-        jira_token = "SECRET"
-        bz_token = "SECRET"
-
         validation_counter = {}
         original_validate = AlertMixin.validate
 
@@ -982,7 +981,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
@@ -1004,7 +1003,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/affects/bulk",
             affects_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
@@ -1021,7 +1020,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/trackers",
             tracker_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
@@ -1033,17 +1032,16 @@ class TestMultiMixinIntegration:
     @pytest.mark.vcr
     def test_affect_validation(
         self,
+        auth_client,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
-        auth_client,
+        jira_token,
         test_api_uri,
         monkeypatch,
     ):
         """Test that Affect endpoint only recreates alerts when needed"""
-        jira_token = "SECRET"
-        bz_token = "SECRET"
-
         validation_counter = {}
         original_validate = AlertMixin.validate
 
@@ -1072,7 +1070,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         body = response.json()
@@ -1096,7 +1094,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/affects/bulk",
             affects_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         # osidb/api_views.py::AffectView:bulk_post triggers flaw save
@@ -1117,7 +1115,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/affects/bulk",
             affects_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200
@@ -1129,17 +1127,16 @@ class TestMultiMixinIntegration:
     @pytest.mark.vcr
     def test_flaw_validation(
         self,
+        auth_client,
+        bugzilla_token,
         enable_bz_async_sync,
         enable_jira_task_sync,
         enable_jira_tracker_sync,
-        auth_client,
-        test_api_uri,
+        jira_token,
         monkeypatch,
+        test_api_uri,
     ):
         """Test that Flaw endpoint only recreates alerts when needed"""
-        jira_token = "SECRET"
-        bz_token = "SECRET"
-
         validation_counter = {}
         original_validate = AlertMixin.validate
 
@@ -1169,7 +1166,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/flaws",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 201
@@ -1189,7 +1186,7 @@ class TestMultiMixinIntegration:
             f"{test_api_uri}/flaws/{flaw.uuid}",
             flaw_data,
             format="json",
-            HTTP_BUGZILLA_API_KEY=bz_token,
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
             HTTP_JIRA_API_KEY=jira_token,
         )
         assert response.status_code == 200

--- a/osidb/tests/test_users.py
+++ b/osidb/tests/test_users.py
@@ -20,7 +20,7 @@ class TestUsers:
 
     @pytest.mark.enable_signals
     @pytest.mark.vcr
-    def test_profile_creation(self, test_user_dict):
+    def test_profile_creation(self, bugzilla_token, jira_token, test_user_dict):
         new_user = User.objects.create(**test_user_dict)
 
         assert new_user.profile
@@ -30,11 +30,9 @@ class TestUsers:
         assert str(new_user.profile) == "foo"
 
         # verify that the user info can be fetched from bugzilla / jira
-        bz_token = get_env("BZIMPORT_BZ_API_KEY")
         bz_url = get_env("BZIMPORT_BZ_URL", "https://bugzilla.redhat.com")
-        jira_token = get_env("JIRA_AUTH_TOKEN")
         jira_url = get_env("JIRA_URL", "https://issues.redhat.com")
-        bz_api = Bugzilla(bz_url, api_key=bz_token, force_rest=True)
+        bz_api = Bugzilla(bz_url, api_key=bugzilla_token, force_rest=True)
         jira_api = JIRA(
             options={
                 "server": jira_url,


### PR DESCRIPTION
This PR added a fixture for creating metadata sample and prod-defs sample in root conftest.

This PR also adds a fixture to automatically set envs during VCR recording.
This PR also moved tokens for tests using VCR for root conftest in order to automatically set user token during VCR recording.
This PR also removes tokens variables set in conftests for tests that does not uses external resources + VCRs.

Closes OSIDB-3492.