### PR TITLE
OSIDB-3816 Add Flaw Labels to advanced search

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enable async Jira task sync and transition (OSIDB-3693)
 - Add collaboration labels on flaw promotion (OSIDB-3804)
 - Add basic end-to-end tests for Flaws, Affects and Trackers (OSIDB-3495)
+- Allow searching by flaw labels (OSIDB-3816)
 
 ### Changed
 - Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814), handled edge-case that would cause failure (OSIDB-3858)

--- a/osidb/djangoql.py
+++ b/osidb/djangoql.py
@@ -9,6 +9,7 @@ from osidb.models import (
     Affect,
     Flaw,
     FlawAcknowledgment,
+    FlawCollaborator,
     FlawCVSS,
     FlawReference,
     Package,
@@ -32,6 +33,7 @@ class FlawQLSchema(DjangoQLSchema):
         Affect,
         Flaw,
         FlawAcknowledgment,
+        FlawCollaborator,
         FlawCVSS,
         FlawReference,
         Package,
@@ -50,6 +52,7 @@ class FlawQLSchema(DjangoQLSchema):
             "source",
             "workflow_state",
         ],
+        FlawCollaborator: ["contributor", "label"],
         FlawCVSS: ["issuer", "version"],
         FlawReference: ["type"],
         Tracker: ["resolution", "status", "type"],
@@ -62,6 +65,8 @@ class FlawQLSchema(DjangoQLSchema):
             exclude += ["snippets", "local_updated_dt"]
             fields.remove("components")
             fields += [FlawComponentField(), FlawEmbargoedField()]
+        elif model == FlawCollaborator:
+            exclude += ["created_dt", "updated_dt", "uuid"]
         return set(fields) - set(exclude)
 
 


### PR DESCRIPTION
Added `FlawCollaborator` model to DjangoQl search, excluding `updated_dt`, `created_dt` and `uuid` fields, and adding suggestions to `contributor` and `label`

Closes OSIDB-3816