### PR TITLE
Optimize CVE file path retrieval in CVEorg

### DIFF
--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -2,7 +2,6 @@ import json
 import os
 import re
 from decimal import Decimal
-from glob import iglob
 from time import sleep
 from typing import Union
 
@@ -154,18 +153,18 @@ class CVEorgCollector(Collector):
 
     def get_cve_file_path(self, cve: str) -> str:
         """
-        Fetch the CVE file path from the cvelistV5 repository for a given `cve`.
+        Retrieve the CVE file path from the cvelistV5 repository for a given `cve`.
         """
-        file_path = [
-            f
-            for f in iglob(f"{self.REPO_PATH}/cves/**", recursive=True)
-            if os.path.isfile(f) and f"{cve}.json" in f
-        ]
-        if len(file_path) != 1:
-            msg = f"Expected to find one file for {cve} but found: {', '.join(file_path) or 'none'}"
+        # Create a path where the CVE file should be stored
+        # E. g. CVE-2024-35339 is stored as "<repo_path>/cves/2024/35xxx/CVE-2024-35339.json"
+        _, year, number = cve.split("-")
+        file_path = f"{self.REPO_PATH}/cves/{year}/{number[:-3]}xxx/{cve}.json"
+
+        if not os.path.isfile(file_path):
+            msg = f"Did not find a file for '{cve}' in the cvelistV5 repository."
             raise CVEorgCollectorException(msg)
 
-        return file_path[0]
+        return file_path
 
     def collect_cve(self, cve: str) -> str:
         """

--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -25,6 +25,7 @@ from collectors.framework.models import Collector
 from collectors.utils import convert_cvss_score_to_impact, handle_urls
 from osidb.core import set_user_acls
 from osidb.models import FlawCVSS, FlawReference, Snippet
+from osidb.validators import CVE_RE_STR
 
 logger = get_task_logger(__name__)
 
@@ -171,6 +172,10 @@ class CVEorgCollector(Collector):
         Collect vulnerability data for a given `cve` from the cvelistV5 repository and store it in OSIDB.
         This method is intended for a manual collector run via the `create_cveorg_flaw` command.
         """
+        if not re.match(CVE_RE_STR, cve):
+            msg = f"Provided '{cve}' is not a valid CVE string."
+            raise CVEorgCollectorException(msg)
+
         # Set osidb.acl to be able to CRUD database properly and essentially bypass ACLs as
         # Celery workers should be able to read/write any information in order to fulfill their jobs
         set_user_acls(settings.ALL_GROUPS)


### PR DESCRIPTION
This PR is a follow-up to #918 and updates the method for retrieving the file path of a given CVE. Instead of looping through all files in the cvelistV5 repository, the file path is now created directly using the known CVE information. Additionally, the CVE collection process exits early if the CVE is invalid.