### PR TITLE
OSIDB-4253: Fix cve.org collector's get_comment_zero and get_references

### DIFF
--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -341,11 +341,10 @@ class CVEorgCollector(Collector):
         """
 
         def get_comment_zero(data: dict) -> str:
-            return [
-                d["value"]
-                for d in data["containers"]["cna"]["descriptions"]
-                if re.match(self.EN_LANG, d["lang"])
-            ][0]
+            for description in data["containers"]["cna"].get("descriptions", []):
+                if re.match(self.EN_LANG, description["lang"]):
+                    return description["value"]
+            return "N/A"
 
         def get_cvss_and_impact(data: dict) -> tuple[list, str]:
             # Keep only data we are interested in (provider, version, vector, score)
@@ -422,7 +421,7 @@ class CVEorgCollector(Collector):
             ]
 
             # Collect all references from CNA and ADP containers
-            all_references = data["containers"]["cna"]["references"]
+            all_references = data["containers"]["cna"].get("references", [])
             for a in data["containers"].get("adp", []):
                 all_references.extend(a.get("references", []))
 

--- a/collectors/cveorg/tests/conftest.py
+++ b/collectors/cveorg/tests/conftest.py
@@ -85,3 +85,9 @@ def cna_cvss_content(repo_path):
 def cisa_cvss_content(repo_path):
     with open(f"{repo_path}/CVE-2025-22871.json", "r") as f:
         return json.load(f)
+
+
+@pytest.fixture
+def no_descriptions_content(repo_path):
+    with open(f"{repo_path}/CVE-2025-37902.json", "r") as f:
+        return json.load(f)

--- a/collectors/cveorg/tests/cvelistV5/CVE-2025-37902.json
+++ b/collectors/cveorg/tests/cvelistV5/CVE-2025-37902.json
@@ -1,0 +1,29 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.1",
+    "cveMetadata": {
+        "cveId": "CVE-2025-37902",
+        "assignerOrgId": "416baaa9-dc9f-4396-8d5f-8c081fb06d67",
+        "state": "REJECTED",
+        "assignerShortName": "Linux",
+        "dateReserved": "2025-04-16T04:51:23.965Z",
+        "datePublished": "2025-05-20T15:21:36.708Z",
+        "dateUpdated": "2025-05-26T10:17:48.887Z",
+        "dateRejected": "2025-05-26T10:17:48.887Z"
+    },
+    "containers": {
+        "cna": {
+            "rejectedReasons": [
+                {
+                    "lang": "en",
+                    "value": "This CVE ID has been rejected or withdrawn by its CVE Numbering Authority."
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "416baaa9-dc9f-4396-8d5f-8c081fb06d67",
+                "shortName": "Linux",
+                "dateUpdated": "2025-05-26T10:17:48.887Z"
+            }
+        }
+    }
+}

--- a/collectors/cveorg/tests/test_processing.py
+++ b/collectors/cveorg/tests/test_processing.py
@@ -82,3 +82,11 @@ class TestCVEorgProcessing:
         collector.upsert_cvss_scores("", [{"foo": "bar"}])
 
         assert FlawCVSS.objects.count() == 0
+
+    def test_get_comment_zero_missing(self, no_descriptions_content):
+        collector = CVEorgCollector()
+        collector.keywords_check_enabled = False
+
+        assert (
+            collector.extract_content(no_descriptions_content)["comment_zero"] == "N/A"
+        )


### PR DESCRIPTION
The above closures fail when parsing rejected CVE records from CVE.org, leading to unexpected errors.

Closes OSIDB-4253