### PR TITLE
fix task sync manager references

### DIFF
--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -711,7 +711,7 @@ class JiraTaskSyncManager(SyncManager):
     def update_synced_links(self):
         from osidb.models import Flaw
 
-        Flaw.objects.filter(uuid=self.sync_id).update(bzsync_manager=self)
+        Flaw.objects.filter(uuid=self.sync_id).update(task_sync_manager=self)
 
     def __str__(self):
         from osidb.models import Flaw
@@ -756,7 +756,7 @@ class JiraTaskTransitionManager(SyncManager):
     def update_synced_links(self):
         from osidb.models import Flaw
 
-        Flaw.objects.filter(uuid=self.sync_id).update(bzsync_manager=self)
+        Flaw.objects.filter(uuid=self.sync_id).update(task_transition_manager=self)
 
     def __str__(self):
         from osidb.models import Flaw


### PR DESCRIPTION
So I wanted to do a last async task management tests and review on UAT - previous tests of the functionality on the stage and UAT both prove that the functionality works as intended and the data in Jira gets modified as expected. As the last safeguard I wanted to monitor flower data. I found some errors and noticed a nasty copy-paste bug which seems not to interrupt the functionality but prevents the sync tasks to store their results. I guess that it happens only under certain circumstances as on local and stage I did not see any errors. Maybe there is some probability? Anyway this fix is vital before the functionality could be turned on on the production.