### PR TITLE
task sync manager preparations

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -164,7 +164,7 @@
         "filename": "apps/taskman/tests/test_flaw_model_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 156,
+        "line_number": 126,
         "is_secret": false
       }
     ],
@@ -184,7 +184,7 @@
         "filename": "apps/workflows/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 294,
+        "line_number": 283,
         "is_secret": false
       }
     ],
@@ -356,7 +356,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_package_versions.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 138,
+        "line_number": 141,
         "is_secret": false
       }
     ],

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -918,6 +918,9 @@ class TestBBSyncSaveIntegration:
 
 
 class TestFlawDraftBBSyncIntegration:
+    @freeze_time(
+        timezone.datetime(2020, 12, 12)
+    )  # freeze against top of the second crossing
     @pytest.mark.vcr
     @pytest.mark.enable_signals
     @pytest.mark.parametrize(

--- a/apps/taskman/constants.py
+++ b/apps/taskman/constants.py
@@ -18,5 +18,7 @@ SYNC_REQUIRED_FIELDS = [
     "is_embargoed",
     "owner",
     "team_id",
+]
+TRANSITION_REQUIRED_FIELDS = [
     "workflow_state",
 ]

--- a/apps/taskman/mixins.py
+++ b/apps/taskman/mixins.py
@@ -14,7 +14,7 @@ class JiraTaskSyncMixin(models.Model):
     class Meta:
         abstract = True
 
-    def save(self, *args, diff=None, jira_token=None, **kwargs):
+    def save(self, *args, diff=None, force_creation=False, jira_token=None, **kwargs):
         """
         save the model and sync it to Jira
 
@@ -26,7 +26,13 @@ class JiraTaskSyncMixin(models.Model):
         # check taskman conditions are met
         # and eventually perform the sync
         if JIRA_TASKMAN_AUTO_SYNC_FLAW and jira_token is not None:
-            self.tasksync(*args, diff=diff, jira_token=jira_token, **kwargs)
+            self.tasksync(
+                *args,
+                diff=diff,
+                force_creation=force_creation,
+                jira_token=jira_token,
+                **kwargs
+            )
 
     def tasksync(self, *args, jira_token, force_creation=False, **kwargs):
         """

--- a/apps/taskman/service.py
+++ b/apps/taskman/service.py
@@ -160,10 +160,21 @@ class JiraTaskmanQuerier(JiraQuerier):
                         **resolution_data,
                     )
                     return Response(
-                        data=self.jira_conn.issue(flaw.task_key).raw,
+                        data={
+                            "key": flaw.task_key,
+                            "resolution": resolution,
+                            "status": status,
+                        },
                         status=200,
                     )
-                return Response(data=issue, status=200)
+                return Response(
+                    data={
+                        "key": flaw.task_key,
+                        "resolution": resolution,
+                        "status": status,
+                    },
+                    status=200,
+                )
         except JIRAError as e:
             creating = not flaw.task_key
             creating_updating_word = "creating" if creating else "updating"

--- a/apps/taskman/tests/cassettes/test_service/TestTaskmanService.test_create_or_update_task.yaml
+++ b/apps/taskman/tests/cassettes/test_service/TestTaskmanService.test_create_or_update_task.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -210,21 +210,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -245,9 +249,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:22 GMT
+      - Tue, 26 Nov 2024 09:33:20 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:22 GMT
+      - Tue, 26 Nov 2024 09:33:20 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -260,7 +264,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -268,9 +272,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64732x1
+      - 573x1697643x1
       x-asessionid:
-      - otwgpl
+      - 1djqwo6
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -282,319 +286,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221342.78f7944
+      - 0.dfb1060.1732613600.7e4e6bca
       x-rh-edge-request-id:
-      - 78f7944
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:22 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:22 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64733x1
-      x-asessionid:
-      - 1teskjn
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221342.78f7970
-      x-rh-edge-request-id:
-      - 78f7970
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
-        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
-        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
-        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
-        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
-        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
-        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:22 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:22 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4215'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64734x1
-      x-asessionid:
-      - bbzhz5
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221342.78f79b7
-      x-rh-edge-request-id:
-      - 78f79b7
+      - 7e4e6bca
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -606,8 +300,8 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2020-10000 kernel: some description", "description": "Comment zero for
       CVE-2020-10000", "labels": ["flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-      "impact:IMPORTANT", "CVE-2020-10000"], "priority": {"name": "Major"}, "assignee":
