### PR TITLE
update Celery and related dependencies

### DIFF
--- a/collectors/framework/constants.py
+++ b/collectors/framework/constants.py
@@ -9,7 +9,7 @@ COLLECTOR_DRY_RUN: bool = get_env("DRY_RUN", default="False", is_bool=True)
 CRONTAB_PARAMS_NAMES = [
     "minute",
     "hour",
-    "day_of_week",
     "day_of_month",
     "month_of_year",
+    "day_of_week",
 ]

--- a/collectors/framework/migrations/0002_crontab.py
+++ b/collectors/framework/migrations/0002_crontab.py
@@ -1,0 +1,44 @@
+import re
+
+from celery.schedules import crontab
+from django.db import migrations, models
+
+# original crontab order
+CRONTAB_PARAMS_NAMES = [
+    "minute",
+    "hour",
+    "day_of_week",
+    "day_of_month",
+    "month_of_year",
+]
+
+
+def forwards_func(apps, schema_editor):
+    """
+    migrate the Collector crontabs to the new format
+    """
+    CollectorMetadata = apps.get_model("framework", "CollectorMetadata")
+    for collector_metadata in CollectorMetadata.objects.all():
+        if not collector_metadata.crontab:
+            continue
+
+        print(f"Migrating crontab format of {collector_metadata.name}")
+
+        values = re.search(
+            r"<crontab: (.*) \(m/h/d/dM/MY\)>", collector_metadata.crontab
+        ).group(1)
+        params = {
+            key: value for key, value in zip(CRONTAB_PARAMS_NAMES, values.split())
+        }
+        collector_metadata.crontab = crontab(**params)
+        collector_metadata.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("framework", "0001_initial_squashed_0004_collector_required_fields_revision"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, migrations.RunPython.noop, atomic=True),
+    ]

--- a/collectors/framework/models.py
+++ b/collectors/framework/models.py
@@ -181,7 +181,7 @@ class CollectorMetadata(NullStrFieldsMixin):
     @property
     def crontab_params(self) -> Optional[Dict[str, str]]:
         if self.crontab:
