### PR TITLE
Fix workflow validation with conditional requirements

### DIFF
--- a/apps/workflows/models.py
+++ b/apps/workflows/models.py
@@ -71,6 +71,10 @@ class Condition:
     def accepts(self, instance):
         return self(instance)
 
+    @property
+    def name(self):
+        return f" {self.condition} ".join(check.name for check in self.checks)
+
 
 class State:
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Introduce new field "labels" in Flaw API (OSIDB-3803)
+
 ### Changed
 - Use keywords from ps-constants in CVEorg collector (OSIDB-3694)
+
+### Fixed
+- Fix workflow validation with conditional requirements (OSIDB-3524)
 
 ## [4.6.1] - 2024-12-06
 ### Fixed


### PR DESCRIPTION
This commit fixes a bug in which the workflow validation fails due to a missing property in conditional requirements, used to populate the list of requirements which are not met.

Closes OSIDB-3524.