### PR TITLE
Collect task changes based on history

### DIFF
--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -40,7 +40,6 @@ class JiraTaskCollector(Collector):
     # Jira API does not seem to have either issues returning large number of results
     # or any restrictions on the maximum query period so we can be quite greedy
     BATCH_PERIOD_DAYS = 10
-    BATCH_PERIOD_END_SHIFT_MINUTES = 1
 
     def __init__(self):
         super().__init__()
@@ -60,11 +59,7 @@ class JiraTaskCollector(Collector):
         get next batch of Jira tasks plus period_end timestamp
         """
         period_start = self.metadata.updated_until_dt or self.BEGINNING
-        period_end = min(
-            timezone.now()
-            - timezone.timedelta(minutes=self.BATCH_PERIOD_END_SHIFT_MINUTES),
-            period_start + timezone.timedelta(days=self.BATCH_PERIOD_DAYS),
-        )
+        period_end = period_start + timezone.timedelta(days=self.BATCH_PERIOD_DAYS)
 
         # query for tasks in the period and return them together with the timestamp
         return (

--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -78,7 +78,7 @@ class JiraTaskCollector(Collector):
 
         # single-task sync
         if task_id is not None:
-            task_data = self.jira_querier.get_issue(task_id)
+            task_data = self.jira_querier.get_issue(task_id, expand="changelog")
             flaw = JiraTaskConvertor(task_data).flaw
             if flaw:
                 self.save(flaw)

--- a/collectors/jiraffe/constants.py
+++ b/collectors/jiraffe/constants.py
@@ -11,6 +11,9 @@ JIRA_TASKMAN_PROJECT_KEY = get_env("JIRA_TASKMAN_PROJECT_KEY", default="OSIM")
 # Jira datetime format string
 JIRA_DT_FMT = "%Y-%m-%d %H:%M"
 
+# Jira datetime full format string
+JIRA_DT_FULL_FMT = "%Y-%m-%dT%H:%M:%S.%f%z"
+
 # Maximum age of connection to Jira in seconds, recommended value is 60
 JIRA_MAX_CONNECTION_AGE = get_env("JIRA_MAX_CONNECTION_AGE")
 
@@ -27,3 +30,11 @@ JIRA_TRACKER_COLLECTOR_ENABLED = get_env(
 JIRA_METADATA_COLLECTOR_ENABLED = get_env(
     "JIRA_METADATA_COLLECTOR_ENABLED", default="True", is_bool=True
 )
+
+TASK_CHANGELOG_FIELD_MAPPING = {
+    "assignee": ["owner"],
+    "customfield_12313240": ["team_id"],
+    "customfield_12311140": ["group_key"],
+    "status": ["workflow_name", "workflow_state"],
+    "resolution": ["workflow_name", "workflow_state"],
+}

--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -20,6 +20,7 @@ from ..utils import (
     tracker_parse_update_stream_component,
     tracker_summary2module_component,
 )
+from .constants import JIRA_DT_FULL_FMT, TASK_CHANGELOG_FIELD_MAPPING
 
 logger = logging.getLogger(__name__)
 
@@ -30,6 +31,11 @@ class JiraTaskConvertor:
         task_data,
     ):
         self._raw = task_data
+        self.histories = getattr(
+            getattr(task_data, "changelog", None),
+            "histories",
+            [],
+        )
         # important that this is last as it might require other fields on self
         self.task_data = self._normalize()
         # set osidb.acl to be able to CRUD database properly and essentially bypass ACLs as
@@ -70,7 +76,7 @@ class JiraTaskConvertor:
             "team_id": self.get_field_attr(self._raw, "customfield_12313240", "id"),
             "group_key": self.get_field_attr(self._raw, "customfield_12311140"),
             "task_updated_dt": datetime.strptime(
-                self.get_field_attr(self._raw, "updated"), "%Y-%m-%dT%H:%M:%S.%f%z"
+                self.get_field_attr(self._raw, "updated"), JIRA_DT_FULL_FMT
             ),
         }
 
@@ -111,6 +117,19 @@ class JiraTaskConvertor:
                 f"Ignoring task ({self.task_data['external_system_id']}) without label containing flaw uuid."
             )
             return None
+
+        changed_fields = set()
+        for record in self.histories[::-1]:
+            record_dt = datetime.strptime(record.created, JIRA_DT_FULL_FMT)
+            if not flaw.task_updated_dt or record_dt > flaw.task_updated_dt:
+                for item in record.items:
+                    record_changed_fields = TASK_CHANGELOG_FIELD_MAPPING.get(item.field)
+                    if record_changed_fields:
+                        changed_fields.update(record_changed_fields)
+            else:
+                # no more new changes in history
+                break
+
         # Avoid updating timestamp of flaws without real changes
         has_changes = (
             flaw
@@ -120,23 +139,30 @@ class JiraTaskConvertor:
                 or flaw.task_updated_dt <= self.task_data["task_updated_dt"]
             )
             and (
-                flaw.team_id != self.task_data["team_id"]
-                or flaw.owner != self.task_data["owner"]
-                or flaw.task_key != self.task_data["external_system_id"]
-                or flaw.group_key != self.task_data["group_key"]
-                or flaw.workflow_name != self.task_data["workflow_name"]
-                or flaw.workflow_state != self.task_data["workflow_state"]
+                flaw.task_key != self.task_data["external_system_id"] or changed_fields
             )
         )
 
         if has_changes:
-            flaw.team_id = self.task_data["team_id"]
-            flaw.owner = self.task_data["owner"]
             flaw.task_key = self.task_data["external_system_id"]
-            flaw.group_key = self.task_data["group_key"]
-            flaw.workflow_name = self.task_data["workflow_name"]
-            flaw.workflow_state = self.task_data["workflow_state"]
-            flaw.task_updated_dt = self.task_data["task_updated_dt"]
+
+            # NOTE: for some unexplainable reason, history record created timestamp
+            #       can actually later in the future (by milliseconds) than Jira issue updated
+            #       timestamp, and thus we need to set the task_updated_dt to higher of
+            #       those values since it would later in the next download fetch changes
+            #       which were already downloaded and stored.
+            if self.histories:
+                latest_record_dt = datetime.strptime(
+                    self.histories[-1].created, JIRA_DT_FULL_FMT
+                )
+                flaw.task_updated_dt = max(
+                    latest_record_dt, self.task_data["task_updated_dt"]
+                )
+            else:
+                flaw.task_updated_dt = self.task_data["task_updated_dt"]
+
+            for field in changed_fields:
+                setattr(flaw, field, self.task_data[field])
             flaw.adjust_acls(save=False)
             return JiraTaskSaver(flaw)
         return None
@@ -374,19 +400,17 @@ class JiraTrackerConvertor(TrackerConvertor):
         self.ps_component = ps_component
         self.ps_update_stream = ps_update_stream
 
-        created_dt = datetime.strptime(
-            self._raw.fields.created, "%Y-%m-%dT%H:%M:%S.%f%z"
-        )
+        created_dt = datetime.strptime(self._raw.fields.created, JIRA_DT_FULL_FMT)
         updated_dt = (
             self._raw.fields.updated
             if self._raw.fields.updated
             else self._raw.fields.created
         )
-        updated_dt = datetime.strptime(updated_dt, "%Y-%m-%dT%H:%M:%S.%f%z")
+        updated_dt = datetime.strptime(updated_dt, JIRA_DT_FULL_FMT)
         resolved_dt = None
         if self._raw.fields.resolutiondate:
             resolved_dt = datetime.strptime(
-                self._raw.fields.resolutiondate, "%Y-%m-%dT%H:%M:%S.%f%z"
+                self._raw.fields.resolutiondate, JIRA_DT_FULL_FMT
             )
 
         return {

--- a/collectors/jiraffe/core.py
+++ b/collectors/jiraffe/core.py
@@ -178,12 +178,12 @@ class JiraQuerier(JiraConnector):
     # SINGLE ISSUE QUERIES #
     ########################
 
-    def get_issue(self, jira_id: str) -> Issue:
+    def get_issue(self, jira_id: str, expand: str = "") -> Issue:
         """
         get Jira issue specified by Jira ID
         """
         try:
-            return self.jira_conn.issue(jira_id)
+            return self.jira_conn.issue(jira_id, expand=expand)
         except JIRAError as e:
             if "Issue Does Not Exist" in str(e):
                 # restricted access cannot be distinguished

--- a/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_collect.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_collect.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -249,9 +249,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:05:55 GMT
+      - Thu, 20 Mar 2025 13:55:45 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:05:55 GMT
+      - Thu, 20 Mar 2025 13:55:45 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -260,9 +260,9 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       content-length:
       - '16539'
       referrer-policy:
@@ -272,23 +272,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 725x1711877x1
+      - 835x378514x1
       x-asessionid:
-      - vmb9sd
+      - c4c1kb
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.dfb1060.1732622755.7eeb4686
+      - 0.5cca4d68.1742478945.ecd6bda
       x-rh-edge-request-id:
-      - 7eeb4686
+      - ecd6bda
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -300,11 +300,11 @@ interactions:
     body: '{"fields": {"issuetype": {"id": "17"}, "project": {"id": "12337520"}, "summary":
       "CVE-2020-10000 kernel: some description", "description": "Comment zero for
       CVE-2020-10000", "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-      "impact:IMPORTANT", "CVE-2020-10000"], "priority": {"name": "Major"}, "assignee":
-      {"name": ""}}}'
+      "impact:IMPORTANT", "major_incident", "CVE-2020-10000"], "priority": {"name":
+      "Major"}, "assignee": {"name": ""}}}'
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -312,7 +312,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '330'
+      - '348'
       Content-Type:
       - application/json
       User-Agent:
@@ -323,32 +323,29 @@ interactions:
     uri: https://example.com/rest/api/2/issue
   response:
     body:
-      string: '{"id": "16312059", "key": "OSIM-14341", "self": "https://example.com/rest/api/2/issue/16312059"}'
+      string: '{"id": "16792993", "key": "OSIM-22680", "self": "https://example.com/rest/api/2/issue/16792993"}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
       Connection:
       - keep-alive
-      - Transfer-Encoding
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:05:58 GMT
+      - Thu, 20 Mar 2025 13:55:47 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:05:58 GMT
+      - Thu, 20 Mar 2025 13:55:47 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
-      Transfer-Encoding:
-      - chunked
       Vary:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '3'
+      - '0'
       content-length:
       - '103'
       referrer-policy:
@@ -358,23 +355,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 725x1711879x1
+      - 835x378515x1
       x-asessionid:
-      - 1iwzs1q
+      - 1vt9m18
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.dfb1060.1732622755.7eeb475a
+      - 0.5cca4d68.1742478945.ecd6e3c
       x-rh-edge-request-id:
-      - 7eeb475a
+      - ecd6e3c
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -386,7 +383,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -400,96 +397,92 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-14341
+    uri: https://example.com/rest/api/2/issue/OSIM-22680
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
-        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
-        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5a9a784d[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2cde79c0[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16792993", "self": "https://example.com/rest/api/2/issue/16792993",
+        "key": "OSIM-22680", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@2ae12381[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@69d9f4bf[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@3f55022c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@601a6c7f[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6b927335[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7fe7cb32[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6834f280[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5bfe126d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@238dd9fc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@62f228e4[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2d9d76c8[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6db746c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@dedd493[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2b37b59d[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@40c08603[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@76fa7d8b[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1550668b[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@35da2e1[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@47e9dc17[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@62daf744[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7428b1aa[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1a0c5f64[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": [], "customfield_12325241": null, "customfield_12325243":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
         "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
-        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
-        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "impact:IMPORTANT", "major_incident"], "aggregatetimeoriginalestimate": null,
+        "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
         [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
         null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
-        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "customfield_12325342":
+        null, "customfield_12325343": null, "subtasks": [], "customfield_12321140":
+        null, "customfield_12325340": null, "customfield_12325341": null, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "aggregateprogress":
         {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-22680/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
-        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
-        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
-        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
-        null, "customfield_12325155": null, "customfield_12320940": null, "project":
-        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
-        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
-        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
-        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
-        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
-        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
-        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12316841": null, "customfield_12319040": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-22680/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2025-03-20T13:55:45.959+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
         [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
         "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-11-26T12:05:56.086+0000", "timeoriginalestimate": null, "description":
+        "False", "id": "27705", "disabled": false}, "updated": "2025-03-20T13:55:45.959+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
         "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
         {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
         "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
         "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
         "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
         "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
-        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
-        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
-        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
-        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
-        null, "customfield_12311940": "2|i21qzr:"}}'
+        "customfield_12323640": null, "customfield_12323642": null, "customfield_12323641":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12310213": null, "customfield_12311940":
+        "1|i0otz3:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -498,9 +491,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:05:58 GMT
+      - Thu, 20 Mar 2025 13:55:47 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:05:58 GMT
+      - Thu, 20 Mar 2025 13:55:47 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -509,11 +502,11 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       content-length:
-      - '9404'
+      - '9070'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -521,23 +514,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 725x1711892x1
+      - 835x378521x2
       x-asessionid:
-      - 5zqvtd
+      - 4jznxq
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.dfb1060.1732622758.7eeb5336
+      - 0.5cca4d68.1742478947.ecd7607
       x-rh-edge-request-id:
-      - 7eeb5336
+      - ecd7607
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -549,7 +542,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -563,96 +556,92 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-14341
+    uri: https://example.com/rest/api/2/issue/OSIM-22680
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
-        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
-        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@6eaa2c7f[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@24fbf62a[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16792993", "self": "https://example.com/rest/api/2/issue/16792993",
+        "key": "OSIM-22680", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3284e8f4[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@48f1e838[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2809e64a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@53380fc7[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a5c61ac[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6203de70[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@55f4fcc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@168a2e97[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7fb27ceb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3bedd33[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7ce0c3a7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3b59b43a[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@38a58b85[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@7fd21481[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@78dc542f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@4db6299e[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@595b7a0e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@36421bb8[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2ca54c73[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@50a37aa0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@52aaf1b0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7413af86[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": [], "customfield_12325241": null, "customfield_12325243":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
         "Major", "id": "3"}, "labels": ["CVE-2020-10000", "flawuuid:fb145b06-82a7-4851-a429-541288633d16",
-        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
-        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
-        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "impact:IMPORTANT", "major_incident"], "aggregatetimeoriginalestimate": null,
+        "timeestimate": null, "versions": [], "issuelinks": [], "customfield_12325240":
+        null, "assignee": null, "customfield_12313942": null, "customfield_12313941":
+        null, "status": {"self": "https://example.com/rest/api/2/status/10016", "description":
+        "Initial creation status. Implies nothing yet and should be very short lived;
+        also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
         "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
         [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
         null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
-        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "customfield_12325342":
+        null, "customfield_12325343": null, "subtasks": [], "customfield_12321140":
+        null, "customfield_12325340": null, "customfield_12325341": null, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "aggregateprogress":
         {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-22680/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
-        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
-        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
-        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
-        null, "customfield_12325155": null, "customfield_12320940": null, "project":
-        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
-        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
-        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
-        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
-        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
-        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
-        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12316841": null, "customfield_12319040": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-22680/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2025-03-20T13:55:45.959+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
         [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
         "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-11-26T12:05:56.086+0000", "timeoriginalestimate": null, "description":
+        "False", "id": "27705", "disabled": false}, "updated": "2025-03-20T13:55:45.959+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
         "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
         {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
         "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
         "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
         "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
         "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
-        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
-        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
-        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
-        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
-        null, "customfield_12311940": "2|i21qzr:"}}'
+        "customfield_12323640": null, "customfield_12323642": null, "customfield_12323641":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12310213": null, "customfield_12311940":
+        "1|i0otz3:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -661,9 +650,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:05:58 GMT
+      - Thu, 20 Mar 2025 13:55:48 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:05:58 GMT
+      - Thu, 20 Mar 2025 13:55:48 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -672,35 +661,35 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       content-length:
-      - '9402'
+      - '9072'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 725x1719582x1
+      - 835x378523x1
       x-asessionid:
-      - 6jtb1l
+      - julacn
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1732622758.880b8d87
+      - 0.64ca4d68.1742478947.5d41eb8
       x-rh-edge-request-id:
-      - 880b8d87
+      - 5d41eb8
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -713,7 +702,7 @@ interactions:
       "impact:IMPORTANT"]}}'
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -729,7 +718,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: PUT
-    uri: https://example.com/rest/api/2/issue/OSIM-14341
+    uri: https://example.com/rest/api/2/issue/OSIM-22680
   response:
     body:
       string: ''
@@ -741,41 +730,41 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:05:59 GMT
+      - Thu, 20 Mar 2025 13:55:54 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:05:59 GMT
+      - Thu, 20 Mar 2025 13:55:54 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 725x1719603x1
+      - 835x378534x1
       x-asessionid:
-      - 10iws4f
+      - a3udx9
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1732622758.880b9351
+      - 0.64ca4d68.1742478953.5d42075
       x-rh-edge-request-id:
-      - 880b9351
+      - 5d42075
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -787,7 +776,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -801,7 +790,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-14341/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-22680/transitions
   response:
     body:
       string: '{"expand": "transitions", "transitions": [{"id": "11", "name": "New",
@@ -846,9 +835,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:05:59 GMT
+      - Thu, 20 Mar 2025 13:55:59 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:05:59 GMT
+      - Thu, 20 Mar 2025 13:55:59 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -857,9 +846,9 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       content-length:
       - '2963'
       referrer-policy:
@@ -867,25 +856,25 @@ interactions:
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 725x1719650x1
+      - 835x378551x1
       x-asessionid:
-      - mnoodr
+      - 1uvscm0
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1732622759.880ba63e
+      - 0.64ca4d68.1742478959.5d43be2
       x-rh-edge-request-id:
-      - 880ba63e
+      - 5d43be2
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -897,7 +886,7 @@ interactions:
     body: '{"transition": {"id": "71"}, "fields": {}}'
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -913,7 +902,7 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: POST
-    uri: https://example.com/rest/api/2/issue/OSIM-14341/transitions
+    uri: https://example.com/rest/api/2/issue/OSIM-22680/transitions
   response:
     body:
       string: ''
@@ -925,41 +914,41 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:06:00 GMT
+      - Thu, 20 Mar 2025 13:56:00 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:06:00 GMT
+      - Thu, 20 Mar 2025 13:56:00 GMT
       Pragma:
       - no-cache
       Retry-After:
       - '0'
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '0'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x1719657x2
+      - 836x378552x1
       x-asessionid:
-      - 1pe58rc
+      - dfas5n
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1732622760.880ba98f
+      - 0.64ca4d68.1742478959.5d4573b
       x-rh-edge-request-id:
-      - 880ba98f
+      - 5d4573b
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -971,7 +960,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -985,96 +974,92 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-14341
+    uri: https://example.com/rest/api/2/issue/OSIM-22680
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
-        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
-        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@5ca7ffaf[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a9012c6[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16792993", "self": "https://example.com/rest/api/2/issue/16792993",
+        "key": "OSIM-22680", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1d6dfe71[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6182ff6e[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4b579d89[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@110bb007[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6ffc127[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@5ce6b771[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2baac2b1[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@676dc44b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1fe3c778[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@7657a6ca[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@b954dfb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@2d38f5e[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@30b754ed[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@46b8b41a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@49d11fc0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@56b0d4f7[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5caae2f0[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5fb1851b[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1edfae32[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4e98c672[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@45ae0033[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@1664ccc0[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": [], "customfield_12325241": null, "customfield_12325243":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
         "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
         "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
-        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
-        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        null, "versions": [], "issuelinks": [], "customfield_12325240": null, "assignee":
+        null, "customfield_12313942": null, "customfield_12313941": null, "status":
+        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
+        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
+        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
+        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
         [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
         null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
-        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "customfield_12325342":
+        null, "customfield_12325343": null, "subtasks": [], "customfield_12321140":
+        null, "customfield_12325340": null, "customfield_12325341": null, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "aggregateprogress":
         {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-22680/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
-        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
-        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
-        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
-        null, "customfield_12325155": null, "customfield_12320940": null, "project":
-        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
-        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
-        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
-        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
-        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
-        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
-        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12316841": null, "customfield_12319040": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-22680/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2025-03-20T13:55:45.959+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
         [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
         "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-11-26T12:06:00.149+0000", "timeoriginalestimate": null, "description":
+        "False", "id": "27705", "disabled": false}, "updated": "2025-03-20T13:56:00.067+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
         "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
         {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
         "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
         "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
         "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
         "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
-        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
-        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
-        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
-        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
-        null, "customfield_12311940": "2|i21qzr:"}}'
+        "customfield_12323640": null, "customfield_12323642": null, "customfield_12323641":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12310213": null, "customfield_12311940":
+        "1|i0otz3:"}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1083,9 +1068,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:06:01 GMT
+      - Thu, 20 Mar 2025 13:56:06 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:06:01 GMT
+      - Thu, 20 Mar 2025 13:56:06 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1094,35 +1079,35 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
-      X-RateLimit-Remaining:
       - '2'
+      X-RateLimit-Remaining:
+      - '1'
       content-length:
-      - '9359'
+      - '9012'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-dc-stg-mpp-1
+      - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x1719674x6
+      - 836x378560x1
       x-asessionid:
-      - a5o1bs
+      - 1kha98q
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.18fb1060.1732622760.880bbd6d
+      - 0.64ca4d68.1742478965.5d45bec
       x-rh-edge-request-id:
-      - 880bbd6d
+      - 5d45bec
       x-seraph-loginreason:
       - OK
       x-xss-protection:
@@ -1134,7 +1119,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -1148,96 +1133,111 @@ interactions:
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-14341
+    uri: https://example.com/rest/api/2/issue/OSIM-22680?expand=changelog
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
-        "id": "16312059", "self": "https://example.com/rest/api/2/issue/16312059",
-        "key": "OSIM-14341", "fields": {"customfield_12324540": "0.0", "fixVersions":
-        [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1c1d45e8[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@10e12080[overall=PullRequestOverallBean{stateCount=0,
+        "id": "16792993", "self": "https://example.com/rest/api/2/issue/16792993",
+        "key": "OSIM-22680", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@56d8f380[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7e73f45[overall=PullRequestOverallBean{stateCount=0,
         state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@6eb9475d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@77c59f2a[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a401143[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@2953613f[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@df448e7[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@5693babc[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@c837324[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3e6ba112[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@11776548[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@5afa6b80[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@57a23121[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@69012187[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5bde352f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@21a7c326[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@674ad50a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@727dd7d[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@2dfaf7fb[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@325bbf91[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@308de55[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@3a7d377c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
         devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
         "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        null, "customfield_12325242": [], "customfield_12325241": null, "customfield_12325243":
         null, "customfield_12313140": null, "priority": {"self": "https://example.com/rest/api/2/priority/3",
         "iconUrl": "https://example.com/images/icons/priorities/major.svg", "name":
         "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
         "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
-        null, "versions": [], "issuelinks": [], "assignee": null, "customfield_12313942":
-        null, "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/15021",
-        "description": "Work is being scoped and discussed (To Do status category;
-        see also Draft)", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "Refinement", "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        null, "versions": [], "issuelinks": [], "customfield_12325240": null, "assignee":
+        null, "customfield_12313942": null, "customfield_12313941": null, "status":
+        {"self": "https://example.com/rest/api/2/status/15021", "description": "Work
+        is being scoped and discussed (To Do status category; see also Draft)", "iconUrl":
+        "https://example.com/images/icons/statuses/generic.png", "name": "Refinement",
+        "id": "15021", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
         "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
         [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
         null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
-        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "subtasks":
-        [], "customfield_12321140": null, "customfield_12320850": null, "reporter":
-        {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
-        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
-        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
-        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
-        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
-        "displayName": "Ondrej Soukup", "active": true, "timeZone": "UTC"}, "aggregateprogress":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "customfield_12325342":
+        null, "customfield_12325343": null, "subtasks": [], "customfield_12321140":
+        null, "customfield_12325340": null, "customfield_12325341": null, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "aggregateprogress":
         {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
         null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
-        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/votes",
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-22680/votes",
         "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "customfield_12325158":
-        null, "issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
-        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12325157":
-        null, "customfield_12325159": null, "customfield_12318341": null, "customfield_12325154":
-        null, "customfield_12325153": null, "customfield_12325156": null, "timespent":
-        null, "customfield_12325155": null, "customfield_12320940": null, "project":
-        {"self": "https://example.com/rest/api/2/project/12337520", "id": "12337520",
-        "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
         "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "customfield_12320944": null, "aggregatetimespent": null, "customfield_12310220":
-        null, "resolutiondate": null, "customfield_12325150": null, "workratio": -1,
-        "customfield_12325152": null, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12325151": null, "customfield_12316841": null, "customfield_12319040":
-        null, "customfield_12325047": null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-14341/watchers",
-        "watchCount": 1, "isWatching": true}, "customfield_12325044": null, "customfield_12325043":
-        null, "customfield_12325046": null, "created": "2024-11-26T12:05:56.086+0000",
-        "customfield_12321240": null, "customfield_12325045": null, "customfield_12320947":
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12316841": null, "customfield_12319040": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-22680/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2025-03-20T13:55:45.959+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
         [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
         "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "customfield_12325040": [], "customfield_12325160":
-        null, "customfield_12325042": null, "customfield_12325041": null, "updated":
-        "2024-11-26T12:06:00.149+0000", "timeoriginalestimate": null, "description":
+        "False", "id": "27705", "disabled": false}, "updated": "2025-03-20T13:56:00.067+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
         "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
         {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
         "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
         "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
         "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
         "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
-        "customfield_12323640": null, "customfield_12325147": null, "customfield_12325146":
-        null, "customfield_12323642": null, "customfield_12325149": null, "customfield_12323641":
-        null, "customfield_12325148": null, "customfield_12325143": null, "customfield_12325142":
-        null, "customfield_12325145": null, "customfield_12325144": null, "customfield_12323644":
-        null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
-        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
-        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
-        0}, "customfield_12325141": null, "customfield_12325140": null, "customfield_12310213":
-        null, "customfield_12311940": "2|i21qzr:"}}'
+        "customfield_12323640": null, "customfield_12323642": null, "customfield_12323641":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12310213": null, "customfield_12311940":
+        "1|i0otz3:"}, "changelog": {"startAt": 0, "maxResults": 2, "total": 2, "histories":
+        [{"id": "62669186", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T13:55:53.460+0000", "items": [{"field": "labels", "fieldtype":
+        "jira", "from": null, "fromString": "CVE-2020-10000 flawuuid:fb145b06-82a7-4851-a429-541288633d16
+        impact:IMPORTANT major_incident", "to": null, "toString": "flawuuid:fb145b06-82a7-4851-a429-541288633d16
+        impact:IMPORTANT"}]}, {"id": "62669187", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T13:56:00.068+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "10016", "fromString": "New", "to": "15021", "toString": "Refinement"}]}]}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -1246,9 +1246,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 26 Nov 2024 12:06:01 GMT
+      - Thu, 20 Mar 2025 13:56:12 GMT
       Expires:
-      - Tue, 26 Nov 2024 12:06:01 GMT
+      - Thu, 20 Mar 2025 13:56:12 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -1257,11 +1257,11 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       content-length:
-      - '9360'
+      - '10853'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
@@ -1269,23 +1269,23 @@ interactions:
       x-anodeid:
       - rh1-jira-dc-stg-mpp-0
       x-arequestid:
-      - 726x1711921x1
+      - 836x378561x1
       x-asessionid:
-      - mr119h
+      - 17bvzdl
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.dfb1060.1732622761.7eeb63c7
+      - 0.5cca4d68.1742478971.ecdee73
       x-rh-edge-request-id:
-      - 7eeb63c7
+      - ecdee73
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_link_on_cve.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_link_on_cve.yaml
@@ -3,7 +3,7 @@ interactions:
     body: null
     headers:
       Accept:
-      - application/json,*.*;q=0.9
+      - application/json,*/*;q=0.9
       Accept-Encoding:
       - gzip, deflate
       Cache-Control:
@@ -13,99 +13,172 @@ interactions:
       Content-Type:
       - application/json
       User-Agent:
-      - python-requests/2.32.0
+      - python-requests/2.32.3
       X-Atlassian-Token:
       - no-check
     method: GET
-    uri: https://example.com/rest/api/2/issue/OSIM-156
+    uri: https://example.com/rest/api/2/issue/OSIM-156?expand=changelog
   response:
     body:
       string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
         "id": "16108541", "self": "https://example.com/rest/api/2/issue/16108541",
-        "key": "OSIM-156", "fields": {"issuetype": {"self": "https://example.com/rest/api/2/issuetype/17",
-        "id": "17", "description": "Created by Jira Software - do not edit or delete.
-        Issue type for a user story.", "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "key": "OSIM-156", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": {"self": "https://example.com/rest/api/2/resolution/1",
+        "id": "1", "description": "This issue is closed, and complete.", "name": "Done"},
+        "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@620ed5be[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a7d587f[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@29c5b7e3[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@396bbc04[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@52193bed[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@7ef1736e[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7a0fb9fc[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1e60a125[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@53d2757[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@70224e9d[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@77e5d93c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@6c17376c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        "2025-03-20T17:22:28.964+0000", "customfield_12325242": [], "customfield_12325241":
+        null, "customfield_12325243": null, "customfield_12313140": null, "priority":
+        {"self": "https://example.com/rest/api/2/priority/10200", "iconUrl": "https://example.com/images/icons/priorities/medium.svg",
+        "name": "Normal", "id": "10200"}, "labels": ["CVE-2024-34703", "flawuuid:9d9132a4-0484-48a5-b484-185abf39b771",
+        "impact:MODERATE"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "customfield_12325240": null, "assignee":
+        {"self": "https://example.com/rest/api/2/user?username=ahanwate1%40redhat.com",
+        "name": "ahanwate1@redhat.com", "key": "JIRAUSER175619", "emailAddress": "ahanwate@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER175619&avatarId=41302",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER175619&avatarId=41302",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER175619&avatarId=41302",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER175619&avatarId=41302"},
+        "displayName": "Avinash Hanwate", "active": true, "timeZone": "Asia/Kolkata"},
+        "customfield_12313942": null, "customfield_12313941": null, "status": {"self":
+        "https://example.com/rest/api/2/status/6", "description": "The issue is closed.
+        See the resolution for context regarding why (for example Done, Abandoned,
+        Duplicate, etc)", "iconUrl": "https://example.com/images/icons/statuses/closed.png",
+        "name": "Closed", "id": "6", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/3",
+        "id": 3, "key": "done", "colorName": "success", "name": "Done"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=proguski%40redhat.com",
+        "name": "proguski@redhat.com", "key": "proguski_rh", "emailAddress": "proguski@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=48",
+        "24x24": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=24",
+        "16x16": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=16",
+        "32x32": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=32"},
+        "displayName": "Przemyslaw Roguski", "active": true, "timeZone": "Africa/Ceuta"},
+        "customfield_12325342": null, "customfield_12325343": null, "subtasks": [],
+        "customfield_12321140": null, "customfield_12325340": null, "customfield_12325341":
+        null, "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=proguski%40redhat.com",
+        "name": "proguski@redhat.com", "key": "proguski_rh", "emailAddress": "proguski@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=48",
+        "24x24": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=24",
+        "16x16": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=16",
+        "32x32": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=32"},
+        "displayName": "Przemyslaw Roguski", "active": true, "timeZone": "Africa/Ceuta"},
+        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12315542":
+        null, "customfield_12313240": null, "customfield_12319742": null, "progress":
+        {"progress": 0, "total": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-156/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
         "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
-        null, "customfield_12324540": "0.0", "timespent": null, "customfield_12320940":
-        null, "project": {"self": "https://example.com/rest/api/2/project/12337520",
-        "id": "12337520", "key": "OSIM", "name": "Open Security Issue Manager", "projectTypeKey":
-        "software", "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
         "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
         "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
         "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
-        "fixVersions": [], "customfield_12320944": null, "aggregatetimespent": null,
-        "resolution": null, "customfield_12310220": null, "customfield_12314740":
-        "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@1f8bbbf[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@9851f41[overall=PullRequestOverallBean{stateCount=0,
-        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
-        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@cb62797[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@2d684e57[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a420a0c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@28a4c575[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@1593d569[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@7a662b7a[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@303e5c50[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@3ebfb84f[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
-        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@358c1a6c[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@7efada5c[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
-        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":true}}",
-        "resolutiondate": null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
-        null, "customfield_12316841": null, "customfield_12315950": null, "customfield_12310940":
-        null, "customfield_12319040": null, "lastViewed": "2024-07-02T13:37:44.726+0000",
-        "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-156/watchers",
-        "watchCount": 1, "isWatching": false}, "created": "2024-07-01T10:38:50.991+0000",
-        "customfield_12321240": null, "customfield_12313140": null, "priority": {"self":
-        "https://example.com/rest/api/2/priority/10200", "iconUrl": "https://example.com/images/icons/priorities/medium.svg",
-        "name": "Normal", "id": "10200"}, "labels": ["CVE-2024-34703", "flawuuid:9d9132a4-0484-48a5-b484-185abf39b771",
-        "impact:MODERATE"], "customfield_12320947": [{"self": "https://example.com/rest/api/2/customFieldOption/27714",
-        "value": "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        "2024-07-05T04:32:56.716+0000", "workratio": -1, "customfield_12316840": null,
+        "customfield_12317379": null, "customfield_12316841": null, "customfield_12319040":
+        null, "watches": {"self": "https://example.com/rest/api/2/issue/OSIM-156/watchers",
+        "watchCount": 1, "isWatching": false}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2024-07-01T10:38:50.991+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
         {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
-        "False", "id": "27705", "disabled": false}, "aggregatetimeoriginalestimate":
-        null, "timeestimate": null, "versions": [], "issuelinks": [], "assignee":
-        null, "updated": "2024-07-02T13:37:43.603+0000", "customfield_12313942": null,
-        "customfield_12313941": null, "status": {"self": "https://example.com/rest/api/2/status/10016",
-        "description": "Initial creation status. Implies nothing yet and should be
-        very short lived; also can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
-        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
-        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
-        [], "timeoriginalestimate": null, "description": "Botan is a C++ cryptography
-        library. X.509 certificates can identify elliptic curves using either an object
-        identifier or using explicit encoding of the parameters. Prior to versions
-        3.3.0 and 2.19.4, an attacker could present an ECDSA X.509 certificate using
-        explicit encoding where the parameters are very large. The proof of concept
-        used a 16Kbit prime for this purpose. When parsing, the parameter is checked
-        to be prime, causing excessive computation. This was patched in 2.19.4 and
-        3.3.0 to allow the prime parameter of the elliptic curve to be at most 521
-        bits. No known workarounds are available. Note that support for explicit encoding
-        of elliptic curve parameters is deprecated in Botan.\n\nReferences:\nhttps://example.com/randombit/botan/commit/08c404b23740babee1f6aa51b54e966029aadee4\nhttps://example.com/randombit/botan/commit/94e9154c143aa5264da6254a6a1be5bc66ee2b5a\nhttps://example.com/randombit/botan/security/advisories/GHSA-w4g2-7m2h-7xj7",
-        "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
-        null, "timetracking": {}, "customfield_12320842": null, "customfield_12310243":
-        null, "attachment": [], "aggregatetimeestimate": null, "customfield_12316542":
-        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
-        "False", "id": "14655", "disabled": false}, "customfield_12317313": null,
-        "customfield_12316543": {"self": "https://example.com/rest/api/2/customFieldOption/14657",
-        "value": "False", "id": "14657", "disabled": false}, "customfield_12310840":
-        "9223372036854775807", "customfield_12316544": "None", "summary": "CVE-2024-34703
+        "False", "id": "27705", "disabled": false}, "updated": "2024-07-05T04:32:56.727+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
+        "Botan is a C++ cryptography library. X.509 certificates can identify elliptic
+        curves using either an object identifier or using explicit encoding of the
+        parameters. Prior to versions 3.3.0 and 2.19.4, an attacker could present
+        an ECDSA X.509 certificate using explicit encoding where the parameters are
+        very large. The proof of concept used a 16Kbit prime for this purpose. When
+        parsing, the parameter is checked to be prime, causing excessive computation.
+        This was patched in 2.19.4 and 3.3.0 to allow the prime parameter of the elliptic
+        curve to be at most 521 bits. No known workarounds are available. Note that
+        support for explicit encoding of elliptic curve parameters is deprecated in
+        Botan.\n\nReferences:\nhttps://example.com/randombit/botan/commit/08c404b23740babee1f6aa51b54e966029aadee4\nhttps://example.com/randombit/botan/commit/94e9154c143aa5264da6254a6a1be5bc66ee2b5a\nhttps://example.com/randombit/botan/security/advisories/GHSA-w4g2-7m2h-7xj7",
+        "timetracking": {}, "attachment": [], "customfield_12316542": {"self": "https://example.com/rest/api/2/customFieldOption/14655",
+        "value": "False", "id": "14655", "disabled": false}, "customfield_12316543":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14657", "value":
+        "False", "id": "14657", "disabled": false}, "customfield_12316544": "None",
+        "customfield_12310840": "9223372036854775807", "summary": "CVE-2024-34703
         Denial of Service Due to Overly Large Elliptic Curve Parameters", "customfield_12323640":
-        null, "customfield_12323642": null, "creator": {"self": "https://example.com/rest/api/2/user?username=proguski%40redhat.com",
-        "name": "proguski@redhat.com", "key": "proguski_rh", "emailAddress": "proguski@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=48",
-        "24x24": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=24",
-        "16x16": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=16",
-        "32x32": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=32"},
-        "displayName": "Przemyslaw Roguski", "active": true, "timeZone": "Africa/Ceuta"},
-        "customfield_12323641": null, "subtasks": [], "customfield_12321140": null,
-        "customfield_12320850": null, "reporter": {"self": "https://example.com/rest/api/2/user?username=proguski%40redhat.com",
-        "name": "proguski@redhat.com", "key": "proguski_rh", "emailAddress": "proguski@redhat.com",
-        "avatarUrls": {"48x48": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=48",
-        "24x24": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=24",
-        "16x16": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=16",
-        "32x32": "https://example.com/avatar/d669861940d8e735534a1ea9865bdd95?d=mm&s=32"},
-        "displayName": "Przemyslaw Roguski", "active": true, "timeZone": "Africa/Ceuta"},
-        "aggregateprogress": {"progress": 0, "total": 0}, "customfield_12323644":
+        null, "customfield_12323642": null, "customfield_12323641": null, "customfield_12323644":
         null, "customfield_12323643": null, "customfield_12323646": null, "customfield_12323645":
-        null, "environment": null, "customfield_12315542": null, "customfield_12315740":
-        null, "customfield_12313441": "", "customfield_12313440": "0.0", "customfield_12313240":
-        null, "duedate": null, "customfield_12311140": null, "customfield_12319742":
-        null, "progress": {"progress": 0, "total": 0}, "comment": {"comments": [],
-        "maxResults": 0, "total": 0, "startAt": 0}, "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-156/votes",
-        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
-        0, "maxResults": 20, "total": 0, "worklogs": []}, "customfield_12310213":
-        null, "archivedby": null, "customfield_12311940": "2|i13yo7:"}}'
+        null, "environment": null, "customfield_12315740": null, "customfield_12313441":
+        "", "customfield_12313440": "0.0", "duedate": null, "customfield_12311140":
+        null, "comment": {"comments": [], "maxResults": 0, "total": 0, "startAt":
+        0}, "customfield_12310213": null, "customfield_12311940": "1|hxmt5r:"}, "changelog":
+        {"startAt": 0, "maxResults": 6, "total": 6, "histories": [{"id": "55073733",
+        "author": {"self": "https://example.com/rest/api/2/user?username=osoukup%40redhat.com",
+        "name": "osoukup@redhat.com", "key": "osoukup", "emailAddress": "osoukup+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?avatarId=17283",
+        "24x24": "https://example.com/secure/useravatar?size=small&avatarId=17283",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&avatarId=17283",
+        "32x32": "https://example.com/secure/useravatar?size=medium&avatarId=17283"},
+        "displayName": "Ondrej Soukup", "active": true, "timeZone": "GMT"}, "created":
+        "2024-07-02T13:37:43.605+0000", "items": [{"field": "labels", "fieldtype":
+        "jira", "from": null, "fromString": "flawuuid:9d9132a4-0484-48a5-b484-185abf39b771
+        impact:MODERATE", "to": null, "toString": "CVE-2024-34703 flawuuid:9d9132a4-0484-48a5-b484-185abf39b771
+        impact:MODERATE"}]}, {"id": "55157157", "author": {"self": "https://example.com/rest/api/2/user?username=ahanwate1%40redhat.com",
+        "name": "ahanwate1@redhat.com", "key": "JIRAUSER175619", "emailAddress": "ahanwate@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER175619&avatarId=41302",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER175619&avatarId=41302",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER175619&avatarId=41302",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER175619&avatarId=41302"},
+        "displayName": "Avinash Hanwate", "active": true, "timeZone": "Asia/Kolkata"},
+        "created": "2024-07-05T04:29:58.932+0000", "items": [{"field": "assignee",
+        "fieldtype": "jira", "from": null, "fromString": null, "to": "JIRAUSER175619",
+        "toString": "Avinash Hanwate"}]}, {"id": "55157248", "author": {"self": "https://example.com/rest/api/2/user?username=ahanwate1%40redhat.com",
+        "name": "ahanwate1@redhat.com", "key": "JIRAUSER175619", "emailAddress": "ahanwate@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER175619&avatarId=41302",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER175619&avatarId=41302",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER175619&avatarId=41302",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER175619&avatarId=41302"},
+        "displayName": "Avinash Hanwate", "active": true, "timeZone": "Asia/Kolkata"},
+        "created": "2024-07-05T04:31:27.611+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "10016", "fromString": "New", "to": "15021", "toString": "Refinement"}]},
+        {"id": "55157158", "author": {"self": "https://example.com/rest/api/2/user?username=ahanwate1%40redhat.com",
+        "name": "ahanwate1@redhat.com", "key": "JIRAUSER175619", "emailAddress": "ahanwate@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER175619&avatarId=41302",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER175619&avatarId=41302",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER175619&avatarId=41302",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER175619&avatarId=41302"},
+        "displayName": "Avinash Hanwate", "active": true, "timeZone": "Asia/Kolkata"},
+        "created": "2024-07-05T04:31:43.001+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "15021", "fromString": "Refinement", "to": "10020", "toString":
+        "To Do"}]}, {"id": "55157370", "author": {"self": "https://example.com/rest/api/2/user?username=ahanwate1%40redhat.com",
+        "name": "ahanwate1@redhat.com", "key": "JIRAUSER175619", "emailAddress": "ahanwate@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER175619&avatarId=41302",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER175619&avatarId=41302",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER175619&avatarId=41302",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER175619&avatarId=41302"},
+        "displayName": "Avinash Hanwate", "active": true, "timeZone": "Asia/Kolkata"},
+        "created": "2024-07-05T04:32:40.900+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "10020", "fromString": "To Do", "to": "10018", "toString":
+        "In Progress"}]}, {"id": "55157256", "author": {"self": "https://example.com/rest/api/2/user?username=ahanwate1%40redhat.com",
+        "name": "ahanwate1@redhat.com", "key": "JIRAUSER175619", "emailAddress": "ahanwate@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=JIRAUSER175619&avatarId=41302",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=JIRAUSER175619&avatarId=41302",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=JIRAUSER175619&avatarId=41302",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=JIRAUSER175619&avatarId=41302"},
+        "displayName": "Avinash Hanwate", "active": true, "timeZone": "Asia/Kolkata"},
+        "created": "2024-07-05T04:32:56.728+0000", "items": [{"field": "resolution",
+        "fieldtype": "jira", "from": null, "fromString": null, "to": "1", "toString":
+        "Done"}, {"field": "status", "fieldtype": "jira", "from": "10018", "fromString":
+        "In Progress", "to": "6", "toString": "Closed"}]}]}}'
     headers:
       Cache-Control:
       - max-age=0, no-cache, no-store
@@ -114,9 +187,9 @@ interactions:
       Content-Type:
       - application/json;charset=UTF-8
       Date:
-      - Tue, 02 Jul 2024 14:06:24 GMT
+      - Thu, 20 Mar 2025 17:23:12 GMT
       Expires:
-      - Tue, 02 Jul 2024 14:06:24 GMT
+      - Thu, 20 Mar 2025 17:23:12 GMT
       Pragma:
       - no-cache
       Retry-After:
@@ -125,35 +198,35 @@ interactions:
       - User-Agent
       - Accept-Encoding
       X-RateLimit-Limit:
-      - '5'
+      - '2'
       X-RateLimit-Remaining:
-      - '4'
+      - '1'
       content-length:
-      - '9499'
+      - '16323'
       referrer-policy:
       - strict-origin-when-cross-origin
       strict-transport-security:
       - max-age=31536000
       x-anodeid:
-      - rh1-jira-prod-1
+      - rh1-jira-dc-stg-mpp-1
       x-arequestid:
-      - 846x23106149x17
+      - 1043x148636x1
       x-asessionid:
-      - 1vstfot
+      - 19ved0l
       x-content-type-options:
       - nosniff
       x-frame-options:
       - SAMEORIGIN
       x-ratelimit-fillrate:
-      - '5'
+      - '2'
       x-ratelimit-interval-seconds:
       - '1'
       x-rh-edge-cache-status:
       - NotCacheable from child
       x-rh-edge-reference-id:
-      - 0.692645f.1719929184.417b969
+      - 0.6797f648.1742491391.daab991
       x-rh-edge-request-id:
-      - 417b969
+      - daab991
       x-seraph-loginreason:
       - OK
       x-xss-protection:

--- a/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_update_only_changed_fields.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_collectors/TestJiraTaskCollector.test_update_only_changed_fields.yaml
@@ -1,0 +1,378 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-22679?expand=changelog
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16792907", "self": "https://example.com/rest/api/2/issue/16792907",
+        "key": "OSIM-22679", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@547a8f66[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@64529be9[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@7b05fe3e[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@bf8af64[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@59a92cbe[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@8b8fb[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@54a852ca[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@1ae544b4[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@a39578a[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@4f33f956[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@599bdc78[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@696bf31b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        "2025-03-20T15:26:22.490+0000", "customfield_12325242": [], "customfield_12325241":
+        null, "customfield_12325243": null, "customfield_12313140": null, "priority":
+        {"self": "https://example.com/rest/api/2/priority/3", "iconUrl": "https://example.com/images/icons/priorities/major.svg",
+        "name": "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
+        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "customfield_12325240": null, "assignee":
+        null, "customfield_12313942": null, "customfield_12313941": null, "status":
+        {"self": "https://example.com/rest/api/2/status/10016", "description": "Initial
+        creation status. Implies nothing yet and should be very short lived; also
+        can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "customfield_12325342":
+        null, "customfield_12325343": null, "subtasks": [], "customfield_12321140":
+        null, "customfield_12325340": null, "customfield_12325341": null, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-22679/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12316841": null, "customfield_12319040": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-22679/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2025-03-20T13:53:20.602+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "updated": "2025-03-20T14:40:14.177+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12323642": null, "customfield_12323641":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12310213": null, "customfield_12311940":
+        "1|i0otyv:"}, "changelog": {"startAt": 0, "maxResults": 3, "total": 3, "histories":
+        [{"id": "62669283", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T13:53:30.946+0000", "items": [{"field": "labels", "fieldtype":
+        "jira", "from": null, "fromString": "CVE-2020-10000 flawuuid:fb145b06-82a7-4851-a429-541288633d16
+        impact:IMPORTANT major_incident", "to": null, "toString": "flawuuid:fb145b06-82a7-4851-a429-541288633d16
+        impact:IMPORTANT"}]}, {"id": "62669284", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T13:53:38.322+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "10016", "fromString": "New", "to": "15021", "toString": "Refinement"}]},
+        {"id": "62669374", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T14:40:14.178+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "15021", "fromString": "Refinement", "to": "10016", "toString":
+        "New"}]}]}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 20 Mar 2025 15:46:24 GMT
+      Expires:
+      - Thu, 20 Mar 2025 15:46:24 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '2'
+      X-RateLimit-Remaining:
+      - '1'
+      content-length:
+      - '11725'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 946x383275x1
+      x-asessionid:
+      - d35wxj
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '2'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.6797f648.1742485583.d479ae5
+      x-rh-edge-request-id:
+      - d479ae5
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json,*/*;q=0.9
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.32.3
+      X-Atlassian-Token:
+      - no-check
+    method: GET
+    uri: https://example.com/rest/api/2/issue/OSIM-22679?expand=changelog
+  response:
+    body:
+      string: '{"expand": "renderedFields,names,schema,operations,editmeta,changelog,versionedRepresentations",
+        "id": "16792907", "self": "https://example.com/rest/api/2/issue/16792907",
+        "key": "OSIM-22679", "fields": {"customfield_12326046": null, "customfield_12324540":
+        "0.0", "fixVersions": [], "resolution": null, "customfield_12314740": "{summaryBean=com.atlassian.jira.plugin.devstatus.rest.SummaryBean@3af4e808[summary={pullrequest=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@4e2a661d[overall=PullRequestOverallBean{stateCount=0,
+        state=''OPEN'', details=PullRequestOverallDetails{openCount=0, mergedCount=0,
+        declinedCount=0}},byInstanceType={}], build=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@5a751e99[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BuildOverallBean@47728144[failedBuildCount=0,successfulBuildCount=0,unknownBuildCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        review=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@21dccf0f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.ReviewsOverallBean@6f14bec[stateCount=0,state=<null>,dueDate=<null>,overDue=false,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        deployment-environment=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@74821c7d[overall=com.atlassian.jira.plugin.devstatus.summary.beans.DeploymentOverallBean@2729db08[topEnvironments=[],showProjects=false,successfulCount=0,count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        repository=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@60cacc55[overall=com.atlassian.jira.plugin.devstatus.summary.beans.CommitOverallBean@6ce8458b[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}],
+        branch=com.atlassian.jira.plugin.devstatus.rest.SummaryItemBean@86dcd9f[overall=com.atlassian.jira.plugin.devstatus.summary.beans.BranchOverallBean@61f5a601[count=0,lastUpdated=<null>,lastUpdatedTimestamp=<null>],byInstanceType={}]},errors=[],configErrors=[]],
+        devSummaryJson={\"cachedValue\":{\"errors\":[],\"configErrors\":[],\"summary\":{\"pullrequest\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":\"OPEN\",\"details\":{\"openCount\":0,\"mergedCount\":0,\"declinedCount\":0,\"total\":0},\"open\":true},\"byInstanceType\":{}},\"build\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"failedBuildCount\":0,\"successfulBuildCount\":0,\"unknownBuildCount\":0},\"byInstanceType\":{}},\"review\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"stateCount\":0,\"state\":null,\"dueDate\":null,\"overDue\":false,\"completed\":false},\"byInstanceType\":{}},\"deployment-environment\":{\"overall\":{\"count\":0,\"lastUpdated\":null,\"topEnvironments\":[],\"showProjects\":false,\"successfulCount\":0},\"byInstanceType\":{}},\"repository\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}},\"branch\":{\"overall\":{\"count\":0,\"lastUpdated\":null},\"byInstanceType\":{}}}},\"isStale\":false}}",
+        "customfield_12315950": null, "customfield_12310940": null, "lastViewed":
+        "2025-03-20T15:26:22.490+0000", "customfield_12325242": [], "customfield_12325241":
+        null, "customfield_12325243": null, "customfield_12313140": null, "priority":
+        {"self": "https://example.com/rest/api/2/priority/3", "iconUrl": "https://example.com/images/icons/priorities/major.svg",
+        "name": "Major", "id": "3"}, "labels": ["flawuuid:fb145b06-82a7-4851-a429-541288633d16",
+        "impact:IMPORTANT"], "aggregatetimeoriginalestimate": null, "timeestimate":
+        null, "versions": [], "issuelinks": [], "customfield_12325240": null, "assignee":
+        null, "customfield_12313942": null, "customfield_12313941": null, "status":
+        {"self": "https://example.com/rest/api/2/status/10016", "description": "Initial
+        creation status. Implies nothing yet and should be very short lived; also
+        can be a Bugzilla status.", "iconUrl": "https://example.com/images/icons/statuses/generic.png",
+        "name": "New", "id": "10016", "statusCategory": {"self": "https://example.com/rest/api/2/statuscategory/2",
+        "id": 2, "key": "new", "colorName": "default", "name": "To Do"}}, "components":
+        [], "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
+        null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
+        null, "customfield_12317313": null, "creator": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "customfield_12325342":
+        null, "customfield_12325343": null, "subtasks": [], "customfield_12321140":
+        null, "customfield_12325340": null, "customfield_12325341": null, "customfield_12320850":
+        null, "reporter": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "aggregateprogress":
+        {"progress": 0, "total": 0}, "customfield_12315542": null, "customfield_12313240":
+        null, "customfield_12319742": null, "progress": {"progress": 0, "total": 0},
+        "votes": {"self": "https://example.com/rest/api/2/issue/OSIM-22679/votes",
+        "votes": 0, "hasVoted": false}, "customfield_12319743": null, "worklog": {"startAt":
+        0, "maxResults": 20, "total": 0, "worklogs": []}, "archivedby": null, "issuetype":
+        {"self": "https://example.com/rest/api/2/issuetype/17", "id": "17", "description":
+        "Created by Jira Software - do not edit or delete. Issue type for a user story.",
+        "iconUrl": "https://example.com/secure/viewavatar?size=xsmall&avatarId=13275&avatarType=issuetype",
+        "name": "Story", "subtask": false, "avatarId": 13275}, "customfield_12318341":
+        null, "timespent": null, "customfield_12320940": null, "project": {"self":
+        "https://example.com/rest/api/2/project/12337520", "id": "12337520", "key":
+        "OSIM", "name": "Open Security Issue Manager", "projectTypeKey": "software",
+        "avatarUrls": {"48x48": "https://example.com/secure/projectavatar?pid=12337520&avatarId=12560",
+        "24x24": "https://example.com/secure/projectavatar?size=small&pid=12337520&avatarId=12560",
+        "16x16": "https://example.com/secure/projectavatar?size=xsmall&pid=12337520&avatarId=12560",
+        "32x32": "https://example.com/secure/projectavatar?size=medium&pid=12337520&avatarId=12560"}},
+        "aggregatetimespent": null, "customfield_12310220": null, "resolutiondate":
+        null, "workratio": -1, "customfield_12316840": null, "customfield_12317379":
+        null, "customfield_12316841": null, "customfield_12319040": null, "watches":
+        {"self": "https://example.com/rest/api/2/issue/OSIM-22679/watchers", "watchCount":
+        1, "isWatching": true}, "customfield_12325840": null, "customfield_12325441":
+        null, "customfield_12325442": null, "created": "2025-03-20T13:53:20.602+0000",
+        "customfield_12321240": null, "customfield_12325440": null, "customfield_12320947":
+        [{"self": "https://example.com/rest/api/2/customFieldOption/27714", "value":
+        "Unclassified", "id": "27714", "disabled": false}], "customfield_12320946":
+        {"self": "https://example.com/rest/api/2/customFieldOption/27705", "value":
+        "False", "id": "27705", "disabled": false}, "updated": "2025-03-20T14:40:14.177+0000",
+        "customfield_12316142": null, "timeoriginalestimate": null, "description":
+        "Comment zero for CVE-2020-10000", "timetracking": {}, "attachment": [], "customfield_12316542":
+        {"self": "https://example.com/rest/api/2/customFieldOption/14655", "value":
+        "False", "id": "14655", "disabled": false}, "customfield_12316543": {"self":
+        "https://example.com/rest/api/2/customFieldOption/14657", "value": "False",
+        "id": "14657", "disabled": false}, "customfield_12316544": "None", "customfield_12310840":
+        "9223372036854775807", "summary": "CVE-2020-10000 kernel: some description",
+        "customfield_12323640": null, "customfield_12323642": null, "customfield_12323641":
+        null, "customfield_12323644": null, "customfield_12323643": null, "customfield_12323646":
+        null, "customfield_12323645": null, "environment": null, "customfield_12315740":
+        null, "customfield_12313441": "", "customfield_12313440": "0.0", "duedate":
+        null, "customfield_12311140": null, "comment": {"comments": [], "maxResults":
+        0, "total": 0, "startAt": 0}, "customfield_12310213": null, "customfield_12311940":
+        "1|i0otyv:"}, "changelog": {"startAt": 0, "maxResults": 3, "total": 3, "histories":
+        [{"id": "62669283", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T13:53:30.946+0000", "items": [{"field": "labels", "fieldtype":
+        "jira", "from": null, "fromString": "CVE-2020-10000 flawuuid:fb145b06-82a7-4851-a429-541288633d16
+        impact:IMPORTANT major_incident", "to": null, "toString": "flawuuid:fb145b06-82a7-4851-a429-541288633d16
+        impact:IMPORTANT"}]}, {"id": "62669284", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T13:53:38.322+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "10016", "fromString": "New", "to": "15021", "toString": "Refinement"}]},
+        {"id": "62669374", "author": {"self": "https://example.com/rest/api/2/user?username=jfrejlac",
+        "name": "jfrejlac", "key": "jfrejlac", "emailAddress": "jfrejlac+stage@redhat.com",
+        "avatarUrls": {"48x48": "https://example.com/secure/useravatar?ownerId=jfrejlac&avatarId=33124",
+        "24x24": "https://example.com/secure/useravatar?size=small&ownerId=jfrejlac&avatarId=33124",
+        "16x16": "https://example.com/secure/useravatar?size=xsmall&ownerId=jfrejlac&avatarId=33124",
+        "32x32": "https://example.com/secure/useravatar?size=medium&ownerId=jfrejlac&avatarId=33124"},
+        "displayName": "Jakub Frejlach", "active": true, "timeZone": "GMT"}, "created":
+        "2025-03-20T14:40:14.178+0000", "items": [{"field": "status", "fieldtype":
+        "jira", "from": "15021", "fromString": "Refinement", "to": "10016", "toString":
+        "New"}]}]}}'
+    headers:
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json;charset=UTF-8
+      Date:
+      - Thu, 20 Mar 2025 15:46:24 GMT
+      Expires:
+      - Thu, 20 Mar 2025 15:46:24 GMT
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '0'
+      Vary:
+      - User-Agent
+      - Accept-Encoding
+      X-RateLimit-Limit:
+      - '2'
+      X-RateLimit-Remaining:
+      - '1'
+      content-length:
+      - '11728'
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      strict-transport-security:
+      - max-age=31536000
+      x-anodeid:
+      - rh1-jira-dc-stg-mpp-0
+      x-arequestid:
+      - 946x383276x1
+      x-asessionid:
+      - 866y6d
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      x-ratelimit-fillrate:
+      - '2'
+      x-ratelimit-interval-seconds:
+      - '1'
+      x-rh-edge-cache-status:
+      - NotCacheable from child
+      x-rh-edge-reference-id:
+      - 0.6797f648.1742485584.d479dab
+      x-rh-edge-request-id:
+      - d479dab
+      x-seraph-loginreason:
+      - OK
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -144,35 +144,6 @@ class TestJiraTaskCollector:
         assert flaw.workflow_state == "TRIAGE"
         assert last_update < flaw.task_updated_dt
 
-    @pytest.mark.parametrize(
-        "updated_until_dt,current_dt,expected_period_end",
-        [
-            (
-                datetime(2025, 3, 3, tzinfo=timezone.utc),
-                datetime(2025, 3, 14, tzinfo=timezone.utc),
-                datetime(2025, 3, 13, tzinfo=timezone.utc),
-            ),
-            (
-                datetime(2025, 3, 3, 12, 30, tzinfo=timezone.utc),
-                datetime(2025, 3, 3, 12, 32, tzinfo=timezone.utc),
-                datetime(2025, 3, 3, 12, 31, tzinfo=timezone.utc),
-            ),
-        ],
-    )
-    def test_get_batch_end_period(
-        self, updated_until_dt, current_dt, expected_period_end, monkeypatch
-    ):
-        # we don't care about collector actually fetching the data batch
-        monkeypatch.setattr(
-            JiraTaskmanQuerier, "get_task_period", lambda *args, **kwargs: None
-        )
-
-        collector = JiraTaskCollector()
-        collector.metadata.updated_until_dt = updated_until_dt
-        with freeze_time(current_dt):
-            _, period_end = collector.get_batch()
-            assert period_end == expected_period_end
-
 
 class TestJiraTrackerCollector:
     """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Make task_key read-only (OSIDB-4080)
 - Split Requests/Responses in API schema
+- Flaw Jira Tasks changes are now fetched based on history to
+  avoid Flaw data reset (OSIDB-4015)
 
 ### Changed
 - Migrate user ids on history Audit models to user emails or usernames (OSIDB-3988)

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -653,7 +653,7 @@ class JiraTaskDownloadManager(SyncManager):
         set_user_acls(settings.ALL_GROUPS)
 
         try:
-            task_data = JiraQuerier().get_issue(task_id)
+            task_data = JiraQuerier().get_issue(task_id, expand="changelog")
             flaw = JiraTaskConvertor(task_data).flaw
             if flaw:
                 flaw.save()


### PR DESCRIPTION
This PR:
* removes the Jira Task Collector window 1 minute shift as it is no longer needed, checking the history is much more precise
* implements history check in Jira Task convertor which check Jira history/changelog (given the fact it is provided) and saves only those changes which are new, this prevents overwriting some changes in OSIDB which are not yet synced to Jira.

Closes OSIDB-4015