### PR TITLE
OSIDB-4246: Don't require third-party integration tokens in headers

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -184,7 +184,7 @@
         "filename": "apps/workflows/tests/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 280,
+        "line_number": 281,
         "is_secret": false
       }
     ],
@@ -432,7 +432,7 @@
         "filename": "osidb/tests/endpoints/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 186,
+        "line_number": 185,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-09T17:04:51Z"
+  "generated_at": "2025-06-12T14:21:50Z"
 }

--- a/apps/workflows/tests/conftest.py
+++ b/apps/workflows/tests/conftest.py
@@ -1,3 +1,6 @@
+import os
+from unittest.mock import MagicMock
+
 import pytest
 
 from apps.workflows.constants import WORKFLOWS_API_VERSION
@@ -82,3 +85,24 @@ def clean_workflows():
     workflow_framework._workflows = []
     yield  # run test here
     workflow_framework._workflows = []
+
+
+@pytest.fixture
+def mock_hvac_client_instance():
+    """Creates a MagicMock instance for hvac.Client."""
+    return MagicMock()
+
+
+@pytest.fixture(autouse=True)
+def patch_hvac_client(monkeypatch, mock_hvac_client_instance):
+    """Patches hvac.Client in vault_integration module to return our mock instance."""
+    MockHvacClientClass = MagicMock(return_value=mock_hvac_client_instance)
+    monkeypatch.setattr("osidb.integrations.hvac.Client", MockHvacClientClass)
+    return MockHvacClientClass
+
+
+@pytest.fixture
+def set_hvac_test_env_vars():
+    os.environ["OSIDB_VAULT_ADDR"] = "https://fake-vault:8200/"
+    os.environ["OSIDB_ROLE_ID"] = "fake-role"
+    os.environ["OSIDB_SECRET_ID"] = "fake-secret"

--- a/apps/workflows/tests/test_endpoints.py
+++ b/apps/workflows/tests/test_endpoints.py
@@ -228,6 +228,7 @@ class TestEndpoints(object):
         monkeypatch,
         auth_client,
         test_api_uri_osidb,
+        set_hvac_test_env_vars,
     ):
         """test flaw state promotion after data change"""
 
@@ -336,6 +337,7 @@ class TestEndpoints(object):
         monkeypatch,
         auth_client,
         test_api_uri_osidb,
+        set_hvac_test_env_vars,
     ):
         """test flaw state promotion after data change"""
 
@@ -434,6 +436,7 @@ class TestFlawDraft:
         auth_client,
         test_api_uri_osidb,
         jira_token,
+        set_hvac_test_env_vars,
     ):
         """
         test that ACLs are set to public when promoting a flaw draft
@@ -559,6 +562,7 @@ class TestFlawDraft:
         auth_client,
         test_api_uri_osidb,
         jira_token,
+        set_hvac_test_env_vars,
     ):
         """
         test that ACLs are still set to internal when rejecting a flaw draft

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -12,8 +12,3 @@ from .celery import app as celery_app  # noqa: F401
 
 django.setup()
 __all__ = ["osidb"]
-
-
-def get_env() -> str:
-    # return "config.settings.env" -> ["config", "settings", "env"] -> "env"
-    return os.getenv("DJANGO_SETTINGS_MODULE", "").split("_")[-1]

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,4 @@
-from config import get_env
+from osidb.helpers import get_execution_env
 
 bind = "0.0.0.0:8000"
 worker_class = "gthread"
@@ -16,7 +16,7 @@ forwarded_allow_ips = "*"
 # exist in deployment environments, setting to shm filesystem avoids this
 worker_tmp_dir = "/dev/shm"
 
-if get_env() in ["stage", "prod", "ci"]:
+if get_execution_env() in ["stage", "prod", "ci"]:
     preload_app = True
     graceful_timeout = 800  # if a restart must happen then let it be graceful
     keepalive = 60  # specifically this should be a value larger then nginx setting

