### PR TITLE
skip non-migrated tracker sync (OSIDB-3966)

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -412,7 +412,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_update_trackers.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 87,
+        "line_number": 89,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-23T19:49:54Z"
+  "generated_at": "2025-01-31T12:34:45Z"
 }

--- a/conftest.py
+++ b/conftest.py
@@ -256,6 +256,18 @@ def enable_bz_async_sync(enable_bz_sync, monkeypatch) -> None:
 
 
 @pytest.fixture
+def enable_bz_tracker_sync(monkeypatch) -> None:
+    """
+    enable the sync of trackers to Bugzilla
+    """
+    import apps.bbsync.mixins as mixins
+    import osidb.models.tracker as tracker
+
+    monkeypatch.setattr(mixins, "SYNC_TO_BZ", True)
+    monkeypatch.setattr(tracker, "SYNC_TRACKERS_TO_BZ", True)
+
+
+@pytest.fixture
 def enable_jira_task_sync(monkeypatch) -> None:
     """
     enable the sync of tasks to Jira

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- Skip non-migrated Bugzilla tracker sync (OSIDB-3966)
+
 ## [4.7.1] - 2025-01-30
 ### Fixed
 - Filter out empty events from history API resutls (OSIDB-3942)

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -2045,7 +2045,7 @@ class FlawSerializer(
                     # If the non-components attributes are unchanged, a tracker update is
                     # necessary only for Vulnerability issuetype Jira trackers because only
                     # those contain components. And this tracker is not Vuln. issuetype.
-                    return
+                    continue
 
                 # perform the tracker update
                 # could be done async eventually


### PR DESCRIPTION
for the open Bugzilla trackers which project already migrated to Jira we need to skip the eventual sync not to interrupt the update