### PR TITLE
Update python version of bindings action to 3.12

### DIFF
--- a/.github/workflows/bindings_integration.yml
+++ b/.github/workflows/bindings_integration.yml
@@ -16,7 +16,7 @@ jobs:
           repository: "RedHatProductSecurity/osidb-bindings"
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.9
+          python-version: 3.12
       - name: Install dependencies
         run: pip install -r devel-requirements.txt
       - name: Download recent OpenAPI schema


### PR DESCRIPTION
The osidb-bindings deps have been compiled using version 3.12. If syncing with 3.9 it fails due to some packages being different, in particular some packages are not compiled with 3.12 but they are in 3.9, resulting in an error when pip tries to get the latest version in the `--require-hashes` mode. This causes the action to fail during the setup.

This commit updates the python version used in the action so it matches the one the deps were compiled with, and the action succeeds.