### PR TITLE
Validate and set ps_component from purl

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement field `embargoed` for advanced search (OSIDB-3549)
 - Implement no-week-ending SLA policy support (OSIDB-3500)
 - Implement complex logic in workflow state requirements (OSIDB-3524)
+- Validate and set ps_component from purl (OSIDB-3410)
 
 ### Changed
 - Add history to several other models: AffectCVSS, FlawAcknowledgment, FlawComment,

--- a/openapi.yml
+++ b/openapi.yml
@@ -7022,6 +7022,7 @@ components:
           readOnly: true
         ps_component:
           type: string
+          nullable: true
           maxLength: 255
         impact:
           oneOf:
@@ -7042,6 +7043,7 @@ components:
           readOnly: true
         purl:
           type: string
+          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7068,7 +7070,6 @@ components:
       - delegated_resolution
       - embargoed
       - flaw
-      - ps_component
       - ps_module
       - ps_product
       - trackers
@@ -7110,6 +7111,7 @@ components:
           readOnly: true
         ps_component:
           type: string
+          nullable: true
           maxLength: 255
         impact:
           oneOf:
@@ -7130,6 +7132,7 @@ components:
           readOnly: true
         purl:
           type: string
+          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7156,7 +7159,6 @@ components:
       - delegated_resolution
       - embargoed
       - flaw
-      - ps_component
       - ps_module
       - ps_product
       - trackers
@@ -7340,6 +7342,7 @@ components:
           readOnly: true
         ps_component:
           type: string
+          nullable: true
           maxLength: 255
         impact:
           oneOf:
@@ -7360,6 +7363,7 @@ components:
           readOnly: true
         purl:
           type: string
+          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7381,7 +7385,6 @@ components:
       - delegated_resolution
       - embargoed
       - flaw
-      - ps_component
       - ps_module
       - ps_product
       - trackers

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1035,6 +1035,11 @@ class AffectSerializer(
     trackers = serializers.SerializerMethodField()
     meta_attr = serializers.SerializerMethodField()
     cvss_scores = AffectCVSSSerializer(many=True, read_only=True)
+    # at least one of ps_component or purl is required
+    ps_component = serializers.CharField(
+        max_length=255, allow_blank=True, allow_null=True, required=False
+    )
+    purl = serializers.CharField(allow_blank=True, allow_null=True, required=False)
 
     @extend_schema_field(
         {

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -300,9 +300,6 @@ class AffectFactory(BaseFactory):
     )
     ps_module = factory.sequence(lambda n: f"ps-module-{n}")
     ps_component = factory.sequence(lambda n: f"ps-component-{n}")
-    purl = factory.sequence(
-        lambda n: f"pkg:rpm/fedora/ps-component-{n}@7.50.3-1.fc25?arch=i386&distro=fedora-25"
-    )
     impact = factory.Faker(
         "random_element",
         elements=filter(lambda i: i != "LOW", list(Impact))


### PR DESCRIPTION
This PR adds validation between `ps_component` and `purl` to check they match each other and also enables the automatic setting of `ps_component` if a request contains only `purl`.

Closes OSIDB-3410