### PR TITLE
Fix workflow tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,6 +72,7 @@ jobs:
           openssl-devel
           postgresql-contrib
           postgresql-devel
+          postgresql-server-devel
           python-srpm-macros
           python3-devel
           python3-pycodestyle

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 92,
+        "line_number": 93,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-02-26T08:57:16Z"
+  "generated_at": "2025-03-18T15:46:17Z"
 }


### PR DESCRIPTION
The workflow tests had started failing when building `psycopg` from
source, with the following error:

```
error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [23 lines of output]
      running egg_info
      creating /tmp/pip-pip-egg-info-jszrgnbb/psycopg2.egg-info
      writing /tmp/pip-pip-egg-info-jszrgnbb/psycopg2.egg-info/PKG-INFO
      writing dependency_links to /tmp/pip-pip-egg-info-jszrgnbb/psycopg2.egg-info/dependency_links.txt
      writing top-level names to /tmp/pip-pip-egg-info-jszrgnbb/psycopg2.egg-info/top_level.txt
      writing manifest file '/tmp/pip-pip-egg-info-jszrgnbb/psycopg2.egg-info/SOURCES.txt'

      Error: pg_config executable not found.

      pg_config is required to build psycopg2 from source.  Please add the directory
      containing pg_config to the $PATH or specify the full executable path with the
      option:

          python setup.py build_ext --pg-config /path/to/pg_config build ...

      or with the pg_config option in 'setup.cfg'.

      If you prefer to avoid building psycopg2 from source, please install the PyPI
      'psycopg2-binary' package instead.

      For further information please check the 'doc/src/install.rst' file (also at
      <https://www.psycopg.org/docs/install.html>).

      [end of output]
```

I tried running a local instance of `fedora:latest` (image used by the
workflow action) which is currently Fedora 41, and installing the same
packages, and indeed `pg_config` command is not found.

This package should be in `/usr/bin/` which is in the `PATH`. Taking a
look, it is there but it is a link to `/usr/bin/pg_server_config` which
is missing.

I checked which package provides this file with
```
dnf provides "*/pg_server_config"
```
and it is provided by `postgres-server-devel` which is not installed.
Installing it fixed the issue.

It is unclear why this started happening, possibly Fedora moved
`pg_server_config` to the other package at some point but the issue is
fixed now so I won't investigate further.

Closes OSIDB-4120.