### PR TITLE
Add E2E tests for major processes

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -243,7 +243,7 @@ def enable_bz_sync(monkeypatch) -> None:
 @pytest.fixture
 def enable_bz_async_sync(enable_bz_sync, monkeypatch) -> None:
     """
-    enable asynchonous synchronization of flaws to Bugzilla
+    enable asynchronous synchronization of flaws to Bugzilla
     enable the sync of trackers to Bugzilla
     """
     import apps.bbsync.constants as bbsync_constants
@@ -268,6 +268,17 @@ def enable_jira_task_sync(monkeypatch) -> None:
     monkeypatch.setattr(serializer, "JIRA_TASKMAN_AUTO_SYNC_FLAW", True)
     monkeypatch.setattr(service, "JIRA_STORY_ISSUE_TYPE_ID", "17")
     monkeypatch.setattr(service, "JIRA_TASKMAN_PROJECT_ID", "12337520")
+
+
+@pytest.fixture
+def enable_jira_task_async_sync(enable_jira_task_sync, monkeypatch) -> None:
+    """
+    enable asynchronous synchronization of tasks to Jira
+    enable the sync of tasks to Jira
+    """
+    from osidb.models.flaw import flaw
+
+    monkeypatch.setattr(flaw, "JIRA_TASKMAN_ASYNCHRONOUS_SYNC", True)
 
 
 @pytest.fixture

--- a/conftest.py
+++ b/conftest.py
@@ -304,7 +304,9 @@ def set_invalid_tokens(is_recording_vcr, monkeypatch):
 
 
 @pytest.fixture(autouse=True)  # Automatically use in tests.
