### PR TITLE
Avoid upadting cve.org repo unless strictly necessary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ tests/htmlcov
 *.db.gz
 osidb_data_backup_dump*
 .DS_Store
+# pyright local configuration file
+pyrightconfig.json

--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -95,6 +95,10 @@ class CVEorgCollector(Collector):
     def update_repo(self) -> None:
         """
         Update the already existing cvelistV5 repository.
+
+        Warning: Do not use this method unless strictly necessary and you know
+        it won't run while another update is running in parallel (e.g. via
+        celery), otherwise this can lead to any further updates failing.
         """
         logger.info("Updating the cvelistV5 repository...")
 
@@ -371,9 +375,11 @@ class CVEorgCollector(Collector):
                     score, vector = values
                     cvss_data.append(
                         {
-                            "issuer": FlawCVSS.CVSSIssuer.CISA
-                            if provider == CISA_ORG_ID
-                            else FlawCVSS.CVSSIssuer.CVEORG,
+                            "issuer": (
+                                FlawCVSS.CVSSIssuer.CISA
+                                if provider == CISA_ORG_ID
+                                else FlawCVSS.CVSSIssuer.CVEORG
+                            ),
                             "version": self.CVSS_TO_FLAWCVSS[version],
                             "vector": vector,
                             # Actual score is generated automatically when FlawCVSS is saved


### PR DESCRIPTION
Since calling said method while a celery worker is running can lead to issues, do not call it during the data migration and instead assume that it's up-to-date with a margin of error of an hour.