### PR TITLE
Introduce resolved_dt into affect model

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add not affected justification field to affects (OSIDB-3809)
 - Add not affected justification field to trackers (OSIDB-3808)
 - Add delegated not affected justification field to affect (OSIDB-3810)
+- Add resolved_dt to affect model (OSIDB-4058)
 
 ### Changed
 - Remove time information when validating embargoed flaws (OSIDB-3862)

--- a/openapi.yml
+++ b/openapi.yml
@@ -7339,6 +7339,10 @@ components:
         delegated_not_affected_justification:
           type: string
           readOnly: true
+        resolved_dt:
+          type: string
+          format: date-time
+          readOnly: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7368,6 +7372,7 @@ components:
       - flaw
       - ps_module
       - ps_product
+      - resolved_dt
       - trackers
       - updated_dt
       - uuid
@@ -7436,6 +7441,10 @@ components:
         delegated_not_affected_justification:
           type: string
           readOnly: true
+        resolved_dt:
+          type: string
+          format: date-time
+          readOnly: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7465,6 +7474,7 @@ components:
       - flaw
       - ps_module
       - ps_product
+      - resolved_dt
       - trackers
       - updated_dt
       - uuid
@@ -7675,6 +7685,10 @@ components:
         delegated_not_affected_justification:
           type: string
           readOnly: true
+        resolved_dt:
+          type: string
+          format: date-time
+          readOnly: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7699,6 +7713,7 @@ components:
       - flaw
       - ps_module
       - ps_product
+      - resolved_dt
       - trackers
       - uuid
     AffectReportData:

