### PR TITLE
Update UBI image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi9/ubi:9.4
+FROM registry.redhat.io/ubi9/ubi:9.5
 
 LABEL summary="OSIDB" \
       maintainer="Product Security DevOps <prodsec-dev@redhat.com>"


### PR DESCRIPTION
This commit updates the UBI imgae from 9.4 to 9.5 to get the latest vulnerability patches, as this was pointed out in the SAR.

Closes OSIDB-4059.