### PR TITLE
Validate flaw impact and RH CVSSv3 score properly

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -372,7 +372,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1335,
+        "line_number": 1344,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T09:12:19Z"
+  "generated_at": "2025-01-23T19:49:54Z"
 }

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -1825,12 +1825,18 @@ class TestTrackerJiraQueryBuilder:
         if flaw_cvss_present:
             assert flaw.cvss_scores.all().count() == 0
             flawcvss = []
-            flawcvss.append(FlawCVSSFactory(flaw=flaw))
+            flawcvss.append(FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.NIST))
             assert flaw.cvss_scores.all().count() == 1
             if multiscore:
-                flawcvss.append(FlawCVSSFactory(flaw=flaw))
-                flawcvss.append(FlawCVSSFactory(flaw=flaw))
-                flawcvss.append(FlawCVSSFactory(flaw=flaw))
+                flawcvss.append(
+                    FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.CVEORG)
+                )
+                flawcvss.append(
+                    FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.CVEORG)
+                )
+                flawcvss.append(
+                    FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.CVEORG)
+                )
 
         if aff_cvss_present:
             assert affect.cvss_scores.all().count() == 0
@@ -2367,7 +2373,11 @@ class TestTrackerJiraQueryBuilder:
             source="REDHAT",
             cwe_id="CWE-1",
         )
-        flwcvss = FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.REDHAT)
+        flwcvss = FlawCVSSFactory(
+            flaw=flaw,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION2,
+        )
         affect = AffectFactory(
             flaw=flaw,
             ps_module="foo-module",
@@ -2386,7 +2396,11 @@ class TestTrackerJiraQueryBuilder:
             cwe_id="CWE-2",
             created_dt=datetime(2024, 10, 1, tzinfo=timezone.utc),
         )
-        flwcvss2 = FlawCVSSFactory(flaw=flaw2, issuer=FlawCVSS.CVSSIssuer.REDHAT)
+        flwcvss2 = FlawCVSSFactory(
+            flaw=flaw2,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION2,
+        )
         affect2 = AffectFactory(
             flaw=flaw2,
             ps_module="foo-module",
@@ -2407,7 +2421,11 @@ class TestTrackerJiraQueryBuilder:
             cwe_id="CWE-3",
             created_dt=datetime(2024, 9, 1, tzinfo=timezone.utc),
         )
-        flwcvss3 = FlawCVSSFactory(flaw=flaw3, issuer=FlawCVSS.CVSSIssuer.REDHAT)
+        flwcvss3 = FlawCVSSFactory(
+            flaw=flaw3,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION2,
+        )
         affect3 = AffectFactory(
             flaw=flaw3,
             ps_module="foo-module",
@@ -2426,7 +2444,11 @@ class TestTrackerJiraQueryBuilder:
             cwe_id="CWE-4",
             created_dt=datetime(2024, 10, 2, tzinfo=timezone.utc),
         )
