### PR TITLE
fix consecutive save calls mid-air collisions

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -184,7 +184,7 @@
         "filename": "apps/workflows/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 283,
+        "line_number": 280,
         "is_secret": false
       }
     ],
@@ -449,5 +449,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-06T14:40:43Z"
+  "generated_at": "2025-01-10T11:24:13Z"
 }

--- a/apps/bbsync/tests/test_integration.py
+++ b/apps/bbsync/tests/test_integration.py
@@ -918,9 +918,6 @@ class TestBBSyncSaveIntegration:
 
 
 class TestFlawDraftBBSyncIntegration:
-    @freeze_time(
-        timezone.datetime(2020, 12, 12)
-    )  # freeze against top of the second crossing
     @pytest.mark.vcr
     @pytest.mark.enable_signals
     @pytest.mark.parametrize(

--- a/apps/workflows/tests/test_endpoints.py
+++ b/apps/workflows/tests/test_endpoints.py
@@ -1,8 +1,5 @@
-from datetime import datetime
-
 import pytest
 from django.conf import settings
-from freezegun import freeze_time
 
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.workflows.models import State, Workflow
@@ -429,7 +426,6 @@ class TestFlawDraft:
     def mock_create_task(self, flaw):
         return "OSIM-123"
 
-    @freeze_time(datetime(2020, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.vcr
     def test_promote(
         self,

--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -282,13 +282,12 @@ class WorkflowModel(models.Model):
 
         self.workflow_state = state_obj.name
 
-        if not save:
-            return
-
-        # keep the save to Jira and BZ separate because BZ can be done asynchronously
-        # (Jira token is passed directly, but BZ token is in kwargs)
-        self.save(jira_token=jira_token, raise_validation_error=False)
-        self.save(raise_validation_error=False, **kwargs)
+        if save:
+            self.save(
+                jira_token=jira_token,
+                raise_validation_error=False,
+                **kwargs,
+            )
 
     def reject(self, save=True, jira_token=None, **kwargs):
         """
@@ -306,13 +305,12 @@ class WorkflowModel(models.Model):
         self.workflow_name = reject_workflow
         self.workflow_state = WorkflowModel.WorkflowState.REJECTED
 
-        if not save:
-            return
-
-        # keep the save to Jira and BZ separate because BZ can be done asynchronously
-        # (Jira token is passed directly, but BZ token is in kwargs)
-        self.save(jira_token=jira_token, raise_validation_error=False)
-        self.save(raise_validation_error=False, **kwargs)
+        if save:
+            self.save(
+                jira_token=jira_token,
+                raise_validation_error=False,
+                **kwargs,
+            )
 
     def jira_status(self):
         return WorkflowFramework().jira_status(self)

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -2,7 +2,6 @@ import json
 from datetime import datetime, timezone
 
 import pytest
-from freezegun import freeze_time
 from jira.exceptions import JIRAError
 
 from apps.taskman.service import JiraTaskmanQuerier
@@ -14,7 +13,6 @@ pytestmark = pytest.mark.integration
 
 
 class TestOSVCollector:
-    @freeze_time(datetime(2020, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.vcr
     def test_collect_osv_record_without_cve(self):
         """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Moved docker-compose images from docker.io to mirror.gcr.io (OSIDB-3653)
 - Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814)
+- Fix workflow mid-air collisions (OSIDB-3842)
 
 ## [4.6.3] - 2025-01-09
 ### Fixed


### PR DESCRIPTION
This PR fixes the issue of the possible mid-air collisions between the consecutive `save` calls. The issue is that inside the call the model in DB is being updated but it is not refreshed between the calls. If the top of the second is crosses during the save call, only the TrackingMixin timestamp is propagated but the `.update` one is not and  the mid-air collision occurs.