### PR TITLE
Add feedback form to tracker description

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -250,7 +250,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 125,
+        "line_number": 126,
         "is_secret": false
       }
     ],
@@ -260,7 +260,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 117,
+        "line_number": 120,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-18T15:46:17Z"
+  "generated_at": "2025-03-25T17:43:50Z"
 }

--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -1,12 +1,14 @@
 """
 common tracker functionality shared between BTSs
 """
+
 from functools import cached_property
 from urllib.parse import urljoin
 
 from apps.bbsync.constants import MAX_SUMMARY_LENGTH, MULTIPLE_DESCRIPTIONS_SUBSTITUTION
 from apps.bbsync.query import summary_shorten
 from apps.trackers.constants import KERNEL_PACKAGES, VIRTUALIZATION_PACKAGES
+from apps.trackers.jira.constants import TRACKER_FEEDBACK_FORM_URL
 from collectors.bzimport.constants import BZ_URL
 from osidb.helpers import cve_id_comparator
 from osidb.models import Flaw, PsModule, PsUpdateStream, Tracker
@@ -197,7 +199,11 @@ class TrackerQueryBuilder:
         if self.ps_component in KERNEL_PACKAGES:
             description_parts.extend(TrackerQueryBuilder._description_kernel())
 
-        # 5) join the parts by empty lines
+        # 5) Tracker feedback form for Jira
+        if self.tracker.type == Tracker.TrackerType.JIRA:
+            description_parts.extend(self._description_feedback_form())
+
+        # 6) join the parts by empty lines
         return "\n\n".join(description_parts)
 
     def _description_bugzilla_footer(self):
@@ -352,3 +358,11 @@ class TrackerQueryBuilder:
             "Reproducers, if any, will remain confidential and never be made public, "
             "unless done so by the security team."
         ]
+
+    def _description_feedback_form(self):
+        """
+        generate tracker feedback form text
+        """
+        if TRACKER_FEEDBACK_FORM_URL is None:
+            return []
+        return [f"Tracker accuracy feedback form: {TRACKER_FEEDBACK_FORM_URL}"]

--- a/apps/trackers/jira/constants.py
+++ b/apps/trackers/jira/constants.py
@@ -10,6 +10,7 @@ JIRA_EMBARGO_SECURITY_LEVEL_NAME = get_env(
 JIRA_INTERNAL_SECURITY_LEVEL_NAME = get_env(
     "JIRA_INTERNAL_SECURITY_LEVEL_NAME", default="Red Hat Employee"
 )
+TRACKER_FEEDBACK_FORM_URL = get_env("TRACKER_FEEDBACK_FORM_URL")
 
 # Translate fields as defined in product definitions to the actual Jira field
 PS_ADDITIONAL_FIELD_TO_JIRA = {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,7 @@ services:
         FLAW_LABELS_URL: ${FLAW_LABELS_URL}
         SNIPPET_CREATION: ${SNIPPET_CREATION}
         TRACKERS_SYNC_TO_JIRA: ${TRACKERS_SYNC_TO_JIRA}
+        TRACKER_FEEDBACK_FORM_URL: ${TRACKER_FEEDBACK_FORM_URL}
       command: ./scripts/setup-osidb-service.sh
       volumes:
         - ${PWD}:/opt/app-root/src:z

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add feedback form to tracker description (OSIDB-4095)
 
 ## [4.10.0] - 2025-03-25
 ### Fixed

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -110,6 +110,9 @@ JIRA_METADATA_COLLECTOR_ENABLED=1
 CVEORG_COLLECTOR_ENABLED=1
 NVD_COLLECTOR_ENABLED=1
 OSV_COLLECTOR_ENABLED=1
+
+# If set, it will append the tracker accuracy feedback form at the end of the description when creating Jira trackers
+TRACKER_FEEDBACK_FORM_URL="https://foo.bar"
 ```
 
 The `.env` file is loaded automatically by podman-compose. It is also loaded as environment variables in a few Makefile targets (run `grep -rF '.env ' mk/` to see which ones).


### PR DESCRIPTION
This commit adds the possibility to make Jira trackers append the tracker accuracy feedback form at the end of the description field upon tracker creation. This will only happen if the
`TRACKER_FEEDBACK_FORM_URL` environment variable is set with the URL of the feedback form.

Closes OSIDB-4095.