### PR TITLE
moved from docker.io to mirror.gcr.io

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -4,7 +4,7 @@ services:
 
     testldap:
       container_name: testldap
-      image: docker.io/bitnami/openldap:2.5
+      image: mirror.gcr.io/bitnami/openldap:2.5
       ports:
         - '1389:1389'
         - '1636:1636'
@@ -45,7 +45,7 @@ services:
 
     locust:
       container_name: locust
-      image: docker.io/locustio/locust:2.20.1
+      image: mirror.gcr.io/locustio/locust:2.20.1
       ports:
         - '9000:8089'
       volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,7 +112,7 @@ services:
       #   retries: 3
 
     osidb-data:
-      image: docker.io/library/postgres:13
+      image: mirror.gcr.io/library/postgres:13
       shm_size: 1gb  # Needed for more consecutive connections
       hostname: osidb-data
       container_name: osidb-data
@@ -240,7 +240,7 @@ services:
     redis:
       container_name: redis
       hostname: redis
-      image: docker.io/library/redis:6
+      image: mirror.gcr.io/library/redis:6
       ports:
         - "6379"
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Changed
+- Moved docker-compose images from docker.io to mirror.gcr.io (OSIDB-3653)
+
 ## [4.6.3] - 2025-01-09
 ### Fixed
 - Reduce flaw save operations to avoid outdated timestamps (OSIDB-3837)


### PR DESCRIPTION
This PR move images from docker.io to mirror.gcr.io making them free from Docker Hub limit download while still publicly available.

Closes OSIDB-3653.