### PR TITLE
Use date instead of datetime when validating embargoed date

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add not affected justification field to affects (OSIDB-380)
 
+### Changed
+- Remove time information when validating embargoed flaws (OSIDB-3862)
+
 ### Fixed
 - Fix CVSS data parsing in NVD collector (OSIDB-4003)
 

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -569,7 +569,7 @@ class Flaw(
         if (
             self.is_embargoed
             and self.unembargo_dt is not None
-            and self.unembargo_dt < timezone.now()
+            and self.unembargo_dt.date() < timezone.now().date()
         ):
             raise ValidationError(
                 "Flaw still embargoed but unembargo date is in the past."


### PR DESCRIPTION
Use **date** instead of **date time** when validating embargoed flaws to allow users to do last minute changes.

This also aligns with the validation in OSIM

Closes OSIDB-3862