-            params = re.search(r"<crontab: (.*) \(m/h/d/dM/MY\)>", self.crontab).group(
+            params = re.search(r"<crontab: (.*) \(m/h/dM/MY/d\)>", self.crontab).group(
                 1
             )
             return {

--- a/devel-requirements.txt
+++ b/devel-requirements.txt
@@ -35,9 +35,9 @@ charset-normalizer==2.0.7 \
     # via
     #   -c requirements.txt
     #   requests
-click==8.0.3 \
-    --hash=sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3 \
-    --hash=sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b
+click==8.1.8 \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
     # via
     #   -c requirements.txt
     #   pip-tools
@@ -97,7 +97,9 @@ coverage[toml]==6.1.2 \
     --hash=sha256:fae3fe111670e51f1ebbc475823899524e3459ea2db2cb88279bbfb2a0b8a3de \
     --hash=sha256:fd92ece726055e80d4e3f01fff3b91f54b18c9c357c48fcf6119e87e2461a091 \
     --hash=sha256:ffa545230ca2ad921ad066bf8fd627e7be43716b6e0fcf8e32af1b8188ccb0ab
-    # via pytest-cov
+    # via
+    #   coverage
+    #   pytest-cov
 detect-secrets==1.4.0 \
     --hash=sha256:d08ecabeee8b68c0acb0e8a354fb98d822a653f6ed05e520cead4c6fc1fc02cd \
     --hash=sha256:d56787e339758cef48c9ccd6692f7a094b9963c979c9813580b0169e41132833
@@ -474,10 +476,6 @@ packaging==24.1 \
     #   pytest
     #   pytest-sugar
     #   tox
-pip==23.3 \
-    --hash=sha256:bb7d4f69f488432e4e96394612f43ab43dd478d073ef7422604a570f7157561e \
-    --hash=sha256:bc38bb52bc286514f8f7cb3a1ba5ed100b76aaef29b521d48574329331c5ae7b
-    # via pip-tools
 pip-tools==7.3.0 \
     --hash=sha256:8717693288720a8c6ebd07149c93ab0be1fced0b5191df9e9decd3263e20d85e \
     --hash=sha256:8e9c99127fe024c025b46a0b2d15c7bd47f18f33226cf7330d35493663fc1d1d
@@ -654,14 +652,6 @@ ruamel-yaml-clib==0.2.6 \
     --hash=sha256:dc6a613d6c74eef5a14a214d433d06291526145431c3b964f5e16529b1842bed \
     --hash=sha256:de9c6b8a1ba52919ae919f3ae96abb72b994dd0350226e28f3686cb4f142165c
     # via ruamel-yaml
-setuptools==65.5.1 \
-    --hash=sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31 \
-    --hash=sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f
-    # via
-    #   -c requirements.txt
-    #   google-auth
-    #   kubernetes
-    #   pip-tools
 six==1.16.0 \
     --hash=sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926 \
     --hash=sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254
@@ -887,3 +877,17 @@ yarl==1.7.2 \
     --hash=sha256:fce78593346c014d0d986b7ebc80d782b7f5e19843ca798ed62f8e3ba8728576 \
     --hash=sha256:fd547ec596d90c8676e369dd8a581a21227fe9b4ad37d0dc7feb4ccf544c2d59
     # via vcrpy
+
+# The following packages are considered to be unsafe in a requirements file:
+pip==23.3 \
+    --hash=sha256:bb7d4f69f488432e4e96394612f43ab43dd478d073ef7422604a570f7157561e \
+    --hash=sha256:bc38bb52bc286514f8f7cb3a1ba5ed100b76aaef29b521d48574329331c5ae7b
+    # via pip-tools
+setuptools==65.5.1 \
+    --hash=sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31 \
+    --hash=sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f
+    # via
+    #   -c requirements.txt
+    #   google-auth
+    #   kubernetes
+    #   pip-tools

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,9 @@
 #
 #    pip-compile --allow-unsafe --generate-hashes --no-emit-index-url requirements.in
 #
-amqp==5.0.9 \
-    --hash=sha256:1e5f707424e544078ca196e72ae6a14887ce74e02bd126be54b7c03c971bef18 \
-    --hash=sha256:9cd81f7b023fc04bbb108718fbac674f06901b77bfcdce85b10e2a5d0ee91be5
+amqp==5.3.1 \
+    --hash=sha256:43b3319e1b4e7d1251833a93d672b4af1e40f3d632d479b98661a95f117880a2 \
+    --hash=sha256:cddc00c725449522023bad949f70fff7b48f0b1ade74d170a6f10ab044739432
     # via kombu
 ansimarkup==1.5.0 \
     --hash=sha256:3146ca74af5f69e48a9c3d41b31085c0d6378f803edeb364856d37c11a684acf \
@@ -35,17 +35,17 @@ backoff==1.11.1 \
     --hash=sha256:61928f8fa48d52e4faa81875eecf308eccfb1016b018bb6bd21e05b5d90a96c5 \
     --hash=sha256:ccb962a2378418c667b3c979b504fdeb7d9e0d29c0579e3b13b86467177728cb
     # via -r requirements.in
-billiard==3.6.4.0 \
-    --hash=sha256:299de5a8da28a783d51b197d496bef4f1595dd023a93a4f59dde1886ae905547 \
-    --hash=sha256:87103ea78fa6ab4d5c751c4909bcff74617d985de7fa8b672cf8618afd5a875b
+billiard==4.2.1 \
+    --hash=sha256:12b641b0c539073fc8d3f5b8b7be998956665c4233c7c1fcd66a7e677c4fb36f \
+    --hash=sha256:40b59a4ac8806ba2c2369ea98d876bc6108b051c227baffd928c644d15d8f3cb
     # via celery
 cattrs==1.8.0 \
     --hash=sha256:5c121ab06a7cac494813c228721a7feb5a6423b17316eeaebf13f5a03e5b0d53 \
     --hash=sha256:901fb2040529ae8fc9d93f48a2cdf7de3e983312ffb2a164ffa4e9847f253af1
     # via requests-cache
-celery[gevent]==5.2.7 \
-    --hash=sha256:138420c020cd58d6707e6257b6beda91fd39af7afde5d36c6334d175302c0e14 \
-    --hash=sha256:fafbd82934d30f8a004f81e8f7a062e31413a23d444be8ee3326553915958c6d
+celery[gevent]==5.5.2 \
+    --hash=sha256:4d6930f354f9d29295425d7a37261245c74a32807c45d764bedc286afd0e724e \
+    --hash=sha256:54425a067afdc88b57cd8d94ed4af2ffaf13ab8c7680041ac2c4ac44357bdf4c
     # via
     #   -r requirements.in
     #   celery-redbeat
@@ -63,9 +63,9 @@ charset-normalizer==2.0.7 \
     --hash=sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0 \
     --hash=sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b
     # via requests
-click==8.0.3 \
-    --hash=sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3 \
-    --hash=sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b
+click==8.1.8 \
+    --hash=sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2 \
+    --hash=sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a
     # via
     #   celery
     #   click-didyoumean
@@ -410,9 +410,9 @@ kerberos==1.3.1 \
     --hash=sha256:98a695c072efef535cb2b5f98e474d00671588859a94ec96c2c1508a113ff3aa \
     --hash=sha256:cdd046142a4e0060f96a00eb13d82a5d9ebc0f2d7934393ed559bac773460a2c
     # via -r requirements.in
-kombu==5.2.3 \
-    --hash=sha256:81a90c1de97e08d3db37dbf163eaaf667445e1068c98bfd89f051a40e9f6dbbd \
-    --hash=sha256:eeaeb8024f3a5cfc71c9250e45cddb8493f269d74ada2f74909a93c59c4b4179
+kombu==5.5.3 \
+    --hash=sha256:021a0e11fcfcd9b0260ef1fb64088c0e92beb976eb59c1dfca7ddd4ad4562ea2 \
+    --hash=sha256:5b0dbceb4edee50aa464f59469d34b97864be09111338cfb224a10b6a163909b
     # via celery
 markdown==3.3.6 \
     --hash=sha256:76df8ae32294ec39dcf89340382882dfa12975f87f45c3ed1ecdb1e8cefc7006 \
@@ -590,6 +590,7 @@ python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
     # via
+    #   celery
     #   celery-redbeat
     #   django-postgres-extra
 python-ldap==3.4.0 \
@@ -600,9 +601,7 @@ python-ldap==3.4.0 \
 pytz==2021.3 \
     --hash=sha256:3672058bc3453457b622aab7a1c3bfd5ab0bdae451512f6cf25f64ed37f5b87c \
     --hash=sha256:acad2d8b20a1af07d4e4c9d2e9285c5ed9104354062f275f3fcd88dcef4f1326
-    # via
-    #   celery
-    #   flower
+    # via flower
 pyyaml==6.0 \
     --hash=sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf \
     --hash=sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293 \
@@ -798,6 +797,10 @@ typing-extensions==4.12.2 \
     #   asgiref
     #   drf-spectacular
     #   jira
+tzdata==2025.2 \
+    --hash=sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8 \
+    --hash=sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9
+    # via kombu
 uritemplate==4.1.1 \
     --hash=sha256:4346edfc5c3b79f694bccd6d6099a322bbeb628dbf2cd86eea55a456ce5124f0 \
     --hash=sha256:830c08b8d99bdd312ea4ead05994a38e8936266f84b9a7878232db50b044e02e
@@ -812,9 +815,9 @@ urllib3==1.26.20 \
     # via
     #   requests
     #   requests-cache
-vine==5.0.0 \
-    --hash=sha256:4c9dceab6f76ed92105027c49c823800dd33cacce13bdedc5b914e3514b7fb30 \
-    --hash=sha256:7d3b1624a953da82ef63462013bbd271d3eb75751489f9807598e8f340bd637e
+vine==5.1.0 \
+    --hash=sha256:40fdf3c48b2cfe1c38a49e9ae2da6fda88e4794c810050a728bd7413811fb1dc \
+    --hash=sha256:8b62e981d35c41049211cf62a0a1242d8c1ee9bd15bb196ce38aefd6799e61e0
     # via
     #   amqp
     #   celery


### PR DESCRIPTION
mainly because of the stability improvements in 5.5.0 which should prevent Celery integration breakage

https://github.com/celery/celery/releases/tag/v5.5.0

Closes OSIDB-4125