### PR TITLE
Revert "Map user name or email to pghistory context..." (6139e55b)

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -83,7 +83,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "osidb.middleware.OsidbHistoryMiddleware",  # adds request user to audit history context
+    "pghistory.middleware.HistoryMiddleware",  # adds request user to audit history context
     "django.middleware.gzip.GZipMiddleware",
     "osidb.middleware.PgCommon",
 ]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add collaboration labels on flaw promotion (OSIDB-3804)
 - Add basic end-to-end tests for Flaws, Affects and Trackers (OSIDB-3495)
 - Allow searching by flaw labels (OSIDB-3816)
-- Map user name or email to flaw audit history entries (OSIDB-3464)
 
 ### Changed
 - Removed `last_validated_dt` from exposed JSON Flaw History data (OSIDB-3814), handled edge-case that would cause failure (OSIDB-3858)

--- a/osidb/middleware.py
+++ b/osidb/middleware.py
@@ -3,12 +3,9 @@
     For a user to access rows in a table it must have the correct acl.
 
 """
-
 import logging
 
-import pghistory
 from django.conf import settings
-from django.core.handlers.wsgi import WSGIRequest
 
 from osidb.core import set_user_acls
 
@@ -35,44 +32,3 @@ class PgCommon:
             _logger.info(f"ACLs set from middleware for user {request.user.username}")
             set_user_acls(request.user.groups.all())
         return self.get_response(request)
-
-
-def get_userstr(user):
-    userstr = str(user)
-    if getattr(user, "is_authenticated", False):
-        if getattr(user, "email", False):
-            userstr = user.email
-        elif getattr(user, "username", False):
-            userstr = user.username
-    return userstr
-
-
-class WSGIRequestWithHook(WSGIRequest):
-    """
-    Updates pghistory context when the request.user attribute is updated in order
-    for context to be set before DB User-model lookup happens. User is added to the request
-    by Django in middleware, but added to the request object in the view layer by
-    django-rest-framework.
-    """
-
-    def __setattr__(self, attr, value):
-        _value = get_userstr(value) if attr == "user" else value
-        return super().__setattr__(attr, _value)
-
-
-class OsidbHistoryMiddleware:
-    """
-    Provides pghistory context with user email or name for use in FlawAudit model
-    """
-
-    def __init__(self, get_response):
-        self.get_response = get_response
-
-    def __call__(self, request):
-        if not request or not hasattr(request, "user"):
-            return self.get_response(request)
-
-        with pghistory.context(user=get_userstr(request.user), path=request.path):
-            if isinstance(request, WSGIRequest):
-                request.__class__ = WSGIRequestWithHook
-            return self.get_response(request)


### PR DESCRIPTION
It looks like this change has to be reverted, the kerberos user data is not being picked up and instead we lose the PK of the user who made the change in favor of `AnonymousUser`. 
![image](https://github.com/user-attachments/assets/a205f7ef-11ed-46a9-84c6-ccb076ea28de)
This is not desirable.