### PR TITLE
OSIDB-4245: Expose third-party integration tokens through API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -432,7 +432,7 @@
         "filename": "osidb/tests/endpoints/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 152,
+        "line_number": 186,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-06T15:14:55Z"
+  "generated_at": "2025-06-09T17:04:51Z"
 }

--- a/openapi.yml
+++ b/openapi.yml
@@ -7457,6 +7457,32 @@ paths:
                     type: string
           description: ''
   /osidb/integrations:
+    get:
+      operationId: osidb_integrations_retrieve
+      description: Set third-party integration tokens for the current user.
+      tags:
+      - osidb
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/IntegrationTokenGet'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
     patch:
       operationId: osidb_integrations_partial_update
       description: Set third-party integration tokens for the current user.
@@ -7466,17 +7492,17 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/PatchedIntegrationTokenRequest'
+              $ref: '#/components/schemas/PatchedIntegrationTokenPatchRequest'
           application/x-www-form-urlencoded:
             schema:
-              $ref: '#/components/schemas/PatchedIntegrationTokenRequest'
+              $ref: '#/components/schemas/PatchedIntegrationTokenPatchRequest'
           multipart/form-data:
             schema:
-              $ref: '#/components/schemas/PatchedIntegrationTokenRequest'
+              $ref: '#/components/schemas/PatchedIntegrationTokenPatchRequest'
       security:
       - OsidbTokenAuthentication: []
       responses:
-        '200':
+        '204':
           content:
             application/json:
               schema:
@@ -9539,6 +9565,18 @@ components:
       - IMPORTANT
       - CRITICAL
       type: string
+    IntegrationTokenGet:
+      type: object
+      properties:
+        jira:
+          type: string
+          nullable: true
+        bugzilla:
+          type: string
+          nullable: true
+      required:
+      - bugzilla
+      - jira
     IssuerEnum:
       enum:
       - CVEORG
@@ -10079,7 +10117,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Tracker'
-    PatchedIntegrationTokenRequest:
+    PatchedIntegrationTokenPatchRequest:
       type: object
       properties:
         jira:

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -2181,7 +2181,12 @@ class FlawCommentPostSerializer(FlawCommentSerializer):
     pass
 
 
-class IntegrationTokenSerializer(serializers.Serializer):
+class IntegrationTokenGetSerializer(serializers.Serializer):
+    jira = serializers.CharField(allow_null=True)
+    bugzilla = serializers.CharField(allow_null=True)
+
+
+class IntegrationTokenPatchSerializer(serializers.Serializer):
     jira = serializers.CharField(required=False, write_only=True)
     bugzilla = serializers.CharField(required=False, write_only=True)
 

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -30,7 +30,7 @@ from .api_views import (
     StatusView,
     TrackerView,
     healthy,
-    set_integration_tokens,
+    integration_tokens,
     whoami,
 )
 from .constants import OSIDB_API_VERSION, OSIDB_API_VERSION_NEXT
@@ -80,7 +80,7 @@ vnext_router.register(
 urlpatterns = [
     path("healthy", healthy),
     path("whoami", whoami),
-    path("integrations", set_integration_tokens),
+    path("integrations", integration_tokens),
     re_path(
         rf"^api/{OSIDB_API_VERSION}/flaws/(?P<flaw_id>[^/.]+)/promote$",
         promote.as_view(),


### PR DESCRIPTION
When performing GET /osidb/integrations, the currently logged-in user's third-party tokens will be returned for use by clients that cannot safely store said tokens on their side.

Closes OSIDB-4245