### PR TITLE
Add all references as links when creating Jira trackers

### DIFF
--- a/apps/trackers/jira/save.py
+++ b/apps/trackers/jira/save.py
@@ -71,8 +71,8 @@ class TrackerJiraSaver(JiraQuerier):
                 issue_key=issue.key,
                 body=comment,
             )
-        # Add upstream links only on tracker creation
-        for reference in tracker.upstream_references:
+        # Add references only on tracker creation
+        for reference in tracker.references:
             self.add_link(
                 issue_key=issue.key,
                 url=reference.url,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow moving a flaw to state DONE if it has no trackers but impact is moderate
   or low (OSIDB-3524)
 - Set hard limit of paginated results (OSIDB-643)
+- Add all references as links when creating Jira trackers (OSIDB-3733)
 
 ## [4.5.6] - 2024-11-08
 ### Fixed

--- a/osidb/models/tracker.py
+++ b/osidb/models/tracker.py
@@ -511,15 +511,13 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         )
 
     @property
-    def upstream_references(self):
-        """Get a list of upstream references related to this tracker."""
+    def references(self):
+        """Get a list of references related to this tracker."""
         from osidb.models.flaw.flaw import Flaw
         from osidb.models.flaw.reference import FlawReference
 
         flaws = Flaw.objects.filter(affects__trackers=self)
-        return FlawReference.objects.filter(
-            flaw__in=flaws, type=FlawReference.FlawReferenceType.UPSTREAM
-        )
+        return FlawReference.objects.filter(flaw__in=flaws)
 
     bz_download_manager = models.ForeignKey(
         BZTrackerDownloadManager, null=True, blank=True, on_delete=models.CASCADE


### PR DESCRIPTION
Instead of only adding references of 'Upstream' type, now references of all types are added as links in Jira trackers.

Closes OSIDB-3733.