### PR TITLE
Fix sync_ps_constants command

### DIFF
--- a/osidb/management/commands/sync_ps_constants.py
+++ b/osidb/management/commands/sync_ps_constants.py
@@ -12,12 +12,14 @@ class Command(BaseCommand):
         now = timezone.now()
 
         (
+            cveorg_keywords,
             sc_packages,
             sla_policies,
             jira_bug_issuetype,
         ) = collect_step_1_fetch()
 
         collect_step_2_sync(
+            cveorg_keywords,
             sc_packages,
             sla_policies,
             jira_bug_issuetype,


### PR DESCRIPTION
This PR is a follow-up to #850 and fixes the custom command `sync_ps_constants`.