-        flwcvss4 = FlawCVSSFactory(flaw=flaw4, issuer=FlawCVSS.CVSSIssuer.REDHAT)
+        flwcvss4 = FlawCVSSFactory(
+            flaw=flaw4,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION2,
+        )
         affect4 = AffectFactory(
             flaw=flaw4,
             ps_module="foo-module",

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -3,7 +3,15 @@ import pytest
 from apps.workflows.exceptions import LastStateException, MissingRequirementsException
 from apps.workflows.models import Check, Condition, State, Workflow
 from apps.workflows.workflow import WorkflowFramework, WorkflowModel
-from osidb.models import Affect, Flaw, FlawReference, FlawSource, Impact, Tracker
+from osidb.models import (
+    Affect,
+    Flaw,
+    FlawCVSS,
+    FlawReference,
+    FlawSource,
+    Impact,
+    Tracker,
+)
 from osidb.tests.factories import (
     AffectFactory,
     FlawCVSSFactory,
@@ -33,7 +41,12 @@ class TestCheck:
         "field,factory",
         [
             ("affects", lambda flaw: AffectFactory(flaw=flaw)),
-            ("cvss_scores", lambda flaw: FlawCVSSFactory(flaw=flaw)),
+            (
+                "cvss_scores",
+                lambda flaw: FlawCVSSFactory(
+                    flaw=flaw, issuer=FlawCVSS.CVSSIssuer.NIST
+                ),
+            ),
             ("package_versions", lambda flaw: PackageFactory(flaw=flaw)),
         ],
     )

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -261,7 +261,7 @@ class TestNVDCollector:
         """
         test that NIST CVSS validation flag is correctly adjusted when NVD CVSSv3 is removed
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(impact=Impact.LOW)
         FlawCVSSFactory(
             flaw=flaw,
             issuer=FlawCVSS.CVSSIssuer.REDHAT,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814), handled edge-case that would cause failure (OSIDB-3858)
 - Trim Jira task summary if flaw's `cve_id` and `title` are too long (OSIDB-3847)
+- Validate that a flaw has an impact set and RH CVSSv3 score is non-zero,
+  or it does not have an impact set and RH CVSSv3 score is zero (OSIDB-3738)
 
 ## [4.6.5] - 2025-01-10
 ### Changed

--- a/osidb/tests/endpoints/flaws/test_cvss_scores.py
+++ b/osidb/tests/endpoints/flaws/test_cvss_scores.py
@@ -1,7 +1,7 @@
 import pytest
 from rest_framework import status
 
-from osidb.models import FlawCVSS
+from osidb.models import FlawCVSS, Impact
 from osidb.tests.factories import AffectFactory, FlawCVSSFactory, FlawFactory
 
 pytestmark = pytest.mark.unit
@@ -17,7 +17,7 @@ class TestEndpointsFlawsCVSSScores:
         """
         Test the creation of FlawCVSS records via a REST API POST request.
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(impact=Impact.LOW)
         cvss_data = {
             "issuer": FlawCVSS.CVSSIssuer.REDHAT,
             "cvss_version": FlawCVSS.CVSSVersion.VERSION3,
@@ -55,7 +55,12 @@ class TestEndpointsFlawsCVSSScores:
         Test the update of FlawCVSS records via a REST API PUT request.
         """
         flaw = FlawFactory()
-        cvss = FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.REDHAT, comment="")
+        cvss = FlawCVSSFactory(
+            flaw=flaw,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION2,
+            comment="",
+        )
 
         response = auth_client().get(
             f"{test_api_uri}/flaws/{str(flaw.uuid)}/cvss_scores/{cvss.uuid}"
@@ -83,7 +88,7 @@ class TestEndpointsFlawsCVSSScores:
         """
         flaw = FlawFactory()
         AffectFactory(flaw=flaw)
-        cvss = FlawCVSSFactory(flaw=flaw)
+        cvss = FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.NIST)
 
         url = f"{test_api_uri}/flaws/{str(flaw.uuid)}/cvss_scores/{cvss.uuid}"
         response = auth_client().get(url)

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -111,7 +111,7 @@ class TestEndpointsFlaws:
         assert response.status_code == status.HTTP_200_OK
         assert len(response.data["cvss_scores"]) == 0
 
-        FlawCVSSFactory(flaw=flaw)
+        FlawCVSSFactory(flaw=flaw, issuer=FlawCVSS.CVSSIssuer.NIST)
 
         response = auth_client().get(f"{test_api_uri}/flaws/{flaw.uuid}")
         assert response.status_code == status.HTTP_200_OK
@@ -327,18 +327,27 @@ class TestEndpointsFlaws:
         body = response.json()
         assert body["count"] == 0
 
-        flaw = FlawFactory()
+        flaw = FlawFactory(impact=Impact.LOW)
 
         response = auth_client().get(f"{test_api_uri}/flaws?{filter_name}__isempty=1")
         assert response.status_code == 200
         body = response.json()
         assert body["count"] == 1
 
-        FlawCVSSFactory(
-            flaw=flaw,
-            issuer=issuer,
-            version=version,
-        )
+        # RH CVSSv3 needs to match with flaw impact
+        if filter_name == "cvss3_rh":
+            FlawCVSSFactory(
+                flaw=flaw,
+                issuer=issuer,
+                version=version,
+                vector="CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H",
+            )
+        else:
+            FlawCVSSFactory(
+                flaw=flaw,
+                issuer=issuer,
+                version=version,
+            )
         response = auth_client().get(f"{test_api_uri}/flaws?{filter_name}__isempty=1")
         assert response.status_code == 200
         body = response.json()

--- a/osidb/tests/endpoints/flaws/test_unembargo.py
+++ b/osidb/tests/endpoints/flaws/test_unembargo.py
@@ -93,7 +93,7 @@ class TestEndpointsFlawsUnembargo:
         FlawAcknowledgmentFactory(flaw=flaw, affiliation="Corp2")
         FlawCommentFactory(flaw=flaw)
         FlawCommentFactory(flaw=flaw)
-        FlawCVSSFactory(flaw=flaw)
+        FlawCVSSFactory(flaw=flaw, version=FlawCVSS.CVSSVersion.VERSION4)
         FlawReferenceFactory(flaw=flaw)
         PackageFactory(flaw=flaw)
         ps_module = PsModuleFactory()

--- a/osidb/tests/test_audit.py
+++ b/osidb/tests/test_audit.py
@@ -6,7 +6,7 @@ import pytest
 from django.db import transaction
 
 from osidb.core import set_user_acls
-from osidb.models import Affect, Flaw, FlawSource, Impact, Tracker
+from osidb.models import Affect, Flaw, FlawCVSS, FlawSource, Impact, Tracker
 from osidb.tests.factories import (
     AffectCVSSFactory,
     AffectFactory,
@@ -182,7 +182,7 @@ class TestAuditFlaw:
         assert flaw_com.acl_read == embargoed_read_groups
         assert flaw_com.acl_write == embargoed_write_groups
 
-        flaw_cvss = FlawCVSSFactory(flaw=flaw)
+        flaw_cvss = FlawCVSSFactory(flaw=flaw, version=FlawCVSS.CVSSVersion.VERSION4)
         assert flaw_cvss.acl_read == embargoed_read_groups
         assert flaw_cvss.acl_write == embargoed_write_groups
 

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -820,7 +820,7 @@ class TestFlawValidators:
         ],
     )
     def test_validate_rh_nist_cvss_severity_diff(
-        self, nist_cvss, rh_cvss, should_alert
+        self, rh_cvss, nist_cvss, should_alert
     ):
         """
         Tests that the NIST and RH CVSSv3 score are not of a different severity.

--- a/osidb/tests/test_rls.py
+++ b/osidb/tests/test_rls.py
@@ -4,7 +4,7 @@ from django.db import transaction
 from django.db.utils import ProgrammingError
 
 from osidb.core import set_user_acls
-from osidb.models import CVSS, Flaw
+from osidb.models import CVSS, Flaw, Impact
 from osidb.tests.factories import FlawCVSSFactory, FlawFactory
 
 pytestmark = pytest.mark.enable_rls
@@ -80,10 +80,13 @@ class TestRLS:
         """
         set_user_acls(settings.ALL_GROUPS)
         f1 = FlawFactory(title="foo", embargoed=False)
-        f2 = FlawFactory(title="bar", embargoed=True)
+        f2 = FlawFactory(title="bar", embargoed=True, impact=Impact.MODERATE)
         # Avoid issuing alerts for f2 so that the error is not due to the RLS in the alert table
         FlawCVSSFactory(
-            flaw=f2, version=CVSS.CVSSVersion.VERSION3, issuer=CVSS.CVSSIssuer.REDHAT
+            flaw=f2,
+            version=CVSS.CVSSVersion.VERSION3,
+            issuer=CVSS.CVSSIssuer.REDHAT,
+            vector="CVSS:3.1/AV:P/AC:L/PR:L/UI:R/S:C/C:H/I:H/A:H",
         )
 
         set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])


### PR DESCRIPTION
This PR consolidates the flaw's impact and RH CVSSv3 score validations as they are currently inconsistent and incomplete.

If RH CVSSv3 is present, score and impact should comply with the following:
- RH CVSSv3 score is not zero and flaw impact is set
- RH CVSSv3 score is zero and flaw impact is not set

Closes OSIDB-3738