### PR TITLE
Trim Jira task summary if flaw's cve_id and title are too long

### DIFF
--- a/apps/taskman/constants.py
+++ b/apps/taskman/constants.py
@@ -3,6 +3,8 @@ from osidb.helpers import get_env
 TASKMAN_API_VERSION = "v1"
 
 JIRA_AUTH_TOKEN = get_env("JIRA_AUTH_TOKEN")
+# The length of summary in a Jira task is restricted to 255
+JIRA_SUMMARY_MAX_LENGTH = 255
 JIRA_STORY_ISSUE_TYPE_ID = get_env("JIRA_STORY_ISSUE_TYPE_ID")
 JIRA_TASKMAN_URL = get_env("JIRA_TASKMAN_URL", default="https://issues.redhat.com")
 JIRA_TASKMAN_PROJECT_ID = get_env("JIRA_TASKMAN_PROJECT_ID")

--- a/apps/taskman/service.py
+++ b/apps/taskman/service.py
@@ -17,6 +17,7 @@ from osidb.models import Flaw, Impact, PsProduct
 
 from .constants import (
     JIRA_STORY_ISSUE_TYPE_ID,
+    JIRA_SUMMARY_MAX_LENGTH,
     JIRA_TASKMAN_PROJECT_ID,
     JIRA_TASKMAN_PROJECT_KEY,
     JIRA_TASKMAN_URL,
@@ -209,6 +210,10 @@ class JiraTaskmanQuerier(JiraQuerier):
             summary = flaw.title
         else:
             summary = f"{flaw.cve_id} {flaw.title}"
+
+        if len(summary) > JIRA_SUMMARY_MAX_LENGTH:
+            # Trim the maximum summary length by 3 to account for the triple dots
+            summary = f"{summary[:JIRA_SUMMARY_MAX_LENGTH-3]}..."
 
         data = {
             "fields": {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814), handled edge-case that would cause failure (OSIDB-3858)
+- Trim Jira task summary if flaw's `cve_id` and `title` are too long (OSIDB-3847)
 
 ## [4.6.5] - 2025-01-10
 ### Changed


### PR DESCRIPTION
This PR adds a check to ensure that the summary in a Jira task is trimmed when the flaw's `cve_id` and `title` exceed the maximum allowed length of 255 characters.

Closes OSIDB-3847