--- a/openapi.yml
+++ b/openapi.yml
@@ -1484,13 +1484,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       tags:
       - osidb
       requestBody:
@@ -1710,7 +1708,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: affect_id
         schema:
@@ -1817,7 +1814,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: affect_id
         schema:
@@ -1873,7 +1869,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: affect_id
         schema:
@@ -1985,13 +1980,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       - in: path
         name: uuid
         schema:
@@ -2043,7 +2036,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: uuid
         schema:
@@ -2082,7 +2074,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       tags:
       - osidb
       requestBody:
@@ -2133,13 +2124,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       tags:
       - osidb
       requestBody:
@@ -2190,7 +2179,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       tags:
       - osidb
       security:
@@ -3776,13 +3764,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       tags:
       - osidb
       requestBody:
@@ -3987,7 +3973,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -4094,7 +4079,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -4150,7 +4134,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -4281,7 +4264,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -4571,7 +4553,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -4678,7 +4659,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -4734,7 +4714,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5145,7 +5124,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5252,7 +5230,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5308,7 +5285,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5562,7 +5538,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5669,7 +5644,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5725,7 +5699,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:
@@ -5910,13 +5883,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       - in: query
         name: create_jira_task
         schema:
@@ -6898,13 +6869,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       tags:
       - osidb
       requestBody:
@@ -7013,13 +6982,11 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: header
         name: Jira-Api-Key
         schema:
           type: string
         description: User generated api key for Jira authentication.
-        required: true
       - in: path
         name: uuid
         schema:
@@ -7397,7 +7364,6 @@ paths:
         schema:
           type: string
         description: User generated api key for Bugzilla authentication.
-        required: true
       - in: path
         name: flaw_id
         schema:

--- a/osidb/integrations.py
+++ b/osidb/integrations.py
@@ -6,7 +6,7 @@ import hvac
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from config import get_env
+from osidb.helpers import get_execution_env
 
 _logger = logging.getLogger(__name__)
 
@@ -20,7 +20,7 @@ class IntegrationSettings(BaseSettings):
 
 
 class IntegrationRepository:
-    BASE_PATH = Path("/osidb-integrations") / Path(get_env())
+    BASE_PATH = Path("/osidb-integrations") / Path(get_execution_env())
     BASE_MOUNTPOINT = "apps"
 
     def __init__(self, settings: IntegrationSettings):

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1,5 +1,5 @@
 """
-    serialize flaw model
+serialize flaw model
 """
 
 import logging
