### PR TITLE
OSIDB-3939: Propagate jira error correctly

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix CVSS data parsing in NVD collector (OSIDB-4003)
 - Handle delete of last affect when updating flaw collaborators (OSIDB-3986)
+- Propagate Jira errors to the user (OSIDB-3939)
 
 ### Removed
 - Remove flaw impact adjustment from NVD collector (OSIDB-3678)


### PR DESCRIPTION
Accesing `.text` property wasn't enough to get the error body from Jira, I've created a small function that returns the `error` object from the response body https://docs.atlassian.com/software/jira/docs/api/REST/9.12.10/#error-responses

There's also `errorMessages` but from my testing was always empty so I decided to leave it out

Closes OSIDB-3939