### PR TITLE
OSIDB-4244: Provide endpoint for proxying storage of third-party tokens

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -250,7 +250,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 126,
+        "line_number": 129,
         "is_secret": false
       }
     ],
@@ -432,7 +432,7 @@
         "filename": "osidb/tests/endpoints/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 101,
+        "line_number": 152,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-02T15:10:23Z"
+  "generated_at": "2025-06-06T15:14:55Z"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,9 @@ services:
         SNIPPET_CREATION: ${SNIPPET_CREATION}
         TRACKERS_SYNC_TO_JIRA: ${TRACKERS_SYNC_TO_JIRA}
         TRACKER_FEEDBACK_FORM_URL: ${TRACKER_FEEDBACK_FORM_URL}
+        OSIDB_VAULT_ADDR: ${OSIDB_VAULT_ADDR} 
+        OSIDB_ROLE_ID: ${OSIDB_ROLE_ID}
+        OSIDB_SECRET_ID: ${OSIDB_SECRET_ID}
       command: ./scripts/setup-osidb-service.sh
       volumes:
         - ${PWD}:/opt/app-root/src:z

--- a/openapi.yml
+++ b/openapi.yml
@@ -7456,6 +7456,42 @@ paths:
                   version:
                     type: string
           description: ''
+  /osidb/integrations:
+    patch:
+      operationId: osidb_integrations_partial_update
+      description: Set third-party integration tokens for the current user.
+      tags:
+      - osidb
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PatchedIntegrationTokenRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/PatchedIntegrationTokenRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/PatchedIntegrationTokenRequest'
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+          description: ''
   /osidb/whoami:
     get:
       operationId: osidb_whoami_retrieve
@@ -7470,32 +7506,19 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                properties:
-                  dt:
-                    type: string
-                    format: date-time
-                  email:
-                    type: string
-                  env:
-                    type: string
-                  groups:
-                    type: array
-                    items:
+                allOf:
+                - $ref: '#/components/schemas/User'
+                - type: object
+                  properties:
+                    dt:
                       type: string
-                  profile:
-                    type: object
-                    properties:
-                      bz_user_id:
-                        type: string
-                      jira_user_id:
-                        type: string
-                  revision:
-                    type: string
-                  username:
-                    type: string
-                  version:
-                    type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
           description: ''
   /trackers/api/v1/file:
     post:
@@ -10056,6 +10079,26 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tracker'
+    PatchedIntegrationTokenRequest:
+      type: object
+      properties:
+        jira:
+          type: string
+          writeOnly: true
+          minLength: 1
+        bugzilla:
+          type: string
+          writeOnly: true
+          minLength: 1
+    Profile:
+      type: object
+      properties:
+        bz_user_id:
+          type: string
+          maxLength: 100
+        jira_user_id:
+          type: string
+          maxLength: 100
     PsStreamSelection:
       type: object
       properties:
@@ -10526,6 +10569,32 @@ components:
       - JIRA
       - BUGZILLA
       type: string
+    User:
+      type: object
+      properties:
+        username:
+          type: string
+          description: Required. 150 characters or fewer. Letters, digits and @/./+/-/_
+            only.
+          pattern: ^[\w.@+-]+$
+          maxLength: 150
+        email:
+          type: string
+          format: email
+          title: Email address
+          maxLength: 254
+        groups:
+          type: array
+          items:
+            type: string
+        profile:
+          allOf:
+          - $ref: '#/components/schemas/Profile'
+          readOnly: true
+      required:
+      - groups
+      - profile
+      - username
   securitySchemes:
     KerberosAuthentication:
       type: http

--- a/osidb/integrations.py
+++ b/osidb/integrations.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional
 
 import hvac
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from config import get_env
@@ -13,9 +14,9 @@ _logger = logging.getLogger(__name__)
 class IntegrationSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OSIDB_")
 
-    vault_addr: str
-    role_id: str
-    secret_id: str
+    vault_addr: str = Field(default=...)
+    role_id: str = Field(default=...)
+    secret_id: str = Field(default=...)
 
 
 class IntegrationRepository:

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -2179,3 +2179,15 @@ class FlawCommentPostSerializer(FlawCommentSerializer):
     # in create().
     # This class is just for schema generation, not for actual execution.
     pass
+
+
+class IntegrationTokenSerializer(serializers.Serializer):
+    jira = serializers.CharField(required=False, write_only=True)
+    bugzilla = serializers.CharField(required=False, write_only=True)
+
+    def validate(self, attrs: dict) -> dict:
+        if "jira" not in attrs and "bugzilla" not in attrs:
+            raise serializers.ValidationError(
+                "At least one third-party integration token must be provided"
+            )
+        return attrs

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -145,3 +146,10 @@ def patch_hvac_client(monkeypatch, mock_hvac_client_instance):
     MockHvacClientClass = MagicMock(return_value=mock_hvac_client_instance)
     monkeypatch.setattr("osidb.integrations.hvac.Client", MockHvacClientClass)
     return MockHvacClientClass
+
+
+@pytest.fixture
+def set_hvac_test_env_vars():
+    os.environ["OSIDB_VAULT_ADDR"] = "https://fake-vault:8200/"
+    os.environ["OSIDB_ROLE_ID"] = "fake-role"
+    os.environ["OSIDB_SECRET_ID"] = "fake-secret"

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -1,6 +1,7 @@
 """
 define urls
 """
+
 from django.urls import include, path, re_path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework import routers
@@ -29,6 +30,7 @@ from .api_views import (
     StatusView,
     TrackerView,
     healthy,
+    set_integration_tokens,
     whoami,
 )
 from .constants import OSIDB_API_VERSION, OSIDB_API_VERSION_NEXT
@@ -78,6 +80,7 @@ vnext_router.register(
 urlpatterns = [
     path("healthy", healthy),
     path("whoami", whoami),
+    path("integrations", set_integration_tokens),
     re_path(
         rf"^api/{OSIDB_API_VERSION}/flaws/(?P<flaw_id>[^/.]+)/promote$",
         promote.as_view(),


### PR DESCRIPTION
This endpoint accepts (for the time being) JIRA and Bugzilla API tokens for the currently logged-in user and stores them in HashiCorp Vault.

The tokens will eventually be available for consumption from the /whoami endpoint.

Closes OSIDB-4244