### PR TITLE
Update resolution of Obsolete trackers to Not affected

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Remove time information when validating embargoed flaws (OSIDB-3862)
+- The "Obsolete" tracker resolution is now treated as "Not affected" to allow its use for erroneously filed trackers
 
 ### Fixed
 - Fix CVSS data parsing in NVD collector (OSIDB-4003)

--- a/osidb/models/tracker.py
+++ b/osidb/models/tracker.py
@@ -479,7 +479,7 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
     @property
     def fix_state(self):
         """
-        Inheritied from SDEngine, see abe12e30a509824629d05e91ce23c5d987e8ad36/sdengine/models.py#L1165
+        Inherited from SDEngine, see abe12e30a509824629d05e91ce23c5d987e8ad36/sdengine/models.py#L1165
         Trackers can be Bugzilla or Jira Issues. Because Jira Projects can configure anything they want as various statuses and
         resolutions, it's hard to sensibly map tracker status to a finite set of display values.
         We'll do the best we can from data gathered by SDEngine up to 2021-12-14, but these will change in the
@@ -494,13 +494,14 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         if self.status in ("won't fix", "obsolete"):
             return Affect.AffectFix.WONTFIX
         if self.status in ("done", "resolved", "closed"):
-            if self.resolution in ("won't do", "won't fix", "wontfix", "obsolete"):
+            if self.resolution in ("won't do", "won't fix", "wontfix"):
                 return Affect.AffectFix.WONTFIX
             # Added rejected to code inherited from SDEngine because samples such as MGDSTRM-4153
             elif self.resolution in (
                 "notabug",
                 "not a bug",
                 "rejected",
+                "obsolete",
             ):
                 return Affect.AffectFix.NOTAFFECTED
             elif self.resolution in ("eol", "out of date"):


### PR DESCRIPTION
With new VEX justifications being enabled for the "Not a bug" Jira resolution, we need to be able to reserve a specific tracker resolution for those trackers that were filed erroneously. Since no VEX justification exists for such state, we need to decide on a specific resolution that will be used for this purpose. Obsolete seems like a good fit.

Yes, the current usage of Obsolete is all over the place, but we can clean that up going forward at least a bit and amend our docs to recommend it as a resolution for invalid trackers. If a tracker was opened in error, it is likely that the underlying component/product is not affected, so we should display it as such on the CVE page as well.