@@ -47,7 +47,7 @@ from osidb.models import (
 
 from .core import generate_acls
 from .exceptions import DataInconsistencyException
-from .helpers import differ, ensure_list
+from .helpers import differ, ensure_list, get_bugzilla_api_key, get_jira_api_key
 from .mixins import ACLMixin, Alert, AlertMixin, TrackingMixin
 
 logger = logging.getLogger(__name__)
@@ -499,12 +499,7 @@ class BugzillaAPIKeyMixin:
     """
 
     def get_bz_api_key(self):
-        bz_api_key = self.context["request"].META.get("HTTP_BUGZILLA_API_KEY")
-        if not bz_api_key:
-            raise serializers.ValidationError(
-                {"Bugzilla-Api-Key": "This HTTP header is required."}
-            )
-        return bz_api_key
+        return get_bugzilla_api_key(self.context["request"])
 
 
 class JiraAPIKeyMixin:
@@ -513,12 +508,7 @@ class JiraAPIKeyMixin:
     """
 
     def get_jira_token(self):
-        jira_token = self.context["request"].META.get("HTTP_JIRA_API_KEY")
-        if not jira_token:
-            raise serializers.ValidationError(
-                {"Jira-Api-Key": "This HTTP header is required."}
-            )
-        return jira_token
+        return get_jira_api_key(self.context["request"])
 
 
 class AlertSerializer(serializers.ModelSerializer):

--- a/osidb/tests/test_hcv_integration.py
+++ b/osidb/tests/test_hcv_integration.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from config import get_env
+from osidb.helpers import get_execution_env
 
 pytestmark = pytest.mark.unit
 
@@ -11,7 +11,7 @@ def test_integration_repo_upsert(fake_integration_repo, mock_hvac_client_instanc
     fake_integration_repo.upsert_secret(Path("foo"), "foo", "bar")
 
     mock_hvac_client_instance.secrets.kv.v2.patch.assert_called_once_with(
-        path=f"/osidb-integrations/{get_env()}/foo",
+        path=f"/osidb-integrations/{get_execution_env()}/foo",
         secret={"foo": "bar"},
         mount_point="apps",
     )
@@ -26,7 +26,7 @@ def test_integration_repo_read(
     }
     assert fake_integration_repo.read_secret(Path("ham"), "eggs") == expected_out
     mock_hvac_client_instance.secrets.kv.v2.read_secret_version.assert_called_once_with(
-        path=f"/osidb-integrations/{get_env()}/ham",
+        path=f"/osidb-integrations/{get_execution_env()}/ham",
         mount_point="apps",
     )
 
@@ -35,7 +35,7 @@ def test_integration_repo_jira_upsert(fake_integration_repo, mock_hvac_client_in
     fake_integration_repo.upsert_jira_token("atorresj", "my-token")
 
     mock_hvac_client_instance.secrets.kv.v2.patch.assert_called_once_with(
-        path=f"/osidb-integrations/{get_env()}/jira",
+        path=f"/osidb-integrations/{get_execution_env()}/jira",
         secret={"atorresj": "my-token"},
         mount_point="apps",
     )
@@ -45,7 +45,7 @@ def test_integration_repo_bz_upsert(fake_integration_repo, mock_hvac_client_inst
     fake_integration_repo.upsert_bz_token("atorresj", "my-token")
 
     mock_hvac_client_instance.secrets.kv.v2.patch.assert_called_once_with(
-        path=f"/osidb-integrations/{get_env()}/bugzilla",
+        path=f"/osidb-integrations/{get_execution_env()}/bugzilla",
         secret={"atorresj": "my-token"},
         mount_point="apps",
     )
@@ -56,7 +56,7 @@ def test_integration_repo_read_jira_token(
 ):
     fake_integration_repo.read_jira_token("atorresj")
     mock_hvac_client_instance.secrets.kv.v2.read_secret_version.assert_called_once_with(
-        path=f"/osidb-integrations/{get_env()}/jira",
+        path=f"/osidb-integrations/{get_execution_env()}/jira",
         mount_point="apps",
     )
 
@@ -66,6 +66,6 @@ def test_integration_repo_read_bz_token(
 ):
     fake_integration_repo.read_bz_token("atorresj")
     mock_hvac_client_instance.secrets.kv.v2.read_secret_version.assert_called_once_with(
-        path=f"/osidb-integrations/{get_env()}/bugzilla",
+        path=f"/osidb-integrations/{get_execution_env()}/bugzilla",
         mount_point="apps",
     )

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -7,7 +7,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 from rest_framework import routers
 
 from apps.workflows.api import promote, reject
-from config import get_env
+from osidb.helpers import get_execution_env
 
 from .api_views import (
     AffectCVSSView,
@@ -117,7 +117,7 @@ urlpatterns.append(
 )
 
 # TODO: undocumented endpoint only is enabled on non production environments and will be removed in the future.
-if get_env() != "prod":
+if get_execution_env() != "prod":
     urlpatterns.append(
         path(
             f"api/{OSIDB_API_VERSION}/jira_stage_forwarder",


### PR DESCRIPTION
While the tokens can still be passed to OSIDB via header (and have precedence), the tokens can now be stored/retrieved using /osidb/integrations.

Closes OSIDB-4246