### PR TITLE
remove unnecessary test time-freeze

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -356,7 +356,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_package_versions.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 141,
+        "line_number": 138,
         "is_secret": false
       }
     ],
@@ -449,5 +449,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-10T11:24:13Z"
+  "generated_at": "2025-01-13T14:41:38Z"
 }

--- a/collectors/cveorg/tests/test_collectors.py
+++ b/collectors/cveorg/tests/test_collectors.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 from django.utils.timezone import datetime, make_aware
-from freezegun import freeze_time
 from jira.exceptions import JIRAError
 
 from apps.taskman.service import JiraTaskmanQuerier
@@ -15,7 +14,6 @@ pytestmark = pytest.mark.integration
 
 class TestCVEorgCollector:
     @pytest.mark.vcr
-    @freeze_time(datetime(2025, 1, 1))
     def test_collect_cveorg_records(self, mock_keywords, mock_repo):
         """
         Test that snippets and flaws are created correctly.

--- a/osidb/tests/endpoints/flaws/test_package_versions.py
+++ b/osidb/tests/endpoints/flaws/test_package_versions.py
@@ -1,7 +1,4 @@
-from datetime import datetime
-
 import pytest
-from freezegun import freeze_time
 from rest_framework import status
 
 from osidb.models import Package, PackageVer
@@ -162,7 +159,6 @@ class TestEndpointsFlawsPackageVersions:
         response_vers = {v["version"] for v in response.data["versions"]}
         assert expected_vers == response_vers
 
-    @freeze_time(datetime(2020, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.parametrize(
         "correct_timestamp",
         [

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -618,7 +618,6 @@ class TestBugzillaJiraMixinIntegration:
         assert issue["fields"]["status"]["name"] == "Closed"
         assert issue["fields"]["resolution"]["name"] == "Won't Do"
 
-    @freeze_time(tzdatetime(2022, 12, 12))  # freeze against top of the second crossing
     @pytest.mark.vcr
     @pytest.mark.enable_signals
     def test_api_changes(

--- a/osidb/tests/test_mixins.py
+++ b/osidb/tests/test_mixins.py
@@ -562,10 +562,6 @@ class TestBugzillaJiraMixinIntegration:
         workflow_framework.register_workflow(workflow_main)
         workflow_framework.register_workflow(workflow_reject)
 
-    # Freezing time because the test sometimes takes long enough to span
-    # the change between seconds, failing at flaw.reject with 1 second
-    # updated_dt offset.
-    @freeze_time(tzdatetime(2024, 8, 1))
     @pytest.mark.vcr
     def test_manual_changes(
         self,
@@ -605,6 +601,7 @@ class TestBugzillaJiraMixinIntegration:
         flaw = Flaw.objects.get(uuid=flaw.uuid)
 
         flaw.promote(jira_token=jira_token, bz_api_key=bugzilla_token)
+        flaw.refresh_from_db()  # need to refresh after update
         assert flaw.workflow_state == WorkflowModel.WorkflowState.TRIAGE
 
         jtq = JiraTaskmanQuerier(jira_token)


### PR DESCRIPTION
During the recent taskman/mixins rework I found some tests sometimes failing on 1s difference. I considered it a valid race condition between cassette and real-time shift but that was a silly and wrong assumption. The `freeze` was actually covering the real mid-air collision issue. Some of the occurrences were already removed during the recent hotfixes but these remained. However, I was not able to reproduce the previous mid-air collision even with a number of artificial delays on various places in the code so I assume the hotfixes actually fixed all of the mid-air collision issues of this kind.

I accidental passed over one extra historical `freeze` and that one was actually only needed because there was no refresh between multiple flaw DB operations which were modifying the update timestamp. I am fixing that one too.