### PR TITLE
Set hard limit to paginated results

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -424,7 +424,7 @@
         "filename": "osidb/tests/endpoints/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 100,
+        "line_number": 101,
         "is_secret": false
       }
     ],
@@ -467,5 +467,5 @@
       }
     ]
   },
-  "generated_at": "2024-11-19T12:20:04Z"
+  "generated_at": "2024-11-21T20:34:54Z"
 }

--- a/config/settings.py
+++ b/config/settings.py
@@ -100,8 +100,9 @@ REST_FRAMEWORK = {
     "DEFAULT_RENDERER_CLASSES": [
         "osidb.renderers.OsidbRenderer",
     ],
-    "DEFAULT_PAGINATION_CLASS": "rest_framework.pagination.LimitOffsetPagination",
+    "DEFAULT_PAGINATION_CLASS": "osidb.pagination.HardLimitOffsetPagination",
     "PAGE_SIZE": 100,
+    "MAX_PAGE_SIZE": 500,
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
     "EXCEPTION_HANDLER": "osidb.exception_handlers.exception_handler",
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Exclude component and version from Jira tracker updates (OSIDB-3677)
 - Allow moving a flaw to state DONE if it has no trackers but impact is moderate
   or low (OSIDB-3524)
+- Set hard limit of paginated results (OSIDB-643)
 
 ## [4.5.6] - 2024-11-08
 ### Fixed

--- a/osidb/pagination.py
+++ b/osidb/pagination.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from rest_framework.pagination import LimitOffsetPagination
+
+
+class HardLimitOffsetPagination(LimitOffsetPagination):
+    """
+    Customisation of LimitOffsetPagination which adds a hard limit that
+    cannot be exceeded. If the user requests more records in a page than
+    the hard limit, it will be capped to the hard limit.
+    """
+
+    limit = settings.REST_FRAMEWORK.get("PAGE_SIZE")
+    hard_limit = settings.REST_FRAMEWORK.get("MAX_PAGE_SIZE")
+
+    def get_limit(self, request):
+        limit = super().get_limit(request)
+        return min(limit, self.hard_limit) if limit else self.limit


### PR DESCRIPTION
By default each page in our views returns 100 results, but the user can specify another limit using the `limit` keyword. Before this commit, there was no limit to the amonut of records that can be specified this way, which could lead to a DoS if the user specifies lots of records.

To avoid this, a hard limit has been implemented in for every paginated view, which cannot be exceeded. If it is exceeded, it is capped to the hard limit.

Closes OSIDB-643.