### PR TITLE
OSIDB-4199: Handle tracking of NIST/CISA CVSS scores in Jira trackers

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Adjust cve.org collector to correctly label CISA-ADP CVSS scores as CISA (OSIDB-4204)
+- Adjust JIRA tracker generator to include NIST/CISA CVSS scores when RH ones
+  don't meet Moderate and CVSS score >= 7.0 criteria (OSIDB-4199)
 
 ### Fixed
 - Prevent running multiple Jira transition managers at the same time (OSIDB-4175) 


### PR DESCRIPTION
With this commit, JIRA engineering trackers with a RH CVSS score < 7.0 but for which there exist NIST/CISA CVSS scores >= 7.0 will now meet the mod7 criteria and will be included in the CVSS field in the aforementioned tracker.

This will help downstream engineering teams to know why a specific tracker was created when the RH CVSS score does not meet the usual criteria.

Closes OSIDB-4199