### PR TITLE
make Jira task collector to write only necessary attributes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Filter out empty events from history API resutls (OSIDB-3942)
+- Make Jira task collector to write only necessary attributes to prevent mid-air collisions (OSIDB-3636)
 
 ## [4.7.0] - 2025-01-28
 ### Added

--- a/osidb/query_sets.py
+++ b/osidb/query_sets.py
@@ -5,9 +5,13 @@ from django.utils import timezone
 class CustomQuerySetUpdatedDt(models.QuerySet):
     """Extend QuerySet to inject updated_dt on update"""
 
-    def update(self, **kwargs):
-        if getattr(self.model, "updated_dt", False):
-            if "updated_dt" not in kwargs:
-                kwargs["updated_dt"] = timezone.now().replace(microsecond=0)
+    def update(self, auto_timestamps=True, **kwargs):
+        """
+        if auto_timestamps is True and updated_dt is NOT present in kwargs updated_dt is set to now
+        """
+        if auto_timestamps:
+            if getattr(self.model, "updated_dt", False):
+                if "updated_dt" not in kwargs:
+                    kwargs["updated_dt"] = timezone.now().replace(microsecond=0)
 
         return super().update(**kwargs)


### PR DESCRIPTION
After finally being able to document an error case in more detail (in the Jira issue reference below) my understanding of the problem is that when a flaw update leading to a consecutive Jira task update happens at the top of the minute, it can happen that the Jira task collector is too fast and fetches the new task changes before the update operation which triggered it could even finish potentially (under circumstances of some unfortunate operation interlacing) reverting part of the changes done by the update.

This is PR mitigates conflict (it will still happen but hopefully with no effect) by making the task collector to write only the task-related flaw attributes. Then, despite the order of the operations we should always end up with the same result.

I am however not able to reproduce the issue and I therefore I am not able to test it or write a test - it is simply too random and I have only a very high-level understanding of what probably happens. Thoughtful review welcome :smile: 

Closes OSIDB-3636