-def set_recording_environments(is_recording_vcr, monkeypatch):
+def set_recording_environments(
+    is_recording_vcr, bugzilla_token, jira_token, monkeypatch
+):
     """
     automatically use local environments variables when writing VCRs cassettes
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement 'in' operator in SLA conditions (OSIDB-3711)
 - Enable async Jira task sync and transition (OSIDB-3693)
 - Add collaboration labels on flaw promotion (OSIDB-3804)
+- Add basic end-to-end tests for Flaws, Affects and Trackers (OSIDB-3495)
 
 ### Changed
 - Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814), handled edge-case that would cause failure (OSIDB-3858)

--- a/osidb/tests/cassettes/test_e2e/TestE2E.test_cveorg_with_workflows.yaml
+++ b/osidb/tests/cassettes/test_e2e/TestE2E.test_cveorg_with_workflows.yaml
@@ -1,0 +1,3654 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:31 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:31 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 832x38865x1
+      x-asessionid:
+      - 1l2e6at
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640351.2a8f5872
+      x-rh-edge-request-id:
+      - 2a8f5872
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-0181 RRJ Nueva Ecija Engineer Online Portal Admin Panel admin_user.php
+      cross site scripting", "description": "A vulnerability was found in RRJ Nueva
+      Ecija Engineer Online Portal 1.0. It has been declared as problematic. Affected
+      by this vulnerability is an unknown functionality of the file /admin/admin_user.php
+      of the component Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+      leads to cross site scripting. The attack can be launched remotely. The exploit
+      has been disclosed to the public and may be used. The identifier VDB-249433
+      was assigned to this vulnerability.", "labels": ["flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+      "impact:LOW", "CVE-2024-0181"], "priority": {"name": "Minor"}, "assignee": {"name":
+      ""}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '838'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349359", "key": "OSIM-20230", "self": "https://example.com/rest/api/2/issue/16349359"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - close
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:33 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:33 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 832x38866x1
+      x-asessionid:
+      - 1cb0tw7
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640351.2a8f5cdc
+      x-rh-edge-request-id:
+      - 2a8f5cdc
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-20230
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349359", "self": "https://example.com/rest/api/2/issue/16349359",
+        "key": "OSIM-20230", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2c94db86[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10d403c9[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2089e14d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@10f374de[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@fd08568[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7fd0ebf4[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10bcfeca[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1b622d87[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10920046[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6865d6eb[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1fd82f83[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@155c37ea[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12326040": null, "customfield_12315950": null, "customfield_12310940":
+        null, "lastViewed": null, "customfield_12313140": null, "priority": {"self":
+        "https://example.com/rest/api/2/priority/4", "iconUrl": "https://example.com/images/icons/priorities/minor.svg",
+        "name": "Minor", "id": "4"}, "labels": ["CVE-2024-0181", "flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+        "impact:LOW"], "aggregatetimeoriginalestimate": null, "timeestimate": null,
+        "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-20230/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-20230/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T13:52:31.548+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2025-01-23T13:52:31.548+0000", "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "A vulnerability was found in RRJ Nueva Ecija Engineer
+        Online Portal 1.0. It has been declared as problematic. Affected by this vulnerability
+        is an unknown functionality of the file /admin/admin_user.php of the component
+        Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+        leads to cross site scripting. The attack can be launched remotely. The exploit
+        has been disclosed to the public and may be used. The identifier VDB-249433
+        was assigned to this vulnerability.", "timetracking": {}, "attachment": [],
+        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12316544": "None",
+        "customfield_12310840": "9223372036854775807", "summary": "CVE-2024-0181 RRJ
+        Nueva Ecija Engineer Online Portal Admin Panel admin_user.php cross site scripting",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tev:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:52 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:52 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '10198'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 832x38870x1
+      x-asessionid:
+      - 5rans5
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640372.e303b
+      x-rh-edge-request-id:
+      - e303b
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:53 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:53 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 832x81754x1
+      x-asessionid:
+      - 58mqwm
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640373.2a90be5e
+      x-rh-edge-request-id:
+      - 2a90be5e
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-4923 Codezips E-Commerce Site addproduct.php unrestricted upload",
+      "description": "A vulnerability has been found in Codezips E-Commerce Site 1.0
+      and classified as critical. This vulnerability affects unknown code of the file
+      admin/addproduct.php. The manipulation of the argument profilepic leads to unrestricted
+      upload. The attack can be initiated remotely. The exploit has been disclosed
+      to the public and may be used. The identifier of this vulnerability is VDB-264460.",
+      "labels": ["flawuuid:45a0d5da-4b1a-4947-81b0-e51ac04ac197", "impact:MODERATE",
+      "CVE-2024-4923"], "priority": {"name": "Normal"}, "assignee": {"name": ""}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '722'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349466", "key": "OSIM-20231", "self": "https://example.com/rest/api/2/issue/16349466"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:56 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:56 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 832x81755x1
+      x-asessionid:
+      - 1t9cmdc
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640373.2a90c4e0
+      x-rh-edge-request-id:
+      - 2a90c4e0
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-20231
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349466", "self": "https://example.com/rest/api/2/issue/16349466",
+        "key": "OSIM-20231", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@71b6f92f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a156a8e[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1b7ec0b0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1a3e884b[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5f86df06[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@3b083bd5[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@561e0744[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@380ca11c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@519b37f4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@2b376881[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@db57e84[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@50ec3a6f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12326040": null, "customfield_12315950": null, "customfield_12310940":
+        null, "lastViewed": null, "customfield_12313140": null, "priority": {"self":
+        "https://example.com/rest/api/2/priority/10200", "iconUrl": "https://example.com/images/icons/priorities/medium.svg",
+        "name": "Normal", "id": "10200"}, "labels": ["CVE-2024-4923", "flawuuid:45a0d5da-4b1a-4947-81b0-e51ac04ac197",
+        "impact:MODERATE"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-20231/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-20231/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T13:52:53.729+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2025-01-23T13:52:53.729+0000", "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "A vulnerability has been found in Codezips E-Commerce
+        Site 1.0 and classified as critical. This vulnerability affects unknown code
+        of the file admin/addproduct.php. The manipulation of the argument profilepic
+        leads to unrestricted upload. The attack can be initiated remotely. The exploit
+        has been disclosed to the public and may be used. The identifier of this vulnerability
+        is VDB-264460.", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2024-4923 Codezips E-Commerce Site
+        addproduct.php unrestricted upload", "customfield_12323640": null, "customfield_12325147":
+        null, "customfield_12325146": null, "customfield_12323642": null, "customfield_12325149":
+        null, "customfield_12323641": null, "customfield_12325148": null, "customfield_12325143":
+        null, "customfield_12325142": null, "customfield_12325145": null, "customfield_12325144":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12325141": null, "customfield_12325140":
+        null, "customfield_12310213": null, "customfield_12311940": "2|i27tf3:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:56 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:56 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '10091'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 832x81758x1
+      x-asessionid:
+      - 1oxofgx
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640376.2a90ea56
+      x-rh-edge-request-id:
+      - 2a90ea56
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:58 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:58 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 832x81760x1
+      x-asessionid:
+      - 5qqyud
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640378.e7700
+      x-rh-edge-request-id:
+      - e7700
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-0181 Spooky vulnerability", "description": "A vulnerability was found
+      in RRJ Nueva Ecija Engineer Online Portal 1.0. It has been declared as problematic.
+      Affected by this vulnerability is an unknown functionality of the file /admin/admin_user.php
+      of the component Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+      leads to cross site scripting. The attack can be launched remotely. The exploit
+      has been disclosed to the public and may be used. The identifier VDB-249433
+      was assigned to this vulnerability.", "labels": ["flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+      "impact:CRITICAL", "CVE-2024-0181"], "priority": {"name": "Critical"}, "assignee":
+      {"name": "concosta@redhat.com"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20230
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:52:59 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:52:59 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 832x81761x1
+      x-asessionid:
+      - 5fmzz6
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640378.e7798
+      x-rh-edge-request-id:
+      - e7798
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:00 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:00 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 833x38872x1
+      x-asessionid:
+      - 1sre0xf
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640380.2a912fe5
+      x-rh-edge-request-id:
+      - 2a912fe5
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-0181 Spooky vulnerability", "description": "A vulnerability was found
+      in RRJ Nueva Ecija Engineer Online Portal 1.0. It has been declared as problematic.
+      Affected by this vulnerability is an unknown functionality of the file /admin/admin_user.php
+      of the component Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+      leads to cross site scripting. The attack can be launched remotely. The exploit
+      has been disclosed to the public and may be used. The identifier VDB-249433
+      was assigned to this vulnerability.", "labels": ["flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+      "impact:CRITICAL", "CVE-2024-0181"], "priority": {"name": "Critical"}, "assignee":
+      {"name": "concosta@redhat.com"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20230
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:00 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:00 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 833x38873x1
+      x-asessionid:
+      - mhvo6r
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640380.2a9131ab
+      x-rh-edge-request-id:
+      - 2a9131ab
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:01 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:01 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 833x37537x1
+      x-asessionid:
+      - 36oxkf
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640381.e9946
+      x-rh-edge-request-id:
+      - e9946
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-0181 Spooky vulnerability", "description": "A vulnerability was found
+      in RRJ Nueva Ecija Engineer Online Portal 1.0. It has been declared as problematic.
+      Affected by this vulnerability is an unknown functionality of the file /admin/admin_user.php
+      of the component Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+      leads to cross site scripting. The attack can be launched remotely. The exploit
+      has been disclosed to the public and may be used. The identifier VDB-249433
+      was assigned to this vulnerability.", "labels": ["flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+      "impact:CRITICAL", "CVE-2024-0181"], "priority": {"name": "Critical"}, "assignee":
+      {"name": "concosta@redhat.com"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20230
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:01 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:01 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 833x37538x1
+      x-asessionid:
+      - nuhqsj
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640381.e9a83
+      x-rh-edge-request-id:
+      - e9a83
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:02 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:02 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 833x38879x1
+      x-asessionid:
+      - 1p4mkad
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640382.2a914ede
+      x-rh-edge-request-id:
+      - 2a914ede
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-0181 Spooky vulnerability", "description": "A vulnerability was found
+      in RRJ Nueva Ecija Engineer Online Portal 1.0. It has been declared as problematic.
+      Affected by this vulnerability is an unknown functionality of the file /admin/admin_user.php
+      of the component Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+      leads to cross site scripting. The attack can be launched remotely. The exploit
+      has been disclosed to the public and may be used. The identifier VDB-249433
+      was assigned to this vulnerability.", "labels": ["flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+      "impact:CRITICAL", "CVE-2024-0181"], "priority": {"name": "Critical"}, "assignee":
+      {"name": "concosta@redhat.com"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20230
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:02 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:02 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 833x38880x1
+      x-asessionid:
+      - zw634p
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640382.2a915013
+      x-rh-edge-request-id:
+      - 2a915013
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:04 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:04 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 833x37554x1
+      x-asessionid:
+      - 1it7f1e
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640384.ebe69
+      x-rh-edge-request-id:
+      - ebe69
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-0181 Spooky vulnerability", "description": "A vulnerability was found
+      in RRJ Nueva Ecija Engineer Online Portal 1.0. It has been declared as problematic.
+      Affected by this vulnerability is an unknown functionality of the file /admin/admin_user.php
+      of the component Admin Panel. The manipulation of the argument Firstname/Lastname/Username
+      leads to cross site scripting. The attack can be launched remotely. The exploit
+      has been disclosed to the public and may be used. The identifier VDB-249433
+      was assigned to this vulnerability.", "labels": ["flawuuid:749322bd-9206-489c-afd2-2452803207a2",
+      "impact:CRITICAL", "CVE-2024-0181"], "priority": {"name": "Critical"}, "assignee":
+      {"name": "concosta@redhat.com"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '799'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20230
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:04 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:04 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 833x37555x1
+      x-asessionid:
+      - 1qvb8eb
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640384.ebf2e
+      x-rh-edge-request-id:
+      - ebf2e
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:05 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:05 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 833x37556x1
+      x-asessionid:
+      - 1o435wv
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640385.2a917968
+      x-rh-edge-request-id:
+      - 2a917968
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-4923 Not a vulnerability", "description": "A vulnerability has been
+      found in Codezips E-Commerce Site 1.0 and classified as critical. This vulnerability
+      affects unknown code of the file admin/addproduct.php. The manipulation of the
+      argument profilepic leads to unrestricted upload. The attack can be initiated
+      remotely. The exploit has been disclosed to the public and may be used. The
+      identifier of this vulnerability is VDB-264460.", "labels": ["flawuuid:45a0d5da-4b1a-4947-81b0-e51ac04ac197",
+      "impact:LOW", "CVE-2024-4923"], "priority": {"name": "Minor"}, "assignee": {"name":
+      ""}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '676'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20231
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:07 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:07 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 833x37557x1
+      x-asessionid:
+      - 17jk9aq
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640385.2a917ae9
+      x-rh-edge-request-id:
+      - 2a917ae9
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{"body": "This was a spam."}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '28'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue/OSIM-20231/comment
+  response:
+    body:
+      string: '{"self": "https://example.com/rest/api/2/issue/16349466/comment/25583261",
+        "id": "25583261", "author": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "body": "This was a spam.", "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "created": "2025-01-23T13:53:07.869+0000", "updated": "2025-01-23T13:53:07.869+0000"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - close
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:09 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:09 GMT
+      Location:
+      - https://example.com/rest/api/2/issue/16349466/comment/25583261
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '1635'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 833x81768x1
+      x-asessionid:
+      - 1w33vwv
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737640387.ef59a
+      x-rh-edge-request-id:
+      - ef59a
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:09 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:09 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 833x81769x1
+      x-asessionid:
+      - 1y4f3oj
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640389.2a91bcba
+      x-rh-edge-request-id:
+      - 2a91bcba
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "CVE-2024-4923 Not a vulnerability", "description": "A vulnerability has been
+      found in Codezips E-Commerce Site 1.0 and classified as critical. This vulnerability
+      affects unknown code of the file admin/addproduct.php. The manipulation of the
+      argument profilepic leads to unrestricted upload. The attack can be initiated
+      remotely. The exploit has been disclosed to the public and may be used. The
+      identifier of this vulnerability is VDB-264460.", "labels": ["flawuuid:45a0d5da-4b1a-4947-81b0-e51ac04ac197",
+      "impact:LOW", "CVE-2024-4923"], "priority": {"name": "Minor"}, "assignee": {"name":
+      ""}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '676'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/OSIM-20231
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 13:53:09 GMT
+      Expires:
+      - Thu, 23 Jan 2025 13:53:09 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-1
+      x-arequestid:
+      - 833x81770x1
+      x-asessionid:
+      - 1yn175u
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737640389.2a91bd4a
+      x-rh-edge-request-id:
+      - 2a91bd4a
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/osidb/tests/cassettes/test_e2e/TestE2E.test_flaw_affect_tracker[False].yaml
+++ b/osidb/tests/cassettes/test_e2e/TestE2E.test_flaw_affect_tracker[False].yaml
@@ -1,0 +1,1749 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.3.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh103"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641239.2ace370e
+      x-rh-edge-request-id:
+      - 2ace370e
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.3.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"can_login": true, "real_name": "Need Real Name", "email":
+        "aander07@packetmaster.com", "name": "aander07@packetmaster.com", "id": 1}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:19 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641239.2ace38e6
+      x-rh-edge-request-id:
+      - 2ace38e6
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
+      "", "severity": "urgent", "priority": "urgent", "summary": "curl: test validations",
+      "description": "this is a simple test", "comment_is_private": false, "keywords":
+      ["Security"], "flags": [], "groups": [], "cc": []}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '363'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.3.0
+    method: POST
+    uri: https://example.com/rest/bug
+  response:
+    body:
+      string: '{"id": 2312352}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:21 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641239.2ace3fe3
+      x-rh-edge-request-id:
+      - 2ace3fe3
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:21 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:07:21 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 847x39708x2
+      x-asessionid:
+      - 1eoa4fk
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641241.4144fe
+      x-rh-edge-request-id:
+      - 4144fe
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "test validations", "description": "this is a simple test", "labels": ["flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892",
+      "impact:CRITICAL"], "priority": {"name": "Critical"}, "assignee": {"name": ""}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '281'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349278", "key": "OSIM-20235", "self": "https://example.com/rest/api/2/issue/16349278"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - close
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:29 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:07:29 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 847x39709x2
+      x-asessionid:
+      - 1o9ow15
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641241.4149b1
+      x-rh-edge-request-id:
+      - 4149b1
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-20235
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349278", "self": "https://example.com/rest/api/2/issue/16349278",
+        "key": "OSIM-20235", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@37718919[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2f43dab0[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4e06a4f9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7f2161d3[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2155cbb6[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@72929147[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9c8c280[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7d130593[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@721479fc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@146ac650[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5b79da9f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3ea363fe[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12326040": null, "customfield_12315950": null, "customfield_12310940":
+        null, "lastViewed": null, "customfield_12313140": null, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892",
+        "impact:CRITICAL"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-20235/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-20235/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:07:21.823+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2025-01-23T14:07:21.823+0000", "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "this is a simple test", "timetracking": {}, "attachment":
+        [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12316544": "None",
+        "customfield_12310840": "9223372036854775807", "summary": "test validations",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tkf:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:43 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:07:43 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '9645'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 847x39731x3
+      x-asessionid:
+      - 1y60yek
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641262.2acf95a6
+      x-rh-edge-request-id:
+      - 2acf95a6
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "components":
+      [{"name": "kernel / Other"}], "priority": {"name": "Critical"}, "description":
+      "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\ntest
+      validations\nhttps://bugzilla.stage.redhat.com/show_bug.cgi?id=2312352\n\nthis
+      is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+      never be made public, unless done so by the security team.", "labels": ["Security",
+      "SecurityTracking", "flaw:bz#2312352", "flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892",
+      "pscomponent:kernel"], "summary": "kernel: test validations [rhel-8]", "security":
+      {"name": "Red Hat Employee"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '687'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349375", "key": "RHEL-59830", "self": "https://example.com/rest/api/2/issue/16349375"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:08:04 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:08:04 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 847x40119x1
+      x-asessionid:
+      - nqzmex
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641264.429df0
+      x-rh-edge-request-id:
+      - 429df0
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59830
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349375", "self": "https://example.com/rest/api/2/issue/16349375",
+        "key": "RHEL-59830", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1bd4cb44[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21f32c29[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49b1c4cf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@711b3bb4[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a028497[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6b1e4798[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2c4e7188[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@420292e[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1a982301[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3a3854d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5c3e7680[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@59d24d70[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312352", "flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59830/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59830/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:07:45.395+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:08:03.064+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312352\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11694",
+        "id": "11694", "description": "Restricts access to Red Hat employees who are
+        approved to view product development information", "name": "Red Hat Engineering
+        Authorized"}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "kernel: test validations [rhel-8]", "customfield_12323640": null,
+        "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349375/comment/25583149",
+        "id": "25583149", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:08:03.064+0000",
+        "updated": "2025-01-23T14:08:03.064+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tkv:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:08:05 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:08:05 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16458'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 848x40130x1
+      x-asessionid:
+      - 1pxoam
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641284.43cf99
+      x-rh-edge-request-id:
+      - 43cf99
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59830
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349375", "self": "https://example.com/rest/api/2/issue/16349375",
+        "key": "RHEL-59830", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@797e14cf[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2bae5edc[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4f160009[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1617ef89[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@63a380e4[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@18fc94ce[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6715d990[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4ed7195c[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@318c04c2[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4daabcd9[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4ba35a5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@72d1c197[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312352", "flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59830/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59830/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:07:45.395+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:08:03.064+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312352\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11694",
+        "id": "11694", "description": "Restricts access to Red Hat employees who are
+        approved to view product development information", "name": "Red Hat Engineering
+        Authorized"}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "kernel: test validations [rhel-8]", "customfield_12323640": null,
+        "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349375/comment/25583149",
+        "id": "25583149", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:08:03.064+0000",
+        "updated": "2025-01-23T14:08:03.064+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tkv:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:08:07 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:08:07 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16460'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 848x40131x1
+      x-asessionid:
+      - l6rsax
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641285.2ad116dd
+      x-rh-edge-request-id:
+      - 2ad116dd
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "components":
+      [{"name": "kernel / Other"}], "priority": {"name": "Critical"}, "description":
+      "Security Tracking Issue\n\nDo not make this issue public.\n\nFlaw:\n-----\n\ntest
+      validations\nhttps://bugzilla.stage.redhat.com/show_bug.cgi?id=2312352\n\nthis
+      is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+      never be made public, unless done so by the security team.", "labels": ["Security",
+      "SecurityTracking", "flaw:bz#2312352", "flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892",
+      "pscomponent:kernel"], "summary": "kernel: test validations [rhel-8.10.z]",
+      "security": {"name": "Red Hat Employee"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '692'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349281", "key": "RHEL-59831", "self": "https://example.com/rest/api/2/issue/16349281"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      - Transfer-Encoding
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:08:27 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:08:27 GMT
+      Pragma:
+      - no-cache
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 848x39764x2
+      x-asessionid:
+      - pzq24h
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641287.2ad1363b
+      x-rh-edge-request-id:
+      - 2ad1363b
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59831
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349281", "self": "https://example.com/rest/api/2/issue/16349281",
+        "key": "RHEL-59831", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3ecdbe4a[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4059a286[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7cbb2951[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@71fbe9d2[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@541635df[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@44b905c7[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@616d4da0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@4ff69d26[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a2bf1ca[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@26b04e75[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d3b174e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@565fa062[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312352", "flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59831/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59831/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:08:08.108+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:08:26.060+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312352\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11694",
+        "id": "11694", "description": "Restricts access to Red Hat employees who are
+        approved to view product development information", "name": "Red Hat Engineering
+        Authorized"}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "kernel: test validations [rhel-8.10.z]", "customfield_12323640":
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349281/comment/25583048",
+        "id": "25583048", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:08:26.060+0000",
+        "updated": "2025-01-23T14:08:26.060+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tlb:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:08:29 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:08:29 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16466'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 848x39887x2
+      x-asessionid:
+      - 1m55bd7
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641307.2ad28763
+      x-rh-edge-request-id:
+      - 2ad28763
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59831
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349281", "self": "https://example.com/rest/api/2/issue/16349281",
+        "key": "RHEL-59831", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5132a125[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7af1adc3[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ee8f00d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1900c7a6[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1d8831f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1160e498[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38a11621[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2703cb64[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@628674e0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@74d4180c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@447418a9[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7d15b3a8[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312352", "flawuuid:d3fe4e81-df6b-4aee-b1be-6d4a41564892", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59831/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59831/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:08:08.108+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:08:26.060+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312352\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11694",
+        "id": "11694", "description": "Restricts access to Red Hat employees who are
+        approved to view product development information", "name": "Red Hat Engineering
+        Authorized"}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "kernel: test validations [rhel-8.10.z]", "customfield_12323640":
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349281/comment/25583048",
+        "id": "25583048", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:08:26.060+0000",
+        "updated": "2025-01-23T14:08:26.060+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tlb:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:08:31 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:08:31 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16465'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 848x40146x2
+      x-asessionid:
+      - 103fvdi
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641309.453b60
+      x-rh-edge-request-id:
+      - 453b60
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/osidb/tests/cassettes/test_e2e/TestE2E.test_flaw_affect_tracker[True].yaml
+++ b/osidb/tests/cassettes/test_e2e/TestE2E.test_flaw_affect_tracker[True].yaml
@@ -1,0 +1,1912 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.3.0
+    method: GET
+    uri: https://example.com/rest/version
+  response:
+    body:
+      string: '{"version": "5.0.4.rh103"}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '25'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:05:41 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641141.3b9d53
+      x-rh-edge-request-id:
+      - 3b9d53
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.3.0
+    method: GET
+    uri: https://example.com/rest/user?ids=1
+  response:
+    body:
+      string: '{"users": [{"can_login": true, "email": "aander07@packetmaster.com",
+        "real_name": "Need Real Name", "name": "aander07@packetmaster.com", "id":
+        1}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:05:42 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641141.3b9e9c
+      x-rh-edge-request-id:
+      - 3b9e9c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"product": "Security Response", "op_sys": "Linux", "platform": "All",
+      "version": "unspecified", "component": "vulnerability", "cf_release_notes":
+      "", "severity": "urgent", "priority": "urgent", "summary": "EMBARGOED curl:
+      test validations", "description": "this is a simple test", "comment_is_private":
+      false, "keywords": ["Security"], "flags": [], "groups": ["qe_staff", "security"],
+      "deadline": "2024-08-07", "cc": []}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '421'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-bugzilla/3.3.0
+    method: POST
+    uri: https://example.com/rest/bug
+  response:
+    body:
+      string: '{"id": 2312351}'
+    headers:
+      Access-Control-Allow-Headers:
+      - origin, content-type, accept, x-requested-with
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - private, must-revalidate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '14'
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:05:43 GMT
+      Strict-Transport-Security:
+      - max-age=63072000; includeSubDomains
+      X-content-type-options:
+      - nosniff
+      X-xss-protection:
+      - 1; mode=block
+      x-rh-edge-cache-status:
+      - Miss from child, Miss from parent
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641142.3ba429
+      x-rh-edge-request-id:
+      - 3ba429
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/mypermissions?projectKey=OSIM
+  response:
+    body:
+      string: '{"permissions": {"ARCHIVE_ISSUES": {"id": "-1", "key": "ARCHIVE_ISSUES",
+        "name": "Archive Issues", "type": "PROJECT", "description": "Ability to archive
+        issues for a specific project.", "havePermission": true}, "VIEW_WORKFLOW_READONLY":
+        {"id": "45", "key": "VIEW_WORKFLOW_READONLY", "name": "View Read-Only Workflow",
+        "type": "PROJECT", "description": "admin.permissions.descriptions.VIEW_WORKFLOW_READONLY",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUES": {"id": "11",
+        "key": "CREATE_ISSUES", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true}, "VIEW_DEV_TOOLS": {"id":
+        "29", "key": "VIEW_DEV_TOOLS", "name": "View Development Tools", "type": "PROJECT",
+        "description": "Allows users in a software project to view development-related
+        information on the issue, such as commits, reviews and build information.",
+        "havePermission": true}, "BULK_CHANGE": {"id": "33", "key": "BULK_CHANGE",
+        "name": "Bulk Change", "type": "GLOBAL", "description": "Ability to modify
+        a collection of issues at once. For example, resolve multiple issues in one
+        step.", "havePermission": true}, "CREATE_ATTACHMENT": {"id": "19", "key":
+        "CREATE_ATTACHMENT", "name": "Create Attachments", "type": "PROJECT", "description":
+        "Users with this permission may create attachments.", "havePermission": true,
+        "deprecatedKey": true}, "DELETE_OWN_COMMENTS": {"id": "37", "key": "DELETE_OWN_COMMENTS",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true}, "WORK_ON_ISSUES":
+        {"id": "20", "key": "WORK_ON_ISSUES", "name": "Work On Issues", "type": "PROJECT",
+        "description": "Ability to log work done against an issue. Only useful if
+        Time Tracking is turned on.", "havePermission": true}, "PROJECT_ADMIN": {"id":
+        "23", "key": "PROJECT_ADMIN", "name": "Administer Projects", "type": "PROJECT",
+        "description": "Ability to administer a project in Jira.", "havePermission":
+        true, "deprecatedKey": true}, "COMMENT_EDIT_ALL": {"id": "34", "key": "COMMENT_EDIT_ALL",
+        "name": "Edit All Comments", "type": "PROJECT", "description": "Ability to
+        edit all comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ATTACHMENT_DELETE_OWN": {"id": "39", "key": "ATTACHMENT_DELETE_OWN",
+        "name": "Delete Own Attachments", "type": "PROJECT", "description": "Users
+        with this permission may delete own attachments.", "havePermission": true,
+        "deprecatedKey": true}, "WORKLOG_DELETE_OWN": {"id": "42", "key": "WORKLOG_DELETE_OWN",
+        "name": "Delete Own Worklogs", "type": "PROJECT", "description": "Ability
+        to delete own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "CLOSE_ISSUE": {"id": "18", "key": "CLOSE_ISSUE", "name": "Close Issues",
+        "type": "PROJECT", "description": "Ability to close issues. Often useful where
+        your developers resolve issues, and a QA department closes them.", "havePermission":
+        true, "deprecatedKey": true}, "MANAGE_WATCHER_LIST": {"id": "32", "key": "MANAGE_WATCHER_LIST",
+        "name": "Manage Watchers", "type": "PROJECT", "description": "Ability to manage
+        the watchers of an issue.", "havePermission": true, "deprecatedKey": true},
+        "VIEW_VOTERS_AND_WATCHERS": {"id": "31", "key": "VIEW_VOTERS_AND_WATCHERS",
+        "name": "View Voters and Watchers", "type": "PROJECT", "description": "Ability
+        to view the voters and watchers of an issue.", "havePermission": true}, "ADD_COMMENTS":
+        {"id": "15", "key": "ADD_COMMENTS", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true}, "COMMENT_DELETE_ALL":
+        {"id": "36", "key": "COMMENT_DELETE_ALL", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true, "deprecatedKey": true}, "CREATE_ISSUE": {"id": "11",
+        "key": "CREATE_ISSUE", "name": "Create Issues", "type": "PROJECT", "description":
+        "Ability to create issues.", "havePermission": true, "deprecatedKey": true},
+        "DELETE_OWN_ATTACHMENTS": {"id": "39", "key": "DELETE_OWN_ATTACHMENTS", "name":
+        "Delete Own Attachments", "type": "PROJECT", "description": "Users with this
+        permission may delete own attachments.", "havePermission": true}, "DELETE_ALL_ATTACHMENTS":
+        {"id": "38", "key": "DELETE_ALL_ATTACHMENTS", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true}, "ASSIGN_ISSUE": {"id": "13", "key":
+        "ASSIGN_ISSUE", "name": "Assign Issues", "type": "PROJECT", "description":
+        "Ability to assign issues to other people.", "havePermission": true, "deprecatedKey":
+        true}, "LINK_ISSUE": {"id": "21", "key": "LINK_ISSUE", "name": "Link Issues",
+        "type": "PROJECT", "description": "Ability to link issues together and create
+        linked issues. Only useful if issue linking is turned on.", "havePermission":
+        true, "deprecatedKey": true}, "EDIT_OWN_WORKLOGS": {"id": "40", "key": "EDIT_OWN_WORKLOGS",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true}, "CREATE_ATTACHMENTS":
+        {"id": "19", "key": "CREATE_ATTACHMENTS", "name": "Create Attachments", "type":
+        "PROJECT", "description": "Users with this permission may create attachments.",
+        "havePermission": true}, "EDIT_ALL_WORKLOGS": {"id": "41", "key": "EDIT_ALL_WORKLOGS",
+        "name": "Edit All Worklogs", "type": "PROJECT", "description": "Ability to
+        edit all worklogs made on issues.", "havePermission": true}, "SCHEDULE_ISSUE":
+        {"id": "28", "key": "SCHEDULE_ISSUE", "name": "Schedule Issues", "type": "PROJECT",
+        "description": "Ability to view or edit an issue''s due date.", "havePermission":
+        true, "deprecatedKey": true}, "CLOSE_ISSUES": {"id": "18", "key": "CLOSE_ISSUES",
+        "name": "Close Issues", "type": "PROJECT", "description": "Ability to close
+        issues. Often useful where your developers resolve issues, and a QA department
+        closes them.", "havePermission": true}, "SET_ISSUE_SECURITY": {"id": "26",
+        "key": "SET_ISSUE_SECURITY", "name": "Set Issue Security", "type": "PROJECT",
+        "description": "Ability to set the level of security on an issue so that only
+        people in that security level can see the issue.", "havePermission": true},
+        "SCHEDULE_ISSUES": {"id": "28", "key": "SCHEDULE_ISSUES", "name": "Schedule
+        Issues", "type": "PROJECT", "description": "Ability to view or edit an issue''s
+        due date.", "havePermission": true}, "WORKLOG_DELETE_ALL": {"id": "43", "key":
+        "WORKLOG_DELETE_ALL", "name": "Delete All Worklogs", "type": "PROJECT", "description":
+        "Ability to delete all worklogs made on issues.", "havePermission": true,
+        "deprecatedKey": true}, "COMMENT_DELETE_OWN": {"id": "37", "key": "COMMENT_DELETE_OWN",
+        "name": "Delete Own Comments", "type": "PROJECT", "description": "Ability
+        to delete own comments made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "ADMINISTER_PROJECTS": {"id": "23", "key": "ADMINISTER_PROJECTS", "name":
+        "Administer Projects", "type": "PROJECT", "description": "Ability to administer
+        a project in Jira.", "havePermission": true}, "DELETE_ALL_COMMENTS": {"id":
+        "36", "key": "DELETE_ALL_COMMENTS", "name": "Delete All Comments", "type":
+        "PROJECT", "description": "Ability to delete all comments made on issues.",
+        "havePermission": true}, "RESOLVE_ISSUES": {"id": "14", "key": "RESOLVE_ISSUES",
+        "name": "Resolve Issues", "type": "PROJECT", "description": "Ability to resolve
+        and reopen issues. This includes the ability to set a fix version.", "havePermission":
+        true}, "VIEW_READONLY_WORKFLOW": {"id": "45", "key": "VIEW_READONLY_WORKFLOW",
+        "name": "View Read-Only Workflow", "type": "PROJECT", "description": "Users
+        with this permission may view a read-only version of a workflow.", "havePermission":
+        true}, "ADMINISTER": {"id": "0", "key": "ADMINISTER", "name": "Jira Administrators",
+        "type": "GLOBAL", "description": "Ability to perform most administration functions
+        (excluding Import & Export, SMTP Configuration, etc.).", "havePermission":
+        false}, "GLOBAL_BROWSE_ARCHIVE": {"id": "-1", "key": "GLOBAL_BROWSE_ARCHIVE",
+        "name": "Browse Archive", "type": "GLOBAL", "description": "Ability to browse
+        all archived issues.", "havePermission": false}, "MOVE_ISSUES": {"id": "25",
+        "key": "MOVE_ISSUES", "name": "Move Issues", "type": "PROJECT", "description":
+        "Ability to move issues between projects or between workflows of the same
+        project (if applicable). Note the user can only move issues to a project he
+        or she has the create permission for.", "havePermission": true}, "TRANSITION_ISSUES":
+        {"id": "46", "key": "TRANSITION_ISSUES", "name": "Transition Issues", "type":
+        "PROJECT", "description": "Ability to transition issues.", "havePermission":
+        true}, "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION": {"id": "-1", "key": "EDIT_SPRINT_NAME_AND_GOAL_PERMISSION",
+        "name": "Edit Sprints", "type": "PROJECT", "description": "Ability to edit
+        sprint name and goal.", "havePermission": false}, "SYSTEM_ADMIN": {"id": "44",
+        "key": "SYSTEM_ADMIN", "name": "Jira System Administrators", "type": "GLOBAL",
+        "description": "Ability to perform all administration functions. There must
+        be at least one group with this permission.", "havePermission": false}, "DELETE_OWN_WORKLOGS":
+        {"id": "42", "key": "DELETE_OWN_WORKLOGS", "name": "Delete Own Worklogs",
+        "type": "PROJECT", "description": "Ability to delete own worklogs made on
+        issues.", "havePermission": true}, "BROWSE": {"id": "10", "key": "BROWSE",
+        "name": "Browse Projects", "type": "PROJECT", "description": "Ability to browse
+        projects and the issues within them.", "havePermission": true, "deprecatedKey":
+        true}, "EDIT_ISSUE": {"id": "12", "key": "EDIT_ISSUE", "name": "Edit Issues",
+        "type": "PROJECT", "description": "Ability to edit issues.", "havePermission":
+        true, "deprecatedKey": true}, "MODIFY_REPORTER": {"id": "30", "key": "MODIFY_REPORTER",
+        "name": "Modify Reporter", "type": "PROJECT", "description": "Ability to modify
+        the reporter when creating or editing an issue.", "havePermission": true},
+        "EDIT_ISSUES": {"id": "12", "key": "EDIT_ISSUES", "name": "Edit Issues", "type":
+        "PROJECT", "description": "Ability to edit issues.", "havePermission": true},
+        "MANAGE_WATCHERS": {"id": "32", "key": "MANAGE_WATCHERS", "name": "Manage
+        Watchers", "type": "PROJECT", "description": "Ability to manage the watchers
+        of an issue.", "havePermission": true}, "EDIT_OWN_COMMENTS": {"id": "35",
+        "key": "EDIT_OWN_COMMENTS", "name": "Edit Own Comments", "type": "PROJECT",
+        "description": "Ability to edit own comments made on issues.", "havePermission":
+        true}, "ASSIGN_ISSUES": {"id": "13", "key": "ASSIGN_ISSUES", "name": "Assign
+        Issues", "type": "PROJECT", "description": "Ability to assign issues to other
+        people.", "havePermission": true}, "BROWSE_PROJECTS": {"id": "10", "key":
+        "BROWSE_PROJECTS", "name": "Browse Projects", "type": "PROJECT", "description":
+        "Ability to browse projects and the issues within them.", "havePermission":
+        true}, "gtmhub-view-OKRs-permissions": {"id": "-1", "key": "gtmhub-view-OKRs-permissions",
+        "name": "View OKRs", "type": "GLOBAL", "description": "Ability to view Quantive
+        Results OKRs (Objective and key results) that are linked to a given issue",
+        "havePermission": false}, "RESTORE_ISSUES": {"id": "-1", "key": "RESTORE_ISSUES",
+        "name": "Restore Issues", "type": "PROJECT", "description": "Ability to restore
+        issues for a specific project.", "havePermission": true}, "BROWSE_ARCHIVE":
+        {"id": "-1", "key": "BROWSE_ARCHIVE", "name": "Browse Project Archive", "type":
+        "PROJECT", "description": "Ability to browse archived issues from a specific
+        project.", "havePermission": true}, "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL": {"id":
+        "-1", "key": "A4J_PERM_IMPERSONATE_ACTOR_GLOBAL", "name": "Impersonate users
+        in A4J global scope", "type": "GLOBAL", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": true},
+        "VIEW_VERSION_CONTROL": {"id": "29", "key": "VIEW_VERSION_CONTROL", "name":
+        "View Development Tools", "type": "PROJECT", "description": "Allows users
+        to view development-related information on the view issue screen, like commits,
+        reviews and build information.", "havePermission": true, "deprecatedKey":
+        true}, "START_STOP_SPRINTS_PERMISSION": {"id": "-1", "key": "START_STOP_SPRINTS_PERMISSION",
+        "name": "Start/Complete Sprints", "type": "PROJECT", "description": "Ability
+        to start and complete sprints.", "havePermission": true}, "WORK_ISSUE": {"id":
+        "20", "key": "WORK_ISSUE", "name": "Work On Issues", "type": "PROJECT", "description":
+        "Ability to log work done against an issue. Only useful if Time Tracking is
+        turned on.", "havePermission": true, "deprecatedKey": true}, "COMMENT_ISSUE":
+        {"id": "15", "key": "COMMENT_ISSUE", "name": "Add Comments", "type": "PROJECT",
+        "description": "Ability to comment on issues.", "havePermission": true, "deprecatedKey":
+        true}, "WORKLOG_EDIT_ALL": {"id": "41", "key": "WORKLOG_EDIT_ALL", "name":
+        "Edit All Worklogs", "type": "PROJECT", "description": "Ability to edit all
+        worklogs made on issues.", "havePermission": true, "deprecatedKey": true},
+        "EDIT_ALL_COMMENTS": {"id": "34", "key": "EDIT_ALL_COMMENTS", "name": "Edit
+        All Comments", "type": "PROJECT", "description": "Ability to edit all comments
+        made on issues.", "havePermission": true}, "DELETE_ISSUE": {"id": "16", "key":
+        "DELETE_ISSUE", "name": "Delete Issues", "type": "PROJECT", "description":
+        "Ability to delete issues.", "havePermission": false, "deprecatedKey": true},
+        "MANAGE_SPRINTS_PERMISSION": {"id": "-1", "key": "MANAGE_SPRINTS_PERMISSION",
+        "name": "Manage Sprints", "type": "PROJECT", "description": "Ability to manage
+        sprints.", "havePermission": true}, "USER_PICKER": {"id": "27", "key": "USER_PICKER",
+        "name": "Browse Users", "type": "GLOBAL", "description": "Ability to select
+        a user or group from a popup window as well as the ability to use the ''share''
+        issues feature. Users with this permission will also be able to see names
+        of all users and groups in the system.", "havePermission": true}, "CREATE_SHARED_OBJECTS":
+        {"id": "22", "key": "CREATE_SHARED_OBJECTS", "name": "Create Shared Objects",
+        "type": "GLOBAL", "description": "Ability to share dashboards and filters
+        with other users, groups and roles.", "havePermission": true}, "ATTACHMENT_DELETE_ALL":
+        {"id": "38", "key": "ATTACHMENT_DELETE_ALL", "name": "Delete All Attachments",
+        "type": "PROJECT", "description": "Users with this permission may delete all
+        attachments.", "havePermission": true, "deprecatedKey": true}, "DELETE_ISSUES":
+        {"id": "16", "key": "DELETE_ISSUES", "name": "Delete Issues", "type": "PROJECT",
+        "description": "Ability to delete issues.", "havePermission": false}, "MANAGE_GROUP_FILTER_SUBSCRIPTIONS":
+        {"id": "24", "key": "MANAGE_GROUP_FILTER_SUBSCRIPTIONS", "name": "Manage Group
+        Filter Subscriptions", "type": "GLOBAL", "description": "Ability to manage
+        (create and delete) group filter subscriptions.", "havePermission": true},
+        "RESOLVE_ISSUE": {"id": "14", "key": "RESOLVE_ISSUE", "name": "Resolve Issues",
+        "type": "PROJECT", "description": "Ability to resolve and reopen issues. This
+        includes the ability to set a fix version.", "havePermission": true, "deprecatedKey":
+        true}, "SERVICEDESK_AGENT": {"id": "-1", "key": "SERVICEDESK_AGENT", "name":
+        "Service Desk Agent", "type": "PROJECT", "description": "Allows users to interact
+        with customers and access Jira Service Management features of a project.",
+        "havePermission": false}, "A4J_PERM_IMPERSONATE_ACTOR_PROJECT": {"id": "-1",
+        "key": "A4J_PERM_IMPERSONATE_ACTOR_PROJECT", "name": "Impersonate users in
+        A4J project scope", "type": "PROJECT", "description": "Having the permission
+        allows to select other user as automation rule actor", "havePermission": false},
+        "ASSIGNABLE_USER": {"id": "17", "key": "ASSIGNABLE_USER", "name": "Assignable
+        User", "type": "PROJECT", "description": "Users with this permission may be
+        assigned to issues.", "havePermission": true}, "TRANSITION_ISSUE": {"id":
+        "46", "key": "TRANSITION_ISSUE", "name": "Transition Issues", "type": "PROJECT",
+        "description": "Ability to transition issues.", "havePermission": true, "deprecatedKey":
+        true}, "COMMENT_EDIT_OWN": {"id": "35", "key": "COMMENT_EDIT_OWN", "name":
+        "Edit Own Comments", "type": "PROJECT", "description": "Ability to edit own
+        comments made on issues.", "havePermission": true, "deprecatedKey": true},
+        "MOVE_ISSUE": {"id": "25", "key": "MOVE_ISSUE", "name": "Move Issues", "type":
+        "PROJECT", "description": "Ability to move issues between projects or between
+        workflows of the same project (if applicable). Note the user can only move
+        issues to a project he or she has the create permission for.", "havePermission":
+        true, "deprecatedKey": true}, "WORKLOG_EDIT_OWN": {"id": "40", "key": "WORKLOG_EDIT_OWN",
+        "name": "Edit Own Worklogs", "type": "PROJECT", "description": "Ability to
+        edit own worklogs made on issues.", "havePermission": true, "deprecatedKey":
+        true}, "DELETE_ALL_WORKLOGS": {"id": "43", "key": "DELETE_ALL_WORKLOGS", "name":
+        "Delete All Worklogs", "type": "PROJECT", "description": "Ability to delete
+        all worklogs made on issues.", "havePermission": true}, "LINK_ISSUES": {"id":
+        "21", "key": "LINK_ISSUES", "name": "Link Issues", "type": "PROJECT", "description":
+        "Ability to link issues together and create linked issues. Only useful if
+        issue linking is turned on.", "havePermission": true}, "gtmhub-view-OKRs-prj-permissions":
+        {"id": "-1", "key": "gtmhub-view-OKRs-prj-permissions", "name": "View OKRs",
+        "type": "PROJECT", "description": "Ability to view Quantive Results OKRs (Objective
+        and key results) that are linked to a given issue", "havePermission": false}}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:05:44 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:05:44 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16539'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 845x39182x1
+      x-asessionid:
+      - 1kly4x5
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641144.3bc0db
+      x-rh-edge-request-id:
+      - 3bc0db
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
+      "test validations", "description": "this is a simple test", "labels": ["flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104",
+      "impact:CRITICAL"], "priority": {"name": "Critical"}, "assignee": {"name": ""}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '281'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349273", "key": "OSIM-20234", "self": "https://example.com/rest/api/2/issue/16349273"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - close
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:05:54 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:05:54 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 845x39184x1
+      x-asessionid:
+      - u4iq98
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641144.3bc2c2
+      x-rh-edge-request-id:
+      - 3bc2c2
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-20234
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349273", "self": "https://example.com/rest/api/2/issue/16349273",
+        "key": "OSIM-20234", "fields": {"customfield_12324540": "0.0", "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@35e670fb[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@34b28025[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1f720d29[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@3f61154a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6e0d75f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@31f87f5c[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3e6c370f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@910becd[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9cada9f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7bba4665[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2431d252[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@28dbe6cf[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12326040": null, "customfield_12315950": null, "customfield_12310940":
+        null, "lastViewed": null, "customfield_12313140": null, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104",
+        "impact:CRITICAL"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
+        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
+        "description": "Initial creation status. Implies nothing yet and should be
+        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "subtasks": [], "customfield_12321140": null, "customfield_12320850": null,
+        "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-20234/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
+        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
+        "id": "17", "description": "Created by Jira Software - do not edit or delete.
+        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
+        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
+        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
+        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
+        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
+        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
+        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-20234/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:05:44.537+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
+        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
+        "2025-01-23T14:05:44.537+0000", "customfield_12316142": null, "timeoriginalestimate":
+        null, "description": "this is a simple test", "timetracking": {}, "attachment":
+        [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12316544": "None",
+        "customfield_12310840": "9223372036854775807", "summary": "test validations",
+        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
+        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
+        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
+        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tjb:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:10 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:10 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '9643'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 846x39395x3
+      x-asessionid:
+      - 730uu8
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641169.3d02af
+      x-rh-edge-request-id:
+      - 3d02af
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "components":
+      [{"name": "kernel / Other"}], "priority": {"name": "Critical"}, "description":
+      "Security Tracking Issue\n\nDo not make this issue public.\n\nNOTE THIS ISSUE
+      IS CURRENTLY EMBARGOED, DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\nWARNING:
+      NOTICE THAT CHANGING THE SECURITY LEVEL FROM \"SECURITY ISSUE\" TO \"RED HAT
+      INTERNAL\" MAY BREAK THE EMBARGO.\n\nFlaw:\n-----\n\ntest validations\nhttps://bugzilla.stage.redhat.com/show_bug.cgi?id=2312351\n\nthis
+      is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+      never be made public, unless done so by the security team.", "labels": ["Security",
+      "SecurityTracking", "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104",
+      "pscomponent:kernel"], "summary": "EMBARGOED kernel: test validations [rhel-8]",
+      "security": {"name": "Embargoed Security Issue"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '928'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349274", "key": "RHEL-59828", "self": "https://example.com/rest/api/2/issue/16349274"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:35 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:35 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 846x39409x1
+      x-asessionid:
+      - 15r5o48
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641171.2aca08d1
+      x-rh-edge-request-id:
+      - 2aca08d1
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59828
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349274", "self": "https://example.com/rest/api/2/issue/16349274",
+        "key": "RHEL-59828", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@48cedc5c[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49ef9c30[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2a4e4c65[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@1f754b00[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@636be4cd[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@1535fe10[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4dc0b5b7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@78d8ca44[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@44a9141e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7ed6b7e5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3673d885[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@8c7aee5[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59828/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59828/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:06:13.303+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:06:33.679+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nNOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO
+        NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\nWARNING: NOTICE THAT
+        CHANGING THE SECURITY LEVEL FROM \"SECURITY ISSUE\" TO \"RED HAT INTERNAL\"
+        MAY BREAK THE EMBARGO.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312351\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11690",
+        "id": "11690", "description": "Restricts access to Product Security and the
+        people involved in resolving the issue. Only Product Security can remove this
+        level once applied", "name": "Embargoed Security Issue"}, "attachment": [],
+        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "EMBARGOED kernel: test validations [rhel-8]", "customfield_12323640":
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349274/comment/25583043",
+        "id": "25583043", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:06:33.679+0000",
+        "updated": "2025-01-23T14:06:33.679+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tjj:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:36 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:36 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16734'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 846x39597x1
+      x-asessionid:
+      - 1b30ppi
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641195.2acb6db8
+      x-rh-edge-request-id:
+      - 2acb6db8
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59828
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349274", "self": "https://example.com/rest/api/2/issue/16349274",
+        "key": "RHEL-59828", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@f74684e[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@20479af0[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@390fce01[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@258343ca[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@631ded65[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@59253939[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1e1d8bda[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@21bf06c0[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d45b157[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@5dd9b937[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2f68ba0d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@76383026[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59828/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59828/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:06:13.303+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:06:33.679+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nNOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO
+        NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\nWARNING: NOTICE THAT
+        CHANGING THE SECURITY LEVEL FROM \"SECURITY ISSUE\" TO \"RED HAT INTERNAL\"
+        MAY BREAK THE EMBARGO.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312351\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11690",
+        "id": "11690", "description": "Restricts access to Product Security and the
+        people involved in resolving the issue. Only Product Security can remove this
+        level once applied", "name": "Embargoed Security Issue"}, "attachment": [],
+        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "EMBARGOED kernel: test validations [rhel-8]", "customfield_12323640":
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349274/comment/25583043",
+        "id": "25583043", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:06:33.679+0000",
+        "updated": "2025-01-23T14:06:33.679+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tjj:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:38 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:38 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16734'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 846x39966x2
+      x-asessionid:
+      - io2kyz
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641196.2acb8574
+      x-rh-edge-request-id:
+      - 2acb8574
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "components":
+      [{"name": "kernel / Other"}], "priority": {"name": "Critical"}, "description":
+      "Security Tracking Issue\n\nDo not make this issue public.\n\nNOTE THIS ISSUE
+      IS CURRENTLY EMBARGOED, DO NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\nWARNING:
+      NOTICE THAT CHANGING THE SECURITY LEVEL FROM \"SECURITY ISSUE\" TO \"RED HAT
+      INTERNAL\" MAY BREAK THE EMBARGO.\n\nFlaw:\n-----\n\ntest validations\nhttps://bugzilla.stage.redhat.com/show_bug.cgi?id=2312351\n\nthis
+      is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+      never be made public, unless done so by the security team.", "labels": ["Security",
+      "SecurityTracking", "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104",
+      "pscomponent:kernel"], "summary": "EMBARGOED kernel: test validations [rhel-8.10.z]",
+      "security": {"name": "Embargoed Security Issue"}}}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '933'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: POST
+    uri: https://example.com/rest/api/2/issue
+  response:
+    body:
+      string: '{"id": "16349275", "key": "RHEL-59829", "self": "https://example.com/rest/api/2/issue/16349275"}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:54 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:54 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '103'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 846x39602x2
+      x-asessionid:
+      - o0by55
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641199.3ec195
+      x-rh-edge-request-id:
+      - 3ec195
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59829
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349275", "self": "https://example.com/rest/api/2/issue/16349275",
+        "key": "RHEL-59829", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5c25d7ef[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4c8fbd3f[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@581ec3cc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@6949fbb5[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3363beda[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2e16a397[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38053a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@260ac2db[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@8312dae[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@13a03d24[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5371ebbf[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@239de710[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59829/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59829/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:06:39.601+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:06:52.847+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nNOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO
+        NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\nWARNING: NOTICE THAT
+        CHANGING THE SECURITY LEVEL FROM \"SECURITY ISSUE\" TO \"RED HAT INTERNAL\"
+        MAY BREAK THE EMBARGO.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312351\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11690",
+        "id": "11690", "description": "Restricts access to Product Security and the
+        people involved in resolving the issue. Only Product Security can remove this
+        level once applied", "name": "Embargoed Security Issue"}, "attachment": [],
+        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "EMBARGOED kernel: test validations [rhel-8.10.z]", "customfield_12323640":
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349275/comment/25583044",
+        "id": "25583044", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:06:52.847+0000",
+        "updated": "2025-01-23T14:06:52.847+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tjr:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:55 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:55 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16737'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 846x39637x4
+      x-asessionid:
+      - 2nll95
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.1f4e4e68.1737641214.3fa7b0
+      x-rh-edge-request-id:
+      - 3fa7b0
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/RHEL-59829
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16349275", "self": "https://example.com/rest/api/2/issue/16349275",
+        "key": "RHEL-59829", "fields": {"customfield_12322243": null, "customfield_12318141":
+        null, "customfield_12322244": null, "customfield_12322640": null, "customfield_12316240":
+        null, "customfield_12324540": "0.0", "customfield_12322241": null, "fixVersions":
+        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5af4b970[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6f1cb1e7[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@425b3c5[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@e3cb92f[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@cb6056c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5ad21c30[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@73c02734[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@18de1da2[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@247ff6b0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6e064d93[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1c8d2ee0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@74d603de[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12317334": null, "customfield_12326040": null, "customfield_12318148":
+        null, "customfield_12326041": null, "customfield_12315950": null, "customfield_12310940":
+        null, "customfield_12321440": null, "lastViewed": null, "customfield_12321040":
+        null, "customfield_12317340": null, "customfield_12323341": null, "customfield_12317341":
+        null, "customfield_12319640": null, "customfield_12317342": null, "customfield_12313140":
+        null, "customfield_12315041": {"self": "https://example.com/rest/api/2/customFieldOption/12953",
+        "value": "Not Started", "id": "12953", "disabled": false}, "priority": {"self":
+        "https://example.com/rest/api/2/priority/2", "iconUrl": "https://example.com/images/icons/priorities/critical.svg",
+        "name": "Critical", "id": "2"}, "labels": ["Security", "SecurityTracking",
+        "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104", "pscomponent:kernel"],
+        "customfield_12311641": null, "customfield_12311240": null, "aggregatetimeoriginalestimate":
+        null, "timeestimate": null, "versions": [], "customfield_12319247": null,
+        "customfield_12317343": null, "issuelinks": [], "customfield_12317345": null,
+        "customfield_12325240": null, "assignee": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12317347":
+        null, "customfield_12317348": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [{"self": "https://example.com/rest/api/2/component/12370079", "id": "12370079",
+        "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
+        null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317278": null, "customfield_12317313": null, "customfield_12316348":
+        null, "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
+        null, "creator": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "customfield_12321541": null, "subtasks": [], "customfield_12321140": null,
+        "customfield_12319740": null, "customfield_12323440": null, "customfield_12320851":
+        null, "customfield_12315141": {"self": "https://example.com/rest/api/2/user?username=kernel-mgr",
+        "name": "kernel-mgr", "key": "kernel-mgr", "emailAddress": "kernel-mgr@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=48",
+        "24x24": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=24",
+        "16x16": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=16",
+        "32x32": "https://example.com/avatar/c8dff0def69aadbb46f9e19222f77075?d=mm&s=32"},
+        "displayName": "kernel-mgr", "active": true, "timeZone": "UTC"}, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=concosta%40redhat.com",
+        "name": "concosta@redhat.com", "key": "JIRAUSER196381", "emailAddress": "concosta+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER196381&avatarId=41326",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER196381&avatarId=41326",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER196381&avatarId=41326",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER196381&avatarId=41326"},
+        "displayName": "Conrado Costa", "active": true, "timeZone": "America/New_York"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12315948": {"self": "https://example.com/rest/api/2/user?username=kernel-qe",
+        "name": "kernel-qe", "key": "JIRAUSER208396", "emailAddress": "kernel-qe@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=48",
+        "24x24": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=24",
+        "16x16": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=16",
+        "32x32": "https://example.com/avatar/f457bbf73384db579496c13768c1a7ee?d=mm&s=32"},
+        "displayName": "Kernel QE", "active": true, "timeZone": "UTC"}, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "customfield_12323040": null, "votes": {"self": "https://example.com/rest/api/2/issue/RHEL-59829/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12315940":
+        null, "customfield_12317843": null, "customfield_12325158": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/1", "id": "1", "description":
+        "A problem that impairs or prevents the functions of the product.", "iconUrl":
+        "https://example.com/secure/viewavatar?size=xsmall&avatarId=13263&avatarType=issuetype",
+        "name": "Bug", "subtask": false, "avatarId": 13263}, "customfield_12325157":
+        null, "customfield_12317370": null, "customfield_12325159": null, "customfield_12317372":
+        null, "customfield_12318341": null, "customfield_12325154": null, "customfield_12325153":
+        null, "customfield_12317374": null, "customfield_12325156": null, "timespent":
+        null, "customfield_12325155": null, "customfield_12320940": null, "project":
+        {"self": "https://example.com/rest/api/2/project/12332745", "id": "12332745",
+        "key": "RHEL", "name": "RHEL", "projectTypeKey": "software", "avatarUrls":
+        {"48x48": "https://example.com/secure/projectavatar?pid=12332745&avatarId=17271",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12332745&avatarId=17271",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12332745&avatarId=17271",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12332745&avatarId=17271"},
+        "projectCategory": {"self": "https://example.com/rest/api/2/projectCategory/10630",
+        "id": "10630", "description": "These are projects which will be migrated to
+        Red hat Jira (issues.redhat.com)", "name": "Product Development-RHEL"}}, "customfield_12320944":
+        null, "aggregatetimespent": null, "customfield_12310220": null, "customfield_12310183":
+        null, "resolutiondate": null, "customfield_12325150": null, "customfield_12318740":
+        null, "workratio": -1, "customfield_12325152": null, "customfield_12316840":
+        null, "customfield_12317379": null, "customfield_12325151": null, "customfield_12316841":
+        null, "customfield_12317259": null, "customfield_12319040": null, "customfield_12325047":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/RHEL-59829/watchers",
+        "watchCount": 1, "isWatching": true}, "customfield_12324753": null, "customfield_12325044":
+        null, "customfield_12319286": {"self": "https://example.com/rest/api/2/customFieldOption/30765",
+        "value": "Unspecified", "id": "30765", "disabled": false}, "customfield_12325043":
+        null, "customfield_12325046": null, "created": "2025-01-23T14:06:39.601+0000",
+        "customfield_12321240": null, "customfield_12325045": null, "customfield_12323940":
+        null, "customfield_12320948": {"self": "https://example.com/rest/api/2/customFieldOption/27850",
+        "value": "Needs Review", "id": "27850", "disabled": false}, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        null, "customfield_12325040": [], "customfield_12325160": null, "customfield_12325042":
+        null, "customfield_12325041": null, "updated": "2025-01-23T14:06:52.847+0000",
+        "customfield_12311840": null, "customfield_12322143": null, "customfield_12322140":
+        null, "customfield_12316142": null, "customfield_12322141": null, "customfield_12322142":
+        null, "timeoriginalestimate": null, "description": "Security Tracking Issue\n\nDo
+        not make this issue public.\n\nNOTE THIS ISSUE IS CURRENTLY EMBARGOED, DO
+        NOT MAKE PUBLIC COMMITS OR COMMENTS ABOUT THIS ISSUE.\n\nWARNING: NOTICE THAT
+        CHANGING THE SECURITY LEVEL FROM \"SECURITY ISSUE\" TO \"RED HAT INTERNAL\"
+        MAY BREAK THE EMBARGO.\n\nFlaw:\n-----\n\ntest validations\nhttps://example.com/show_bug.cgi?id=2312351\n\nthis
+        is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+        never be made public, unless done so by the security team.", "customfield_12322148":
+        null, "timetracking": {}, "security": {"self": "https://example.com/rest/api/2/securitylevel/11690",
+        "id": "11690", "description": "Restricts access to Product Security and the
+        people involved in resolving the issue. Only Product Security can remove this
+        level once applied", "name": "Embargoed Security Issue"}, "attachment": [],
+        "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12318446":
+        {"self": "https://example.com/rest/api/2/customFieldOption/39953", "value":
+        "No", "id": "39953", "disabled": false}, "customfield_12324041": null, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12324040": null,
+        "customfield_12316544": "None", "customfield_12310840": "9223372036854775807",
+        "summary": "EMBARGOED kernel: test validations [rhel-8.10.z]", "customfield_12323640":
+        null, "customfield_12325147": null, "customfield_12325146": null, "customfield_12323642":
+        null, "customfield_12325149": null, "customfield_12317360": null, "customfield_12323641":
+        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12318450":
+        null, "customfield_12325142": null, "customfield_12323242": null, "customfield_12325145":
+        null, "customfield_12325144": null, "customfield_12313040": null, "customfield_12323649":
+        null, "customfield_12321740": null, "customfield_12323644": null, "customfield_12323643":
+        null, "customfield_12323646": null, "customfield_12323645": null, "environment":
+        null, "customfield_12315740": null, "customfield_12313441": "", "customfield_12313440":
+        "0.0", "duedate": null, "customfield_12311140": null, "customfield_12319940":
+        null, "customfield_12319269": null, "customfield_12317366": null, "comment":
+        {"comments": [{"self": "https://example.com/rest/api/2/issue/16349275/comment/25583044",
+        "id": "25583044", "author": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "body": "\n                    h4.
+        Found errors for component \u201ckernel / Other\u201d while setting the following
+        fields according to [ownership mapping information in the source repository|https://example.com/bugzilla-data/components/-/blob/main/RHEL9/kernel
+        / Other]:\n\n                    {quote}\n                    * Pool Team:
+        no matching Jira value found for value \u201csst_kernel_maintainers_rhel_9\u201d
+        provided in the repository.\n\n                    {quote}\n                ",
+        "updateAuthor": {"self": "https://example.com/rest/api/2/user?username=autobot-jira-api",
+        "name": "autobot-jira-api", "key": "autobot-jira-api", "emailAddress": "pme-bot@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=48",
+        "24x24": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=24",
+        "16x16": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=16",
+        "32x32": "https://example.com/avatar/573dcb2fa1491b2623023b4ce48e2ea2?d=mm&s=32"},
+        "displayName": "pme bot", "active": true, "timeZone": "UTC"}, "created": "2025-01-23T14:06:52.847+0000",
+        "updated": "2025-01-23T14:06:52.847+0000", "visibility": {"type": "group",
+        "value": "Red Hat Employee"}}], "maxResults": 1, "total": 1, "startAt": 0},
+        "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
+        null, "customfield_12311940": "2|i27tjr:"}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:06:57 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:06:57 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      content-length:
+      - '16737'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-2
+      x-arequestid:
+      - 846x39639x3
+      x-asessionid:
+      - 1w43t8k
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641216.2accce8c
+      x-rh-edge-request-id:
+      - 2accce8c
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "priority":
+      {"name": "Critical"}, "description": "Security Tracking Issue\n\nDo not make
+      this issue public.\n\nFlaw:\n-----\n\ntest validations\nhttps://bugzilla.stage.redhat.com/show_bug.cgi?id=2312351\n\nthis
+      is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+      never be made public, unless done so by the security team.", "labels": ["Security",
+      "SecurityTracking", "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104",
+      "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104", "pscomponent:kernel"], "summary":
+      "kernel: test validations [rhel-8]", "security": {"name": "Red Hat Employee"}},
+      "key": "RHEL-59828"}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '713'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/RHEL-59828
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:11 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:07:11 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 846x40063x2
+      x-asessionid:
+      - 1u551z7
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641218.2accfd64
+      x-rh-edge-request-id:
+      - 2accfd64
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '{"fields": {"issuetype": {"name": "Bug"}, "project": {"key": "RHEL"}, "priority":
+      {"name": "Critical"}, "description": "Security Tracking Issue\n\nDo not make
+      this issue public.\n\nFlaw:\n-----\n\ntest validations\nhttps://bugzilla.stage.redhat.com/show_bug.cgi?id=2312351\n\nthis
+      is a simple test\n\n~~~\n\nReproducers, if any, will remain confidential and
+      never be made public, unless done so by the security team.", "labels": ["Security",
+      "SecurityTracking", "flaw:bz#2312351", "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104",
+      "flawuuid:bff85e2a-bdd9-4c5e-8b54-e1cc426a4104", "pscomponent:kernel"], "summary":
+      "kernel: test validations [rhel-8.10.z]", "security": {"name": "Red Hat Employee"}},
+      "key": "RHEL-59829"}'
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '718'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: PUT
+    uri: https://example.com/rest/api/2/issue/RHEL-59829
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 23 Jan 2025 14:07:18 GMT
+      Expires:
+      - Thu, 23 Jan 2025 14:07:18 GMT
+      Pragma:
+      - no-cache
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 847x40096x2
+      x-asessionid:
+      - t9p3gb
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.44e4e68.1737641231.2acdc9f2
+      x-rh-edge-request-id:
+      - 2acdc9f2
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/osidb/tests/test_e2e.py
+++ b/osidb/tests/test_e2e.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from django.utils import timezone
 from freezegun import freeze_time
@@ -6,8 +8,11 @@ from apps.taskman.service import JiraTaskmanQuerier
 from apps.trackers.constants import TRACKERS_API_VERSION
 from apps.workflows.models import Workflow
 from apps.workflows.workflow import WorkflowFramework, WorkflowModel
+from collectors.cveorg import tests as cveorg_tests
+from collectors.cveorg.collectors import CVEorgCollector
+from collectors.cveorg.models import Keyword
 from collectors.jiraffe.collectors import JiraTrackerCollector
-from osidb.models import Affect, Flaw, PsUpdateStream, Tracker
+from osidb.models import Affect, Flaw, PsUpdateStream, Snippet, Tracker
 from osidb.sync_manager import (
     BZSyncManager,
     JiraTaskSyncManager,
@@ -20,6 +25,48 @@ pytestmark = pytest.mark.unit
 @pytest.fixture
 def test_trackers_api_uri() -> str:
     return f"http://osidb-service:8000/trackers/api/{TRACKERS_API_VERSION}"
+
+
+@pytest.fixture()
+def mock_keywords() -> None:
+    """
+    Set testing keywords to mock the ones from the ps-constants repository.
+    """
+    Keyword(keyword="kernel", type=Keyword.Type.ALLOWLIST).save()
+    Keyword(keyword=r"(?:\W|^)\.NET\b", type=Keyword.Type.ALLOWLIST_SPECIAL_CASE).save()
+    Keyword(keyword=".*plugin.*for WordPress", type=Keyword.Type.BLOCKLIST).save()
+    Keyword(keyword="Cisco", type=Keyword.Type.BLOCKLIST).save()
+    Keyword(keyword="IBM Tivoli", type=Keyword.Type.BLOCKLIST).save()
+    Keyword(keyword="iTunes", type=Keyword.Type.BLOCKLIST).save()
+    Keyword(keyword="iOS", type=Keyword.Type.BLOCKLIST_SPECIAL_CASE).save()
+
+
+@pytest.fixture()
+def mock_repo(monkeypatch) -> None:
+    """
+    Set testing data and variables to mock the cvelistV5 repository.
+    """
+    repo_path = f"{Path(cveorg_tests.__file__).resolve().parent}/cvelistV5"
+    cve_path = r"CVE-(?:1999|2\d{3})-(?!0{4})(?:0\d{3}|[1-9]\d{3,}).json$"
+
+    def clone_repo(self):
+        return
+
+    def update_repo(self):
+        return
+
+    def get_repo_changes(self):
+        stdout = "CVE-2024-0181.json\nCVE-2024-0203.json\nCVE-2024-1087.json\nCVE-2024-4923.json\n"
+        period_end = timezone.datetime(
+            2024, 7, 1, tzinfo=timezone.get_current_timezone()
+        )
+        return stdout, period_end
+
+    monkeypatch.setattr(CVEorgCollector, "REPO_PATH", repo_path)
+    monkeypatch.setattr(CVEorgCollector, "CVE_PATH", cve_path)
+    monkeypatch.setattr(CVEorgCollector, "clone_repo", clone_repo)
+    monkeypatch.setattr(CVEorgCollector, "update_repo", update_repo)
+    monkeypatch.setattr(CVEorgCollector, "get_repo_changes", get_repo_changes)
 
 
 def tzdatetime(*args):
@@ -287,3 +334,313 @@ class TestE2E:
         assert any(
             h["pgh_diff"] and "task_key" in h["pgh_diff"] for h in body["history"]
         )
+
+    @pytest.mark.vcr
+    @freeze_time(tzdatetime(2024, 8, 6))
+    def test_cveorg_with_workflows(
+        self,
+        auth_client,
+        bugzilla_token,
+        client,
+        enable_bz_async_sync,
+        enable_jira_task_async_sync,
+        enable_jira_tracker_sync,
+        jira_token,
+        mock_keywords,
+        mock_repo,
+        monkeypatch,
+        test_api_uri,
+    ):
+        """
+        Test that snippets and flaws are created correctly and can
+        be edited and promoted until closed
+        """
+        # Simulates user behavior for task sync
+        monkeypatch.setattr(JiraTaskmanQuerier, "is_service_account", lambda x: False)
+
+        # 1) setup workflows for test
+        workflow_framework = WorkflowFramework()
+        workflow_framework._workflows = []
+
+        state_new = {
+            "name": WorkflowModel.WorkflowState.NEW,
+            "requirements": [],
+            "jira_state": "New",
+            "jira_resolution": None,
+        }
+
+        state_triage = {
+            "name": WorkflowModel.WorkflowState.TRIAGE,
+            "requirements": ["has owner"],
+            "jira_state": "Refinement",
+            "jira_resolution": None,
+        }
+
+        state_sec = {
+            "name": WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT,
+            "requirements": ["has owner"],
+            "jira_state": "In Progress",
+            "jira_resolution": None,
+        }
+
+        state_done = {
+            "name": WorkflowModel.WorkflowState.DONE,
+            "requirements": [
+                {
+                    "condition": "OR",
+                    "requirements": [
+                        "has trackers",
+                        "impact is low",
+                        "impact is moderate",
+                    ],
+                }
+            ],
+            "jira_state": "Closed",
+            "jira_resolution": "Done",
+        }
+
+        workflow = Workflow(
+            {
+                "name": "DEFAULT",
+                "description": "random description",
+                "priority": 1,
+                "conditions": [],
+                "states": [state_new, state_triage, state_sec, state_done],
+            }
+        )
+
+        state_reject = {
+            "name": WorkflowModel.WorkflowState.REJECTED,
+            "requirements": [],
+            "jira_state": "Closed",
+            "jira_resolution": "Won't Do",
+        }
+        workflow_reject = Workflow(
+            {
+                "name": "REJECTED",
+                "description": "random description",
+                "priority": 0,
+                "conditions": [],
+                "states": [state_reject],
+            }
+        )
+        workflow_framework.register_workflow(workflow)
+        workflow_framework.register_workflow(workflow_reject)
+
+        # 2) collect well formated CVEs
+        cc = CVEorgCollector()
+        cc.snippet_creation_enabled = True
+        cc.snippet_creation_start_date = None
+        cc.collect()
+
+        assert Snippet.objects.count() == 2
+        assert Flaw.objects.count() == 2
+
+        flaw1 = Flaw.objects.get(cve_id="CVE-2024-0181")
+        flaw1._create_or_update_task(jira_token)
+        snippet1 = Snippet.objects.get(external_id="CVE-2024-0181")
+        assert flaw1
+        assert snippet1
+        assert snippet1.flaw == flaw1
+
+        flaw2 = Flaw.objects.get(cve_id="CVE-2024-4923")
+        flaw2._create_or_update_task(jira_token)
+        snippet2 = Snippet.objects.get(external_id="CVE-2024-4923")
+        assert flaw2
+        assert snippet2
+        assert snippet2.flaw == flaw2
+
+        # 3) validate access control
+        assert flaw1.is_internal
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 404
+        response = auth_client().get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        flaw1_body = response.json()
+
+        assert flaw2.is_internal
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw2.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 404
+        response = auth_client().get(
+            f"{test_api_uri}/flaws/{flaw2.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        flaw2_body = response.json()
+
+        # 4) Test editing collected flaw
+        flaw_data = {
+            "title": "Spooky vulnerability",
+            "comment_zero": flaw1_body["comment_zero"],
+            "impact": "CRITICAL",
+            "components": ["curl"],
+            "source": "CVEORG",
+            "owner": "concosta@redhat.com",
+            "reported_dt": flaw1_body["reported_dt"],
+            "unembargo_dt": flaw1_body["unembargo_dt"],
+            "updated_dt": flaw1_body["updated_dt"],
+            "embargoed": False,
+        }
+        response = auth_client().put(
+            f"{test_api_uri}/flaws/{flaw1.uuid}",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+
+        # 4.1) validate flaw still in NEW state
+        response = auth_client().get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["classification"]["state"] == WorkflowModel.WorkflowState.NEW
+
+        # 4.2) validate access control
+        flaw1.refresh_from_db()
+        flaw1._create_or_update_task(jira_token)
+        assert flaw1.is_internal
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 404
+
+        # 5) Validate workflow
+        response = auth_client().post(
+            f"{test_api_uri}/flaws/{flaw1.uuid}/promote",
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+        flaw1.refresh_from_db()
+        flaw1._create_or_update_task(jira_token)
+        assert flaw1.workflow_state == WorkflowModel.WorkflowState.TRIAGE
+        assert flaw1.is_internal
+
+        # 5.1) validate flaw is promoted
+        response = auth_client().get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["classification"]["state"] == WorkflowModel.WorkflowState.TRIAGE
+
+        # 5.2) validate access control
+        flaw1.refresh_from_db()
+        flaw1._create_or_update_task(jira_token)
+        assert flaw1.is_internal
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 404
+
+        # 5.3) Validate promotion to secondary assessment
+        response = auth_client().post(
+            f"{test_api_uri}/flaws/{flaw1.uuid}/promote",
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+        flaw1.refresh_from_db()
+        flaw1._create_or_update_task(jira_token)
+        assert flaw1.workflow_state == WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT
+
+        # TODO remove this manual call after async task sync is calling it automatically
+        flaw1.adjust_acls(save=False)
+        flaw1.save(raise_validation_error=False)
+
+        assert not flaw1.is_internal
+        assert flaw1.is_public
+
+        # 5.4) validate flaw is promoted and publicly accessible
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert (
+            body["classification"]["state"]
+            == WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT
+        )
+
+        # 5.4) Validate promotion to done
+        response = auth_client().post(
+            f"{test_api_uri}/flaws/{flaw1.uuid}/promote",
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+        flaw1.refresh_from_db()
+        flaw1._create_or_update_task(jira_token)
+        assert flaw1.workflow_state == WorkflowModel.WorkflowState.DONE
+        assert not flaw1.is_internal
+        assert flaw1.is_public
+
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw1.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["classification"]["state"] == WorkflowModel.WorkflowState.DONE
+
+        # 6) Test editing rejected collected flaw
+        flaw_data = {
+            "title": "Not a vulnerability",
+            "comment_zero": flaw2_body["comment_zero"],
+            "impact": "LOW",
+            "components": ["curl"],
+            "source": "CVEORG",
+            "reported_dt": flaw2_body["reported_dt"],
+            "unembargo_dt": flaw2_body["unembargo_dt"],
+            "updated_dt": flaw2_body["updated_dt"],
+            "embargoed": False,
+        }
+        response = auth_client().put(
+            f"{test_api_uri}/flaws/{flaw2.uuid}",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+        flaw2.refresh_from_db()
+        flaw2._create_or_update_task(jira_token)
+        assert flaw2.is_internal
+
+        # 6.1) Test rejecting collected flaw
+        response = auth_client().post(
+            f"{test_api_uri}/flaws/{flaw2.uuid}/reject",
+            data={"reason": "This was a spam."},
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        body = response.json()
+        assert response.status_code == 200
+        assert body["classification"]["workflow"] == "REJECTED"
+        assert body["classification"]["state"] == WorkflowModel.WorkflowState.REJECTED
+        flaw2.refresh_from_db()
+        flaw2._create_or_update_task(jira_token)
+        assert flaw2.is_internal
+
+        # 6.2) Test access control
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw2.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 404
+        response = auth_client().get(
+            f"{test_api_uri}/flaws/{flaw2.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["classification"]["state"] == WorkflowModel.WorkflowState.REJECTED

--- a/osidb/tests/test_e2e.py
+++ b/osidb/tests/test_e2e.py
@@ -1,0 +1,289 @@
+import pytest
+from django.utils import timezone
+from freezegun import freeze_time
+
+from apps.taskman.service import JiraTaskmanQuerier
+from apps.trackers.constants import TRACKERS_API_VERSION
+from apps.workflows.models import Workflow
+from apps.workflows.workflow import WorkflowFramework, WorkflowModel
+from collectors.jiraffe.collectors import JiraTrackerCollector
+from osidb.models import Affect, Flaw, PsUpdateStream, Tracker
+from osidb.sync_manager import (
+    BZSyncManager,
+    JiraTaskSyncManager,
+    JiraTrackerLinkManager,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.fixture
+def test_trackers_api_uri() -> str:
+    return f"http://osidb-service:8000/trackers/api/{TRACKERS_API_VERSION}"
+
+
+def tzdatetime(*args):
+    return timezone.datetime(*args, tzinfo=timezone.get_current_timezone())
+
+
+class TestE2E:
+    """
+    Test complete use case scenarios with all sync enabled,
+    relying on REST API to simulate user behavior
+    """
+
+    @pytest.mark.parametrize("embargoed", [True, False])
+    @freeze_time(tzdatetime(2024, 8, 6))
+    @pytest.mark.vcr
+    def test_flaw_affect_tracker(
+        self,
+        auth_client,
+        bugzilla_token,
+        client,
+        embargoed,
+        enable_bz_async_sync,
+        enable_jira_task_async_sync,
+        enable_jira_tracker_sync,
+        jira_token,
+        monkeypatch,
+        setup_sample_external_resources,
+        test_api_uri,
+        test_trackers_api_uri,
+    ):
+        """
+        Test a user can create a flaw from scratch, including:
+        - create flaw and sync with bz and jira task
+        - create affect
+        - create async tracker
+        - collect tracker data and link with affect
+        - validate access rights in all steps
+        """
+        unembargoed_dt = "2024-08-06T00:00:00.000Z"
+        expected_status = 200
+        if embargoed:
+            unembargoed_dt = "2024-08-07T00:00:00.000Z"
+            expected_status = 404
+
+        # Simulates user behavior for task sync
+        monkeypatch.setattr(JiraTaskmanQuerier, "is_service_account", lambda x: False)
+
+        # 1) create flaw
+        flaw_data = {
+            "title": "test validations",
+            "comment_zero": "this is a simple test",
+            "impact": "CRITICAL",
+            "components": ["curl"],
+            "source": "REDHAT",
+            "reported_dt": "2024-08-06T00:00:00.000Z",
+            "unembargo_dt": unembargoed_dt,
+            "embargoed": embargoed,
+        }
+
+        response = auth_client().post(
+            f"{test_api_uri}/flaws",
+            flaw_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+
+        # 1.1) validade flaw was created and bz sync is scheduled
+        assert response.status_code == 201
+        body = response.json()
+        assert BZSyncManager.objects.get(sync_id=body["uuid"])
+        assert JiraTaskSyncManager.objects.get(sync_id=body["uuid"])
+
+        # 1.2) synchronously bzsync instead of waiting on Celery
+        flaw = Flaw.objects.get(uuid=body["uuid"])
+        flaw._perform_bzsync(bz_api_key=bugzilla_token)
+        flaw._create_or_update_task(jira_token)
+
+        # 1.3) validate access control
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == expected_status
+        if not embargoed:
+            assert response.json()["title"] == "test validations"
+            assert "curl" in response.json()["components"]
+            assert response.json()["meta_attr"]["bz_id"]
+
+        # 2) get valid external data
+        ps_update_streams = PsUpdateStream.objects.filter(
+            active_to_ps_module__bts_name="jboss"
+        ).order_by("name")[:2]
+        ps_module = ps_update_streams[0].active_to_ps_module
+        ps_module.private_trackers_allowed = True
+        ps_module.save()
+
+        # 3) create affect
+        affects_data = [
+            {
+                "flaw": str(flaw.uuid),
+                "affectedness": "AFFECTED",
+                "resolution": "DELEGATED",
+                "ps_module": ps_module.name,
+                "ps_component": ps_module.default_component,
+                "impact": "CRITICAL",
+                "embargoed": embargoed,
+            }
+        ]
+        response = auth_client().post(
+            f"{test_api_uri}/affects/bulk",
+            affects_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        affect = Affect.objects.get(uuid=body["results"][0]["uuid"])
+
+        # 3.1) validate access control for affects
+        response = client.get(f"{test_api_uri}/flaws/{flaw.uuid}")
+        assert response.status_code == expected_status
+        if not embargoed:
+            assert len(response.json()["affects"]) == 1
+
+        # 4) get and validate trackers suggestions
+        response = auth_client().post(
+            f"{test_trackers_api_uri}/file",
+            data={"flaw_uuids": [flaw.uuid]},
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        body = response.json()
+        comp = body["modules_components"][0]
+        assert comp["ps_module"] == ps_module.name
+        assert comp["ps_component"] == ps_module.default_component
+
+        suggested_trackers = [stream["ps_update_stream"] for stream in comp["streams"]]
+        assert ps_update_streams[0].name in suggested_trackers
+        assert ps_update_streams[1].name in suggested_trackers
+
+        # 5) create trackers
+        for stream in ps_update_streams:
+            tracker_data = {
+                "affects": [affect.uuid],
+                "embargoed": flaw.embargoed,
+                "ps_update_stream": stream.name,
+            }
+            response = auth_client().post(
+                f"{test_api_uri}/trackers",
+                tracker_data,
+                format="json",
+                HTTP_BUGZILLA_API_KEY=bugzilla_token,
+                HTTP_JIRA_API_KEY=jira_token,
+            )
+            assert response.status_code == 201
+            body = response.json()
+            assert body["external_system_id"]
+            tracker_id = body["external_system_id"]
+            assert body["type"] == Tracker.TrackerType.JIRA
+            assert body["ps_update_stream"] == stream.name
+            jc = JiraTrackerCollector()
+            jc.collect(tracker_id)
+            JiraTrackerLinkManager.link_tracker_with_affects(tracker_id)
+
+        # 5.1) validate access control for trackers
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == expected_status
+        if not embargoed:
+            assert len(response.json()["trackers"]) == 2
+            assert len(response.json()["affects"]) == 1
+            assert len(response.json()["affects"][0]["trackers"]) == 2
+            assert "curl" in response.json()["components"]
+            assert response.json()["meta_attr"]["bz_id"]
+
+        # 6) validate users can promote flaws
+        # 6.1) setup workflows for test
+        workflow_framework = WorkflowFramework()
+        workflow_framework._workflows = []
+
+        state_new = {
+            "name": WorkflowModel.WorkflowState.NEW,
+            "requirements": [],
+            "jira_state": "New",
+            "jira_resolution": None,
+        }
+
+        state_first = {
+            "name": WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT,
+            "requirements": ["has title"],
+            "jira_state": "In Progress",
+            "jira_resolution": None,
+        }
+
+        workflow = Workflow(
+            {
+                "name": "DEFAULT",
+                "description": "random description",
+                "priority": 0,
+                "conditions": [],
+                "states": [state_new, state_first],
+            }
+        )
+        workflow_framework.register_workflow(workflow)
+
+        # 6.2) promote flaw
+        response = auth_client().post(
+            f"{test_api_uri}/flaws/{flaw.uuid}/promote",
+            data={},
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+        assert response.status_code == 200
+
+        # 6.3) validate promotion were applied
+        response = auth_client().get(
+            f"{test_api_uri}/flaws/{flaw.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert (
+            body["classification"]["state"]
+            == WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT
+        )
+
+        # 7) validate users can unembargo flaw
+        if embargoed:
+            with freeze_time(tzdatetime(2024, 8, 15)):
+                flaw.refresh_from_db()
+                flaw_data = {
+                    "title": "test validations",
+                    "comment_zero": "this is a simple test",
+                    "impact": "CRITICAL",
+                    "components": ["curl"],
+                    "source": "REDHAT",
+                    "reported_dt": "2024-08-06T00:00:00.000Z",
+                    "unembargo_dt": unembargoed_dt,
+                    "updated_dt": flaw.updated_dt,
+                    "embargoed": False,
+                }
+                response = auth_client().put(
+                    f"{test_api_uri}/flaws/{flaw.uuid}",
+                    flaw_data,
+                    format="json",
+                    HTTP_BUGZILLA_API_KEY=bugzilla_token,
+                    HTTP_JIRA_API_KEY=jira_token,
+                )
+                assert response.status_code == 200
+
+        response = client.get(
+            f"{test_api_uri}/flaws/{flaw.uuid}?include_meta_attr=bz_id&include_history=true"
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["trackers"]) == 2
+        assert len(body["affects"]) == 1
+        assert len(body["affects"][0]["trackers"]) == 2
+        assert "curl" in body["components"]
+        assert body["meta_attr"]["bz_id"]
+        # test modifications made while embargoed are now public
+        assert any(
+            h["pgh_diff"] and "task_key" in h["pgh_diff"] for h in body["history"]
+        )


### PR DESCRIPTION
This PR add a test that simulates user behavior on creating flaw with its affect and trackers, while all syncs are enabled.

I decided to merge OSIDB-3496 and OSIDB-3497 into a single test since the e2e tests doesn´t intent to test a single functionality and the environment were already setup for both to happen altogether without duplicating code.

Closes OSIDB-3495.
Closes OSIDB-3496.
Closes OSIDB-3497.
