### PR TITLE
Flaw data reset corner case - part 1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,6 @@ jobs:
           python3-pytest-cov
           python3.9
           python36
-          python38
           redhat-rpm-config
           rpm-build
           rpmlint

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -134,7 +134,7 @@
         "filename": ".github/workflows/test.yml",
         "hashed_secret": "a94a8fe5ccb19ba61c4c0873d391e987982fbbd3",
         "is_verified": false,
-        "line_number": 93,
+        "line_number": 92,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-03-25T17:43:50Z"
+  "generated_at": "2025-04-23T08:18:22Z"
 }

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -163,6 +163,7 @@ class TestJiraTaskCollector:
 
         # 5 - simulate user promoting a flaw
         flaw.workflow_state = WorkflowModel.WorkflowState.TRIAGE
+        flaw.save(auto_timestamps=False)
         # provide a fake diff just to pretend that the workflow state has changed
         flaw.tasksync(diff={"workflow_state": None}, jira_token=jira_token)
         flaw = Flaw.objects.get(uuid=flaw.uuid)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add feedback form to tracker description (OSIDB-4095)
 
+### Changed
+- Adjust ACLs upon workflow advancement in OSIDB and do not wait for Jira sync (OSIDB-4136)
+
 ### Fixed
 - Postpone Jira task download when there are sync or transition managers pending (OSIDB-4136)
 - Consider affect in AFFECTED/DELEGATED state as not resolved (OSIDB-4137)
 - Fix missing include_history field on Affect and Flaw API documentation (OSIDB-3960)
+- Remove redundant Flaw workflow update (OSIDB-4136)
 
 ## [4.10.0] - 2025-03-25
 ### Fixed

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -1071,6 +1071,13 @@ class Flaw(
                 JiraTaskSyncManager.schedule(str(self.uuid))
 
             if transition_task:
+                # workflow transition may result in ACL change
+                self.adjust_acls(save=False)
+                Flaw.objects.filter(uuid=self.uuid).update(
+                    acl_read=self.acl_read,
+                    acl_write=self.acl_write,
+                )
+
                 JiraTaskTransitionManager.check_for_reschedules()
                 JiraTaskTransitionManager.schedule(str(self.uuid))
 
@@ -1079,6 +1086,13 @@ class Flaw(
                 self._create_or_update_task(jira_token)
 
             if transition_task:
+                # workflow transition may result in ACL change
+                self.adjust_acls(save=False)
+                Flaw.objects.filter(uuid=self.uuid).update(
+                    acl_read=self.acl_read,
+                    acl_write=self.acl_write,
+                )
+
                 self._transition_task(jira_token)
 
     def _create_or_update_task(self, jira_token=None):
@@ -1111,14 +1125,6 @@ class Flaw(
         jtq = JiraTaskmanQuerier(token=jira_token)
 
         jtq.transition_task(self)
-        # workflow transition may result in ACL change
-        self.adjust_acls(save=False)
-        Flaw.objects.filter(uuid=self.uuid).update(
-            acl_read=self.acl_read,
-            acl_write=self.acl_write,
-            workflow_name=self.workflow_name,
-            workflow_state=self.workflow_state,
-        )
 
     download_manager = models.ForeignKey(
         FlawDownloadManager, null=True, blank=True, on_delete=models.CASCADE

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -88,6 +88,11 @@ class SyncManager(models.Model):
         cls.objects.get_or_create(sync_id=sync_id)
         cls.objects.filter(sync_id=sync_id).update(last_scheduled_dt=timezone.now())
 
+        # Create model linkage if possible to make checking for conflicting
+        # sync managers possible
+        manager = cls.objects.get(sync_id=sync_id)
+        manager.update_synced_links()
+
         def schedule_task():
             try:
                 cls.sync_task.apply_async(


### PR DESCRIPTION
This PR:
* minor - creates the linkage between the updated model and the sync manager right upon schedule if possible so the conflicting sync managers check won't have a blind spot during the period between the sync managers creation and the first execution
* removes the redundant workflow update after the successful sync into Jira so there are no data overwrites (e.g. transition manager which syncs PRE_SECONDARY_ASSESSMENT finishes earlier than transition manager which syncs TRIAGE), this is unfortunately still imperfect as the Flaw data reset won't now happen directly in OSIDB but can still happen in Jira (e.g. PRE_SECONDARY_ASSESSMENT is written earlier than TRIAGE and TRIAGE then overwrites it) which will eventually be downloaded back to OSIDB, to fix this, we need to implement solution proposed in OSIDB-4175
* moves ACL adjustment upon workflow advancing as it should happen right away when we do advance the workflow in OSIDB and not to wait until we sync it into Jira, this seems like a remaining part from the synchronous task manager

Closes OSIDB-4136