### PR TITLE
custom validations before standard ones

### DIFF
--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -175,16 +175,11 @@ class Affect(
     def save(self, *args, **kwargs):
         if self.purl and not self.ps_component:
             try:
+                # try to parse the PS component from the PURL but do not raise any
+                # error on failure as that will be done as part of the validations
                 self.ps_component = PackageURL.from_string(self.purl).name
             except ValueError:
                 pass
-
-        # TODO: if ps_component is still missing, we must catch an error now
-        #  because the error message in AlertMixin's standard validations is
-        #  not helpful and changing the order of validations is not possible now
-        #  (this should be removed once custom validations run before standard validations)
-        if not self.ps_component:
-            self._validate_purl_and_ps_component()
 
         super().save(*args, **kwargs)
 


### PR DESCRIPTION
This PR changes the order of the validations. The standard Django validations which were run through **full_clean** are now postponed after the custom ones. The reason is that the custom ones provide more refined error messages and if we run them after the standard ones the user can get an error which is not really the correct one.

This was the reason why there was one affect validation run in the **save** method however that was breaking the concept of the **AlertMixin** where there is an option to suppress the exception and only store the alert. This PR comes as a prerequisite of the orphaned tracker linking where a dummy affects will need to be automatically created and they will possibly be partially invalid due to a missing information. A non-suppressible exception is a blocker.