### PR TITLE
Handle empty queryset before unpacking

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix CVSS data parsing in NVD collector (OSIDB-4003)
+- Handle delete of last affect when updating flaw collaborators (OSIDB-3986)
 
 ### Removed
 - Remove flaw impact adjustment from NVD collector (OSIDB-3678)

--- a/osidb/models/flaw/label.py
+++ b/osidb/models/flaw/label.py
@@ -96,13 +96,14 @@ class FlawCollaboratorManager(TrackingMixinManager):
     def create_from_flaw(flaw: Flaw):
         """Add new labels to the flaw based on the flaw"""
 
-        [ps_modules, ps_components] = list(
-            zip(
-                *Affect.objects.filter(flaw=flaw).values_list(
-                    "ps_module", "ps_component"
-                )
-            )
+        ps_values = Affect.objects.filter(flaw=flaw).values_list(
+            "ps_module", "ps_component"
         )
+
+        if not ps_values:
+            return []
+
+        [ps_modules, ps_components] = list(zip(*ps_values))
         labels = FlawLabel.objects.get_filtered(ps_modules, ps_components)
 
         for label in labels:

--- a/osidb/models/tests/test_flaw_collaborator.py
+++ b/osidb/models/tests/test_flaw_collaborator.py
@@ -112,3 +112,22 @@ class TestFlawCollaborator:
 
         # This should not raise an error
         collaborator.save()
+
+    def test_create_from_flaw(self):
+        flaw = FlawFactory(
+            embargoed=False,
+            workflow_state=WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT,
+        )
+        FlawLabel.objects.create(
+            name="test_module_label",
+            type=FlawLabel.FlawLabelType.PRODUCT_FAMILY,
+            ps_modules=["test_module"],
+        )
+
+        # This should not raise an error
+        FlawCollaborator.objects.create_from_flaw(flaw)
+        assert FlawCollaborator.objects.count() == 0
+
+        AffectFactory(flaw=flaw, ps_module="test_module", ps_component="test_component")
+        FlawCollaborator.objects.create_from_flaw(flaw)
+        assert FlawCollaborator.objects.count() == 1


### PR DESCRIPTION
When deleting the last Affect in a Flaw, we were throwing a `not enough values to unpack` error, this change adds a conditional to check emptiness and return early.

It is not a critical issue, since this scenario is not possible, there's a validation in place to force at least 1 affect in `SECONDARY_ASSESSMENT` state, but because of this error, we are throwing an 500 server error instead of the validation error.

Closes OSIDB-3986