--- a/osidb/migrations/0185_add_affect_resolved_dt.py
+++ b/osidb/migrations/0185_add_affect_resolved_dt.py
@@ -1,0 +1,107 @@
+from django.conf import settings
+from django.db import migrations, models
+from itertools import islice
+from osidb.core import set_user_acls
+
+import pgtrigger.compiler
+import pgtrigger.migrations
+
+def forwards_func(apps, schema_editor):
+    """
+    Best effort to estimate resolved_dt for affects resolved in the past
+    based on audit logs, in case affect is too old to have audit logs
+    use last updated date for resolved_dt
+    """
+    BATCH_SIZE = 10000
+    set_user_acls(settings.ALL_GROUPS)
+
+    # Events are not available during migrations, using dumped instance from audit instead
+    AffectAudit = apps.get_model("osidb", "affectaudit")
+    Affect = apps.get_model("osidb", "Affect")
+
+    resolved_affects = Affect.objects.exclude(
+        resolution="", affectedness__in=["NEW", ""]
+    )
+
+    total = resolved_affects.count()
+    resolved_affects = resolved_affects.iterator()
+    print(f"\n    Found {total} resolved affects.")
+
+    history_count = 0
+    batch_pointer = 0
+    while True:
+        batch = list(islice(resolved_affects, BATCH_SIZE))
+        if not batch:
+            break
+        print(f"      Working from {batch_pointer} to {batch_pointer + len(batch)}.")
+        batch_pointer += len(batch)
+        
+        for affect in batch:
+            # get the latest audit event that changed from
+            # unresolved to a resolved state
+            resolved_event = AffectAudit.objects.filter(
+                resolution="",
+                affectedness="NEW",
+                pgh_obj_id=affect.uuid,
+            ).order_by("-pgh_created_at").first()
+
+            resolved_dt = affect.updated_dt
+            if resolved_event:
+                resolved_dt = resolved_event.pgh_created_at
+                history_count += 1
+            affect.resolved_dt = resolved_dt
+        
+        Affect.objects.bulk_update(batch, ["resolved_dt"])
+    print(f"    Found {history_count} resolved_dt from audit logs. {total-history_count} defaulted to affect.updated_dt.")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osidb', '0184_tracker_not_affected_justification'),
+    ]
+
+    operations = [
+        pgtrigger.migrations.RemoveTrigger(
+            model_name='affect',
+            name='insert_insert',
+        ),
+        pgtrigger.migrations.RemoveTrigger(
+            model_name='affect',
+            name='update_update',
+        ),
+        pgtrigger.migrations.RemoveTrigger(
+            model_name='affect',
+            name='delete_delete',
+        ),
+        migrations.AddField(
+            model_name='affect',
+            name='resolved_dt',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='affectaudit',
+            name='resolved_dt',
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.RunPython(forwards_func, migrations.RunPython.noop, atomic=True),
+        pgtrigger.migrations.AddTrigger(
+            model_name='affect',
+            trigger=pgtrigger.compiler.Trigger(name='insert_insert', sql=pgtrigger.compiler.UpsertTriggerSql(func='INSERT INTO "osidb_affectaudit" ("acl_read", "acl_write", "affectedness", "created_dt", "flaw_id", "impact", "last_validated_dt", "not_affected_justification", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "ps_component", "ps_module", "purl", "resolution", "resolved_dt", "updated_dt", "uuid") VALUES (NEW."acl_read", NEW."acl_write", NEW."affectedness", NEW."created_dt", NEW."flaw_id", NEW."impact", NEW."last_validated_dt", NEW."not_affected_justification", _pgh_attach_context(), NOW(), \'insert\', NEW."uuid", NEW."ps_component", NEW."ps_module", NEW."purl", NEW."resolution", NEW."resolved_dt", NEW."updated_dt", NEW."uuid"); RETURN NULL;', hash='c3091ecede2b467c3d7b3bc5ba0e375d7deec805', operation='INSERT', pgid='pgtrigger_insert_insert_0d1b1', table='osidb_affect', when='AFTER')),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name='affect',
+            trigger=pgtrigger.compiler.Trigger(name='update_update', sql=pgtrigger.compiler.UpsertTriggerSql(condition='WHEN (OLD."acl_read" IS DISTINCT FROM (NEW."acl_read") OR OLD."acl_write" IS DISTINCT FROM (NEW."acl_write") OR OLD."affectedness" IS DISTINCT FROM (NEW."affectedness") OR OLD."created_dt" IS DISTINCT FROM (NEW."created_dt") OR OLD."flaw_id" IS DISTINCT FROM (NEW."flaw_id") OR OLD."impact" IS DISTINCT FROM (NEW."impact") OR OLD."last_validated_dt" IS DISTINCT FROM (NEW."last_validated_dt") OR OLD."not_affected_justification" IS DISTINCT FROM (NEW."not_affected_justification") OR OLD."ps_component" IS DISTINCT FROM (NEW."ps_component") OR OLD."ps_module" IS DISTINCT FROM (NEW."ps_module") OR OLD."purl" IS DISTINCT FROM (NEW."purl") OR OLD."resolution" IS DISTINCT FROM (NEW."resolution") OR OLD."resolved_dt" IS DISTINCT FROM (NEW."resolved_dt") OR OLD."updated_dt" IS DISTINCT FROM (NEW."updated_dt") OR OLD."uuid" IS DISTINCT FROM (NEW."uuid"))', func='INSERT INTO "osidb_affectaudit" ("acl_read", "acl_write", "affectedness", "created_dt", "flaw_id", "impact", "last_validated_dt", "not_affected_justification", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "ps_component", "ps_module", "purl", "resolution", "resolved_dt", "updated_dt", "uuid") VALUES (NEW."acl_read", NEW."acl_write", NEW."affectedness", NEW."created_dt", NEW."flaw_id", NEW."impact", NEW."last_validated_dt", NEW."not_affected_justification", _pgh_attach_context(), NOW(), \'update\', NEW."uuid", NEW."ps_component", NEW."ps_module", NEW."purl", NEW."resolution", NEW."resolved_dt", NEW."updated_dt", NEW."uuid"); RETURN NULL;', hash='20478c48735abce37e10a181039f0ea18ea0c096', operation='UPDATE', pgid='pgtrigger_update_update_fdef6', table='osidb_affect', when='AFTER')),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name='affect',
+            trigger=pgtrigger.compiler.Trigger(name='delete_delete', sql=pgtrigger.compiler.UpsertTriggerSql(func='INSERT INTO "osidb_affectaudit" ("acl_read", "acl_write", "affectedness", "created_dt", "flaw_id", "impact", "last_validated_dt", "not_affected_justification", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "ps_component", "ps_module", "purl", "resolution", "resolved_dt", "updated_dt", "uuid") VALUES (OLD."acl_read", OLD."acl_write", OLD."affectedness", OLD."created_dt", OLD."flaw_id", OLD."impact", OLD."last_validated_dt", OLD."not_affected_justification", _pgh_attach_context(), NOW(), \'delete\', OLD."uuid", OLD."ps_component", OLD."ps_module", OLD."purl", OLD."resolution", OLD."resolved_dt", OLD."updated_dt", OLD."uuid"); RETURN NULL;', hash='d4d791f32656966fbb8aa84fb1c8f8dbe727f299', operation='DELETE', pgid='pgtrigger_delete_delete_cc8c5', table='osidb_affect', when='AFTER')),
+        ),
+    ]
+
+
+
+
+
+
+

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -158,6 +158,8 @@ class Affect(
         choices=NotAffectedJustification.choices, max_length=100, blank=True
     )
 
+    resolved_dt = models.DateTimeField(null=True, blank=True)
+
     # non operational meta data
     meta_attr = HStoreField(default=dict)
 

--- a/osidb/models/tests/test_affect.py
+++ b/osidb/models/tests/test_affect.py
@@ -1,0 +1,86 @@
+from osidb.models import Affect, Impact
+from osidb.tests.factories import AffectFactory, FlawFactory, PsModuleFactory
+
+
+class TestAffect:
+    def test_resolved_dt_auto_update(self):
+        """
+        test resolve_dt is null when an affect is unresolved and is
+        automatically updated when first entered in a resolved state
+        """
+        flaw = FlawFactory()
+
+        # Check factory behavior
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.NEW,
+            resolution=Affect.AffectResolution.NOVALUE,
+        )
+        assert not affect.is_resolved
+        assert not affect.resolved_dt
+
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.NEW,
+            resolution=Affect.AffectResolution.WONTFIX,
+        )
+        assert affect.is_resolved
+        assert affect.resolved_dt
+
+        ps_module = PsModuleFactory(name="test-module")
+
+        # Check creation behavior
+        affect_unresolved = Affect(
+            impact=Impact.MODERATE,
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.NEW,
+            resolution=Affect.AffectResolution.NOVALUE,
+            ps_component="component-10",
+            ps_module=ps_module.name,
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+        affect_unresolved.save()
+
+        assert not affect_unresolved.is_resolved
+        assert not affect_unresolved.resolved_dt
+
+        affect_resolved = Affect(
+            impact=Impact.MODERATE,
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_component="component-20",
+            ps_module=ps_module.name,
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+        affect_resolved.save()
+
+        assert affect_resolved.is_resolved
+        assert affect_resolved.resolved_dt
+
+        # Check update behavior from unresolved to resolved
+        affect_unresolved.affectedness = Affect.AffectAffectedness.AFFECTED
+        affect_unresolved.resolution = Affect.AffectResolution.DELEGATED
+        affect_unresolved.save()
+
+        assert affect_unresolved.is_resolved
+        assert affect_unresolved.resolved_dt
+
+        # Check update behavior from resolved to resolved
+        current_resolved_dt = affect_resolved.resolved_dt
+        affect_resolved.affectedness = Affect.AffectAffectedness.AFFECTED
+        affect_resolved.resolution = Affect.AffectResolution.WONTFIX
+        affect_resolved.save()
+
+        assert affect_resolved.is_resolved
+        assert affect_resolved.resolved_dt == current_resolved_dt
+
+        # Check update behavior from resolved to unresolved
+        affect_resolved.affectedness = Affect.AffectAffectedness.NEW
+        affect_resolved.resolution = Affect.AffectResolution.NOVALUE
+        affect_resolved.save()
+
+        assert not affect_resolved.is_resolved
+        assert not affect_resolved.resolved_dt

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1103,6 +1103,7 @@ class AffectSerializer(
         max_length=255, allow_blank=True, allow_null=True, required=False
     )
     purl = serializers.CharField(allow_blank=True, allow_null=True, required=False)
+    resolved_dt = serializers.DateTimeField(read_only=True)
 
     @extend_schema_field(
         {
@@ -1148,6 +1149,7 @@ class AffectSerializer(
                 "purl",
                 "not_affected_justification",
                 "delegated_not_affected_justification",
+                "resolved_dt",
             ]
             + ACLMixinSerializer.Meta.fields
             + AlertMixinSerializer.Meta.fields

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -36,7 +36,10 @@ from osidb.models import (
     SpecialConsiderationPackage,
     Tracker,
 )
-from osidb.models.affect import AFFECTEDNESS_VALID_RESOLUTIONS
+from osidb.models.affect import (
+    AFFECTEDNESS_UNRESOLVED_RESOLUTIONS,
+    AFFECTEDNESS_VALID_RESOLUTIONS,
+)
 
 DATA_PRODSEC_ACL_READ = uuid.uuid5(
     uuid.NAMESPACE_URL,
@@ -280,6 +283,12 @@ class AffectFactory(BaseFactory):
     )
     resolution = factory.LazyAttribute(
         lambda a: AFFECTEDNESS_VALID_RESOLUTIONS[a.affectedness][0]
+    )
+    resolved_dt = factory.LazyAttribute(
+        lambda a: factory.Faker("date_time", tzinfo=UTC)
+        if a.affectedness not in AFFECTEDNESS_UNRESOLVED_RESOLUTIONS
+        or a.resolution not in AFFECTEDNESS_UNRESOLVED_RESOLUTIONS[a.affectedness]
+        else None
     )
     not_affected_justification = factory.LazyAttribute(
         lambda a: (


### PR DESCRIPTION
This PR introduces resolved_dt into affect model.
This PR also tries to estimate the resolved_dt for affects resolved in the past during its migration.
This PR also includes an automation of the resolved_dt timestamp when an affect leaves the `NEW:NOVALUE` state.

Closes OSIDB-4058.