### PR TITLE
Provide workaround for parsing modular components from PURLs

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Workaround for parsing modular components from PURLs (OSIDB-4292)
+
 ### Fixed
 - Properly parse modular components in Jira queries (OSIDB-4224)
 - Properly handle schedule_options parameter in SyncManager (OSIDB-4260)

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -201,6 +201,8 @@ class Affect(
                     return f"{prefix}/{purl.name}"
                 except (KeyError, IndexError):
                     raise ValueError("Invalid repository_url in OCI PURL")
+            elif "rpmmod" in purl.qualifiers:
+                return f"{purl.qualifiers['rpmmod']}/{purl.name}"
             else:
                 return purl.name
         except ValueError:

--- a/osidb/models/tests/test_affect.py
+++ b/osidb/models/tests/test_affect.py
@@ -80,3 +80,33 @@ class TestAffect:
         affect.save()
         assert affect.is_resolved == is_resolved_2
         assert affect.resolved_dt or not is_resolved_2
+
+    @pytest.mark.parametrize(
+        "purl,ps_component",
+        [
+            ("pkg:rpm/redhat/php@7.2?arch=src&rpmmod=php:7.2", "php:7.2/php"),
+            ("pkg:rpm/redhat/squid@4?arch=src&rpmmod=squid:4", "squid:4/squid"),
+            (
+                "pkg:rpm/redhat/gstreamer1-plugins-good@flatpak?arch=src&rpmmod=libreoffice:flatpak",
+                "libreoffice:flatpak/gstreamer1-plugins-good",
+            ),
+            ("pkg:rpm/redhat/redis@6?arch=src&rpmmod=redis:6", "redis:6/redis"),
+            (
+                "pkg:rpm/redhat/ghostscript@flatpak?arch=src&rpmmod=gimp:flatpak",
+                "gimp:flatpak/ghostscript",
+            ),
+            ("pkg:rpm/redhat/idm@DL1?arch=src&rpmmod=idm:DL1", "idm:DL1/idm"),
+            (
+                "pkg:rpm/redhat/nginx@1.14.1-9.module+el8.0.0+4108+cba21616?arch=x86_64&rpmmod=mainstream",
+                "mainstream/nginx",
+            ),
+            (
+                "pkg:oci/example-component?repository_url=registry.example.io/namespace/example-component",
+                "namespace/example-component",
+            ),
+        ],
+    )
+    def test_ps_component_from_purl(self, purl, ps_component):
+        affect = AffectFactory(purl=purl, ps_component=None)
+
+        assert affect.ps_component == ps_component


### PR DESCRIPTION
For compatibility reasons, a special case is handled of deriving a ps_component from a PURL where the format of the ps_component name will be the rpmmod qualifier as namespace for the PURL name.

Closes OSIDB-4292