### PR TITLE
Mark affect resolved_dt nullable in API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extend tracker model with resolved date (OSIDB-4064)
 - Extend tracker model with special handling (OSIDB-4065)
 
+### Fixed
+- Affect resolved_dt marked correctly as nullable in API schema
+
 ## [4.8.0] - 2025-03-03
 ### Added
 - Add not affected justification field to affects (OSIDB-3809)
@@ -16,7 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add delegated not affected justification field to affect (OSIDB-3810)
 - Add resolved_dt to affect model (OSIDB-4058)
 - Map user name or email to flaw audit history entries (OSIDB-3464)
-
 
 ### Changed
 - Remove time information when validating embargoed flaws (OSIDB-3862)

--- a/openapi.yml
+++ b/openapi.yml
@@ -7343,6 +7343,7 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7445,6 +7446,7 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -7689,6 +7691,7 @@ components:
           type: string
           format: date-time
           readOnly: true
+          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1108,7 +1108,7 @@ class AffectSerializer(
         max_length=255, allow_blank=True, allow_null=True, required=False
     )
     purl = serializers.CharField(allow_blank=True, allow_null=True, required=False)
-    resolved_dt = serializers.DateTimeField(read_only=True)
+    resolved_dt = serializers.DateTimeField(read_only=True, allow_null=True)
 
     @extend_schema_field(
         {


### PR DESCRIPTION
This PR:
* correctly marks `resolved_dt` as nullable in API schema to correctly reflect reality, this bug caused osidb-bindings generate inaccurately and throw errors parsing affects with no `resolved_dt`.

Note: no immediate release of OSIDB is necessary, once this is in master I will simply create new version of osidb-bindings (4.8.1) which will use the corrected openapi schema