-      {"name": ""}}}'
+      "impact:MODERATE", "major_incident", "CVE-2020-10000"], "priority": {"name":
+      "Normal"}, "assignee": {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -618,42 +312,45 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '330'
+      - '348'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16099409", "key": "OSIM-2166", "self": "https://example.com/rest/api/2/issue/16099409"}'
+      string: '{"id": "16312111", "key": "OSIM-14332", "self": "https://example.com/rest/api/2/issue/16312111"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
+      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:24 GMT
+      - Tue, 26 Nov 2024 09:33:21 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:24 GMT
+      - Tue, 26 Nov 2024 09:33:21 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
+      Transfer-Encoding:
+      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '4'
+      - '3'
       content-length:
-      - '102'
+      - '103'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -661,9 +358,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64735x1
+      - 573x1697645x1
       x-asessionid:
-      - 1nzpcic
+      - mp7chf
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -675,9 +372,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221342.78f7a43
+      - 0.dfb1060.1732613600.7e4e6c78
       x-rh-edge-request-id:
-      - 78f7a43
+      - 7e4e6c78
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -699,90 +396,101 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
+    uri: https://example.com/rest/api/2/issue/OSIM-14332
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@204fd7b0[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@76151726[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312111", "self": "https://example.com/rest/api/2/issue/16312111",
+        "key": "OSIM-14332", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@419a4c4f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@688b1061[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@55a05cc6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@b52cd73[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5656aa7b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3af40619[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6d653bed[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@70415a67[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13a72366[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@9793bc5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4d87c354[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@376f2ae1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@160c6e36[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@26347c8e[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21e68732[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@192e59d5[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6c26f918[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6973281e[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7cb9fd15[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1732f3a6[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4c873661[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3cc4c437[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-07-17T13:02:22.933+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10200",
+        "iconUrl": "https://example.com/images/icons/priorities/medium.svg", "name":
+        "Normal", "id": "10200"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
+        "impact:MODERATE", "major_incident"], "aggregatetimeoriginalestimate": null,
+        "timeestimate": null, "versions": [], "issuelinks": [], "assignee": null,
+        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
+        "https://example.com/rest/api/2/status/10016", "description": "Initial creation
+        status. Implies nothing yet and should be very short lived; also can be a
+        Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-2166/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14332/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i128rb:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14332/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T09:33:20.785+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T09:33:20.785+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i21qw7:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -791,9 +499,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:24 GMT
+      - Tue, 26 Nov 2024 09:33:22 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:24 GMT
+      - Tue, 26 Nov 2024 09:33:22 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -806,7 +514,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8820'
+      - '9431'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -814,9 +522,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64736x1
+      - 573x1697652x1
       x-asessionid:
-      - 8seqy6
+      - j29on7
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -828,9 +536,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221344.78f7c7b
+      - 0.dfb1060.1732613601.7e4e6ffc
       x-rh-edge-request-id:
-      - 78f7c7b
+      - 7e4e6ffc
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -852,7 +560,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -1049,21 +757,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -1084,9 +796,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:24 GMT
+      - Tue, 26 Nov 2024 09:33:22 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:24 GMT
+      - Tue, 26 Nov 2024 09:33:22 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1099,7 +811,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1107,9 +819,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64737x1
+      - 573x1697655x1
       x-asessionid:
-      - 1qe3u4j
+      - i1vnbr
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1121,319 +833,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221344.78f7d24
+      - 0.dfb1060.1732613602.7e4e7093
       x-rh-edge-request-id:
-      - 78f7d24
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:24 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:24 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64738x1
-      x-asessionid:
-      - no9adj
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221344.78f7df7
-      x-rh-edge-request-id:
-      - 78f7df7
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
-        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
-        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
-        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
-        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
-        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
-        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:24 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:24 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4215'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64739x1
-      x-asessionid:
-      - f2f925
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221344.78f7e23
-      x-rh-edge-request-id:
-      - 78f7e23
+      - 7e4e7093
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1445,8 +847,9 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2020-10000 kernel: some description edited title", "description": "Comment
       zero for CVE-2020-10000", "labels": ["flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-      "impact:IMPORTANT", "CVE-2020-10000"], "priority": {"name": "Major"}, "assignee":
-      {"name": "concosta@redhat.com"}, "customfield_12313240": "2861"}}'
+      "impact:MODERATE", "major_incident", "CVE-2020-10000"], "priority": {"name":
+      "Normal"}, "assignee": {"name": "concosta@redhat.com"}, "customfield_12313240":
+      "2861"}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -1457,15 +860,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '394'
+      - '412'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
+    uri: https://example.com/rest/api/2/issue/OSIM-14332
   response:
     body:
       string: ''
@@ -1477,354 +880,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:25 GMT
+      - Tue, 26 Nov 2024 09:33:23 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:25 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '2'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64740x1
-      x-asessionid:
-      - 1ymhccx
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221344.78f7e4e
-      x-rh-edge-request-id:
-      - 78f7e4e
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@580b3633[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@39081ef6[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@19b47d24[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@60b23f4a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@265233a3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@456b576b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f0c4fbf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@eb5777b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@39cd9225[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@26825a78[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3b6e98a0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1ec52e19[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "updated": "2024-07-17T13:02:25.005+0000", "customfield_12313942": null, "customfield_12313941":
-        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
-        "Initial creation status. Implies nothing yet and should be very short lived;
-        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description edited title", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        {"id": 2861, "name": "OSIDB"}, "duedate": null, "customfield_12311140": null,
-        "customfield_12319742": null, "progress": {"progress": 0, "total": 0}, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/votes", "votes": 0, "hasVoted":
-        false}, "customfield_12319743": null, "worklog": {"startAt": 0, "maxResults":
-        20, "total": 0, "worklogs": []}, "customfield_12310213": null, "archivedby":
-        null, "customfield_12311940": "2|i128rb:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:26 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:26 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '9552'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64741x1
-      x-asessionid:
-      - 8g0p9q
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221346.78f80d4
-      x-rh-edge-request-id:
-      - 78f80d4
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166/transitions
-  response:
-    body:
-      string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
-        "description": "", "opsbarSequence": 10, "to": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "71", "name": "Refinement", "description": "", "opsbarSequence": 20, "to":
-        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
-        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
-        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
-        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "31", "name": "To Do", "description": "", "opsbarSequence": 30, "to": {"self":
-        "https://example.com/rest/api/2/status/10020", "description": "The team is
-        planning to do this work and it has a priority set", "iconUrl": "https://example.com/",
-        "name": "To Do", "id": "10020", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "41", "name": "In Progress", "description": "", "opsbarSequence": 40, "to":
-        {"self": "https://example.com/rest/api/2/status/10018", "description": "Work
-        has started", "iconUrl": "https://example.com/images/icons/status_generic.gif",
-        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
-        {"id": "51", "name": "Review", "description": "", "opsbarSequence": 50, "to":
-        {"self": "https://example.com/rest/api/2/status/12422", "description": "Work
-        is being reviewed. This can be for multiple purposes: QE validation, engineer
-        review, or some kind of peer review.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Review", "id": "12422", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
-        {"id": "61", "name": "Closed", "description": "", "opsbarSequence": 60, "to":
-        {"self": "https://example.com/rest/api/2/status/6", "description": "The issue
-        is closed. See the resolution for context regarding why (for example Done,
-        Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
-        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
-        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:26 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:26 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '2963'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64742x1
-      x-asessionid:
-      - pnwf6u
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221346.78f8146
-      x-rh-edge-request-id:
-      - 78f8146
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"transition": {"id": "71"}, "fields": {}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '42'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-2166/transitions
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:27 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:27 GMT
+      - Tue, 26 Nov 2024 09:33:23 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1840,9 +898,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64743x1
+      - 573x1697657x1
       x-asessionid:
-      - j9t6gh
+      - 1d9ln8k
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1854,9 +912,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221346.78f81a2
+      - 0.dfb1060.1732613602.7e4e712c
       x-rh-edge-request-id:
-      - 78f81a2
+      - 7e4e712c
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1878,168 +936,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@16ef3c1b[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@32818771[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2462489[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3c4291bf[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12827a5c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@49e91a8c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ab81d54[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@52dfb4d5[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@538e6448[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@52b239cf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@685acc70[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@470ca4b2[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "updated": "2024-07-17T13:02:26.475+0000", "customfield_12313942": null, "customfield_12313941":
-        null, "status": {"self": "https://example.com/rest/api/2/status/15021", "description":
-        "Work is being scoped and discussed (To Do status category; see also Draft)",
-        "iconUrl": "https://example.com/images/icons/statuses/generic.png", "name":
-        "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description edited title", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        {"id": 2861, "name": "OSIDB"}, "duedate": null, "customfield_12311140": null,
-        "customfield_12319742": null, "progress": {"progress": 0, "total": 0}, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/votes", "votes": 0, "hasVoted":
-        false}, "customfield_12319743": null, "worklog": {"startAt": 0, "maxResults":
-        20, "total": 0, "worklogs": []}, "customfield_12310213": null, "archivedby":
-        null, "customfield_12311940": "2|i128rb:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:27 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:27 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '9526'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64744x1
-      x-asessionid:
-      - 1cqm0e2
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221347.78f8345
-      x-rh-edge-request-id:
-      - 78f8345
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -2236,21 +1133,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -2271,9 +1172,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:27 GMT
+      - Tue, 26 Nov 2024 09:33:23 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:27 GMT
+      - Tue, 26 Nov 2024 09:33:23 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2286,7 +1187,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2294,9 +1195,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64745x1
+      - 573x1697664x1
       x-asessionid:
-      - kusjip
+      - 19y4her
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2308,319 +1209,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221347.78f8401
+      - 0.dfb1060.1732613603.7e4e74ce
       x-rh-edge-request-id:
-      - 78f8401
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:28 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:28 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64746x1
-      x-asessionid:
-      - 64ylp9
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221347.78f84ea
-      x-rh-edge-request-id:
-      - 78f84ea
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
-        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
-        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
-        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
-        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
-        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
-        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:28 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:28 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4215'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64747x1
-      x-asessionid:
-      - 1fef5lq
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221348.78f8532
-      x-rh-edge-request-id:
-      - 78f8532
+      - 7e4e74ce
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2632,8 +1223,9 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2020-10000 kernel: some description edited title", "description": "Comment
       zero for CVE-2020-10000", "labels": ["flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-      "impact:IMPORTANT", "CVE-2020-10000"], "priority": {"name": "Major"}, "assignee":
-      {"name": "concosta@redhat.com"}, "customfield_12313240": "2861"}}'
+      "impact:MODERATE", "major_incident", "CVE-2020-10000"], "priority": {"name":
+      "Normal"}, "assignee": {"name": "concosta@redhat.com"}, "customfield_12313240":
+      "2861"}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -2644,15 +1236,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '394'
+      - '412'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
+    uri: https://example.com/rest/api/2/issue/OSIM-14332
   response:
     body:
       string: ''
@@ -2664,9 +1256,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:28 GMT
+      - Tue, 26 Nov 2024 09:33:23 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:28 GMT
+      - Tue, 26 Nov 2024 09:33:23 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2682,9 +1274,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64748x1
+      - 573x1697666x1
       x-asessionid:
-      - psuflt
+      - 1qkbpxe
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2696,9 +1288,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221348.78f8570
+      - 0.dfb1060.1732613603.7e4e7578
       x-rh-edge-request-id:
-      - 78f8570
+      - 7e4e7578
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2720,512 +1312,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@32b4310[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5990074a[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@60bc6201[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@394f830b[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e34d9b9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@53c0fe52[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@506f2241[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@15fdb49c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6d7c5e8b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@399a0f18[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@104e4f40[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@68ef4081[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "updated": "2024-07-17T13:02:26.475+0000", "customfield_12313942": null, "customfield_12313941":
-        null, "status": {"self": "https://example.com/rest/api/2/status/15021", "description":
-        "Work is being scoped and discussed (To Do status category; see also Draft)",
-        "iconUrl": "https://example.com/images/icons/statuses/generic.png", "name":
-        "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description edited title", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        {"id": 2861, "name": "OSIDB"}, "duedate": null, "customfield_12311140": null,
-        "customfield_12319742": null, "progress": {"progress": 0, "total": 0}, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/votes", "votes": 0, "hasVoted":
-        false}, "customfield_12319743": null, "worklog": {"startAt": 0, "maxResults":
-        20, "total": 0, "worklogs": []}, "customfield_12310213": null, "archivedby":
-        null, "customfield_12311940": "2|i128rb:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:29 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:29 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '9526'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64749x1
-      x-asessionid:
-      - rj25qv
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221348.78f860e
-      x-rh-edge-request-id:
-      - 78f860e
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166/transitions
-  response:
-    body:
-      string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
-        "description": "", "opsbarSequence": 10, "to": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "71", "name": "Refinement", "description": "", "opsbarSequence": 20, "to":
-        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
-        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
-        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
-        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "31", "name": "To Do", "description": "", "opsbarSequence": 30, "to": {"self":
-        "https://example.com/rest/api/2/status/10020", "description": "The team is
-        planning to do this work and it has a priority set", "iconUrl": "https://example.com/",
-        "name": "To Do", "id": "10020", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
-        "41", "name": "In Progress", "description": "", "opsbarSequence": 40, "to":
-        {"self": "https://example.com/rest/api/2/status/10018", "description": "Work
-        has started", "iconUrl": "https://example.com/images/icons/status_generic.gif",
-        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
-        {"id": "51", "name": "Review", "description": "", "opsbarSequence": 50, "to":
-        {"self": "https://example.com/rest/api/2/status/12422", "description": "Work
-        is being reviewed. This can be for multiple purposes: QE validation, engineer
-        review, or some kind of peer review.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Review", "id": "12422", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
-        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
-        {"id": "61", "name": "Closed", "description": "", "opsbarSequence": 60, "to":
-        {"self": "https://example.com/rest/api/2/status/6", "description": "The issue
-        is closed. See the resolution for context regarding why (for example Done,
-        Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
-        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
-        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}]}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:29 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:29 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '2963'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64751x1
-      x-asessionid:
-      - 1ajq43o
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221349.78f8755
-      x-rh-edge-request-id:
-      - 78f8755
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"transition": {"id": "31"}, "fields": {}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '42'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-2166/transitions
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:30 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:30 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64752x1
-      x-asessionid:
-      - 15vjgf3
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221349.78f8820
-      x-rh-edge-request-id:
-      - 78f8820
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6676728b[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@43496d1a[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2f6470db[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@27cdf990[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f963d96[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@389beb63[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@34f5b603[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7cbcc874[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@122830f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@758f112d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6c53e431[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@76367ea7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "updated": "2024-07-17T13:02:29.813+0000", "customfield_12313942": null, "customfield_12313941":
-        null, "status": {"self": "https://example.com/rest/api/2/status/10020", "description":
-        "The team is planning to do this work and it has a priority set", "iconUrl":
-        "https://example.com/", "name": "To Do", "id": "10020", "statusCategory":
-        {"self": "https://example.com/rest/api/2/statuscategory/2", "id": 2, "key":
-        "new", "colorName": "default", "name": "To Do"}}, "components": [], "timeoriginalestimate":
-        null, "description": "Comment zero for CVE-2020-10000", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description edited title", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        {"id": 2861, "name": "OSIDB"}, "duedate": null, "customfield_12311140": null,
-        "customfield_12319742": null, "progress": {"progress": 0, "total": 0}, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/votes", "votes": 0, "hasVoted":
-        false}, "customfield_12319743": null, "worklog": {"startAt": 0, "maxResults":
-        20, "total": 0, "worklogs": []}, "customfield_12310213": null, "archivedby":
-        null, "customfield_12311940": "2|i128rb:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:30 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:30 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '9477'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64753x1
-      x-asessionid:
-      - qmexa8
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221350.78f89e5
-      x-rh-edge-request-id:
-      - 78f89e5
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -3422,21 +1509,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -3457,9 +1548,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:31 GMT
+      - Tue, 26 Nov 2024 09:33:24 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:31 GMT
+      - Tue, 26 Nov 2024 09:33:24 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3472,7 +1563,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -3480,9 +1571,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64754x1
+      - 573x1697668x1
       x-asessionid:
-      - 8u0zvb
+      - ravk2s
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3494,319 +1585,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221351.78f8a40
+      - 0.dfb1060.1732613603.7e4e7643
       x-rh-edge-request-id:
-      - 78f8a40
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:31 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:31 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64755x1
-      x-asessionid:
-      - 3k9k7h
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221351.78f8a9a
-      x-rh-edge-request-id:
-      - 78f8a9a
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Service Desk
-        Team": "https://example.com/rest/api/2/project/12337520/role/11240", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Service Desk
-        Customers": "https://example.com/rest/api/2/project/12337520/role/11241",
-        "Administrators": "https://example.com/rest/api/2/project/12337520/role/10002",
-        "Approver": "https://example.com/rest/api/2/project/12337520/role/10840",
-        "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440", "Users":
-        "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:31 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:31 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4215'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64756x1
-      x-asessionid:
-      - jnz39y
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221351.78f8ac6
-      x-rh-edge-request-id:
-      - 78f8ac6
+      - 7e4e7643
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3818,8 +1599,8 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2020-10000 kernel: some description edited title", "description": "Comment
       zero for CVE-2020-10000", "labels": ["flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-      "impact:IMPORTANT", "CVE-2020-10000"], "priority": {"name": "Major"}, "assignee":
-      {"name": ""}, "customfield_12313240": "2861"}}'
+      "impact:MODERATE", "major_incident", "CVE-2020-10000"], "priority": {"name":
+      "Normal"}, "assignee": {"name": ""}, "customfield_12313240": "2861"}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -3830,15 +1611,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '375'
+      - '393'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
+    uri: https://example.com/rest/api/2/issue/OSIM-14332
   response:
     body:
       string: ''
@@ -3850,9 +1631,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:32 GMT
+      - Tue, 26 Nov 2024 09:33:24 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:32 GMT
+      - Tue, 26 Nov 2024 09:33:24 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3860,7 +1641,7 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '2'
+      - '3'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -3868,9 +1649,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64757x1
+      - 573x1697670x1
       x-asessionid:
-      - 1hf19v9
+      - 1cx7otm
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3882,9 +1663,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221351.78f8afa
+      - 0.dfb1060.1732613604.7e4e76c5
       x-rh-edge-request-id:
-      - 78f8afa
+      - 7e4e76c5
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3906,90 +1687,101 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
+    uri: https://example.com/rest/api/2/issue/OSIM-14332
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "16312111", "self": "https://example.com/rest/api/2/issue/16312111",
+        "key": "OSIM-14332", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3c06cb70[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4a90ddd2[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7431bce0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@388391f9[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3edb7031[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@75dea4f0[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@c71c017[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@28599439[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4d6633fb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4d1fe783[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4fecf74f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2bf05ad7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/10200",
+        "iconUrl": "https://example.com/images/icons/priorities/medium.svg", "name":
+        "Normal", "id": "10200"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
+        "impact:MODERATE", "major_incident"], "aggregatetimeoriginalestimate": null,
+        "timeestimate": null, "versions": [], "issuelinks": [], "assignee": null,
+        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
+        "https://example.com/rest/api/2/status/10016", "description": "Initial creation
+        status. Implies nothing yet and should be very short lived; also can be a
+        Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        {"id": 2861, "name": "OSIDB"}, "customfield_12319742": null, "progress": {"progress":
+        0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14332/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@46fba798[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@75cddbd7[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3117e055[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2a9f96c3[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1552afc8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@65c6944c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6b5dc5e9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3d227fcf[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3d8eab4c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6cbb3c45[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@69ccceb6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@47be1847[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14332/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T09:33:20.785+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-07-17T13:02:31.458+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10020",
-        "description": "The team is planning to do this work and it has a priority
-        set", "iconUrl": "https://example.com/", "name": "To Do", "id": "10020", "statusCategory":
-        {"self": "https://example.com/rest/api/2/statuscategory/2", "id": 2, "key":
-        "new", "colorName": "default", "name": "To Do"}}, "components": [], "timeoriginalestimate":
-        null, "description": "Comment zero for CVE-2020-10000", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description edited title", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        {"id": 2861, "name": "OSIDB"}, "duedate": null, "customfield_12311140": null,
-        "customfield_12319742": null, "progress": {"progress": 0, "total": 0}, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/votes", "votes": 0, "hasVoted":
-        false}, "customfield_12319743": null, "worklog": {"startAt": 0, "maxResults":
-        20, "total": 0, "worklogs": []}, "customfield_12310213": null, "archivedby":
-        null, "customfield_12311940": "2|i128rb:"}}'
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T09:33:24.184+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description
+        edited title", "customfield_12323640": null, "customfield_12325147": null,
+        "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
+        null, "customfield_12323641": null, "customfield_12325148": null, "customfield_12325143":
+        null, "customfield_12325142": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i21qw7:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -3998,9 +1790,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Wed, 17 Jul 2024 13:02:33 GMT
+      - Tue, 26 Nov 2024 09:33:25 GMT
       Expires:
-      - Wed, 17 Jul 2024 13:02:33 GMT
+      - Tue, 26 Nov 2024 09:33:25 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -4013,7 +1805,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8781'
+      - '9465'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -4021,9 +1813,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 782x64758x1
+      - 573x1697676x1
       x-asessionid:
-      - 2mgr7d
+      - kokpnp
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -4035,162 +1827,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.74f02217.1721221352.78f8cfb
+      - 0.dfb1060.1732613605.7e4e79e5
       x-rh-edge-request-id:
-      - 78f8cfb
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-2166
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16099409", "self": "https://example.com/rest/api/2/issue/16099409",
-        "key": "OSIM-2166", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@270bb248[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@33c6344a[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7cd25f13[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7eb440a7[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f4d38a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3050617f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e149aa1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2f948bc[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@54a7c056[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@67cf0824[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d7457ee[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@55804054[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-07-17T13:02:22.933+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:9d9b3b14-0c44-4030-883c-8610f7e2879b",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-07-17T13:02:31.458+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10020",
-        "description": "The team is planning to do this work and it has a priority
-        set", "iconUrl": "https://example.com/", "name": "To Do", "id": "10020", "statusCategory":
-        {"self": "https://example.com/rest/api/2/statuscategory/2", "id": 2, "key":
-        "new", "colorName": "default", "name": "To Do"}}, "components": [], "timeoriginalestimate":
-        null, "description": "Comment zero for CVE-2020-10000", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description edited title", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        {"id": 2861, "name": "OSIDB"}, "duedate": null, "customfield_12311140": null,
-        "customfield_12319742": null, "progress": {"progress": 0, "total": 0}, "comment":
-        {"comments": [], "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-2166/votes", "votes": 0, "hasVoted":
-        false}, "customfield_12319743": null, "worklog": {"startAt": 0, "maxResults":
-        20, "total": 0, "worklogs": []}, "customfield_12310213": null, "archivedby":
-        null, "customfield_12311940": "2|i128rb:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Wed, 17 Jul 2024 13:02:33 GMT
-      Expires:
-      - Wed, 17 Jul 2024 13:02:33 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '8780'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 782x64759x1
-      x-asessionid:
-      - 1fcn4td
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.74f02217.1721221353.78f8df1
-      x-rh-edge-request-id:
-      - 78f8df1
+      - 7e4e79e5
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/apps/taskman/tests/test_flaw_model_integration.py
+++ b/apps/taskman/tests/test_flaw_model_integration.py
@@ -185,8 +185,8 @@ class TestFlawModelIntegration(object):
             HTTP_JIRA_API_KEY="SECRET",
         )
         assert response.status_code == 200
-        # update and transition forced
-        assert sync_count == 2
+        # changes require sync
+        assert sync_count == 1
 
     def test_create_jira_task_param(self, monkeypatch, auth_client, test_osidb_api_uri):
         def mock_create_or_update_task(self, flaw):

--- a/apps/taskman/tests/test_flaw_model_integration.py
+++ b/apps/taskman/tests/test_flaw_model_integration.py
@@ -29,17 +29,7 @@ class TestFlawModelIntegration(object):
         def mock_create_or_update_task(self, flaw):
             nonlocal sync_count
             sync_count += 1
-            return Response(
-                data={
-                    "key": "TASK-123",
-                    "fields": {
-                        "status": {"name": "New"},
-                        "resolution": None,
-                        "updated": "2024-06-25T21:20:43.988+0000",
-                    },
-                },
-                status=200,
-            )
+            return None
 
         monkeypatch.setattr(
             JiraTaskmanQuerier, "create_or_update_task", mock_create_or_update_task
@@ -77,17 +67,7 @@ class TestFlawModelIntegration(object):
         def mock_create_or_update_task(self, flaw):
             nonlocal sync_count
             sync_count += 1
-            return Response(
-                data={
-                    "key": "TASK-123",
-                    "fields": {
-                        "status": {"name": "New"},
-                        "resolution": None,
-                        "updated": "2024-06-25T21:20:43.988+0000",
-                    },
-                },
-                status=200,
-            )
+            return "TASK-123"
 
         monkeypatch.setattr(
             JiraTaskmanQuerier, "create_or_update_task", mock_create_or_update_task
@@ -122,17 +102,7 @@ class TestFlawModelIntegration(object):
         def mock_create_or_update_task(self, flaw):
             nonlocal sync_count
             sync_count += 1
-            return Response(
-                data={
-                    "key": "TASK-123",
-                    "fields": {
-                        "status": {"name": "New"},
-                        "resolution": None,
-                        "updated": "2024-06-25T21:20:43.988+0000",
-                    },
-                },
-                status=200,
-            )
+            return "TASK-123"
 
         monkeypatch.setattr(
             JiraTaskmanQuerier, "create_or_update_task", mock_create_or_update_task
@@ -162,24 +132,13 @@ class TestFlawModelIntegration(object):
     def test_update_api(self, monkeypatch, auth_client, test_osidb_api_uri):
         sync_count = 0
 
-        def mock_create_or_update_task(self, flaw):
+        def mock(self, flaw):
             nonlocal sync_count
             sync_count += 1
-            return Response(
-                data={
-                    "key": "TASK-123",
-                    "fields": {
-                        "status": {"name": "New"},
-                        "resolution": None,
-                        "updated": "2024-06-25T21:20:43.988+0000",
-                    },
-                },
-                status=200,
-            )
+            return None
 
-        monkeypatch.setattr(
-            JiraTaskmanQuerier, "create_or_update_task", mock_create_or_update_task
-        )
+        monkeypatch.setattr(JiraTaskmanQuerier, "create_or_update_task", mock)
+        monkeypatch.setattr(JiraTaskmanQuerier, "transition_task", mock)
 
         flaw = FlawFactory(embargoed=False, impact=Impact.IMPORTANT)
         AffectFactory(flaw=flaw)
@@ -226,22 +185,13 @@ class TestFlawModelIntegration(object):
             HTTP_JIRA_API_KEY="SECRET",
         )
         assert response.status_code == 200
-        assert sync_count == 1
+        # update and transition forced
+        assert sync_count == 2
 
     def test_create_jira_task_param(self, monkeypatch, auth_client, test_osidb_api_uri):
         def mock_create_or_update_task(self, flaw):
             flaw.task_key = "TASK-123"
-            return Response(
-                data={
-                    "key": "TASK-123",
-                    "fields": {
-                        "status": {"name": "New"},
-                        "resolution": None,
-                        "updated": "2024-06-25T21:20:43.988+0000",
-                    },
-                },
-                status=200,
-            )
+            return "TASK-123"
 
         monkeypatch.setattr(
             JiraTaskmanQuerier, "create_or_update_task", mock_create_or_update_task

--- a/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_promote.yaml
+++ b/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_promote.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
     method: GET
     uri: https://example.com/v1/vulns/GHSA-3hwm-922r-47hw
   response:
@@ -37,11 +37,11 @@ interactions:
       Content-Length:
       - '1676'
       Date:
-      - Thu, 25 Jul 2024 20:23:47 GMT
+      - Tue, 26 Nov 2024 08:45:02 GMT
       Server:
       - Google Frontend
       X-Cloud-Trace-Context:
-      - 6a13b1807a6264b5971e4bfde8c28277
+      - fab5ecad8d69e910896da259e1566d11
       alt-svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       content-type:
@@ -57,4 +57,966 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:45:04 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:45:04 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 525x1686755x1
+      x-asessionid:
+      - gs7ggr
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8dc83017.1732610704.7dcdba9c
+      x-rh-edge-request-id:
+      - 7dcdba9c
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-123/transitions
+  response:
+    body:
+      string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
+        "description": "", "opsbarSequence": 10, "to": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "71", "name": "Refinement", "description": "", "opsbarSequence": 20, "to":
+        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
+        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
+        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
+        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "31", "name": "To Do", "description": "", "opsbarSequence": 30, "to": {"self":
+        "https://example.com/rest/api/2/status/10020", "description": "The team is
+        planning to do this work and it has a priority set", "iconUrl": "https://example.com/",
+        "name": "To Do", "id": "10020", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "41", "name": "In Progress", "description": "", "opsbarSequence": 40, "to":
+        {"self": "https://example.com/rest/api/2/status/10018", "description": "Work
+        has started", "iconUrl": "https://example.com/images/icons/status_generic.gif",
+        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
+        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
+        {"id": "51", "name": "Review", "description": "", "opsbarSequence": 50, "to":
+        {"self": "https://example.com/rest/api/2/status/12422", "description": "Work
+        is being reviewed. This can be for multiple purposes: QE validation, engineer
+        review, or some kind of peer review.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "Review", "id": "12422", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
+        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
+        {"id": "61", "name": "Closed", "description": "", "opsbarSequence": 60, "to":
+        {"self": "https://example.com/rest/api/2/status/6", "description": "The issue
+        is closed. See the resolution for context regarding why (for example Done,
+        Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
+        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
+        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:45:04 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:45:04 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '3'
+      content-length:
+      - '2963'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 525x1686756x1
+      x-asessionid:
+      - l02z73
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8dc83017.1732610704.7dcdbc55
+      x-rh-edge-request-id:
+      - 7dcdbc55
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": "71"}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '42'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue/OSIM-123/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:45:05 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:45:05 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 525x1686757x1
+      x-asessionid:
+      - 82a08r
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8dc83017.1732610704.7dcdbe5b
+      x-rh-edge-request-id:
+      - 7dcdbe5b
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:45:07 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:45:07 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 525x1689963x2
+      x-asessionid:
+      - g5adq9
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8dc83017.1732610706.7dcdd63a
+      x-rh-edge-request-id:
+      - 7dcdd63a
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-123/transitions
+  response:
+    body:
+      string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
+        "description": "", "opsbarSequence": 10, "to": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "71", "name": "Refinement", "description": "", "opsbarSequence": 20, "to":
+        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
+        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
+        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
+        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "31", "name": "To Do", "description": "", "opsbarSequence": 30, "to": {"self":
+        "https://example.com/rest/api/2/status/10020", "description": "The team is
+        planning to do this work and it has a priority set", "iconUrl": "https://example.com/",
+        "name": "To Do", "id": "10020", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "41", "name": "In Progress", "description": "", "opsbarSequence": 40, "to":
+        {"self": "https://example.com/rest/api/2/status/10018", "description": "Work
+        has started", "iconUrl": "https://example.com/images/icons/status_generic.gif",
+        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
+        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
+        {"id": "51", "name": "Review", "description": "", "opsbarSequence": 50, "to":
+        {"self": "https://example.com/rest/api/2/status/12422", "description": "Work
+        is being reviewed. This can be for multiple purposes: QE validation, engineer
+        review, or some kind of peer review.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "Review", "id": "12422", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
+        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
+        {"id": "61", "name": "Closed", "description": "", "opsbarSequence": 60, "to":
+        {"self": "https://example.com/rest/api/2/status/6", "description": "The issue
+        is closed. See the resolution for context regarding why (for example Done,
+        Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
+        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
+        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:45:07 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:45:07 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '3'
+      content-length:
+      - '2963'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 525x1689964x1
+      x-asessionid:
+      - 1j98owl
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8dc83017.1732610707.7dcdd816
+      x-rh-edge-request-id:
+      - 7dcdd816
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": "31"}, "fields": {}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '42'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue/OSIM-123/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:45:08 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:45:08 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 525x1689966x1
+      x-asessionid:
+      - 1pxgqko
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8dc83017.1732610707.7dcdd98c
+      x-rh-edge-request-id:
+      - 7dcdd98c
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
 version: 1

--- a/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_reject.yaml
+++ b/apps/workflows/tests/cassettes/test_endpoints/TestFlawDraft.test_reject.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
     method: GET
     uri: https://example.com/v1/vulns/GHSA-3hwm-922r-47hw
   response:
@@ -37,11 +37,11 @@ interactions:
       Content-Length:
       - '1676'
       Date:
-      - Thu, 25 Jul 2024 20:23:52 GMT
+      - Tue, 26 Nov 2024 08:43:20 GMT
       Server:
       - Google Frontend
       X-Cloud-Trace-Context:
-      - 0ab4c1ff858f90419b9f96749ab305bb
+      - 10eb1ed699eaa469c6bb291b8b019423
       alt-svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
       content-type:
@@ -57,4 +57,486 @@ interactions:
     status:
       code: 200
       message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:43:22 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:43:22 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 523x1689357x2
+      x-asessionid:
+      - aro4mx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8bc83017.1732610601.1488b959
+      x-rh-edge-request-id:
+      - 1488b959
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-123/transitions
+  response:
+    body:
+      string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
+        "description": "", "opsbarSequence": 10, "to": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "71", "name": "Refinement", "description": "", "opsbarSequence": 20, "to":
+        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
+        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
+        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
+        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "31", "name": "To Do", "description": "", "opsbarSequence": 30, "to": {"self":
+        "https://example.com/rest/api/2/status/10020", "description": "The team is
+        planning to do this work and it has a priority set", "iconUrl": "https://example.com/",
+        "name": "To Do", "id": "10020", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}}, {"id":
+        "41", "name": "In Progress", "description": "", "opsbarSequence": 40, "to":
+        {"self": "https://example.com/rest/api/2/status/10018", "description": "Work
+        has started", "iconUrl": "https://example.com/images/icons/status_generic.gif",
+        "name": "In Progress", "id": "10018", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
+        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
+        {"id": "51", "name": "Review", "description": "", "opsbarSequence": 50, "to":
+        {"self": "https://example.com/rest/api/2/status/12422", "description": "Work
+        is being reviewed. This can be for multiple purposes: QE validation, engineer
+        review, or some kind of peer review.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "Review", "id": "12422", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/4",
+        "id": 4, "key": "indeterminate", "colorName": "inprogress", "name": "In Progress"}}},
+        {"id": "61", "name": "Closed", "description": "", "opsbarSequence": 60, "to":
+        {"self": "https://example.com/rest/api/2/status/6", "description": "The issue
+        is closed. See the resolution for context regarding why (for example Done,
+        Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
+        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
+        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}}]}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:43:22 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:43:22 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      content-length:
+      - '2963'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 523x1689359x1
+      x-asessionid:
+      - 1bpiz5a
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8bc83017.1732610602.1488bae0
+      x-rh-edge-request-id:
+      - 1488bae0
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"transition": {"id": "61"}, "fields": {"resolution": {"name": "Won''t
+      Do"}}}'
+    headers:
+      Accept:
+      - application/json,*.*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '76'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue/OSIM-123/transitions
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Tue, 26 Nov 2024 08:43:23 GMT
+      Expires:
+      - Tue, 26 Nov 2024 08:43:23 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      X-RateLimit-Limit:
+      - '5'
+      X-RateLimit-Remaining:
+      - '4'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 523x1689361x1
+      x-asessionid:
+      - 106bb1q
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '5'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.8bc83017.1732610602.1488bd53
+      x-rh-edge-request-id:
+      - 1488bd53
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
 version: 1

--- a/apps/workflows/tests/test_endpoints.py
+++ b/apps/workflows/tests/test_endpoints.py
@@ -1,5 +1,8 @@
+from datetime import datetime
+
 import pytest
 from django.conf import settings
+from freezegun import freeze_time
 
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.workflows.models import State, Workflow
@@ -426,6 +429,7 @@ class TestFlawDraft:
     def mock_create_task(self, flaw):
         return "OSIM-123"
 
+    @freeze_time(datetime(2020, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.vcr
     def test_promote(
         self,

--- a/apps/workflows/tests/test_endpoints.py
+++ b/apps/workflows/tests/test_endpoints.py
@@ -1,6 +1,5 @@
 import pytest
 from django.conf import settings
-from rest_framework.response import Response
 
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.workflows.models import State, Workflow
@@ -232,24 +231,11 @@ class TestEndpoints(object):
     ):
         """test flaw state promotion after data change"""
 
-        def mock_create_or_update_task(self, flaw):
-            return Response(
-                data={
-                    "key": "TASK-123",
-                    "fields": {
-                        "status": {
-                            "name": WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT
-                        },
-                        "resolution": None,
-                        "updated": "2024-06-25T21:20:43.988+0000",
-                    },
-                },
-                status=200,
-            )
+        def mock(self, flaw):
+            return None
 
-        monkeypatch.setattr(
-            JiraTaskmanQuerier, "create_or_update_task", mock_create_or_update_task
-        )
+        monkeypatch.setattr(JiraTaskmanQuerier, "create_or_update_task", mock)
+        monkeypatch.setattr(JiraTaskmanQuerier, "transition_task", mock)
 
         workflow_framework = WorkflowFramework()
         workflow_framework._workflows = []
@@ -286,7 +272,7 @@ class TestEndpoints(object):
         )
         workflow_framework.register_workflow(workflow)
 
-        flaw = FlawFactory(cwe_id="", cve_description="", task_key="TASK-123")
+        flaw = FlawFactory(cwe_id="", cve_description="", task_key="OSIM-123")
         AffectFactory(flaw=flaw)
 
         assert flaw.classification["workflow"] == "DEFAULT"
@@ -438,21 +424,7 @@ class TestEndpoints(object):
 
 class TestFlawDraft:
     def mock_create_task(self, flaw):
-        data = {
-            "key": "TASK-123",
-            "fields": {
-                "status": {"name": "New"},
-                "resolution": None,
-                "updated": "2024-06-25T21:20:43.988+0000",
-            },
-        }
-        if flaw.workflow_state:
-            status, resolution = flaw.jira_status()
-            data["fields"]["status"]["name"] = status
-            if resolution:
-                data["fields"]["resolution"] = {"name": resolution}
-
-        return Response(data=data, status=200)
+        return "OSIM-123"
 
     @pytest.mark.vcr
     def test_promote(
@@ -480,7 +452,7 @@ class TestFlawDraft:
         flaw = Flaw.objects.first()
         assert flaw.classification["workflow"] == "DEFAULT"
         assert flaw.classification["state"] == WorkflowModel.WorkflowState.NEW
-        assert flaw.task_key == "TASK-123"
+        assert flaw.task_key == "OSIM-123"
         assert flaw.is_internal
 
         # set owner to comply with TRIAGE requirements
@@ -524,7 +496,7 @@ class TestFlawDraft:
         flaw.refresh_from_db()
         assert flaw.classification["workflow"] == "DEFAULT"
         assert flaw.classification["state"] == WorkflowModel.WorkflowState.TRIAGE
-        assert flaw.task_key == "TASK-123"
+        assert flaw.task_key == "OSIM-123"
 
         # check that a flaw and related objects (except for snippets)
         # still have internal ACLs as we publish only after the triage
@@ -563,7 +535,7 @@ class TestFlawDraft:
             flaw.classification["state"]
             == WorkflowModel.WorkflowState.PRE_SECONDARY_ASSESSMENT
         )
-        assert flaw.task_key == "TASK-123"
+        assert flaw.task_key == "OSIM-123"
 
         # check that a flaw and related objects (except for snippets) have public ACLs
         assert flaw.is_public
@@ -608,7 +580,7 @@ class TestFlawDraft:
 
         assert Flaw.objects.count() == 1
         flaw = Flaw.objects.first()
-        assert flaw.task_key == "TASK-123"
+        assert flaw.task_key == "OSIM-123"
         assert flaw.classification["workflow"] == "DEFAULT"
         assert flaw.classification["state"] == WorkflowModel.WorkflowState.NEW
         assert flaw.is_internal is True

--- a/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_collect.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_collect.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -210,21 +210,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -245,9 +249,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:39 GMT
+      - Tue, 26 Nov 2024 12:05:55 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:39 GMT
+      - Tue, 26 Nov 2024 12:05:55 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -260,17 +264,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 702x214280x1
+      - 725x1711877x1
       x-asessionid:
-      - 154jn9w
+      - vmb9sd
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -282,316 +286,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719574959.32d64b5b
+      - 0.dfb1060.1732622755.7eeb4686
       x-rh-edge-request-id:
-      - 32d64b5b
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:39 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:39 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 702x214281x1
-      x-asessionid:
-      - 18gu9x1
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719574959.32d64c48
-      x-rh-edge-request-id:
-      - 32d64c48
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:39 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:39 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 702x214282x1
-      x-asessionid:
-      - 16x8lvt
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719574959.32d64d90
-      x-rh-edge-request-id:
-      - 32d64d90
+      - 7eeb4686
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -603,7 +300,8 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2020-10000 kernel: some description", "description": "Comment zero for
       CVE-2020-10000", "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-      "impact:IMPORTANT", "major_incident"], "priority": {"name": "Major"}}}'
+      "impact:IMPORTANT", "CVE-2020-10000"], "priority": {"name": "Major"}, "assignee":
+      {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -614,18 +312,18 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '304'
+      - '330'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16090950", "key": "OSIM-495", "self": "https://example.com/rest/api/2/issue/16090950"}'
+      string: '{"id": "16312059", "key": "OSIM-14341", "self": "https://example.com/rest/api/2/issue/16312059"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -635,9 +333,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:40 GMT
+      - Tue, 26 Nov 2024 12:05:58 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:40 GMT
+      - Tue, 26 Nov 2024 12:05:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -650,19 +348,19 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '2'
+      - '3'
       content-length:
-      - '101'
+      - '103'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 702x214283x1
+      - 725x1711879x1
       x-asessionid:
-      - 1dkzmpl
+      - 1iwzs1q
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -674,9 +372,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719574959.32d64ebb
+      - 0.dfb1060.1732622755.7eeb475a
       x-rh-edge-request-id:
-      - 32d64ebb
+      - 7eeb475a
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -698,90 +396,100 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-495
+    uri: https://example.com/rest/api/2/issue/OSIM-14341
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090950", "self": "https://example.com/rest/api/2/issue/16090950",
-        "key": "OSIM-495", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@56aa7440[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f4961c7[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
+        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5a9a784d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2cde79c0[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3effbc10[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@a0ca551[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f116272[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7274a6dd[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@31a88bbf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5e6196f6[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a376dba[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5da2606f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28a2fd17[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7a2608d3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f55022c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@601a6c7f[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6b927335[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7fe7cb32[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6834f280[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5bfe126d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@238dd9fc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@62f228e4[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d9d76c8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6db746c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-495/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T11:42:39.549+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT", "major_incident"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T11:42:39.549+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:fb145b06-82a7-4851-a429-541288633d16",
+        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-495/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z5r:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T12:05:56.086+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i21qzr:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -790,9 +498,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:40 GMT
+      - Tue, 26 Nov 2024 12:05:58 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:40 GMT
+      - Tue, 26 Nov 2024 12:05:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -805,17 +513,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8817'
+      - '9404'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 702x214284x1
+      - 725x1711892x1
       x-asessionid:
-      - 182ivda
+      - 5zqvtd
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -827,9 +535,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719574960.32d65c1b
+      - 0.dfb1060.1732622758.7eeb5336
       x-rh-edge-request-id:
-      - 32d65c1b
+      - 7eeb5336
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -851,90 +559,100 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-495
+    uri: https://example.com/rest/api/2/issue/OSIM-14341
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090950", "self": "https://example.com/rest/api/2/issue/16090950",
-        "key": "OSIM-495", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7197c949[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5fe357f8[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
+        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6eaa2c7f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@24fbf62a[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@47f6a126[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@26f62b7[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@22d8e44b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@d749f1e[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7f79e007[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6fa4f85[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@636519ad[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4ac0e6b0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a095e37[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2edbb094[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2809e64a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@53380fc7[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a5c61ac[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6203de70[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@55f4fcc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@168a2e97[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7fb27ceb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3bedd33[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ce0c3a7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3b59b43a[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-495/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T11:42:39.549+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT", "major_incident"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T11:42:39.549+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:fb145b06-82a7-4851-a429-541288633d16",
+        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-495/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z5r:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T12:05:56.086+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i21qzr:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -943,9 +661,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:41 GMT
+      - Tue, 26 Nov 2024 12:05:58 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:41 GMT
+      - Tue, 26 Nov 2024 12:05:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -958,7 +676,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8816'
+      - '9402'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -966,9 +684,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 702x214285x1
+      - 725x1719582x1
       x-asessionid:
-      - wdprau
+      - 6jtb1l
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -980,9 +698,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719574961.89d44fec
+      - 0.18fb1060.1732622758.880b8d87
       x-rh-edge-request-id:
-      - 89d44fec
+      - 880b8d87
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1003,15 +721,15 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '87'
+      - '93'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-495
+    uri: https://example.com/rest/api/2/issue/OSIM-14341
   response:
     body:
       string: ''
@@ -1023,9 +741,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:42 GMT
+      - Tue, 26 Nov 2024 12:05:59 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:42 GMT
+      - Tue, 26 Nov 2024 12:05:59 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1041,9 +759,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 702x214286x1
+      - 725x1719603x1
       x-asessionid:
-      - zw3wvg
+      - 10iws4f
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1055,9 +773,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719574961.89d45322
+      - 0.18fb1060.1732622758.880b9351
       x-rh-edge-request-id:
-      - 89d45322
+      - 880b9351
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1079,11 +797,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-495/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14341/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -1128,9 +846,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:42 GMT
+      - Tue, 26 Nov 2024 12:05:59 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:42 GMT
+      - Tue, 26 Nov 2024 12:05:59 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1151,9 +869,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 702x214287x1
+      - 725x1719650x1
       x-asessionid:
-      - 1x9wp1t
+      - mnoodr
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1165,9 +883,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719574962.89d46e7e
+      - 0.18fb1060.1732622759.880ba63e
       x-rh-edge-request-id:
-      - 89d46e7e
+      - 880ba63e
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1191,11 +909,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-495/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14341/transitions
   response:
     body:
       string: ''
@@ -1207,9 +925,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:43 GMT
+      - Tue, 26 Nov 2024 12:06:00 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:43 GMT
+      - Tue, 26 Nov 2024 12:06:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1217,7 +935,7 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '3'
+      - '4'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1225,9 +943,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 702x214288x1
+      - 726x1719657x2
       x-asessionid:
-      - 1a7zcl5
+      - 1pe58rc
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1239,9 +957,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719574962.89d4724a
+      - 0.18fb1060.1732622760.880ba98f
       x-rh-edge-request-id:
-      - 89d4724a
+      - 880ba98f
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1263,843 +981,100 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-495
+    uri: https://example.com/rest/api/2/issue/OSIM-14341
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090950", "self": "https://example.com/rest/api/2/issue/16090950",
-        "key": "OSIM-495", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6ad753ba[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2064b2b5[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
+        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5ca7ffaf[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a9012c6[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@240175b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@734ecbc[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@54677d6d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@50189044[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5260bfd3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7291e82f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1df26f05[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@97c464f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5eb5fe94[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2318b5fd[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4b579d89[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@110bb007[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ffc127[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5ce6b771[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2baac2b1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@676dc44b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1fe3c778[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7657a6ca[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b954dfb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2d38f5e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-495/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T11:42:39.549+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
         "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T11:42:42.803+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-495/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z5r:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:43 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:43 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8767'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 702x214289x1
-      x-asessionid:
-      - 19ief8q
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719574963.89d489aa
-      x-rh-edge-request-id:
-      - 89d489aa
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-495
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090950", "self": "https://example.com/rest/api/2/issue/16090950",
-        "key": "OSIM-495", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
         "id": "17", "description": "Created by Jira Software - do not edit or delete.
         Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7e54ab7e[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d842f2d[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@26547ad1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1a15d471[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@29425975[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@55b4d718[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5033ad8d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@64314da6[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f8329a4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2c7c295b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@61eeb69c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@fdc8b7a[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-495/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T11:42:39.549+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
-        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
-        "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T11:42:42.803+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-495/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z5r:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:44 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:44 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8769'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 702x214290x1
-      x-asessionid:
-      - 858pih
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719574964.89d491b8
-      x-rh-edge-request-id:
-      - 89d491b8
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
-  response:
-    body:
-      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
-        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
-        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
-        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
-        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
-        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
-        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
-        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
-        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
-        "description": "Allows users in a software project to view development-related
-        information on the issue, such as commits, reviews and build information.",
-        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
-        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
-        a collection of issues at once. For example, resolve multiple issues in one
-        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
-        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
-        "Users with this permission may create attachments.", "havePermission": true,
-        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
-        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
-        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
-        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
-        "description": "Ability to log work done against an issue. Only useful if
-        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
-        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
-        "description": "Ability to administer a project in Jira.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
-        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
-        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
-        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
-        with this permission may delete own attachments.", "havePermission": true,
-        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
-        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
-        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
-        "type": "PROJECT", "description": "Ability to close issues. Often useful where
-        your developers resolve issues, and a QA department closes them.", "havePermission":
-        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
-        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
-        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
-        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
-        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
-        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
-        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
-        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
-        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
-        "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
-        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
-        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
-        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
-        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
-        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
-        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
-        "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
-        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
-        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
-        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
-        "type": "PROJECT", "description": "Ability to link issues together and create
-        linked issues. Only useful if issue linking is turned on.", "havePermission":
-        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
-        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
-        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
-        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
-        "PROJECT", "description": "Users with this permission may create attachments.",
-        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
-        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
-        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
-        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
-        "description": "Ability to view or edit an issue''s due date.", "havePermission":
-        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
-        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
-        issues. Often useful where your developers resolve issues, and a QA department
-        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
-        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
-        "description": "Ability to set the level of security on an issue so that only
-        people in that security level can see the issue.", "havePermission": true},
-        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
-        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
-        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
-        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
-        "Ability to delete all worklogs made on issues.", "havePermission": true,
-        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
-        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
-        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
-        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
-        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
-        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
-        "PROJECT", "description": "Ability to delete all comments made on issues.",
-        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
-        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
-        and reopen issues. This includes the ability to set a fix version.", "havePermission":
-        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
-        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
-        with this permission may view a read-only version of a workflow.", "havePermission":
-        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
-        "type": "GLOBAL", "description": "Ability to perform most administration functions
-        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
-        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
-        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
-        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
-        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
-        "Ability to move issues between projects or between workflows of the same
-        project (if applicable). Note the user can only move issues to a project he
-        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
-        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
-        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
-        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
-        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
-        "description": "Ability to perform all administration functions. There must
-        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
-        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
-        "type": "PROJECT", "description": "Ability to delete own worklogs made on
-        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
-        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
-        projects and the issues within them.", "havePermission": true, "deprecatedKey":
-        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
-        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
-        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
-        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
-        the reporter when creating or editing an issue.", "havePermission": true},
-        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
-        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
-        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
-        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
-        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
-        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
-        "description": "Ability to edit own comments made on issues.", "havePermission":
-        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
-        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
-        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
-        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
-        "Ability to browse projects and the issues within them.", "havePermission":
-        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
-        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
-        Results OKRs (Objective and key results) that are linked to a given issue",
-        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
-        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
-        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
-        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
-        "PROJECT", "description": "Ability to browse archived issues from a specific
-        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
-        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
-        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
-        allows to select other user as automation rule actor", "havePermission": true},
-        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
-        "View Development Tools", "type": "PROJECT", "description": "Allows users
-        to view development-related information on the view issue screen, like commits,
-        reviews and build information.", "havePermission": true, "deprecatedKey":
-        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
-        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
-        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
-        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
-        "Ability to log work done against an issue. Only useful if Time Tracking is
-        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
-        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
-        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
-        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
-        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
-        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
-        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
-        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
-        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
-        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
-        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
-        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
-        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
-        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
-        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
-        a user or group from a popup window as well as the ability to use the ''share''
-        issues feature. Users with this permission will also be able to see names
-        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
-        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
-        "type": "GLOBAL", "description": "Ability to share dashboards and filters
-        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
-        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
-        "type": "PROJECT", "description": "Users with this permission may delete all
-        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
-        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
-        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
-        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
-        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
-        (create and delete) group filter subscriptions.", "havePermission": true},
-        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
-        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
-        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
-        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
-        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
-        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
-        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
-        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
-        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
-        "Ability to link issues together and create linked issues. Only useful if
-        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
-        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
-        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
-        and key results) that are linked to a given issue", "havePermission": false}}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:44 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:44 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '16299'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 702x590423x1
-      x-asessionid:
-      - 9wyfv0
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719574964.32d68c84
-      x-rh-edge-request-id:
-      - 32d68c84
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:44 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:44 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 702x590424x1
-      x-asessionid:
-      - 1jko7js
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719574964.32d68db1
-      x-rh-edge-request-id:
-      - 32d68db1
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T12:06:00.149+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i21qzr:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2108,9 +1083,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:44 GMT
+      - Tue, 26 Nov 2024 12:06:01 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:44 GMT
+      - Tue, 26 Nov 2024 12:06:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2118,99 +1093,22 @@ interactions:
       Vary:
       - User-Agent
       - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 702x590425x1
-      x-asessionid:
-      - 1m1bb79
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719574964.32d68f9e
-      x-rh-edge-request-id:
-      - 32d68f9e
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "CVE-2020-10000 kernel: some description", "description": "Comment zero for
-      CVE-2020-10000", "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-      "impact:IMPORTANT", "major_incident"], "priority": {"name": "Minor"}}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '298'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-495
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 11:42:45 GMT
-      Expires:
-      - Fri, 28 Jun 2024 11:42:45 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
       - '2'
+      content-length:
+      - '9359'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 702x590426x1
+      - 726x1719674x6
       x-asessionid:
-      - 137s4aq
+      - a5o1bs
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2222,16 +1120,16 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719574964.32d690d6
+      - 0.18fb1060.1732622760.880bbd6d
       x-rh-edge-request-id:
-      - 32d690d6
+      - 880bbd6d
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
     status:
-      code: 204
-      message: No Content
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
@@ -2246,90 +1144,100 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-495
+    uri: https://example.com/rest/api/2/issue/OSIM-14341
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090950", "self": "https://example.com/rest/api/2/issue/16090950",
-        "key": "OSIM-495", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@753b60ec[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e5a457a[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
+        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1c1d45e8[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10e12080[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4c2735a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@40dad8ce[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3052dce[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4952cd5c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3cad43ce[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2aa7e03d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@66c3fa[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5f01d687[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9645d9a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1c57e283[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6eb9475d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@77c59f2a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a401143[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2953613f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@df448e7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5693babc[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@c837324[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3e6ba112[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@11776548[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5afa6b80[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-495/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T11:42:39.549+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT", "major_incident"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T11:42:44.995+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
+        "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
+        "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
+        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Comment zero for CVE-2020-10000",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "CVE-2020-10000
-        kernel: some description", "customfield_12323640": null, "customfield_12323642":
-        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-495/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z5r:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T12:06:00.149+0000", "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i21qzr:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2338,9 +1246,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 11:42:46 GMT
+      - Tue, 26 Nov 2024 12:06:01 GMT
       Expires:
-      - Fri, 28 Jun 2024 11:42:46 GMT
+      - Tue, 26 Nov 2024 12:06:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2353,7 +1261,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8783'
+      - '9360'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2361,9 +1269,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 702x590430x1
+      - 726x1711921x1
       x-asessionid:
-      - 1sch7qu
+      - mr119h
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2375,9 +1283,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719574965.32d69c5b
+      - 0.dfb1060.1732622761.7eeb63c7
       x-rh-edge-request-id:
-      - 32d69c5b
+      - 7eeb63c7
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -2,6 +2,7 @@ import json
 from datetime import datetime, timezone
 
 import pytest
+from freezegun import freeze_time
 from jira.exceptions import JIRAError
 
 from apps.taskman.service import JiraTaskmanQuerier
@@ -13,6 +14,7 @@ pytestmark = pytest.mark.integration
 
 
 class TestOSVCollector:
+    @freeze_time(datetime(2020, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.vcr
     def test_collect_osv_record_without_cve(self):
         """

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1048,9 +1048,6 @@ class Flaw(
         def _create_new_flaw():
             issue = jtq.create_or_update_task(self)
             self.task_key = issue.data["key"]
-            self.task_updated_dt = datetime.strptime(
-                issue.data["fields"]["updated"], "%Y-%m-%dT%H:%M:%S.%f%z"
-            )
             self.workflow_state = WorkflowModel.WorkflowState.NEW
             self.save(no_alerts=True, *args, **kwargs)
 
@@ -1097,9 +1094,6 @@ class Flaw(
                 )
                 self.workflow_state = workflow_state
                 self.workflow_name = workflow_name
-                self.task_updated_dt = datetime.strptime(
-                    issue.data["fields"]["updated"], "%Y-%m-%dT%H:%M:%S.%f%z"
-                )
                 self.adjust_acls(save=False)
                 self.save(no_alerts=True, *args, **kwargs)
         except Flaw.DoesNotExist:

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1049,8 +1049,7 @@ class Flaw(
         """
 
         def _create_new_flaw():
-            issue = jtq.create_or_update_task(self)
-            self.task_key = issue.data["key"]
+            self.task_key = jtq.create_or_update_task(self)
             self.workflow_state = WorkflowModel.WorkflowState.NEW
             self.save(no_alerts=True, *args, **kwargs)
 

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1047,9 +1047,6 @@ class Flaw(
 
         If the flaw is not OSIDB-authored then it's a no-op.
         """
-        # if there was no flaw then fail right away
-        old_flaw = Flaw.objects.get(uuid=self.uuid)
-
         def _create_task():
             self.task_updated_dt = timezone.now()  # timestamp at or before the change
             self.task_key = jtq.create_or_update_task(self)
@@ -1076,12 +1073,12 @@ class Flaw(
             return
 
         # we're handling a new OSIDB-authored flaw from collectors -- create
-        if not old_flaw.meta_attr.get("bz_id") and old_flaw.task_key == "":
+        if not self.meta_attr.get("bz_id") and self.task_key == "":
             _create_task()
             return
 
         # the flaw exists but the task doesn't, not an OSIDB-authored flaw -- no-op
-        if not old_flaw.task_key:
+        if not self.task_key:
             return
 
         # we're handling an existing OSIDB-authored flaw -- update

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1028,7 +1028,6 @@ class Flaw(
         jira_token,
         diff=None,
         force_creation=False,
-        force_update=False,
         *args,
         **kwargs,
     ):
@@ -1099,11 +1098,6 @@ class Flaw(
         # old pre-OSIDB flaw
         # resolved without task
         if not self.task_key:
-            return
-
-        # task force-update
-        if force_update:
-            _update_task(diff or {})
             return
 
         # task update

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1048,7 +1048,7 @@ class Flaw(
         If the flaw is not OSIDB-authored then it's a no-op.
         """
 
-        def _create_new_flaw():
+        def _create_task():
             self.task_key = jtq.create_or_update_task(self)
             self.workflow_state = WorkflowModel.WorkflowState.NEW
             self.save(no_alerts=True, *args, **kwargs)
@@ -1065,7 +1065,7 @@ class Flaw(
 
         # REST API can force new tasks since it has no access to flaw creation runtime -- create
         if force_creation:
-            _create_new_flaw()
+            _create_task()
             return
 
         try:
@@ -1073,7 +1073,7 @@ class Flaw(
 
             # we're handling a new OSIDB-authored flaw from collectors -- create
             if not old_flaw.meta_attr.get("bz_id") and old_flaw.task_key == "":
-                _create_new_flaw()
+                _create_task()
                 return
 
             # the flaw exists but the task doesn't, not an OSIDB-authored flaw -- no-op
@@ -1097,7 +1097,7 @@ class Flaw(
 
         except Flaw.DoesNotExist:
             # we're handling a new OSIDB-authored flaw -- create
-            _create_new_flaw()
+            _create_task()
 
     download_manager = models.ForeignKey(
         FlawDownloadManager, null=True, blank=True, on_delete=models.CASCADE

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1562,7 +1562,6 @@ class FlawSerializer(
     WorkflowModelSerializer,
     IncludeExcludeFieldsMixin,
     IncludeMetaAttrMixin,
-    JiraAPIKeyMixin,
     AlertMixinSerializer,
     HistoryMixinSerializer,
 ):

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -20,7 +20,7 @@ from pghistory.models import Events
 from rest_framework import serializers
 
 from apps.bbsync.mixins import BugzillaSyncMixin
-from apps.taskman.constants import JIRA_TASKMAN_AUTO_SYNC_FLAW, SYNC_REQUIRED_FIELDS
+from apps.taskman.constants import JIRA_TASKMAN_AUTO_SYNC_FLAW
 from apps.taskman.mixins import JiraTaskSyncMixin
 from apps.workflows.serializers import WorkflowModelSerializer
 from osidb.models import (
@@ -931,16 +931,9 @@ class JiraTaskSyncMixinSerializer(JiraAPIKeyMixin, serializers.ModelSerializer):
         """
         # to allow other mixings to override update we call parent's update method
         # and validate if an important change were made forcing a sync when it is needed
-        sync_required = any(
-            field in validated_data
-            and getattr(instance, field) != validated_data[field]
-            for field in SYNC_REQUIRED_FIELDS
-        )
         updated_instance = super().update(instance, validated_data)
-        if JIRA_TASKMAN_AUTO_SYNC_FLAW and sync_required:
-            updated_instance.tasksync(
-                jira_token=self.get_jira_token(), force_update=True
-            )
+        if JIRA_TASKMAN_AUTO_SYNC_FLAW:
+            updated_instance.tasksync(jira_token=self.get_jira_token())
         return updated_instance
 
     class Meta:

--- a/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinIntegration.test_api_changes.yaml
+++ b/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinIntegration.test_api_changes.yaml
@@ -11,12 +11,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh103"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -27,11 +27,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:40 GMT
+      - Tue, 26 Nov 2024 14:42:12 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -41,9 +41,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576400.331f802d
+      - 0.14fb1060.1732632131.934cc2
       x-rh-edge-request-id:
-      - 331f802d
+      - 934cc2
     status:
       code: 200
       message: OK
@@ -59,12 +59,14 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/user?match=monke%40banana.com
   response:
     body:
-      string: '{"users": []}'
+      string: '{"code": 505, "message": "Logged-out users cannot use the \"match\"
+        argument to this function to access any user information.", "documentation":
+        "https://example.com/docs/en/html/api/index.html", "error": true}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -75,11 +77,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '12'
+      - '211'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:40 GMT
+      - Tue, 26 Nov 2024 14:42:12 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -89,12 +91,12 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576400.331f8421
+      - 0.14fb1060.1732632132.9354c6
       x-rh-edge-request-id:
-      - 331f8421
+      - 9354c6
     status:
-      code: 200
-      message: OK
+      code: 401
+      message: Unauthorized
 - request:
     body: null
     headers:
@@ -109,14 +111,15 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
     uri: https://example.com/rest/api/2/user/search?includeActive=True&includeInactive=False&maxResults=50&username=monke%40banana.com
   response:
     body:
-      string: '[]'
+      string: '{"message": "Client must be authenticated to access this resource.",
+        "status-code": 401}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -125,53 +128,41 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:41 GMT
+      - Tue, 26 Nov 2024 14:42:13 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:41 GMT
+      - Tue, 26 Nov 2024 14:42:13 GMT
       Pragma:
       - no-cache
-      Retry-After:
-      - '0'
       Vary:
       - User-Agent
       - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
+      WWW-Authenticate:
+      - OAuth realm="https%3A%2F%2Fissues.redhat.com"
       content-length:
-      - '2'
+      - '85'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-prod-0
       x-arequestid:
-      - 726x591631x2
-      x-asessionid:
-      - f7tojn
+      - 882x19460475x9
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576401.8a6530cf
+      - 0.12fb1060.1732632132.847cc98f
       x-rh-edge-request-id:
-      - 8a6530cf
-      x-seraph-loginreason:
-      - OK
+      - 847cc98f
       x-xss-protection:
       - 1; mode=block
     status:
-      code: 200
-      message: OK
+      code: 401
+      message: Unauthorized
 - request:
     body: null
     headers:
@@ -186,7 +177,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -383,21 +374,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -418,9 +413,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:42 GMT
+      - Tue, 26 Nov 2024 14:42:13 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:42 GMT
+      - Tue, 26 Nov 2024 14:42:13 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -433,17 +428,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x216404x2
+      - 882x1730691x1
       x-asessionid:
-      - 11eww74
+      - b3dmg3
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -455,316 +450,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576401.8a654a93
+      - 0.18fb1060.1732632133.89f49d9a
       x-rh-edge-request-id:
-      - 8a654a93
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:42 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:42 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216405x2
-      x-asessionid:
-      - 3zz4mt
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576402.8a654ddb
-      x-rh-edge-request-id:
-      - 8a654ddb
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:42 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:42 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216406x2
-      x-asessionid:
-      - ng2afe
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576402.8a655214
-      x-rh-edge-request-id:
-      - 8a655214
+      - 89f49d9a
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -774,8 +462,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "Foo", "description": "test", "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-      "impact:LOW"], "priority": {"name": "Minor"}}}'
+      "Foo", "description": "test", "labels": ["flawuuid:fe329917-ace4-45d2-9876-9d00f6b715c6",
+      "impact:LOW"], "priority": {"name": "Minor"}, "assignee": {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -786,18 +474,18 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '217'
+      - '243'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16090954", "key": "OSIM-506", "self": "https://example.com/rest/api/2/issue/16090954"}'
+      string: '{"id": "16312414", "key": "OSIM-14639", "self": "https://example.com/rest/api/2/issue/16312414"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -806,9 +494,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:43 GMT
+      - Tue, 26 Nov 2024 14:42:14 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:43 GMT
+      - Tue, 26 Nov 2024 14:42:14 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -819,19 +507,19 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '2'
+      - '4'
       content-length:
-      - '101'
+      - '103'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x216407x2
+      - 882x1730695x2
       x-asessionid:
-      - 1ny3sxy
+      - iyslkg
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -843,9 +531,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576402.8a655594
+      - 0.18fb1060.1732632133.89f49f98
       x-rh-edge-request-id:
-      - 8a655594
+      - 89f49f98
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -867,88 +555,99 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
+    uri: https://example.com/rest/api/2/issue/OSIM-14639
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1bb7f36d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3b1faca4[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312414", "self": "https://example.com/rest/api/2/issue/16312414",
+        "key": "OSIM-14639", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@390ef63a[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67f63463[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@35c307ef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@737fe77f[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@758fc205[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@391924b6[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1448a005[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1880e9ec[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13149f13[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@63d83553[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3241e9a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2d91a988[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@443c3eff[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@123f5f37[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a96f2e5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3d8967eb[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@18677d63[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@70c94fbf[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1da58a99[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6be510f9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48caf483[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@72c4ee92[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-506/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:42.381+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Minor", "id": "4"}, "labels": ["flawuuid:fe329917-ace4-45d2-9876-9d00f6b715c6",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14639/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14639/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T14:42:13.583+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T14:42:13.583+0000", "timeoriginalestimate": null, "description":
+        "test", "timetracking": {}, "attachment": [], "customfield_12316542": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14655", "value": "False",
+        "id": "14655", "disabled": false}, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
         "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12323641": null, "customfield_12325148":
+        null, "customfield_12325143": null, "customfield_12325142": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "comment": {"comments":
+        [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141": null,
+        "customfield_12325140": null, "customfield_12310213": null, "customfield_12311940":
+        "2|i21swn:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -957,9 +656,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:43 GMT
+      - Tue, 26 Nov 2024 14:42:15 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:43 GMT
+      - Tue, 26 Nov 2024 14:42:15 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -972,17 +671,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8733'
+      - '9319'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x216410x1
+      - 882x1730711x2
       x-asessionid:
-      - 84m72m
+      - 155orw9
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -994,471 +693,13 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576403.8a657bc4
+      - 0.18fb1060.1732632134.89f4aff6
       x-rh-edge-request-id:
-      - 8a657bc4
+      - 89f4aff6
       x-seraph-loginreason:
       - OK
       x-xss-protection:
       - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:44 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576403.8a658ae2
-      x-rh-edge-request-id:
-      - 8a658ae2
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "id": 1, "email": "aander07@packetmaster.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:45 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576404.8a659bb4
-      x-rh-edge-request-id:
-      - 8a659bb4
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
-      "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
-      "", "severity": "low", "priority": "low", "summary": "curl: Foo", "description":
-      "test", "comment_is_private": false, "keywords": ["Security"], "flags": [],
-      "groups": [], "cc": [], "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-      \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-      \"mitigation\": \"mitigation\"}"}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '507'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: POST
-    uri: https://example.com/rest/bug
-  response:
-    body:
-      string: '{"id": 2294460}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '14'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:46 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576405.8a65ac55
-      x-rh-edge-request-id:
-      - 8a65ac55
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:46 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576406.33200950
-      x-rh-edge-request-id:
-      - '33200950'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"id": 1, "email": "aander07@packetmaster.com", "name":
-        "aander07@packetmaster.com", "can_login": true, "real_name": "Need Real Name"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:47 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576406.33200c4e
-      x-rh-edge-request-id:
-      - 33200c4e
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_last_closed": null, "status": "NEW", "cf_major_incident":
-        null, "groups": [], "deadline": null, "classification": "Other", "cf_pgm_internal":
-        "", "cf_conditional_nak": [], "url": "", "estimated_time": 0, "description":
-        "test", "alias": [], "cf_qe_conditional_nak": [], "blocks": [], "cf_clone_of":
-        null, "cf_pm_score": "0", "resolution": "", "severity": "low", "cf_doc_type":
-        "If docs needed, set a value", "component": ["vulnerability-draft"], "is_creator_accessible":
-        true, "cf_internal_whiteboard": "", "creator_detail": {"name": "conrado@redhat.com",
-        "real_name": "Conrado Costa", "active": true, "partner": false, "email": "conrado@redhat.com",
-        "insider": true, "id": 482384}, "sub_components": {}, "tags": [], "summary":
-        "curl: Foo", "creator": "conrado@redhat.com", "cf_embargoed": null, "is_cc_accessible":
-        true, "remaining_time": 0, "actual_time": 0, "cf_srtnotes": "{\"public\":
-        \"2000-01-01T22:03:26Z\", \"reported\": \"2022-11-22T15:55:22Z\", \"impact\":
-        \"low\", \"source\": \"debian\", \"mitigation\": \"mitigation\"}", "cf_cust_facing":
-        "---", "last_change_time": "2024-06-28T12:06:45Z", "cc": [], "op_sys": "Linux",
-        "depends_on": [], "cf_devel_whiteboard": "", "platform": "All", "target_milestone":
-        "---", "external_bugs": [], "cf_build_id": "", "data_category": "Public",
-        "keywords": ["Security"], "product": "Security Response", "cf_release_notes":
-        "", "assigned_to_detail": {"partner": false, "id": 377884, "insider": true,
-        "email": "prodsec-dev@redhat.com", "real_name": "Product Security DevOps Team",
-        "name": "prodsec-dev@redhat.com", "active": true}, "cf_environment": "", "qa_contact":
-        "", "cc_detail": [], "flags": [], "dupe_of": null, "cf_fixed_in": "", "id":
-        2294460, "creation_time": "2024-06-28T12:06:45Z", "comments": [{"count": 0,
-        "attachment_id": null, "bug_id": 2294460, "id": 18021221, "creation_time":
-        "2024-06-28T12:06:45Z", "text": "test", "time": "2024-06-28T12:06:45Z", "private_groups":
-        [], "creator_id": 482384, "is_private": false, "creator": "conrado@redhat.com",
-        "tags": []}], "whiteboard": "", "version": ["unspecified"], "assigned_to":
-        "prodsec-dev@redhat.com", "is_open": true, "is_confirmed": true, "cf_qa_whiteboard":
-        "", "target_release": ["---"], "priority": "low", "docs_contact": ""}], "faults":
-        []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:48 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2159'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576407.33201461
-      x-rh-edge-request-id:
-      - '33201461'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"url": "", "estimated_time": 0, "cf_pgm_internal": "", "cf_conditional_nak":
-        [], "deadline": null, "groups": [], "classification": "Other", "status": "NEW",
-        "cf_major_incident": null, "cf_last_closed": null, "cf_embargoed": null, "remaining_time":
-        0, "is_cc_accessible": true, "actual_time": 0, "cf_internal_whiteboard": "",
-        "creator_detail": {"partner": false, "insider": true, "id": 482384, "email":
-        "conrado@redhat.com", "real_name": "Conrado Costa", "name": "conrado@redhat.com",
-        "active": true}, "tags": [], "creator": "conrado@redhat.com", "summary": "curl:
-        Foo", "sub_components": {}, "is_creator_accessible": true, "severity": "low",
-        "resolution": "", "cf_doc_type": "If docs needed, set a value", "component":
-        ["vulnerability-draft"], "cf_pm_score": "0", "cf_qe_conditional_nak": [],
-        "blocks": [], "cf_clone_of": null, "description": "test", "alias": [], "keywords":
-        ["Security"], "cf_build_id": "", "data_category": "Public", "external_bugs":
-        [], "platform": "All", "target_milestone": "---", "depends_on": [], "cf_devel_whiteboard":
-        "", "last_change_time": "2024-06-28T12:06:45Z", "op_sys": "Linux", "cc": [],
-        "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\": \"2022-11-22T15:55:22Z\",
-        \"impact\": \"low\", \"source\": \"debian\", \"mitigation\": \"mitigation\"}",
-        "cf_cust_facing": "---", "target_release": ["---"], "priority": "low", "docs_contact":
-        "", "cf_qa_whiteboard": "", "whiteboard": "", "version": ["unspecified"],
-        "assigned_to": "prodsec-dev@redhat.com", "is_confirmed": true, "is_open":
-        true, "id": 2294460, "creation_time": "2024-06-28T12:06:45Z", "comments":
-        [{"creation_time": "2024-06-28T12:06:45Z", "id": 18021221, "bug_id": 2294460,
-        "count": 0, "attachment_id": null, "tags": [], "creator": "conrado@redhat.com",
-        "creator_id": 482384, "is_private": false, "private_groups": [], "time": "2024-06-28T12:06:45Z",
-        "text": "test"}], "cf_fixed_in": "", "cc_detail": [], "flags": [], "dupe_of":
-        null, "cf_environment": "", "qa_contact": "", "product": "Security Response",
-        "cf_release_notes": "", "assigned_to_detail": {"id": 377884, "insider": true,
-        "email": "prodsec-dev@redhat.com", "partner": false, "active": true, "real_name":
-        "Product Security DevOps Team", "name": "prodsec-dev@redhat.com"}}], "faults":
-        []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:48 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2159'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576408.332025f5
-      x-rh-edge-request-id:
-      - 332025f5
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460/comment
-  response:
-    body:
-      string: '{"comments": {}, "bugs": {"2294460": {"comments": [{"tags": [], "creator_id":
-        482384, "time": "2024-06-28T12:06:45Z", "creator": "conrado@redhat.com", "id":
-        18021221, "private_groups": [], "count": 0, "bug_id": 2294460, "creation_time":
-        "2024-06-28T12:06:45Z", "attachment_id": null, "text": "test", "is_private":
-        false}]}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '296'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:49 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576408.33203378
-      x-rh-edge-request-id:
-      - '33203378'
     status:
       code: 200
       message: OK
@@ -1476,7 +717,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -1673,21 +914,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -1708,9 +953,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:49 GMT
+      - Tue, 26 Nov 2024 14:42:16 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:49 GMT
+      - Tue, 26 Nov 2024 14:42:16 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1723,7 +968,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1731,9 +976,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 726x216443x2
+      - 882x1770039x1
       x-asessionid:
-      - mynjty
+      - 1hx2bzl
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1745,9 +990,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576409.8a663913
+      - 0.dfb1060.1732632135.7f5ff67e
       x-rh-edge-request-id:
-      - 8a663913
+      - 7f5ff67e
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1769,545 +1014,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:49 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:49 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216444x1
-      x-asessionid:
-      - ra68ez
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576409.8a663bc0
-      x-rh-edge-request-id:
-      - 8a663bc0
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:50 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:50 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216446x2
-      x-asessionid:
-      - vhoh30
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576410.8a66403b
-      x-rh-edge-request-id:
-      - 8a66403b
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "Foo", "description": "test", "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-      "impact:LOW", "team:program"], "priority": {"name": "Minor"}}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '233'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-506
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:51 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:51 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216448x1
-      x-asessionid:
-      - baoucq
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576410.8a664355
-      x-rh-edge-request-id:
-      - 8a664355
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@654aa075[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@677334f3[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@46752288[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@38df5219[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@84279c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@15f49f75[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a7a8e21[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@38f754ed[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@19ee3ca8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@28d007d7[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6758f6a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@427f375[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-506/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW", "team:program"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:50.370+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:51 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:51 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8744'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216454x1
-      x-asessionid:
-      - 1srvurq
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576411.8a666ba4
-      x-rh-edge-request-id:
-      - 8a666ba4
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14639/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -2352,9 +1063,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:51 GMT
+      - Tue, 26 Nov 2024 14:42:16 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:51 GMT
+      - Tue, 26 Nov 2024 14:42:16 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2375,9 +1086,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 726x216457x3
+      - 882x1770043x3
       x-asessionid:
-      - 1agccjf
+      - 1cbc6r0
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2389,9 +1100,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576411.8a6670ab
+      - 0.dfb1060.1732632136.7f5ff6f7
       x-rh-edge-request-id:
-      - 8a6670ab
+      - 7f5ff6f7
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2415,11 +1126,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-506/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14639/transitions
   response:
     body:
       string: ''
@@ -2431,9 +1142,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:52 GMT
+      - Tue, 26 Nov 2024 14:42:17 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:52 GMT
+      - Tue, 26 Nov 2024 14:42:17 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2449,9 +1160,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 726x216458x1
+      - 882x1770048x2
       x-asessionid:
-      - 1platfb
+      - tzfi25
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2463,9 +1174,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576411.8a667440
+      - 0.dfb1060.1732632136.7f5ff775
       x-rh-edge-request-id:
-      - 8a667440
+      - 7f5ff775
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2487,88 +1198,99 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
+    uri: https://example.com/rest/api/2/issue/OSIM-14639
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@12db716b[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3958633d[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16312414", "self": "https://example.com/rest/api/2/issue/16312414",
+        "key": "OSIM-14639", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2d355ec6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5bcf8108[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@e2864b3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7493afc0[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6653cca2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2905e4d2[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@644510bd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@dc15e5a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@758fb59c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@73aaec8b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f26dabb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3812608b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ce6c537[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@4b86ce62[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2ed1ad07[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5624981b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@cb12095[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@71b90abf[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5223381a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@20b58605[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2585af0e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1c50b5f3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-506/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW", "team:program"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:51.807+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        "Minor", "id": "4"}, "labels": ["flawuuid:fe329917-ace4-45d2-9876-9d00f6b715c6",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14639/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14639/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T14:42:13.583+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T14:42:16.335+0000", "timeoriginalestimate": null, "description":
+        "test", "timetracking": {}, "attachment": [], "customfield_12316542": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14655", "value": "False",
+        "id": "14655", "disabled": false}, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
         "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12323641": null, "customfield_12325148":
+        null, "customfield_12325143": null, "customfield_12325142": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "comment": {"comments":
+        [], "maxResults": 0, "total": 0, "startAt": 0}, "customfield_12325141": null,
+        "customfield_12325140": null, "customfield_12310213": null, "customfield_12311940":
+        "2|i21swn:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2577,9 +1299,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:52 GMT
+      - Tue, 26 Nov 2024 14:42:17 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:52 GMT
+      - Tue, 26 Nov 2024 14:42:17 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2592,17 +1314,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8720'
+      - '9292'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x216463x2
+      - 882x1730736x1
       x-asessionid:
-      - 1x5j7qw
+      - t2t3z9
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2614,682 +1336,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576412.8a668813
+      - 0.18fb1060.1732632137.89f4cc12
       x-rh-edge-request-id:
-      - 8a668813
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:52 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576412.33208c11
-      x-rh-edge-request-id:
-      - 33208c11
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"id": 1, "email": "aander07@packetmaster.com", "name":
-        "aander07@packetmaster.com", "can_login": true, "real_name": "Need Real Name"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:53 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576412.33208e63
-      x-rh-edge-request-id:
-      - 33208e63
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&include_fields=id&include_fields=last_change_time
-  response:
-    body:
-      string: '{"faults": [], "bugs": [{"data_category": "Public", "id": 2294460,
-        "last_change_time": "2024-06-28T12:06:45Z"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '104'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:53 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576413.332097c3
-      x-rh-edge-request-id:
-      - 332097c3
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
-      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
-      "", "severity": "low", "priority": "low", "summary": "curl: Foo", "keywords":
-      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
-      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-      \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-      \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
-      \"ps_component\": \"ps-component-0\", \"affectedness\": \"new\", \"resolution\":
-      null, \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
-      "cf_fixed_in": "", "ids": ["2294460"]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '751'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: PUT
-    uri: https://example.com/rest/bug/2294460
-  response:
-    body:
-      string: '{"bugs": [{"alias": [], "last_change_time": "2024-06-28T12:06:54Z",
-        "changes": {"component": {"added": "vulnerability", "removed": "vulnerability-draft"},
-        "cf_srtnotes": {"removed": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\":
-        \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\", \"mitigation\":
-        \"mitigation\"}", "added": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\":
-        \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\", \"mitigation\":
-        \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
-        \"ps-component-0\", \"affectedness\": \"new\", \"resolution\": null, \"impact\":
-        \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}"}}, "id": 2294460}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '718'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:55 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576414.3320a34c
-      x-rh-edge-request-id:
-      - 3320a34c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:55 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576415.3320c423
-      x-rh-edge-request-id:
-      - 3320c423
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"real_name": "Need Real Name", "name": "aander07@packetmaster.com",
-        "id": 1, "email": "aander07@packetmaster.com", "can_login": true}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:56 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576415.3320c6cf
-      x-rh-edge-request-id:
-      - 3320c6cf
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_pm_score": "0", "deadline": null, "platform": "All",
-        "blocks": [], "depends_on": [], "target_release": ["---"], "groups": [], "cf_clone_of":
-        null, "comments": [{"creator_id": 482384, "time": "2024-06-28T12:06:45Z",
-        "tags": [], "creator": "conrado@redhat.com", "private_groups": [], "count":
-        0, "id": 18021221, "bug_id": 2294460, "creation_time": "2024-06-28T12:06:45Z",
-        "is_private": false, "text": "test", "attachment_id": null}], "cf_internal_whiteboard":
-        "", "cf_last_closed": null, "docs_contact": "", "description": "test", "is_cc_accessible":
-        true, "creator_detail": {"partner": false, "name": "conrado@redhat.com", "real_name":
-        "Conrado Costa", "id": 482384, "active": true, "insider": true, "email": "conrado@redhat.com"},
-        "qa_contact": "", "cf_release_notes": "", "summary": "curl: Foo", "flags":
-        [], "cf_conditional_nak": [], "is_confirmed": true, "cf_doc_type": "If docs
-        needed, set a value", "is_open": true, "priority": "low", "cf_environment":
-        "", "assigned_to_detail": {"real_name": "Product Security DevOps Team", "partner":
-        false, "name": "prodsec-dev@redhat.com", "email": "prodsec-dev@redhat.com",
-        "insider": true, "active": true, "id": 377884}, "remaining_time": 0, "tags":
-        [], "external_bugs": [], "cf_devel_whiteboard": "", "version": ["unspecified"],
-        "id": 2294460, "last_change_time": "2024-06-28T12:06:54Z", "creation_time":
-        "2024-06-28T12:06:45Z", "cf_qe_conditional_nak": [], "assigned_to": "prodsec-dev@redhat.com",
-        "cf_fixed_in": "", "severity": "low", "cf_pgm_internal": "", "cf_cust_facing":
-        "---", "cc": [], "component": ["vulnerability"], "creator": "conrado@redhat.com",
-        "cc_detail": [], "resolution": "", "data_category": "Public", "sub_components":
-        {}, "whiteboard": "", "actual_time": 0, "cf_build_id": "", "url": "", "is_creator_accessible":
-        true, "cf_major_incident": null, "alias": [], "estimated_time": 0, "classification":
-        "Other", "keywords": ["Security"], "status": "NEW", "cf_embargoed": null,
-        "cf_qa_whiteboard": "", "product": "Security Response", "target_milestone":
-        "---", "op_sys": "Linux", "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-        \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
-        \"ps_component\": \"ps-component-0\", \"affectedness\": \"new\", \"resolution\":
-        null, \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
-        "dupe_of": null}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:56 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2361'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576416.3320d25a
-      x-rh-edge-request-id:
-      - 3320d25a
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_cust_facing": "---", "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-        \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
-        \"ps_component\": \"ps-component-0\", \"affectedness\": \"new\", \"resolution\":
-        null, \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
-        "last_change_time": "2024-06-28T12:06:54Z", "cc": [], "op_sys": "Linux", "depends_on":
-        [], "cf_devel_whiteboard": "", "target_milestone": "---", "platform": "All",
-        "external_bugs": [], "cf_build_id": "", "data_category": "Public", "keywords":
-        ["Security"], "cf_release_notes": "", "product": "Security Response", "assigned_to_detail":
-        {"active": true, "name": "prodsec-dev@redhat.com", "real_name": "Product Security
-        DevOps Team", "email": "prodsec-dev@redhat.com", "insider": true, "id": 377884,
-        "partner": false}, "cf_environment": "", "qa_contact": "", "flags": [], "cc_detail":
-        [], "dupe_of": null, "cf_fixed_in": "", "id": 2294460, "comments": [{"id":
-        18021221, "creation_time": "2024-06-28T12:06:45Z", "count": 0, "attachment_id":
-        null, "bug_id": 2294460, "creator_id": 482384, "is_private": false, "tags":
-        [], "creator": "conrado@redhat.com", "text": "test", "time": "2024-06-28T12:06:45Z",
-        "private_groups": []}], "creation_time": "2024-06-28T12:06:45Z", "version":
-        ["unspecified"], "whiteboard": "", "is_confirmed": true, "is_open": true,
-        "assigned_to": "prodsec-dev@redhat.com", "cf_qa_whiteboard": "", "target_release":
-        ["---"], "docs_contact": "", "priority": "low", "cf_last_closed": null, "status":
-        "NEW", "cf_major_incident": null, "classification": "Other", "groups": [],
-        "deadline": null, "cf_conditional_nak": [], "cf_pgm_internal": "", "url":
-        "", "estimated_time": 0, "alias": [], "description": "test", "cf_qe_conditional_nak":
-        [], "blocks": [], "cf_clone_of": null, "cf_pm_score": "0", "cf_doc_type":
-        "If docs needed, set a value", "severity": "low", "resolution": "", "component":
-        ["vulnerability"], "is_creator_accessible": true, "cf_internal_whiteboard":
-        "", "creator": "conrado@redhat.com", "tags": [], "sub_components": {}, "summary":
-        "curl: Foo", "creator_detail": {"partner": false, "email": "conrado@redhat.com",
-        "insider": true, "id": 482384, "name": "conrado@redhat.com", "real_name":
-        "Conrado Costa", "active": true}, "actual_time": 0, "remaining_time": 0, "is_cc_accessible":
-        true, "cf_embargoed": null}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:58 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2361'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576416.3320e1fc
-      x-rh-edge-request-id:
-      - 3320e1fc
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460/comment
-  response:
-    body:
-      string: '{"bugs": {"2294460": {"comments": [{"bug_id": 2294460, "count": 0,
-        "attachment_id": null, "creation_time": "2024-06-28T12:06:45Z", "id": 18021221,
-        "private_groups": [], "time": "2024-06-28T12:06:45Z", "text": "test", "tags":
-        [], "creator": "conrado@redhat.com", "creator_id": 482384, "is_private": false}]}},
-        "comments": {}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '296'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:58 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576418.33210278
-      x-rh-edge-request-id:
-      - '33210278'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7d1a7d43[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2f1b7267[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e97170a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6a6bd6f5[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@31d6bed8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4dc26c6b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6b4b1d9e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5fa3b27c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5b87e72e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5f87901[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@366c23cd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@741e572e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-506/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW", "team:program"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:51.807+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:59 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:59 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8721'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216516x2
-      x-asessionid:
-      - 1fh1qbr
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576419.8a6773a4
-      x-rh-edge-request-id:
-      - 8a6773a4
+      - 89f4cc12
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3311,7 +1360,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -3508,21 +1557,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -3543,9 +1596,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:59 GMT
+      - Tue, 26 Nov 2024 14:42:18 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:59 GMT
+      - Tue, 26 Nov 2024 14:42:18 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3558,17 +1611,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 726x591679x2
+      - 882x1770069x1
       x-asessionid:
-      - 15hshsf
+      - 1wx4ltu
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3580,9 +1633,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576419.8a6781d5
+      - 0.dfb1060.1732632138.7f5ffd06
       x-rh-edge-request-id:
-      - 8a6781d5
+      - 7f5ffd06
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3604,545 +1657,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 727x591680x1
-      x-asessionid:
-      - z58vp3
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576420.8a67855e
-      x-rh-edge-request-id:
-      - 8a67855e
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 727x591682x2
-      x-asessionid:
-      - 1tkqktd
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576420.8a67899e
-      x-rh-edge-request-id:
-      - 8a67899e
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "Foo", "description": "test", "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-      "impact:LOW", "team:program"], "priority": {"name": "Minor"}}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '233'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-506
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '2'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 727x591684x2
-      x-asessionid:
-      - kdmxje
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576420.8a678d5b
-      x-rh-edge-request-id:
-      - 8a678d5b
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@38e7b49f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@138202a6[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7e0fd3d6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7d1b6983[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7960163e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4c87e8dd[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4c9603f8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@6a672c98[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@13cf060c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@60fdd5a8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1c88938c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@4f586f69[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-506/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW", "team:program"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:51.807+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:07:00 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '2'
-      content-length:
-      - '8722'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 727x591687x1
-      x-asessionid:
-      - t8ly3a
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576420.8a6793e4
-      x-rh-edge-request-id:
-      - 8a6793e4
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14639/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -4187,9 +1706,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:07:00 GMT
+      - Tue, 26 Nov 2024 14:42:18 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:07:00 GMT
+      - Tue, 26 Nov 2024 14:42:18 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -4208,11 +1727,11 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 727x591692x3
+      - 882x1770071x1
       x-asessionid:
-      - 1k7h5gz
+      - 1x4cl5y
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -4224,9 +1743,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576420.8a679e5d
+      - 0.dfb1060.1732632138.7f5ffd79
       x-rh-edge-request-id:
-      - 8a679e5d
+      - 7f5ffd79
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -4251,11 +1770,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-506/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14639/transitions
   response:
     body:
       string: ''
@@ -4267,9 +1786,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:07:01 GMT
+      - Tue, 26 Nov 2024 14:42:19 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:07:01 GMT
+      - Tue, 26 Nov 2024 14:42:19 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -4277,17 +1796,17 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '2'
+      - '4'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 727x591694x1
+      - 882x1770073x1
       x-asessionid:
-      - 1ebh55o
+      - 16mvedj
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -4299,9 +1818,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576420.8a67a2a1
+      - 0.dfb1060.1732632138.7f5ffdfb
       x-rh-edge-request-id:
-      - 8a67a2a1
+      - 7f5ffdfb
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -4309,673 +1828,6 @@ interactions:
     status:
       code: 204
       message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
-        "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@18edebb6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1135fd[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ff198d7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@76c6e409[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@706d450d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4bf17e3e[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38b570b7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@79122d04[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@634d5a06[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@230dc8df[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@302e24c1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@583c45cd[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-06-28T12:07:00.897+0000", "workratio": -1, "customfield_12316840":
-        null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
-        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-506/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000",
-        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
-        "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW", "team:program"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:07:00.919+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
-        "description": "The issue is closed. See the resolution for context regarding
-        why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
-        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
-        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:01 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:07:01 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8908'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 727x591695x1
-      x-asessionid:
-      - 1fee283
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576421.8a67be66
-      x-rh-edge-request-id:
-      - 8a67be66
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:02 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576422.33215bbb
-      x-rh-edge-request-id:
-      - 33215bbb
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "id": 1, "email": "aander07@packetmaster.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:02 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576422.33215edc
-      x-rh-edge-request-id:
-      - 33215edc
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&include_fields=id&include_fields=last_change_time
-  response:
-    body:
-      string: '{"bugs": [{"id": 2294460, "data_category": "Public", "last_change_time":
-        "2024-06-28T12:06:54Z"}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '104'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:03 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576422.3321652f
-      x-rh-edge-request-id:
-      - 3321652f
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
-      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
-      "", "severity": "low", "priority": "low", "summary": "curl: Foo", "keywords":
-      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
-      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-      \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-      \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
-      \"ps_component\": \"ps-component-0\", \"affectedness\": \"new\", \"resolution\":
-      null, \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
-      "cf_fixed_in": "", "ids": ["2294460"]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '751'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: PUT
-    uri: https://example.com/rest/bug/2294460
-  response:
-    body:
-      string: '{"bugs": [{"id": 2294460, "alias": [], "changes": {}, "last_change_time":
-        "2024-06-28T12:06:54Z"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '91'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:04 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576423.33217358
-      x-rh-edge-request-id:
-      - '33217358'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:05 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576425.8a684389
-      x-rh-edge-request-id:
-      - 8a684389
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"name": "aander07@packetmaster.com", "real_name": "Need
-        Real Name", "can_login": true, "id": 1, "email": "aander07@packetmaster.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:06 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576425.8a684d15
-      x-rh-edge-request-id:
-      - 8a684d15
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"severity": "low", "cf_fixed_in": "", "assigned_to": "prodsec-dev@redhat.com",
-        "creation_time": "2024-06-28T12:06:45Z", "cf_qe_conditional_nak": [], "last_change_time":
-        "2024-06-28T12:06:54Z", "id": 2294460, "version": ["unspecified"], "external_bugs":
-        [], "tags": [], "cf_devel_whiteboard": "", "url": "", "is_creator_accessible":
-        true, "actual_time": 0, "cf_build_id": "", "whiteboard": "", "sub_components":
-        {}, "cc_detail": [], "resolution": "", "data_category": "Public", "component":
-        ["vulnerability"], "creator": "conrado@redhat.com", "cc": [], "cf_cust_facing":
-        "---", "cf_pgm_internal": "", "cf_embargoed": null, "status": "NEW", "classification":
-        "Other", "estimated_time": 0, "keywords": ["Security"], "cf_major_incident":
-        null, "alias": [], "dupe_of": null, "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\",
-        \"reported\": \"2022-11-22T15:55:22Z\", \"impact\": \"low\", \"source\": \"debian\",
-        \"mitigation\": \"mitigation\", \"affects\": [{\"ps_module\": \"ps-module-0\",
-        \"ps_component\": \"ps-component-0\", \"affectedness\": \"new\", \"resolution\":
-        null, \"impact\": \"low\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}",
-        "op_sys": "Linux", "target_milestone": "---", "cf_qa_whiteboard": "", "product":
-        "Security Response", "deadline": null, "cf_pm_score": "0", "target_release":
-        ["---"], "cf_clone_of": null, "groups": [], "blocks": [], "depends_on": [],
-        "platform": "All", "cf_release_notes": "", "qa_contact": "", "summary": "curl:
-        Foo", "creator_detail": {"real_name": "Conrado Costa", "name": "conrado@redhat.com",
-        "partner": false, "email": "conrado@redhat.com", "insider": true, "id": 482384,
-        "active": true}, "is_cc_accessible": true, "description": "test", "docs_contact":
-        "", "comments": [{"tags": [], "creator_id": 482384, "time": "2024-06-28T12:06:45Z",
-        "creator": "conrado@redhat.com", "id": 18021221, "private_groups": [], "count":
-        0, "creation_time": "2024-06-28T12:06:45Z", "bug_id": 2294460, "attachment_id":
-        null, "text": "test", "is_private": false}], "cf_internal_whiteboard": "",
-        "cf_last_closed": null, "remaining_time": 0, "assigned_to_detail": {"email":
-        "prodsec-dev@redhat.com", "insider": true, "active": true, "id": 377884, "real_name":
-        "Product Security DevOps Team", "partner": false, "name": "prodsec-dev@redhat.com"},
-        "is_open": true, "priority": "low", "cf_environment": "", "cf_doc_type": "If
-        docs needed, set a value", "is_confirmed": true, "cf_conditional_nak": [],
-        "flags": []}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:07 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2361'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576426.8a685b44
-      x-rh-edge-request-id:
-      - 8a685b44
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"url": "", "is_creator_accessible": true, "cf_build_id":
-        "", "actual_time": 0, "whiteboard": "", "sub_components": {}, "cc_detail":
-        [], "resolution": "", "data_category": "Public", "component": ["vulnerability"],
-        "creator": "conrado@redhat.com", "cc": [], "cf_cust_facing": "---", "cf_pgm_internal":
-        "", "severity": "low", "assigned_to": "prodsec-dev@redhat.com", "cf_fixed_in":
-        "", "creation_time": "2024-06-28T12:06:45Z", "cf_qe_conditional_nak": [],
-        "last_change_time": "2024-06-28T12:06:54Z", "id": 2294460, "version": ["unspecified"],
-        "cf_devel_whiteboard": "", "external_bugs": [], "tags": [], "dupe_of": null,
-        "cf_srtnotes": "{\"public\": \"2000-01-01T22:03:26Z\", \"reported\": \"2022-11-22T15:55:22Z\",
-        \"impact\": \"low\", \"source\": \"debian\", \"mitigation\": \"mitigation\",
-        \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\": \"ps-component-0\",
-        \"affectedness\": \"new\", \"resolution\": null, \"impact\": \"low\", \"cvss2\":
-        null, \"cvss3\": null, \"cvss4\": null}]}", "op_sys": "Linux", "target_milestone":
-        "---", "cf_qa_whiteboard": "", "product": "Security Response", "cf_embargoed":
-        null, "status": "NEW", "classification": "Other", "estimated_time": 0, "keywords":
-        ["Security"], "cf_major_incident": null, "alias": [], "cf_clone_of": null,
-        "target_release": ["---"], "groups": [], "blocks": [], "depends_on": [], "platform":
-        "All", "deadline": null, "cf_pm_score": "0", "remaining_time": 0, "assigned_to_detail":
-        {"partner": false, "name": "prodsec-dev@redhat.com", "real_name": "Product
-        Security DevOps Team", "id": 377884, "active": true, "email": "prodsec-dev@redhat.com",
-        "insider": true}, "is_open": true, "cf_environment": "", "priority": "low",
-        "cf_doc_type": "If docs needed, set a value", "is_confirmed": true, "cf_conditional_nak":
-        [], "flags": [], "qa_contact": "", "cf_release_notes": "", "summary": "curl:
-        Foo", "creator_detail": {"insider": true, "email": "conrado@redhat.com", "active":
-        true, "id": 482384, "real_name": "Conrado Costa", "name": "conrado@redhat.com",
-        "partner": false}, "is_cc_accessible": true, "description": "test", "docs_contact":
-        "", "cf_internal_whiteboard": "", "comments": [{"id": 18021221, "count": 0,
-        "private_groups": [], "creator": "conrado@redhat.com", "tags": [], "creator_id":
-        482384, "time": "2024-06-28T12:06:45Z", "text": "test", "attachment_id": null,
-        "is_private": false, "creation_time": "2024-06-28T12:06:45Z", "bug_id": 2294460}],
-        "cf_last_closed": null}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:07 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2361'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576427.8a6882bf
-      x-rh-edge-request-id:
-      - 8a6882bf
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294460/comment
-  response:
-    body:
-      string: '{"comments": {}, "bugs": {"2294460": {"comments": [{"text": "test",
-        "time": "2024-06-28T12:06:45Z", "private_groups": [], "creator_id": 482384,
-        "is_private": false, "tags": [], "creator": "conrado@redhat.com", "count":
-        0, "attachment_id": null, "bug_id": 2294460, "id": 18021221, "creation_time":
-        "2024-06-28T12:06:45Z"}]}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '296'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:07:08 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576427.8a689369
-      x-rh-edge-request-id:
-      - 8a689369
-    status:
-      code: 200
-      message: OK
 - request:
     body: '{"body": "This is not a bug."}'
     headers:
@@ -4992,42 +1844,42 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-506/comment
+    uri: https://example.com/rest/api/2/issue/OSIM-14639/comment
   response:
     body:
-      string: '{"self": "https://example.com/rest/api/2/issue/16090954/comment/24973988",
-        "id": "24973988", "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "body": "This is not a bug.", "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "created": "2024-06-28T12:07:08.840+0000", "updated": "2024-06-28T12:07:08.840+0000"}'
+      string: '{"self": "https://example.com/rest/api/2/issue/16312414/comment/25580077",
+        "id": "25580077", "author": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "body":
+        "This is not a bug.", "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "created":
+        "2024-11-26T14:42:19.959+0000", "updated": "2024-11-26T14:42:19.959+0000"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - close
+      - keep-alive
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:07:10 GMT
+      - Tue, 26 Nov 2024 14:42:21 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:07:10 GMT
+      - Tue, 26 Nov 2024 14:42:21 GMT
       Location:
-      - https://example.com/rest/api/2/issue/16090954/comment/24973988
+      - https://example.com/rest/api/2/issue/16312414/comment/25580077
       Pragma:
       - no-cache
       Retry-After:
@@ -5040,7 +1892,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '1637'
+      - '1407'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -5048,9 +1900,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 727x591700x1
+      - 882x1730737x1
       x-asessionid:
-      - zjsnci
+      - 10z96de
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -5062,9 +1914,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576428.8a68ba37
+      - 0.18fb1060.1732632139.89f4e5fc
       x-rh-edge-request-id:
-      - 8a68ba37
+      - 89f4e5fc
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -5086,105 +1938,118 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-506
+    uri: https://example.com/rest/api/2/issue/OSIM-14639
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16090954", "self": "https://example.com/rest/api/2/issue/16090954",
-        "key": "OSIM-506", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
+        "id": "16312414", "self": "https://example.com/rest/api/2/issue/16312414",
+        "key": "OSIM-14639", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
         "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7f632cab[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7bf72d3f[overall=PullRequestOverallBean{stateCount=0,
+        Do"}, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@916b7aa[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5e40becc[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@772c27d6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@357062d9[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2de5f983[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5e635e48[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4867d0c5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7e3715ba[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7c1cd21e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@38c952cb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4e5e4cef[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@8021a5b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c302eac[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@775d5338[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7e272cde[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@55acdb37[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@78c4ca60[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@659d82d3[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@229b1362[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@115d0165[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f144ee4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@4616d6cf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-06-28T12:07:00.897+0000", "workratio": -1, "customfield_12316840":
-        null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
-        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-506/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-06-28T12:06:42.381+0000",
-        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
-        "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:c20bb4c0-f7d1-4076-802a-d52f47e1f1c1",
-        "impact:LOW", "team:program"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:07:08.840+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
+        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
+        "Minor", "id": "4"}, "labels": ["flawuuid:fe329917-ace4-45d2-9876-9d00f6b715c6",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
         "description": "The issue is closed. See the resolution for context regarding
         why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
         "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
         "id": 3, "key": "done", "colorName": "success", "name": "Done"}}, "components":
-        [], "timeoriginalestimate": null, "description": "test", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14639/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": "2024-11-26T14:42:18.753+0000", "customfield_12325150":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12319040": null, "customfield_12325047": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-14639/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-26T14:42:13.583+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-26T14:42:19.959+0000", "timeoriginalestimate": null, "description":
+        "test", "timetracking": {}, "attachment": [], "customfield_12316542": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14655", "value": "False",
+        "id": "14655", "disabled": false}, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
         "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
         "None", "customfield_12310840": "9223372036854775807", "summary": "Foo", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [{"self":
-        "https://example.com/rest/api/2/issue/16090954/comment/24973988", "id": "24973988",
-        "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "body": "This is not a bug.", "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "created": "2024-06-28T12:07:08.840+0000", "updated": "2024-06-28T12:07:08.840+0000"}],
-        "maxResults": 1, "total": 1, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-506/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z87:"}}'
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12323641": null, "customfield_12325148":
+        null, "customfield_12325143": null, "customfield_12325142": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "comment": {"comments":
+        [{"self": "https://example.com/rest/api/2/issue/16312414/comment/25580077",
+        "id": "25580077", "author": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "body":
+        "This is not a bug.", "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "created":
+        "2024-11-26T14:42:19.959+0000", "updated": "2024-11-26T14:42:19.959+0000"}],
+        "maxResults": 1, "total": 1, "startAt": 0}, "customfield_12325141": null,
+        "customfield_12325140": null, "customfield_12310213": null, "customfield_12311940":
+        "2|i21swn:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -5193,9 +2058,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:07:10 GMT
+      - Tue, 26 Nov 2024 14:42:21 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:07:10 GMT
+      - Tue, 26 Nov 2024 14:42:21 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -5208,17 +2073,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '10546'
+      - '10887'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 727x216659x2
+      - 882x1730739x1
       x-asessionid:
-      - 1gm4uo
+      - 2poovu
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -5230,9 +2095,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576430.8a6779c6
+      - 0.18fb1060.1732632141.89f4cefc
       x-rh-edge-request-id:
-      - 8a6779c6
+      - 89f4cefc
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinIntegration.test_manual_changes.yaml
+++ b/osidb/tests/cassettes/test_mixins/TestBugzillaJiraMixinIntegration.test_manual_changes.yaml
@@ -13,7 +13,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -210,21 +210,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -245,9 +249,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:05:59 GMT
+      - Mon, 25 Nov 2024 09:52:54 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:05:59 GMT
+      - Mon, 25 Nov 2024 09:52:54 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -260,17 +264,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 725x591513x1
+      - 592x1465814x1
       x-asessionid:
-      - 84elv4
+      - 47bem0
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -282,316 +286,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576359.8a5fc2b4
+      - 0.18fb1060.1732528374.722cdb10
       x-rh-edge-request-id:
-      - 8a5fc2b4
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:05:59 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:05:59 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 725x591514x1
-      x-asessionid:
-      - xn0f4e
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576359.8a5fc613
-      x-rh-edge-request-id:
-      - 8a5fc613
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:05:59 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:05:59 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 725x591515x1
-      x-asessionid:
-      - 8vapaq
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576359.8a5fcb88
-      x-rh-edge-request-id:
-      - 8a5fcb88
+      - 722cdb10
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -601,8 +298,8 @@ interactions:
       message: OK
 - request:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "title", "description": "comment_zero", "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-      "impact:LOW"], "priority": {"name": "Minor"}}}'
+      "title", "description": "comment_zero", "labels": ["flawuuid:341ac0fd-f128-4666-b758-877fa7429b82",
+      "impact:LOW"], "priority": {"name": "Minor"}, "assignee": {"name": ""}}}'
     headers:
       Accept:
       - application/json,*.*;q=0.9
@@ -613,33 +310,36 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '227'
+      - '253'
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16091066", "key": "OSIM-505", "self": "https://example.com/rest/api/2/issue/16091066"}'
+      string: '{"id": "16311787", "key": "OSIM-14264", "self": "https://example.com/rest/api/2/issue/16311787"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
-      - close
+      - keep-alive
+      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:01 GMT
+      - Mon, 25 Nov 2024 09:52:55 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:01 GMT
+      - Mon, 25 Nov 2024 09:52:55 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
+      Transfer-Encoding:
+      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
@@ -648,17 +348,17 @@ interactions:
       X-RateLimit-Remaining:
       - '3'
       content-length:
-      - '101'
+      - '103'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 726x591516x1
+      - 592x1465816x1
       x-asessionid:
-      - 1pm1jyt
+      - a6g19e
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -670,9 +370,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576359.8a5fd7b3
+      - 0.18fb1060.1732528374.722cdca0
       x-rh-edge-request-id:
-      - 8a5fd7b3
+      - 722cdca0
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -694,89 +394,99 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
+    uri: https://example.com/rest/api/2/issue/OSIM-14264
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@24c37110[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@841cdac[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16311787", "self": "https://example.com/rest/api/2/issue/16311787",
+        "key": "OSIM-14264", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3c40d462[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2975c37f[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2bf3e115[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2dd9656a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5956e73e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7734d909[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@437b65b3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@256fba83[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4beec607[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@1ac3b2e2[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@28d1af4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5a6e0384[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@72ecbfee[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7585f4f7[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@14c88487[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7013d821[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@67971a02[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@3d6f784b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6dd33fdd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@36f2096[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5cf77df3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1a9cfb06[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-505/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:00.035+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "Minor", "id": "4"}, "labels": ["flawuuid:341ac0fd-f128-4666-b758-877fa7429b82",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
         "description": "Initial creation status. Implies nothing yet and should be
         very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14264/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14264/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-25T09:52:54.359+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-25T09:52:54.359+0000", "timeoriginalestimate": null, "description":
+        "comment_zero", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "title", "customfield_12323640": null, "customfield_12325147":
+        null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
+        null, "customfield_12323641": null, "customfield_12325148": null, "customfield_12325143":
+        null, "customfield_12325142": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i21pa7:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -785,9 +495,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:02 GMT
+      - Mon, 25 Nov 2024 09:52:55 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:02 GMT
+      - Mon, 25 Nov 2024 09:52:55 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -800,17 +510,17 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8741'
+      - '9328'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 726x591521x1
+      - 592x1465823x1
       x-asessionid:
-      - 1h5enly
+      - 1def5ii
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -822,9 +532,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576362.8a60248c
+      - 0.18fb1060.1732528375.722ce774
       x-rh-edge-request-id:
-      - 8a60248c
+      - 722ce774
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -844,12 +554,12 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/version
   response:
     body:
-      string: '{"version": "5.0.4.rh98"}'
+      string: '{"version": "5.0.4.rh103"}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -860,11 +570,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '24'
+      - '25'
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:04 GMT
+      - Mon, 25 Nov 2024 09:52:55 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -874,9 +584,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576363.331c2a8f
+      - 0.18fb1060.1732528375.722cec75
       x-rh-edge-request-id:
-      - 331c2a8f
+      - 722cec75
     status:
       code: 200
       message: OK
@@ -892,13 +602,13 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: GET
     uri: https://example.com/rest/user?ids=1
   response:
     body:
-      string: '{"users": [{"real_name": "Need Real Name", "can_login": true, "name":
-        "aander07@packetmaster.com", "email": "aander07@packetmaster.com", "id": 1}]}'
+      string: '{"users": [{"id": 1, "can_login": true, "name": "aander07@packetmaster.com",
+        "email": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -913,7 +623,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:05 GMT
+      - Mon, 25 Nov 2024 09:52:56 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -923,9 +633,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576364.331c30ac
+      - 0.18fb1060.1732528376.722cee62
       x-rh-edge-request-id:
-      - 331c30ac
+      - 722cee62
     status:
       code: 200
       message: OK
@@ -934,9 +644,7 @@ interactions:
       "version": "unspecified", "component": "vulnerability-draft", "cf_release_notes":
       "", "severity": "low", "priority": "low", "summary": "curl: title", "description":
       "comment_zero", "comment_is_private": false, "keywords": ["Security"], "flags":
-      [], "groups": [], "cc": [], "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
-      \"reported\": \"2024-06-28T12:05:58Z\", \"impact\": \"low\", \"source\": \"internet\",
-      \"cwe\": \"CWE-1\"}"}'
+      [], "groups": [], "cc": []}'
     headers:
       Accept:
       - '*/*'
@@ -945,16 +653,16 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '507'
+      - '343'
       Content-Type:
       - application/json
       User-Agent:
-      - python-bugzilla/3.2.0
+      - python-bugzilla/3.3.0
     method: POST
     uri: https://example.com/rest/bug
   response:
     body:
-      string: '{"id": 2294459}'
+      string: '{"id": 2307728}'
     headers:
       Access-Control-Allow-Headers:
       - origin, content-type, accept, x-requested-with
@@ -969,7 +677,7 @@ interactions:
       Content-Type:
       - application/json; charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:07 GMT
+      - Mon, 25 Nov 2024 09:52:57 GMT
       Strict-Transport-Security:
       - max-age=63072000; includeSubDomains
       X-content-type-options:
@@ -979,314 +687,9 @@ interactions:
       x-rh-edge-cache-status:
       - Miss from child, Miss from parent
       x-rh-edge-reference-id:
-      - 0.4e24c317.1719576365.331c4cad
+      - 0.18fb1060.1732528376.722cf238
       x-rh-edge-request-id:
-      - 331c4cad
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:07 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576367.331c7b0a
-      x-rh-edge-request-id:
-      - 331c7b0a
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"email": "aander07@packetmaster.com", "id": 1, "can_login":
-        true, "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:08 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576368.331c7da8
-      x-rh-edge-request-id:
-      - 331c7da8
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_doc_type": "If docs needed, set a value", "flags": [],
-        "cf_conditional_nak": [], "is_confirmed": true, "assigned_to_detail": {"real_name":
-        "Product Security DevOps Team", "name": "prodsec-dev@redhat.com", "partner":
-        false, "insider": true, "email": "prodsec-dev@redhat.com", "id": 377884, "active":
-        true}, "remaining_time": 0, "is_open": true, "priority": "low", "cf_environment":
-        "", "description": "comment_zero", "comments": [{"id": 18021220, "private_groups":
-        [], "count": 0, "creator": "conrado@redhat.com", "time": "2024-06-28T12:06:06Z",
-        "creator_id": 482384, "tags": [], "is_private": false, "attachment_id": null,
-        "text": "comment_zero", "creation_time": "2024-06-28T12:06:06Z", "bug_id":
-        2294459}], "cf_internal_whiteboard": "", "cf_last_closed": null, "docs_contact":
-        "", "creator_detail": {"id": 482384, "active": true, "email": "conrado@redhat.com",
-        "insider": true, "name": "conrado@redhat.com", "partner": false, "real_name":
-        "Conrado Costa"}, "cf_release_notes": "", "qa_contact": "", "summary": "curl:
-        title", "is_cc_accessible": true, "platform": "All", "blocks": [], "depends_on":
-        [], "target_release": ["---"], "groups": [], "cf_clone_of": null, "deadline":
-        null, "cf_pm_score": "0", "cf_qa_whiteboard": "", "product": "Security Response",
-        "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-06-28T12:05:58Z\",
-        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\"}", "dupe_of":
-        null, "target_milestone": "---", "op_sys": "Linux", "estimated_time": 0, "classification":
-        "Other", "keywords": ["Security"], "status": "NEW", "cf_major_incident": null,
-        "alias": [], "cf_embargoed": null, "creator": "conrado@redhat.com", "component":
-        ["vulnerability-draft"], "resolution": "", "cc_detail": [], "data_category":
-        "Public", "cf_pgm_internal": "", "cf_cust_facing": "---", "cc": [], "cf_build_id":
-        "", "actual_time": 0, "url": "", "is_creator_accessible": true, "sub_components":
-        {}, "whiteboard": "", "id": 2294459, "cf_devel_whiteboard": "", "external_bugs":
-        [], "tags": [], "version": ["unspecified"], "assigned_to": "prodsec-dev@redhat.com",
-        "cf_fixed_in": "", "severity": "low", "last_change_time": "2024-06-28T12:06:06Z",
-        "creation_time": "2024-06-28T12:06:06Z", "cf_qe_conditional_nak": []}], "faults":
-        []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:09 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2167'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576368.331c9506
-      x-rh-edge-request-id:
-      - 331c9506
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_devel_whiteboard": "", "depends_on": [], "cc": [], "op_sys":
-        "Linux", "last_change_time": "2024-06-28T12:06:06Z", "cf_srtnotes": "{\"public\":
-        \"2000-01-01T00:00:00Z\", \"reported\": \"2024-06-28T12:05:58Z\", \"impact\":
-        \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\"}", "cf_cust_facing":
-        "---", "keywords": ["Security"], "data_category": "Public", "cf_build_id":
-        "", "external_bugs": [], "platform": "All", "target_milestone": "---", "cf_fixed_in":
-        "", "dupe_of": null, "cc_detail": [], "flags": [], "qa_contact": "", "cf_environment":
-        "", "assigned_to_detail": {"id": 377884, "insider": true, "email": "prodsec-dev@redhat.com",
-        "partner": false, "active": true, "real_name": "Product Security DevOps Team",
-        "name": "prodsec-dev@redhat.com"}, "product": "Security Response", "cf_release_notes":
-        "", "priority": "low", "docs_contact": "", "target_release": ["---"], "cf_qa_whiteboard":
-        "", "assigned_to": "prodsec-dev@redhat.com", "is_open": true, "is_confirmed":
-        true, "whiteboard": "", "version": ["unspecified"], "creation_time": "2024-06-28T12:06:06Z",
-        "comments": [{"private_groups": [], "time": "2024-06-28T12:06:06Z", "text":
-        "comment_zero", "creator": "conrado@redhat.com", "tags": [], "creator_id":
-        482384, "is_private": false, "bug_id": 2294459, "count": 0, "attachment_id":
-        null, "creation_time": "2024-06-28T12:06:06Z", "id": 18021220}], "id": 2294459,
-        "cf_last_closed": null, "estimated_time": 0, "url": "", "cf_pgm_internal":
-        "", "cf_conditional_nak": [], "deadline": null, "groups": [], "classification":
-        "Other", "cf_major_incident": null, "status": "NEW", "component": ["vulnerability-draft"],
-        "severity": "low", "resolution": "", "cf_doc_type": "If docs needed, set a
-        value", "cf_pm_score": "0", "cf_clone_of": null, "cf_qe_conditional_nak":
-        [], "blocks": [], "description": "comment_zero", "alias": [], "cf_embargoed":
-        null, "actual_time": 0, "remaining_time": 0, "is_cc_accessible": true, "creator_detail":
-        {"active": true, "name": "conrado@redhat.com", "real_name": "Conrado Costa",
-        "email": "conrado@redhat.com", "insider": true, "id": 482384, "partner": false},
-        "creator": "conrado@redhat.com", "sub_components": {}, "tags": [], "summary":
-        "curl: title", "cf_internal_whiteboard": "", "is_creator_accessible": true}],
-        "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:10 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2167'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576369.331ca84f
-      x-rh-edge-request-id:
-      - 331ca84f
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459/comment
-  response:
-    body:
-      string: '{"bugs": {"2294459": {"comments": [{"tags": [], "time": "2024-06-28T12:06:06Z",
-        "creator_id": 482384, "count": 0, "id": 18021220, "private_groups": [], "creator":
-        "conrado@redhat.com", "bug_id": 2294459, "creation_time": "2024-06-28T12:06:06Z",
-        "text": "comment_zero", "attachment_id": null, "is_private": false}]}}, "comments":
-        {}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '304'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:10 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576370.331cb89d
-      x-rh-edge-request-id:
-      - 331cb89d
+      - 722cf238
     status:
       code: 200
       message: OK
@@ -1304,7 +707,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -1501,21 +904,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -1536,9 +943,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:11 GMT
+      - Mon, 25 Nov 2024 09:52:58 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:11 GMT
+      - Mon, 25 Nov 2024 09:52:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1551,7 +958,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1559,9 +966,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591531x1
+      - 592x1513429x1
       x-asessionid:
-      - z650mg
+      - iwc0gy
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -1573,9 +980,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576371.8a613ad7
+      - 0.dfb1060.1732528378.7802f8e0
       x-rh-edge-request-id:
-      - 8a613ad7
+      - 7802f8e0
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1597,546 +1004,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:11 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:11 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591534x2
-      x-asessionid:
-      - yojon4
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576371.8a613fbf
-      x-rh-edge-request-id:
-      - 8a613fbf
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:11 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:11 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591537x3
-      x-asessionid:
-      - 1o4zltt
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576371.8a6147f1
-      x-rh-edge-request-id:
-      - 8a6147f1
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "title", "description": "comment_zero", "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-      "impact:LOW", "team:only"], "priority": {"name": "Minor"}}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '240'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-505
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:12 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:12 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591538x1
-      x-asessionid:
-      - 1hiurib
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576371.8a614cce
-      x-rh-edge-request-id:
-      - 8a614cce
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@53387c65[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c1c4b21[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@225a0b58[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6cd10971[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6863241c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@56dd73f1[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@242fa2b9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@40d1bdcc[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3163320e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@c1c9d28[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@557fdc78[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@188d24c6[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-505/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW", "team:only"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:11.802+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:13 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:13 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8754'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591547x1
-      x-asessionid:
-      - e7h10d
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576372.8a617b53
-      x-rh-edge-request-id:
-      - 8a617b53
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14264/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -2181,9 +1053,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:13 GMT
+      - Mon, 25 Nov 2024 09:52:58 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:13 GMT
+      - Mon, 25 Nov 2024 09:52:58 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2194,7 +1066,7 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '4'
+      - '3'
       content-length:
       - '2963'
       referrer-policy:
@@ -2204,9 +1076,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591548x1
+      - 592x1513430x1
       x-asessionid:
-      - 5h7fl2
+      - 19frix0
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2218,9 +1090,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576373.8a618251
+      - 0.dfb1060.1732528378.7802fa29
       x-rh-edge-request-id:
-      - 8a618251
+      - 7802fa29
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2244,11 +1116,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-505/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14264/transitions
   response:
     body:
       string: ''
@@ -2260,9 +1132,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:14 GMT
+      - Mon, 25 Nov 2024 09:52:59 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:14 GMT
+      - Mon, 25 Nov 2024 09:52:59 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2278,9 +1150,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591549x1
+      - 592x1513431x1
       x-asessionid:
-      - satst7
+      - 1yukynk
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2292,9 +1164,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576373.8a618770
+      - 0.dfb1060.1732528378.7802fb73
       x-rh-edge-request-id:
-      - 8a618770
+      - 7802fb73
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -2316,89 +1188,99 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
+    uri: https://example.com/rest/api/2/issue/OSIM-14264
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@7192037e[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@15faaac6[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16311787", "self": "https://example.com/rest/api/2/issue/16311787",
+        "key": "OSIM-14264", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2bbd64a6[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7bf3bea1[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6c4881e5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2c24ba30[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c476bd2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@26bb921c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@ed46887[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7a8b657[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10a6548b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6af70ff1[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@474ac278[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@512dec8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64b3985c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@25334dd[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6a6cef1d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@14f8c02b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6cf1cb90[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@779fef0f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a06e2e6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@282d8c15[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4a627fcb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@428d061f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-505/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000", "customfield_12321240":
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
         "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW", "team:only"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:13.358+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
+        "Minor", "id": "4"}, "labels": ["flawuuid:341ac0fd-f128-4666-b758-877fa7429b82",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
         "description": "Work is being scoped and discussed (To Do status category;
         see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14264/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14264/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-25T09:52:54.359+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-25T09:52:58.621+0000", "timeoriginalestimate": null, "description":
+        "comment_zero", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "title", "customfield_12323640": null, "customfield_12325147":
+        null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
+        null, "customfield_12323641": null, "customfield_12325148": null, "customfield_12325143":
+        null, "customfield_12325142": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i21pa7:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -2407,9 +1289,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:14 GMT
+      - Mon, 25 Nov 2024 09:53:00 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:14 GMT
+      - Mon, 25 Nov 2024 09:53:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -2422,7 +1304,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8726'
+      - '9302'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -2430,9 +1312,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591550x1
+      - 593x1513432x1
       x-asessionid:
-      - s16kst
+      - uqbtif
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -2444,682 +1326,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576374.8a61a68d
+      - 0.18fb1060.1732528379.722d1d25
       x-rh-edge-request-id:
-      - 8a61a68d
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:14 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576374.331d2395
-      x-rh-edge-request-id:
-      - 331d2395
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"email": "aander07@packetmaster.com", "can_login": true,
-        "id": 1, "name": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:15 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576374.331d273d
-      x-rh-edge-request-id:
-      - 331d273d
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&include_fields=id&include_fields=last_change_time
-  response:
-    body:
-      string: '{"faults": [], "bugs": [{"last_change_time": "2024-06-28T12:06:06Z",
-        "id": 2294459, "data_category": "Public"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '104'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:15 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576375.331d32ed
-      x-rh-edge-request-id:
-      - 331d32ed
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
-      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
-      "", "severity": "low", "priority": "low", "summary": "curl: title", "keywords":
-      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
-      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
-      \"reported\": \"2024-06-28T12:05:58Z\", \"impact\": \"low\", \"source\": \"internet\",
-      \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
-      \"ps-component-0\", \"affectedness\": \"new\", \"resolution\": null, \"impact\":
-      \"critical\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}", "cf_fixed_in":
-      "", "ids": ["2294459"]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '748'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: PUT
-    uri: https://example.com/rest/bug/2294459
-  response:
-    body:
-      string: '{"bugs": [{"alias": [], "id": 2294459, "last_change_time": "2024-06-28T12:06:17Z",
-        "changes": {"cf_srtnotes": {"added": "{\"public\": \"2000-01-01T00:00:00Z\",
-        \"reported\": \"2024-06-28T12:05:58Z\", \"impact\": \"low\", \"source\": \"internet\",
-        \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
-        \"ps-component-0\", \"affectedness\": \"new\", \"resolution\": null, \"impact\":
-        \"critical\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}", "removed":
-        "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-06-28T12:05:58Z\",
-        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\"}"}, "component":
-        {"added": "vulnerability", "removed": "vulnerability-draft"}}}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '703'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:17 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576375.331d3c83
-      x-rh-edge-request-id:
-      - 331d3c83
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:18 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576377.8a622e03
-      x-rh-edge-request-id:
-      - 8a622e03
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"can_login": true, "email": "aander07@packetmaster.com",
-        "id": 1, "name": "aander07@packetmaster.com", "real_name": "Need Real Name"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:18 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576378.8a623500
-      x-rh-edge-request-id:
-      - 8a623500
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"faults": [], "bugs": [{"cf_qa_whiteboard": "", "docs_contact": "",
-        "priority": "low", "target_release": ["---"], "comments": [{"creation_time":
-        "2024-06-28T12:06:06Z", "id": 18021220, "bug_id": 2294459, "attachment_id":
-        null, "count": 0, "creator": "conrado@redhat.com", "tags": [], "creator_id":
-        482384, "is_private": false, "private_groups": [], "time": "2024-06-28T12:06:06Z",
-        "text": "comment_zero"}], "creation_time": "2024-06-28T12:06:06Z", "id": 2294459,
-        "is_open": true, "is_confirmed": true, "assigned_to": "prodsec-dev@redhat.com",
-        "version": ["unspecified"], "whiteboard": "", "dupe_of": null, "flags": [],
-        "cc_detail": [], "cf_fixed_in": "", "assigned_to_detail": {"active": true,
-        "real_name": "Product Security DevOps Team", "name": "prodsec-dev@redhat.com",
-        "insider": true, "id": 377884, "email": "prodsec-dev@redhat.com", "partner":
-        false}, "cf_release_notes": "", "product": "Security Response", "qa_contact":
-        "", "cf_environment": "", "data_category": "Public", "cf_build_id": "", "keywords":
-        ["Security"], "target_milestone": "---", "platform": "All", "external_bugs":
-        [], "cf_devel_whiteboard": "", "depends_on": [], "cf_cust_facing": "---",
-        "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-06-28T12:05:58Z\",
-        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\", \"affects\":
-        [{\"ps_module\": \"ps-module-0\", \"ps_component\": \"ps-component-0\", \"affectedness\":
-        \"new\", \"resolution\": null, \"impact\": \"critical\", \"cvss2\": null,
-        \"cvss3\": null, \"cvss4\": null}]}", "op_sys": "Linux", "cc": [], "last_change_time":
-        "2024-06-28T12:06:17Z", "summary": "curl: title", "sub_components": {}, "tags":
-        [], "creator": "conrado@redhat.com", "creator_detail": {"partner": false,
-        "insider": true, "id": 482384, "email": "conrado@redhat.com", "real_name":
-        "Conrado Costa", "name": "conrado@redhat.com", "active": true}, "cf_internal_whiteboard":
-        "", "remaining_time": 0, "is_cc_accessible": true, "actual_time": 0, "cf_embargoed":
-        null, "is_creator_accessible": true, "cf_pm_score": "0", "component": ["vulnerability"],
-        "cf_doc_type": "If docs needed, set a value", "resolution": "", "severity":
-        "low", "alias": [], "description": "comment_zero", "cf_clone_of": null, "cf_qe_conditional_nak":
-        [], "blocks": [], "cf_conditional_nak": [], "cf_pgm_internal": "", "estimated_time":
-        0, "url": "", "cf_major_incident": null, "status": "NEW", "classification":
-        "Other", "deadline": null, "groups": [], "cf_last_closed": null}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:19 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2374'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576378.8a624536
-      x-rh-edge-request-id:
-      - 8a624536
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"cf_last_closed": null, "cf_major_incident": null, "status":
-        "NEW", "groups": [], "deadline": null, "classification": "Other", "cf_pgm_internal":
-        "", "cf_conditional_nak": [], "url": "", "estimated_time": 0, "description":
-        "comment_zero", "alias": [], "cf_clone_of": null, "cf_qe_conditional_nak":
-        [], "blocks": [], "cf_pm_score": "0", "component": ["vulnerability"], "severity":
-        "low", "resolution": "", "cf_doc_type": "If docs needed, set a value", "is_creator_accessible":
-        true, "creator_detail": {"partner": false, "email": "conrado@redhat.com",
-        "id": 482384, "insider": true, "name": "conrado@redhat.com", "real_name":
-        "Conrado Costa", "active": true}, "creator": "conrado@redhat.com", "sub_components":
-        {}, "summary": "curl: title", "tags": [], "cf_internal_whiteboard": "", "cf_embargoed":
-        null, "is_cc_accessible": true, "actual_time": 0, "remaining_time": 0, "cf_srtnotes":
-        "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-06-28T12:05:58Z\",
-        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\", \"affects\":
-        [{\"ps_module\": \"ps-module-0\", \"ps_component\": \"ps-component-0\", \"affectedness\":
-        \"new\", \"resolution\": null, \"impact\": \"critical\", \"cvss2\": null,
-        \"cvss3\": null, \"cvss4\": null}]}", "cf_cust_facing": "---", "op_sys": "Linux",
-        "cc": [], "last_change_time": "2024-06-28T12:06:17Z", "cf_devel_whiteboard":
-        "", "depends_on": [], "platform": "All", "target_milestone": "---", "external_bugs":
-        [], "data_category": "Public", "cf_build_id": "", "keywords": ["Security"],
-        "assigned_to_detail": {"name": "prodsec-dev@redhat.com", "real_name": "Product
-        Security DevOps Team", "active": true, "partner": false, "email": "prodsec-dev@redhat.com",
-        "id": 377884, "insider": true}, "product": "Security Response", "cf_release_notes":
-        "", "qa_contact": "", "cf_environment": "", "dupe_of": null, "cc_detail":
-        [], "flags": [], "cf_fixed_in": "", "creation_time": "2024-06-28T12:06:06Z",
-        "comments": [{"bug_id": 2294459, "count": 0, "attachment_id": null, "creation_time":
-        "2024-06-28T12:06:06Z", "id": 18021220, "private_groups": [], "time": "2024-06-28T12:06:06Z",
-        "text": "comment_zero", "tags": [], "creator": "conrado@redhat.com", "is_private":
-        false, "creator_id": 482384}], "id": 2294459, "assigned_to": "prodsec-dev@redhat.com",
-        "is_confirmed": true, "is_open": true, "whiteboard": "", "version": ["unspecified"],
-        "cf_qa_whiteboard": "", "priority": "low", "docs_contact": "", "target_release":
-        ["---"]}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:19 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2374'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576379.8a625d48
-      x-rh-edge-request-id:
-      - 8a625d48
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459/comment
-  response:
-    body:
-      string: '{"comments": {}, "bugs": {"2294459": {"comments": [{"tags": [], "creator":
-        "conrado@redhat.com", "creator_id": 482384, "is_private": false, "time": "2024-06-28T12:06:06Z",
-        "private_groups": [], "text": "comment_zero", "creation_time": "2024-06-28T12:06:06Z",
-        "id": 18021220, "bug_id": 2294459, "attachment_id": null, "count": 0}]}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '304'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:20 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576379.8a62711c
-      x-rh-edge-request-id:
-      - 8a62711c
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5c2d7a13[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@dbe1572[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@d608ac8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@70081b93[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4628bee6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@287f6dbd[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@214084b0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@11a4c788[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@12f884d4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@41b911b3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64797830[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@53567bb0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-505/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW", "team:only"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:13.358+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:21 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:21 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8727'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216078x2
-      x-asessionid:
-      - zsm2lz
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576380.8a6298d5
-      x-rh-edge-request-id:
-      - 8a6298d5
+      - 722d1d25
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3141,7 +1350,7 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
@@ -3338,21 +1547,25 @@ interactions:
         "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
         "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
         includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
-        true}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT",
-        "name": "Impersonate users in A4J project scope", "type": "PROJECT", "description":
-        "Having the permission allows to select other user as automation rule actor",
-        "havePermission": false}, "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER",
-        "name": "Assignable User", "type": "PROJECT", "description": "Users with this
-        permission may be assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE":
-        {"id": "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type":
-        "PROJECT", "description": "Ability to transition issues.", "havePermission":
-        true, "deprecatedKey": true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN",
-        "name": "Edit Own Comments", "type": "PROJECT", "description": "Ability to
-        edit own comments made on issues.", "havePermission": true, "deprecatedKey":
-        true}, "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues",
-        "type": "PROJECT", "description": "Ability to move issues between projects
-        or between workflows of the same project (if applicable). Note the user can
-        only move issues to a project he or she has the create permission for.", "havePermission":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
         true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
         "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
         edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
@@ -3373,9 +1586,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:21 GMT
+      - Mon, 25 Nov 2024 09:53:00 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:21 GMT
+      - Mon, 25 Nov 2024 09:53:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -3388,7 +1601,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '16299'
+      - '16539'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -3396,9 +1609,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591567x3
+      - 593x1513433x1
       x-asessionid:
-      - od7mrg
+      - 8jb7en
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -3410,9 +1623,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576381.8a62a5e8
+      - 0.18fb1060.1732528380.722d21d7
       x-rh-edge-request-id:
-      - 8a62a5e8
+      - 722d21d7
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -3434,546 +1647,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issuetype
-  response:
-    body:
-      string: '[{"self":"https://example.com/rest/api/2/issuetype/3","id":"3","description":"Represents
-        a small unit of work that is not end-user facing.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/5","id":"5","description":"The
-        sub-task of the issue","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-task","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/17","id":"17","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a user story.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/1","id":"1","description":"A
-        problem that impairs or prevents the functions of the product.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/16","id":"16","description":"Created
-        by Jira Software - do not edit or delete. Issue type for a big user story
-        that needs to be broken down.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype","name":"Epic","subtask":false,"avatarId":13267},{"self":"https://example.com/rest/api/2/issuetype/11406","id":"11406","description":"Expresses
-        areas of concern for a project or program''s success.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/10100","id":"10100","description":"A
-        large product/portfolio goal or focus area that has clear start and completion
-        criteria","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10800","id":"10800","description":"Represents
-        a research-related task.''","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=37062&avatarType=issuetype","name":"Spike","subtask":false,"avatarId":37062},{"self":"https://example.com/rest/api/2/issuetype/12102","id":"12102","description":"Organizational
-        objective focused on a measurable outcome. May be in support of larger strategic
-        goals.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Outcome","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/2","id":"2","description":"Feature
-        requests from customers and/or users","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature
-        Request","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/13","id":"13","description":"An
-        enhancement to or refactoring of existing functionality that is not configurable
-        by an end user (typically a change made by an internal team that affects users)","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Enhancement","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/18","id":"18","description":"A
-        technical task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Technical
-        task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11403","id":"11403","description":"Used
-        to track RCA work with specific custom fields defined by the QE Closed Loop
-        Process.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Closed
-        Loop","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/8","id":"8","description":"A
-        one-off patch related to a customer support case, provided by Support and
-        not Engineering","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Support
-        Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/4","id":"4","description":"An
-        improvement or enhancement to an existing feature or task. Includes patches
-        submitted by community commiters.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Patch","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/7","id":"7","description":"Indicates
-        a possible testsuite challenge","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17262&avatarType=issuetype","name":"CTS
-        Challenge","subtask":false,"avatarId":17262},{"self":"https://example.com/rest/api/2/issuetype/9","id":"9","description":"A
-        container task to coordinate the tasks for a given release.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Release","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10","id":"10","description":"A
-        potential bug.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype","name":"Quality
-        Risk","subtask":false,"avatarId":13268},{"self":"https://example.com/rest/api/2/issuetype/11","id":"11","description":"A
-        subtask tracking an update to a bundled component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade Subtask","subtask":true,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/12","id":"12","description":"A
-        task tracking an update to a bundled component or revision of component upstream
-        of the project.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Component
-        Upgrade","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11401","id":"11401","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"RFE","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/10700","id":"10700","description":"Capability
-        or a well-defined set of functionality that delivers business value. Features
-        can include additions or changes to existing functionality. Features can easily
-        span multiple teams, and potentially multiple releases.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/14","id":"14","description":"Upgrade
-        of a library dependency","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Library
-        Upgrade","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/15","id":"15","description":"A
-        clarification needed to a specification based on community feedback","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Clarification","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/19","id":"19","description":"Issue
-        tracking a bug fix or improvement in another component","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Tracker","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/20","id":"20","description":"Used
-        for conducting internal reviews of our products and process with 3rd party
-        auditors","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Requirement","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/21","id":"21","description":"Same
-        as Requirement type but for subtasks","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Sub-requirement
-        ","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/22","id":"22","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Documentation","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/24","id":"24","description":"Support
-        Request","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Support
-        Request","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10000","id":"10000","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Content
-        Change","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10001","id":"10001","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Technical
-        Requirement","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10002","id":"10002","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"Business
-        Requirement","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10300","id":"10300","description":"Development
-        task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Task","subtask":false,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/10301","id":"10301","description":"QE
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"QE
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/10302","id":"10302","description":"Docs
-        Task","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Task","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10400","id":"10400","description":"Objectives
-        and Key Results","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13274&avatarType=issuetype","name":"OKR","subtask":false,"avatarId":13274},{"self":"https://example.com/rest/api/2/issuetype/10500","id":"10500","description":"Policies
-        are the way we interact with our work and with each other.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Policy","subtask":false,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/10600","id":"10600","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13280&avatarType=issuetype","name":"Question","subtask":false,"avatarId":13280},{"self":"https://example.com/rest/api/2/issuetype/10601","id":"10601","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Analysis","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/10701","id":"10701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10300&avatarType=issuetype","name":"Request","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10702","id":"10702","description":"Customer-impacting
-        issue requiring coordinated response","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=10304&avatarType=issuetype","name":"Flare","subtask":false},{"self":"https://example.com/rest/api/2/issuetype/10900","id":"10900","description":"This
-        issue type is created for Service Desk functions in Jira Software","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Service
-        Request","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/10901","id":"10901","description":"Used
-        to represent an interrupt request identifying a problem that must be addressed,
-        usually from customer support","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Incident","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/10902","id":"10902","description":"Custom
-        Task issuetype for OCSPLAT","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Platform","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11000","id":"11000","description":"A
-        request for change, often with an approval step at the beginning to confirm
-        the change.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Change
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11100","id":"11100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Support
-        Exception","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11101","id":"11101","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype","name":"Review","subtask":true,"avatarId":13276},{"self":"https://example.com/rest/api/2/issuetype/11200","id":"11200","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Simple
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11201","id":"11201","description":"The
-        sub-task of the issue used to track related QE work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"QE
-        Sub-task","subtask":true,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11202","id":"11202","description":"The
-        sub-task of the issue used to track related development work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17260&avatarType=issuetype","name":"Dev
-        Sub-task","subtask":true,"avatarId":17260},{"self":"https://example.com/rest/api/2/issuetype/11203","id":"11203","description":"The
-        sub-task of the issue used to track related documentation work","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13266&avatarType=issuetype","name":"Docs
-        Sub-task","subtask":true,"avatarId":13266},{"self":"https://example.com/rest/api/2/issuetype/11204","id":"11204","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Simple
-        Sub-task","subtask":true,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11300","id":"11300","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Next
-        Action","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11400","id":"11400","description":"This
-        is a Business Unit Initiative a.k.a. \"BUI\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"BU
-        Initiative","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11402","id":"11402","description":"General
-        issue to be triaged","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Issue","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11404","id":"11404","description":"HSS
-        PA tracking issue for Milestones","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Milestone","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11405","id":"11405","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Build
-        Task","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11407","id":"11407","description":"RT355021","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Report","subtask":false,"avatarId":13270},{"self":"https://example.com/rest/api/2/issuetype/11408","id":"11408","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Schedule","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11409","id":"11409","description":"For
-        Documentation Issues","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Doc","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11410","id":"11410","description":"Mixed
-        type for Feature as Story","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Technical
-        Feature","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11411","id":"11411","description":"Used
-        for grouping release operations, typically to identify milestones associated
-        with shipping a major release","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13273&avatarType=issuetype","name":"Release
-        Milestone","subtask":false,"avatarId":13273},{"self":"https://example.com/rest/api/2/issuetype/11412","id":"11412","description":"tracks
-        major releases","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Release
-        tracker","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/11413","id":"11413","description":"Generic
-        Service issue or operations request from an end user.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Ticket","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11414","id":"11414","description":"Higher
-        level than an epic","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"Project","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/11415","id":"11415","description":"Root
-        Cause Analysis","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13269&avatarType=issuetype","name":"Root
-        Cause Analysis","subtask":false,"avatarId":13269},{"self":"https://example.com/rest/api/2/issuetype/11416","id":"11416","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13264&avatarType=issuetype","name":"Weather-item","subtask":false,"avatarId":13264},{"self":"https://example.com/rest/api/2/issuetype/11417","id":"11417","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype","name":"Ad-Hoc
-        Task","subtask":false,"avatarId":13278},{"self":"https://example.com/rest/api/2/issuetype/11419","id":"11419","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=17261&avatarType=issuetype","name":"Stakeholder
-        Request","subtask":false,"avatarId":17261},{"self":"https://example.com/rest/api/2/issuetype/11600","id":"11600","description":"A
-        defect that needs to be fixed before Story can be \"Done\"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Story
-        Bug","subtask":true,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/11700","id":"11700","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39777&avatarType=issuetype","name":"Info","subtask":false,"avatarId":39777},{"self":"https://example.com/rest/api/2/issuetype/11701","id":"11701","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Team
-        Improvement","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11702","id":"11702","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Wireframe","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/11800","id":"11800","description":"Product
-        Security Supply Chain Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=39905&avatarType=issuetype","name":"Supply
-        Chain Exception","subtask":false,"avatarId":39905},{"self":"https://example.com/rest/api/2/issuetype/11900","id":"11900","description":"ProdSec
-        Software Security Exception","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=40577&avatarType=issuetype","name":"Software
-        Security Exception","subtask":false,"avatarId":40577},{"self":"https://example.com/rest/api/2/issuetype/12100","id":"12100","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13260&avatarType=issuetype","name":"Objective","subtask":false,"avatarId":13260},{"self":"https://example.com/rest/api/2/issuetype/12101","id":"12101","description":"Large,
-        strategic focus area typically defined by leadership teams to achieve organizational
-        long-term vision.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=50977&avatarType=issuetype","name":"Strategic
-        Goal","subtask":false,"avatarId":50977},{"self":"https://example.com/rest/api/2/issuetype/12206","id":"12206","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55783&avatarType=issuetype","name":"Weakness","subtask":false,"avatarId":55783},{"self":"https://example.com/rest/api/2/issuetype/12207","id":"12207","description":"","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=55784&avatarType=issuetype","name":"Vulnerability","subtask":false,"avatarId":55784},{"self":"https://example.com/rest/api/2/issuetype/12300","id":"12300","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype","name":"Epic
-        Story","subtask":false,"avatarId":13275},{"self":"https://example.com/rest/api/2/issuetype/12301","id":"12301","description":"CASE-461","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype","name":"Epic
-        Bug","subtask":false,"avatarId":13263},{"self":"https://example.com/rest/api/2/issuetype/23","id":"23","description":"A
-        new feature of the product, which has yet to be developed.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13271&avatarType=issuetype","name":"New
-        Feature","subtask":false,"avatarId":13271},{"self":"https://example.com/rest/api/2/issuetype/10200","id":"10200","description":"An
-        improvement or enhancement to an existing feature or task.","iconUrl":"https://example.com/secure/viewavatar?size=xsmall&avatarId=13270&avatarType=issuetype","name":"Improvement","subtask":false,"avatarId":13270}]'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:21 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:21 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '25109'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591568x1
-      x-asessionid:
-      - h4k82y
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576381.8a62ae59
-      x-rh-edge-request-id:
-      - 8a62ae59
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/project/OSIM
-  response:
-    body:
-      string: '{"expand": "description,lead,url,projectKeys", "self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "description": "This project will serve Incident
-        Response team as a task repository, managing the workflow in PSIR and integrating
-        with OSIDB.", "lead": {"self": "https://example.com/rest/api/2/user?username=concosta@redhat.com",
-        "key": "JIRAUSER196381", "name": "concosta@redhat.com", "avatarUrls": {"48x48":
-        "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true}, "components": [], "issueTypes":
-        [{"self": "https://example.com/rest/api/2/issuetype/3", "id": "3", "description":
-        "Represents a small unit of work that is not end-user facing.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13278&avatarType=issuetype",
-        "name": "Task", "subtask": false, "avatarId": 13278}, {"self": "https://example.com/rest/api/2/issuetype/5",
-        "id": "5", "description": "The sub-task of the issue", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13276&avatarType=issuetype",
-        "name": "Sub-task", "subtask": true, "avatarId": 13276}, {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, {"self": "https://example.com/rest/api/2/issuetype/1",
-        "id": "1", "description": "A problem that impairs or prevents the functions
-        of the product.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
-        "name": "Bug", "subtask": false, "avatarId": 13263}, {"self": "https://example.com/rest/api/2/issuetype/16",
-        "id": "16", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a big user story that needs to be broken down.", "iconUrl":
-        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13267&avatarType=issuetype",
-        "name": "Epic", "subtask": false, "avatarId": 13267}, {"self": "https://example.com/rest/api/2/issuetype/11406",
-        "id": "11406", "description": "Expresses areas of concern for a project or
-        program''s success.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13268&avatarType=issuetype",
-        "name": "Risk", "subtask": false, "avatarId": 13268}], "assigneeType": "UNASSIGNED",
-        "versions": [], "name": "Open Security Issue Manager", "roles": {"Scrum master":
-        "https://example.com/rest/api/2/project/12337520/role/10540", "Developers":
-        "https://example.com/rest/api/2/project/12337520/role/10001", "Administrators":
-        "https://example.com/rest/api/2/project/12337520/role/10002", "Approver":
-        "https://example.com/rest/api/2/project/12337520/role/10840", "Viewers": "https://example.com/rest/api/2/project/12337520/role/10440",
-        "Users": "https://example.com/rest/api/2/project/12337520/role/10000", "Curriculum
-        Developer External": "https://example.com/rest/api/2/project/12337520/role/11140"},
-        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"},
-        "projectTypeKey": "software", "archived": false}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:21 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:21 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '3'
-      content-length:
-      - '4024'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591570x1
-      x-asessionid:
-      - 2aohyv
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576381.8a62b2c4
-      x-rh-edge-request-id:
-      - 8a62b2c4
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
-      "title", "description": "comment_zero", "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-      "impact:LOW", "team:only"], "priority": {"name": "Minor"}}}'
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '240'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-505
-  response:
-    body:
-      string: ''
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:22 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:22 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '2'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591572x2
-      x-asessionid:
-      - hrqnnc
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576381.8a62b6ca
-      x-rh-edge-request-id:
-      - 8a62b6ca
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 204
-      message: No Content
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@25752097[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@22a55b5a[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@70563aa2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@78a1d079[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@15f45711[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@371c830b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@76de2c60[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@8a18da[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@37f18b05[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6426522b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@631cdfe3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@33005792[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": null, "watches": {"self":
-        "https://example.com/rest/api/2/issue/OSIM-505/watchers", "watchCount": 1,
-        "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000", "customfield_12321240":
-        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
-        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
-        "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW", "team:only"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:13.358+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:22 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:22 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '2'
-      content-length:
-      - '8727'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-0
-      x-arequestid:
-      - 726x591575x2
-      x-asessionid:
-      - 145zays
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576382.8a62bb90
-      x-rh-edge-request-id:
-      - 8a62bb90
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14264/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -4018,9 +1696,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:22 GMT
+      - Mon, 25 Nov 2024 09:53:00 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:22 GMT
+      - Mon, 25 Nov 2024 09:53:00 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -4041,9 +1719,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591579x2
+      - 593x1513435x1
       x-asessionid:
-      - 1epdygg
+      - xh77uk
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -4055,9 +1733,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576382.8a62c67e
+      - 0.18fb1060.1732528380.722d2364
       x-rh-edge-request-id:
-      - 8a62c67e
+      - 722d2364
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -4082,11 +1760,11 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-505/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-14264/transitions
   response:
     body:
       string: ''
@@ -4098,9 +1776,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:23 GMT
+      - Mon, 25 Nov 2024 09:53:01 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:23 GMT
+      - Mon, 25 Nov 2024 09:53:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -4108,7 +1786,7 @@ interactions:
       X-RateLimit-Limit:
       - '5'
       X-RateLimit-Remaining:
-      - '2'
+      - '3'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -4116,9 +1794,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591580x1
+      - 593x1513436x1
       x-asessionid:
-      - dddifs
+      - pn6ebj
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -4130,9 +1808,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576382.8a62cc46
+      - 0.18fb1060.1732528380.722d2553
       x-rh-edge-request-id:
-      - 8a62cc46
+      - 722d2553
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -4154,90 +1832,102 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
+    uri: https://example.com/rest/api/2/issue/OSIM-14264
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
+        "id": "16311787", "self": "https://example.com/rest/api/2/issue/16311787",
+        "key": "OSIM-14264", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
         "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@4e7811c5[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3fea498b[overall=PullRequestOverallBean{stateCount=0,
+        Do"}, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@51b09c6e[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ef5005[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@50ff411c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3db4fc99[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@77c57ee0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1589dbbd[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3fd48fb1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@259efce6[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@79f0a4cb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@22ffdc7b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@394d6692[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6b66c491[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64083820[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@189b23dc[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@79f0c1cc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3c37d568[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@19db23f6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@581f66d2[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@279e32bc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@25803fb2[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@65847c67[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@460eaff3[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-06-28T12:06:22.612+0000", "workratio": -1, "customfield_12316840":
-        null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
-        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-505/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000",
-        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
-        "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW", "team:only"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:22.631+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/4",
+        "iconUrl": "https://example.com/images/icons/priorities/minor.svg", "name":
+        "Minor", "id": "4"}, "labels": ["flawuuid:341ac0fd-f128-4666-b758-877fa7429b82",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
         "description": "The issue is closed. See the resolution for context regarding
         why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
         "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
         "id": 3, "key": "done", "colorName": "success", "name": "Done"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
+        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
+        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14264/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": "2024-11-25T09:53:00.839+0000", "customfield_12325150":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12319040": null, "customfield_12325047": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-14264/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2024-11-25T09:52:54.359+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2024-11-25T09:53:00.861+0000", "timeoriginalestimate": null, "description":
+        "comment_zero", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "title", "customfield_12323640": null, "customfield_12325147":
+        null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
+        null, "customfield_12323641": null, "customfield_12325148": null, "customfield_12325143":
+        null, "customfield_12325142": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i21pa7:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -4246,9 +1936,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Fri, 28 Jun 2024 12:06:23 GMT
+      - Mon, 25 Nov 2024 09:53:01 GMT
       Expires:
-      - Fri, 28 Jun 2024 12:06:23 GMT
+      - Mon, 25 Nov 2024 09:53:01 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -4261,7 +1951,7 @@ interactions:
       X-RateLimit-Remaining:
       - '4'
       content-length:
-      - '8917'
+      - '9490'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -4269,9 +1959,9 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x591586x1
+      - 593x1513441x1
       x-asessionid:
-      - 1ugv6bh
+      - 17hjt5d
       x-content-type-options:
       - nosniff
       x-frame-options:
@@ -4283,677 +1973,9 @@ interactions:
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.4c24c317.1719576383.8a62ec2b
+      - 0.18fb1060.1732528381.722d203a
       x-rh-edge-request-id:
-      - 8a62ec2b
-      x-seraph-loginreason:
-      - OK
-      x-xss-protection:
-      - 1; mode=block
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:24 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576383.331e053f
-      x-rh-edge-request-id:
-      - 331e053f
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"id": 1, "can_login": true, "email": "aander07@packetmaster.com",
-        "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:24 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576384.331e083e
-      x-rh-edge-request-id:
-      - 331e083e
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags&include_fields=id&include_fields=last_change_time
-  response:
-    body:
-      string: '{"bugs": [{"data_category": "Public", "id": 2294459, "last_change_time":
-        "2024-06-28T12:06:17Z"}], "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '104'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:25 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576384.331e11d6
-      x-rh-edge-request-id:
-      - 331e11d6
-    status:
-      code: 200
-      message: OK
-- request:
-    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
-      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
-      "", "severity": "low", "priority": "low", "summary": "curl: title", "keywords":
-      {"add": ["Security"]}, "flags": [], "groups": {"add": [], "remove": []}, "cc":
-      {"add": [], "remove": []}, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
-      \"reported\": \"2024-06-28T12:05:58Z\", \"impact\": \"low\", \"source\": \"internet\",
-      \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
-      \"ps-component-0\", \"affectedness\": \"new\", \"resolution\": null, \"impact\":
-      \"critical\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}", "cf_fixed_in":
-      "", "ids": ["2294459"]}'
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '748'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: PUT
-    uri: https://example.com/rest/bug/2294459
-  response:
-    body:
-      string: '{"bugs": [{"changes": {}, "last_change_time": "2024-06-28T12:06:17Z",
-        "alias": [], "id": 2294459}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '91'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:26 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576385.331e21b9
-      x-rh-edge-request-id:
-      - 331e21b9
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/version
-  response:
-    body:
-      string: '{"version": "5.0.4.rh98"}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '24'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:26 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576386.331e400a
-      x-rh-edge-request-id:
-      - 331e400a
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/user?ids=1
-  response:
-    body:
-      string: '{"users": [{"id": 1, "can_login": true, "email": "aander07@packetmaster.com",
-        "real_name": "Need Real Name", "name": "aander07@packetmaster.com"}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '137'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:26 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576386.331e45ca
-      x-rh-edge-request-id:
-      - 331e45ca
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"faults": [], "bugs": [{"severity": "low", "cf_fixed_in": "", "assigned_to":
-        "prodsec-dev@redhat.com", "cf_qe_conditional_nak": [], "creation_time": "2024-06-28T12:06:06Z",
-        "last_change_time": "2024-06-28T12:06:17Z", "id": 2294459, "version": ["unspecified"],
-        "external_bugs": [], "tags": [], "cf_devel_whiteboard": "", "url": "", "is_creator_accessible":
-        true, "actual_time": 0, "cf_build_id": "", "whiteboard": "", "sub_components":
-        {}, "data_category": "Public", "cc_detail": [], "resolution": "", "creator":
-        "conrado@redhat.com", "component": ["vulnerability"], "cc": [], "cf_cust_facing":
-        "---", "cf_pgm_internal": "", "cf_embargoed": null, "status": "NEW", "keywords":
-        ["Security"], "classification": "Other", "estimated_time": 0, "alias": [],
-        "cf_major_incident": null, "dupe_of": null, "cf_srtnotes": "{\"public\": \"2000-01-01T00:00:00Z\",
-        \"reported\": \"2024-06-28T12:05:58Z\", \"impact\": \"low\", \"source\": \"internet\",
-        \"cwe\": \"CWE-1\", \"affects\": [{\"ps_module\": \"ps-module-0\", \"ps_component\":
-        \"ps-component-0\", \"affectedness\": \"new\", \"resolution\": null, \"impact\":
-        \"critical\", \"cvss2\": null, \"cvss3\": null, \"cvss4\": null}]}", "op_sys":
-        "Linux", "target_milestone": "---", "product": "Security Response", "cf_qa_whiteboard":
-        "", "deadline": null, "cf_pm_score": "0", "cf_clone_of": null, "target_release":
-        ["---"], "groups": [], "depends_on": [], "blocks": [], "platform": "All",
-        "summary": "curl: title", "qa_contact": "", "cf_release_notes": "", "creator_detail":
-        {"id": 482384, "active": true, "insider": true, "email": "conrado@redhat.com",
-        "name": "conrado@redhat.com", "partner": false, "real_name": "Conrado Costa"},
-        "is_cc_accessible": true, "description": "comment_zero", "docs_contact": "",
-        "cf_last_closed": null, "cf_internal_whiteboard": "", "comments": [{"creator_id":
-        482384, "time": "2024-06-28T12:06:06Z", "tags": [], "creator": "conrado@redhat.com",
-        "id": 18021220, "count": 0, "private_groups": [], "bug_id": 2294459, "creation_time":
-        "2024-06-28T12:06:06Z", "is_private": false, "text": "comment_zero", "attachment_id":
-        null}], "remaining_time": 0, "assigned_to_detail": {"name": "prodsec-dev@redhat.com",
-        "partner": false, "real_name": "Product Security DevOps Team", "active": true,
-        "id": 377884, "email": "prodsec-dev@redhat.com", "insider": true}, "priority":
-        "low", "cf_environment": "", "is_open": true, "cf_doc_type": "If docs needed,
-        set a value", "is_confirmed": true, "cf_conditional_nak": [], "flags": []}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:27 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2374'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576387.331e4fd3
-      x-rh-edge-request-id:
-      - 331e4fd3
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459?extra_fields=comments&extra_fields=description&extra_fields=external_bugs&extra_fields=flags&extra_fields=sub_components&extra_fields=tags
-  response:
-    body:
-      string: '{"bugs": [{"is_open": true, "is_confirmed": true, "assigned_to": "prodsec-dev@redhat.com",
-        "version": ["unspecified"], "whiteboard": "", "comments": [{"id": 18021220,
-        "creation_time": "2024-06-28T12:06:06Z", "count": 0, "attachment_id": null,
-        "bug_id": 2294459, "creator_id": 482384, "is_private": false, "tags": [],
-        "creator": "conrado@redhat.com", "text": "comment_zero", "private_groups":
-        [], "time": "2024-06-28T12:06:06Z"}], "creation_time": "2024-06-28T12:06:06Z",
-        "id": 2294459, "docs_contact": "", "priority": "low", "target_release": ["---"],
-        "cf_qa_whiteboard": "", "qa_contact": "", "cf_environment": "", "assigned_to_detail":
-        {"id": 377884, "insider": true, "email": "prodsec-dev@redhat.com", "partner":
-        false, "active": true, "real_name": "Product Security DevOps Team", "name":
-        "prodsec-dev@redhat.com"}, "cf_release_notes": "", "product": "Security Response",
-        "cf_fixed_in": "", "dupe_of": null, "flags": [], "cc_detail": [], "external_bugs":
-        [], "target_milestone": "---", "platform": "All", "keywords": ["Security"],
-        "data_category": "Public", "cf_build_id": "", "op_sys": "Linux", "cc": [],
-        "last_change_time": "2024-06-28T12:06:17Z", "cf_cust_facing": "---", "cf_srtnotes":
-        "{\"public\": \"2000-01-01T00:00:00Z\", \"reported\": \"2024-06-28T12:05:58Z\",
-        \"impact\": \"low\", \"source\": \"internet\", \"cwe\": \"CWE-1\", \"affects\":
-        [{\"ps_module\": \"ps-module-0\", \"ps_component\": \"ps-component-0\", \"affectedness\":
-        \"new\", \"resolution\": null, \"impact\": \"critical\", \"cvss2\": null,
-        \"cvss3\": null, \"cvss4\": null}]}", "cf_devel_whiteboard": "", "depends_on":
-        [], "is_creator_accessible": true, "remaining_time": 0, "is_cc_accessible":
-        true, "actual_time": 0, "cf_embargoed": null, "sub_components": {}, "creator":
-        "conrado@redhat.com", "summary": "curl: title", "tags": [], "creator_detail":
-        {"active": true, "real_name": "Conrado Costa", "name": "conrado@redhat.com",
-        "insider": true, "id": 482384, "email": "conrado@redhat.com", "partner": false},
-        "cf_internal_whiteboard": "", "cf_clone_of": null, "blocks": [], "cf_qe_conditional_nak":
-        [], "alias": [], "description": "comment_zero", "component": ["vulnerability"],
-        "cf_doc_type": "If docs needed, set a value", "resolution": "", "severity":
-        "low", "cf_pm_score": "0", "classification": "Other", "groups": [], "deadline":
-        null, "cf_major_incident": null, "status": "NEW", "estimated_time": 0, "url":
-        "", "cf_pgm_internal": "", "cf_conditional_nak": [], "cf_last_closed": null}],
-        "faults": []}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:28 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      content-length:
-      - '2374'
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576387.331e5f88
-      x-rh-edge-request-id:
-      - 331e5f88
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-bugzilla/3.2.0
-    method: GET
-    uri: https://example.com/rest/bug/2294459/comment
-  response:
-    body:
-      string: '{"comments": {}, "bugs": {"2294459": {"comments": [{"bug_id": 2294459,
-        "creation_time": "2024-06-28T12:06:06Z", "is_private": false, "attachment_id":
-        null, "text": "comment_zero", "time": "2024-06-28T12:06:06Z", "creator_id":
-        482384, "tags": [], "private_groups": [], "id": 18021220, "count": 0, "creator":
-        "conrado@redhat.com"}]}}}'
-    headers:
-      Access-Control-Allow-Headers:
-      - origin, content-type, accept, x-requested-with
-      Access-Control-Allow-Origin:
-      - '*'
-      Cache-Control:
-      - private, must-revalidate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '304'
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:29 GMT
-      Strict-Transport-Security:
-      - max-age=63072000; includeSubDomains
-      X-content-type-options:
-      - nosniff
-      X-xss-protection:
-      - 1; mode=block
-      x-rh-edge-cache-status:
-      - Miss from child, Miss from parent
-      x-rh-edge-reference-id:
-      - 0.4e24c317.1719576388.331e7348
-      x-rh-edge-request-id:
-      - 331e7348
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - application/json,*.*;q=0.9
-      Accept-Encoding:
-      - gzip, deflate
-      Cache-Control:
-      - no-cache
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - python-requests/2.32.0
-      X-Atlassian-Token:
-      - no-check
-    method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-505
-  response:
-    body:
-      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16091066", "self": "https://example.com/rest/api/2/issue/16091066",
-        "key": "OSIM-505", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
-        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
-        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
-        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": {"self": "https://example.com/rest/api/2/resolution/10000",
-        "id": "10000", "description": "This issue was rejected.", "name": "Won''t
-        Do"}, "customfield_12310220": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6114a598[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5d1f9854[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7772b0c2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@560e4b40[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1a26bc05[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5e366014[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3ca02fb0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@18d0272f[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@373966a4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5a628697[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6702efc4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7ef25554[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
-        "resolutiondate": "2024-06-28T12:06:22.612+0000", "workratio": -1, "customfield_12316840":
-        null, "customfield_12317379": null, "customfield_12316841": null, "customfield_12315950":
-        null, "customfield_12310940": null, "customfield_12319040": null, "lastViewed":
-        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-505/watchers",
-        "watchCount": 1, "isWatching": true}, "created": "2024-06-28T12:06:00.035+0000",
-        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
-        "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
-        "name": "Minor", "id": "4"}, "labels": ["flawuuid:0cc5b3a1-c992-48d8-be4e-6ac34a857743",
-        "impact:LOW", "team:only"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
-        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-06-28T12:06:22.631+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/6",
-        "description": "The issue is closed. See the resolution for context regarding
-        why (for example Done, Abandoned, Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
-        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
-        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}, "components":
-        [], "timeoriginalestimate": null, "description": "comment_zero", "customfield_12314040":
-        null, "customfield_12320844": null, "archiveddate": null, "timetracking":
-        {}, "customfield_12320842": null, "customfield_12310243": null, "attachment":
-        [], "aggregatetimeestimate": null, "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
-        "value": "False", "id": "14655", "disabled": false}, "customfield_12317313":
-        null, "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12316544":
-        "None", "customfield_12310840": "9223372036854775807", "summary": "title",
-        "customfield_12323640": null, "customfield_12323642": null, "creator": {"self":
-        "https://example.com/rest/api/2/user?username=concosta%40redhat.com", "name":
-        "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
-        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
-        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
-        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
-        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-505/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i10z7z:"}}'
-    headers:
-      Cache-Control:
-      - max-age=0, no-cache, no-store
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json;charset=UTF-8
-      Date:
-      - Fri, 28 Jun 2024 12:06:30 GMT
-      Expires:
-      - Fri, 28 Jun 2024 12:06:30 GMT
-      Pragma:
-      - no-cache
-      Retry-After:
-      - '0'
-      Vary:
-      - User-Agent
-      - Accept-Encoding
-      X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
-      - '4'
-      content-length:
-      - '8917'
-      referrer-policy:
-      - strict-origin-when-cross-origin
-      strict-transport-security:
-      - max-age=31536000
-      x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
-      x-arequestid:
-      - 726x216381x2
-      x-asessionid:
-      - 1djnwxi
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-      x-ratelimit-fillrate:
-      - '5'
-      x-ratelimit-interval-seconds:
-      - '1'
-      x-rh-edge-cache-status:
-      - NotCacheable from child
-      x-rh-edge-reference-id:
-      - 0.4c24c317.1719576390.8a629ee2
-      x-rh-edge-request-id:
-      - 8a629ee2
+      - 722d203a
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/osidb/tests/endpoints/flaws/test_package_versions.py
+++ b/osidb/tests/endpoints/flaws/test_package_versions.py
@@ -1,4 +1,7 @@
+from datetime import datetime
+
 import pytest
+from freezegun import freeze_time
 from rest_framework import status
 
 from osidb.models import Package, PackageVer
@@ -159,6 +162,7 @@ class TestEndpointsFlawsPackageVersions:
         response_vers = {v["version"] for v in response.data["versions"]}
         assert expected_vers == response_vers
 
+    @freeze_time(datetime(2020, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.parametrize(
         "correct_timestamp",
         [

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -618,6 +618,7 @@ class TestBugzillaJiraMixinIntegration:
         assert issue["fields"]["status"]["name"] == "Closed"
         assert issue["fields"]["resolution"]["name"] == "Won't Do"
 
+    @freeze_time(tzdatetime(2022, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.vcr
     @pytest.mark.enable_signals
     def test_api_changes(


### PR DESCRIPTION
This PR is a move towards async task management. It aims to simplify the stuff a bit and remove some more unnecessary Jira API calls. This time we focus on the calls which sync back the task right after we updated it. We will just assume that when the update is successful the Jira issue will have the values we set. We also set the task last update timestamp on our side which may be a little bit before the actual update in Jira but will be synced by the collector in a short while so no big deal. A number of test changes were necessary along the way.

I added some more parts. I reworked the decision logic regarding the task management and moved some functionality so the execution parts are at the end separated methods which can be called both synchronously and async.

Then I run into an issue that the broken way serializers update the flaws (and other and create but that was put aside) means that the **save** and all the parameters are not used all at once but it is called multiple times with different context - or **tasksync** used to be called completely separately outside of the `save` call. It required quite some serializer rework which is definitely not complete but already brought what I needed. I think that the result is actually simpler and more understandable then it was before but I am glad for any feedback.