### PR TITLE
make get_env_date helper to account for the default empty string

### DIFF
--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -101,6 +101,11 @@ def get_env(
 def get_env_date(key: str, default: str) -> Union[datetime, None]:
     """get a date environment variable of the ISO format (YYYY-MM-DD)"""
     value = getenv(key, default)
+    # consider empty string as empty value
+    # as setting the value to non-existing env variable
+    # in compose.yml results in an empty string
+    if value == "":
+        value = default
     return make_aware(datetime.fromisoformat(value))
 
 


### PR DESCRIPTION
...as otherwise having CVEORG_START_DATE undefined results in
(as explained in the helper method above the problematic one)

```
Traceback (most recent call last):
  File "/usr/local/bin/celery", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/celery/__main__.py", line 15, in main
    sys.exit(_main())
  File "/usr/local/lib/python3.9/site-packages/celery/bin/celery.py", line 217, in main
    return celery(auto_envvar_prefix="CELERY")
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1128, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1053, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1659, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 1395, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.9/site-packages/click/core.py", line 754, in invoke
    return __callback(*args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/bin/base.py", line 134, in caller
    return f(ctx, *args, **kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/bin/worker.py", line 343, in worker
    worker = app.Worker(
  File "/usr/local/lib/python3.9/site-packages/celery/worker/worker.py", line 94, in __init__
    self.app.loader.init_worker()
  File "/usr/local/lib/python3.9/site-packages/celery/loaders/base.py", line 111, in init_worker
    self.import_default_modules()
  File "/usr/local/lib/python3.9/site-packages/celery/loaders/base.py", line 105, in import_default_modules
    raise response
  File "/usr/local/lib/python3.9/site-packages/celery/utils/dispatch/signal.py", line 276, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/usr/local/lib/python3.9/site-packages/vine/promises.py", line 160, in __call__
    return self.throw()
  File "/usr/local/lib/python3.9/site-packages/vine/promises.py", line 157, in __call__
    retval = fun(*final_args, **final_kwargs)
  File "/usr/local/lib/python3.9/site-packages/celery/app/base.py", line 688, in _autodiscover_tasks
    return self._autodiscover_tasks_from_names(packages, related_name)
  File "/usr/local/lib/python3.9/site-packages/celery/app/base.py", line 693, in _autodiscover_tasks_from_names
    return self.loader.autodiscover_tasks(
  File "/usr/local/lib/python3.9/site-packages/celery/loaders/base.py", line 221, in autodiscover_tasks
    mod.__name__ for mod in autodiscover_tasks(packages or (),
  File "/usr/local/lib/python3.9/site-packages/celery/loaders/base.py", line 247, in autodiscover_tasks
    return [find_related_module(pkg, related_name) for pkg in packages]
  File "/usr/local/lib/python3.9/site-packages/celery/loaders/base.py", line 247, in <listcomp>
    return [find_related_module(pkg, related_name) for pkg in packages]
  File "/usr/local/lib/python3.9/site-packages/celery/loaders/base.py", line 268, in find_related_module
    return importlib.import_module(module_name)
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/opt/app-root/src/collectors/cveorg/tasks.py", line 4, in <module>
    from collectors.cveorg.collectors import CVEorgCollector
  File "/opt/app-root/src/collectors/cveorg/collectors.py", line 17, in <module>
    from collectors.cveorg.constants import CELERY_PVC_PATH, CVEORG_START_DATE
  File "/opt/app-root/src/collectors/cveorg/constants.py", line 8, in <module>
    CVEORG_START_DATE = get_env_date("CVEORG_START_DATE", default="2024-10-01")
  File "/opt/app-root/src/osidb/helpers.py", line 104, in get_env_date
    return make_aware(datetime.fromisoformat(value))
ValueError: Invalid isoformat string: ''
```
The same issue is with OSV_START_DATE