### PR TITLE
OSIDB-3579: Handle models without manager

### DIFF
--- a/osidb/tasks.py
+++ b/osidb/tasks.py
@@ -34,6 +34,10 @@ def stale_alert_cleanup():
     for content_type in content_types:
         model_class = content_type.model_class()
 
+        if not model_class:
+            logger.error(f"Model class not found for content type {content_type}")
+            continue
+
         subquery = Subquery(
             model_class.objects.filter(
                 pk=Cast(OuterRef("object_id"), output_field=model_class._meta.pk)


### PR DESCRIPTION
From my testing locally, all content-types had a manager to acces the `model.objects` field, but on stage, this task is failing because there's at least one model without a manager.

I've added a  log message to report the error and continue the loop