### PR TITLE
OSIDB-3792: Update certificates

### DIFF
--- a/scripts/install-certs.sh
+++ b/scripts/install-certs.sh
@@ -3,9 +3,9 @@
 if [[ -z "${1}" ]]; then
     echo -e "\e[1;33mWARNING: RH_CERT_URL environment variable not set, internal RH resources won't be accessible\e[0m"
 else
-    curl "${1%/}/certs/2015-IT-Root-CA.pem" -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
-    curl "${1%/}/certs/2022-IT-Root-CA.pem" -o /etc/pki/ca-trust/source/anchors/2022-IT-Root-CA.pem
+    curl "${1%/}/certs/Current-IT-Root-CAs.pem" -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CAs.pem
     mkdir /etc/ipa
-    curl "${1%/}/chains/ipa-ca-chain-2015.crt" -o /etc/ipa/ipa.crt
+    curl "${1%/}/chains/ipa-ca-chain-2022.crt" -o /etc/ipa/ipa.crt
+    curl "${1%/}/chains/rhcs-ca-chain-2022-self-signed.crt" -o /etc/ipa/rhcs.crt
     update-ca-trust
 fi


### PR DESCRIPTION
Certificates expired December 8th, currently the pipeline is failing to install python dependencies with an SSL error.

I've added the updated CA Chain and also migrated the `2015` and `2022` Certificate authorities to the `Current` which is updated automatically with the latest certificates

Closes OSIDB-3792