### PR TITLE
Migrate user ids to username/email on Audit entries

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make task_key read-only (OSIDB-4080)
 - Split Requests/Responses in API schema
 
+### Changed
+- Migrate user ids on history Audit models to user emails or usernames (OSIDB-3988)
+
 ## [4.9.1] - 2025-03-10
 ### Fixed
 - Prefix PURL-derived ps_components with path in some cases (OSIDB-4071)

--- a/osidb/migrations/0188_map_user_id_to_user_email_or_name.py
+++ b/osidb/migrations/0188_map_user_id_to_user_email_or_name.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+from django.contrib.auth.models import User
+
+
+def forwards_func(apps, schema_editor):
+
+    context_model = next(
+        (
+            model
+            for model in apps.get_models("osidb")
+            if model._meta.model_name == "context"
+        ),
+        None,
+    )
+
+    if not context_model:
+        return
+
+    context_entries = context_model.objects.all().iterator()
+    for entry in context_entries:
+        if "user" in entry.metadata and isinstance(entry.metadata["user"], int):
+            user_id = entry.metadata["user"]
+            user = User.objects.get(id=user_id)
+            if user and (user.email or user.username):
+                entry.metadata["user"] = user.email or user.username
+                entry.metadata["user_id"] = user_id
+                entry.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("osidb", "0187_add_tracker_special_handling"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, migrations.RunPython.noop),
+    ]


### PR DESCRIPTION
When a single flaw is requested, this PR adds logic during serialization of Flaw that checks its related Audit entries (FlawAudit, AffectAudit, FlawCommentAudit, etc)  replaces numerical ids with the username or email of the corresponding users. 

Closes OSIDB-3988

- [x] Tested on stage