### PR TITLE
Fix fatal error for NoneType values

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Changed
-- Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814)
+- Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814), handled edge-case that would cause failure (OSIDB-3858)
 
 ## [4.6.5] - 2025-01-10
 ### Changed

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -604,7 +604,10 @@ class HistoricalEventSerializer(serializers.ModelSerializer):
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
-        if representation["pgh_diff"]:
+        if (
+            isinstance(representation["pgh_diff"], dict)
+            and "last_validated_dt" in representation["pgh_diff"]
+        ):
             representation["pgh_diff"].pop("last_validated_dt")
         return representation
 


### PR DESCRIPTION
Adds a more strict guard conditional for the action to strip `last_validated_dt` field in `serializer.py::HistoricalEventSerializer`.

Closes OSIDB-3814 (once more, with feeling)