### PR TITLE
no Jira tracker component & version changes on update

### DIFF
--- a/apps/bbsync/query.py
+++ b/apps/bbsync/query.py
@@ -67,7 +67,7 @@ class BugzillaQueryBuilder:
         return self._query
 
     @property
-    def creation(self):
+    def is_creating(self):
         """
         boolean property True on creation and False on update
         """
@@ -276,7 +276,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         """
         generate query for flaw description on create
         """
-        if self.creation:
+        if self.is_creating:
             self._query["description"] = self.flaw.comment_zero
             self._query["comment_is_private"] = False
 
@@ -287,7 +287,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
 
         if a collector created a flaw, check the external ID, as CVE might not be present
         """
-        if self.creation:
+        if self.is_creating:
             if self.flaw.cve_id is not None:
                 # create query requires pure list
                 self._query["alias"] = [self.flaw.cve_id]
@@ -315,7 +315,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         generate keywords query based on creation|update
         """
         self._query["keywords"] = (
-            ["Security"] if self.creation else {"add": ["Security"]}
+            ["Security"] if self.is_creating else {"add": ["Security"]}
         )
 
     def generate_flags(self):
@@ -450,7 +450,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
             groups = ["redhat"]
 
         # on creation we provide a list of groups
-        if self.creation:
+        if self.is_creating:
             self._query["groups"] = groups
 
         # otherwise we provide the differences
@@ -473,7 +473,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
                 self._query["deadline"] = self.flaw.unembargo_dt.strftime(DATE_FMT)
 
         # unembargo
-        elif not self.creation and self.embargoed:
+        elif not self.is_creating and self.embargoed:
             self._query["deadline"] = ""
 
     def generate_cc(self):
@@ -484,7 +484,7 @@ class FlawBugzillaQueryBuilder(BugzillaQueryBuilder):
         # let us ignore CCs to be removed
         add_cc, _ = cc_builder.content
 
-        if self.creation:
+        if self.is_creating:
             self._query["cc"] = add_cc
 
         else:

--- a/apps/trackers/bugzilla/query.py
+++ b/apps/trackers/bugzilla/query.py
@@ -81,7 +81,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
             )
         )
 
-        if self.creation:
+        if self.is_creating:
             self._query["blocks"] = flaw_ids
 
             # update blocks in meta_attr
@@ -111,7 +111,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         generate query for CC list
         """
 
-        if self.tracker.external_system_id:
+        if not self.is_creating:
             # Add CCs only on creation.
             return
 
@@ -207,7 +207,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         """
         generate query for flaw description
         """
-        if self.creation:
+        if self.is_creating:
             self._query["description"] = self.description
             # auto-created description should be always public
             self._query["comment_is_private"] = False
@@ -219,7 +219,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         generate query for Bugzilla flags
         """
         # we add flags on creation only
-        if not self.creation:
+        if not self.is_creating:
             return
 
         self._query["flags"] = []
@@ -249,7 +249,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
             groups = self.ps_module.bts_groups["public"]
 
         # on creation we provide a list of groups
-        if self.creation:
+        if self.is_creating:
             self._query["groups"] = groups
 
         # otherwise we provide the differences
@@ -269,7 +269,7 @@ class TrackerBugzillaQueryBuilder(BugzillaQueryBuilder, TrackerQueryBuilder):
         """
         self._query["keywords"] = (
             ["Security", "SecurityTracking"]
-            if self.creation
+            if self.is_creating
             else {"add": ["Security", "SecurityTracking"]}
         )
 

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -40,6 +40,13 @@ class TrackerQueryBuilder:
         """
         return self.instance
 
+    @property
+    def is_creating(self):
+        """
+        True on tracker creation
+        """
+        return not self.tracker.external_system_id
+
     @cached_property
     def flaws(self):
         """

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -203,6 +203,9 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         Generate Jira "components" field (with 1 component)
         """
+        # exclude from updates
+        if not self.is_creating:
+            return
 
         component = self.ps_component
 
@@ -385,6 +388,10 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         generates the versions
         """
+        # exclude from updates
+        if not self.is_creating:
+            return
+
         versions = JiraProjectFields.objects.filter(
             project_key=self.ps_module.bts_key, field_name="Affects Version/s"
         )

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -458,12 +458,11 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         """
         generate query for CC list
         """
-
         # Each instance of OldTrackerJiraQueryBuilder is used only once, but if ever used twice,
         # always produce consistent query and comment.
         self._comment = None
 
-        if self.tracker.external_system_id:
+        if not self.is_creating:
             # Add CCs only on creation.
             return
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   FlawCVSS, FlawReference, Snippet and Tracker. (OSIDB-3466)
 - Moved metadata creation during tests to root level conftest and
   automatically set envs during VCR recording (OSIDB-3492)
+- Exclude component and version from Jira tracker updates (OSIDB-3677)
 
 ## [4.5.6] - 2024-11-08
 ### Fixed


### PR DESCRIPTION
We are supposed to only set these on tracker creation as it is common that engineers set them more specifically and the tracker updates then reverts their changes which makes them not totally super-happy.

Closes OSIDB-3677