### PR TITLE
Add include_history in openapi description

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Postpone Jira task download when there are sync or transition managers pending (OSIDB-4136)
 - Consider affect in AFFECTED/DELEGATED state as not resolved (OSIDB-4137)
+- Fix missing include_history field on Affect and Flaw API documentation (OSIDB-3960)
 
 ## [4.10.0] - 2025-03-25
 ### Fixed

--- a/openapi.yml
+++ b/openapi.yml
@@ -1137,6 +1137,12 @@ paths:
           may be separated by commas. Dot notation can be used to filter on related
           model fields. Example: `include_fields=field,related_model_field.field`'
       - in: query
+        name: include_history
+        schema:
+          type: boolean
+        description: 'Indicates whether the response should include the model''s change
+          history. Set to ''true'' to include historical changes. Default: false.'
+      - in: query
         name: include_meta_attr
         schema:
           type: array
@@ -1898,6 +1904,12 @@ paths:
         description: 'Include only specified fields in the response. Multiple values
           may be separated by commas. Dot notation can be used to filter on related
           model fields. Example: `include_fields=field,related_model_field.field`'
+      - in: query
+        name: include_history
+        schema:
+          type: boolean
+        description: 'Indicates whether the response should include the model''s change
+          history. Set to ''true'' to include historical changes. Default: false.'
       - in: query
         name: include_meta_attr
         schema:
@@ -3119,6 +3131,12 @@ paths:
         description: 'Include only specified fields in the response. Multiple values
           may be separated by commas. Dot notation can be used to filter on related
           model fields. Example: `include_fields=field,related_model_field.field`'
+      - in: query
+        name: include_history
+        schema:
+          type: boolean
+        description: 'Indicates whether the response should include the model''s change
+          history. Set to ''true'' to include historical changes. Default: false.'
       - in: query
         name: include_meta_attr
         schema:
@@ -5801,6 +5819,12 @@ paths:
         description: 'Include only specified fields in the response. Multiple values
           may be separated by commas. Dot notation can be used to filter on related
           model fields. Example: `include_fields=field,related_model_field.field`'
+      - in: query
+        name: include_history
+        schema:
+          type: boolean
+        description: 'Indicates whether the response should include the model''s change
+          history. Set to ''true'' to include historical changes. Default: false.'
       - in: query
         name: include_meta_attr
         schema:

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -321,6 +321,18 @@ exclude_fields_param = OpenApiParameter(
     ),
 )
 
+include_history_param = OpenApiParameter(
+    "include_history",
+    type=bool,
+    required=False,
+    location=OpenApiParameter.QUERY,
+    description=(
+        "Indicates whether the response should include the "
+        "model's change history. Set to 'true' to include "
+        "historical changes. Default: false."
+    ),
+)
+
 include_meta_attr = OpenApiParameter(
     "include_meta_attr",
     type={"type": "array", "items": {"type": "string"}},
@@ -434,6 +446,21 @@ def include_exclude_fields_extend_schema_view(
     )(cls)
 
 
+def include_history_extend_schema_view(
+    cls: Type[ViewSetMixin],
+) -> Type[ViewSetMixin]:
+    """
+    Decorator which adds `include_history` query parameter description
+    into the schema for `list` and `retrieve` methods
+    """
+    return (
+        extend_schema_view(
+            list=extend_schema(parameters=[include_history_param]),
+            retrieve=extend_schema(parameters=[include_history_param]),
+        )
+    )(cls)
+
+
 def query_extend_schema_view(
     cls: Type[ViewSetMixin],
 ) -> Type[ViewSetMixin]:
@@ -476,6 +503,7 @@ class FlawIntrospectionView(RudimentaryUserPathLoggingMixin, APIView):
 @query_extend_schema_view
 @include_meta_attr_extend_schema_view
 @include_exclude_fields_extend_schema_view
+@include_history_extend_schema_view
 @bz_api_key_extend_schema_view
 @jira_api_key_extend_schema_view
 @extend_schema_view(
@@ -825,6 +853,7 @@ class FlawPackageVersionView(
 
 @include_meta_attr_extend_schema_view
 @include_exclude_fields_extend_schema_view
+@include_history_extend_schema_view
 @bz_api_key_extend_schema_view
 @jira_api_key_extend_schema_view
 @extend_schema_view(


### PR DESCRIPTION
This PR adds missing include_history query param to openapi documentation.
This is considered a patch fix, the fields were already present in the API, not requiring a minor release.

Closes OSIDB-3960.