### PR TITLE
Make task_key field read-only

### DIFF
--- a/apps/workflows/serializers.py
+++ b/apps/workflows/serializers.py
@@ -145,6 +145,7 @@ class RejectSerializer(serializers.Serializer):
 class WorkflowModelSerializer(serializers.ModelSerializer):
 
     classification = serializers.SerializerMethodField()
+    task_key = serializers.CharField(read_only=True, allow_null=True)
 
     class Meta:
         model = WorkflowModel

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Affect resolved_dt marked correctly as nullable in API schema
+- Make task_key read-only (OSIDB-4080)
 
 ## [4.8.0] - 2025-03-03
 ### Added

--- a/openapi.yml
+++ b/openapi.yml
@@ -8089,7 +8089,8 @@ components:
           maxLength: 60
         task_key:
           type: string
-          maxLength: 60
+          readOnly: true
+          nullable: true
         team_id:
           type: string
           maxLength: 8
@@ -8111,6 +8112,7 @@ components:
       - labels
       - package_versions
       - references
+      - task_key
       - title
       - trackers
       - updated_dt
@@ -8784,7 +8786,8 @@ components:
           maxLength: 60
         task_key:
           type: string
-          maxLength: 60
+          readOnly: true
+          nullable: true
         team_id:
           type: string
           maxLength: 8
@@ -8806,6 +8809,7 @@ components:
       - labels
       - package_versions
       - references
+      - task_key
       - title
       - trackers
       - uuid


### PR DESCRIPTION
This field is not set as read-only in the API when it should be, allowing users to accidentally rewrite it and break integration with Jira tasks.

Closes OSIDB-4080.