### PR TITLE
Implement sync manager postponing

### DIFF
--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -153,8 +153,6 @@ class TestJiraTaskCollector:
 
         # 3 - get the current Jira task and make sure db is in-sync
         issue = jtq.jira_conn.issue(flaw.task_key)
-        last_update = datetime.strptime(issue.fields.updated, "%Y-%m-%dT%H:%M:%S.%f%z")
-        assert last_update == flaw.task_updated_dt
         assert issue.fields.status.name == "New"
 
         # 4 - freeze the issue in time to simulate long queries being outdated
@@ -168,7 +166,6 @@ class TestJiraTaskCollector:
         # provide a fake diff just to pretend that the workflow state has changed
         flaw.tasksync(diff={"workflow_state": None}, jira_token=jira_token)
         flaw = Flaw.objects.get(uuid=flaw.uuid)
-        assert last_update < flaw.task_updated_dt
         assert flaw.workflow_state == "TRIAGE"
 
         # 6 - make sure collector does not change flaw if it is holding outdated issue
@@ -176,7 +173,6 @@ class TestJiraTaskCollector:
         collector.collect(flaw.task_key)
         flaw = Flaw.objects.get(uuid=flaw.uuid)
         assert flaw.workflow_state == "TRIAGE"
-        assert last_update < flaw.task_updated_dt
 
 
 class TestJiraTrackerCollector:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add feedback form to tracker description (OSIDB-4095)
 
+### Fixed
+- Postpone Jira task download when there are sync or transition managers pending (OSIDB-4136)
+
 ## [4.10.0] - 2025-03-25
 ### Fixed
 - Make task_key read-only (OSIDB-4080)

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1090,23 +1090,16 @@ class Flaw(
 
         jtq = JiraTaskmanQuerier(token=jira_token)
 
-        # timestamp at or before the change
-        self.task_updated_dt = timezone.now()
-
         # creation
         if not self.task_key:
             self.task_key = jtq.create_or_update_task(self)
             self.workflow_state = WorkflowModel.WorkflowState.NEW
             Flaw.objects.filter(uuid=self.uuid).update(
                 task_key=self.task_key,
-                task_updated_dt=self.task_updated_dt,
                 workflow_state=self.workflow_state,
             )
         else:
             jtq.create_or_update_task(self)
-            Flaw.objects.filter(uuid=self.uuid).update(
-                task_updated_dt=self.task_updated_dt
-            )
 
     def _transition_task(self, jira_token=None):
         """
@@ -1117,14 +1110,12 @@ class Flaw(
 
         jtq = JiraTaskmanQuerier(token=jira_token)
 
-        self.task_updated_dt = timezone.now()  # timestamp at or before the change
         jtq.transition_task(self)
         # workflow transition may result in ACL change
         self.adjust_acls(save=False)
         Flaw.objects.filter(uuid=self.uuid).update(
             acl_read=self.acl_read,
             acl_write=self.acl_write,
-            task_updated_dt=self.task_updated_dt,
             workflow_name=self.workflow_name,
             workflow_state=self.workflow_state,
         )


### PR DESCRIPTION
This PR:
* adds possibility for each sync manager to implement their own `check_conflicting_sync_managers` so if there is any conflict there can be suitable strategy applied to resolve its (revoke, postpone, etc.)
* implements such conflict check for `JiraTaskDownloadManager` so it is not downloading any changes while sync to Jira or workflow transition is pending towards Jira. This should fix some corner cases of Flaw data reset.

Closes OSIDB-4136