### PR TITLE
OSIDB-4284: Update local_updated_dt when flaw-related models are updated

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Properly parse modular components in Jira queries (OSIDB-4224)
 - Properly handle schedule_options parameter in SyncManager (OSIDB-4260)
+- Take into account flaw-related model updates in changed_{after,before}
+  filters (OSIDB-4284)
 
 ### Changed
 - Swap out local krb5_auth for django-kaminarimon (OSIDB-4243)


### PR DESCRIPTION
Before this commit, some flaw-related models would not trigger an update of their related flaw's local_updated_dt field, this field's freshness is paramount to the correct computation of the changed_{before,after} filters in the API.

Due to this bug, services that poll for updated flaws would miss updates when said updates affected related entities to a flaw but not the flaw itself.

After this commit, said related entities correctly update the local_updated_dt field in the related flaw, thus making the aforementioned API filters correct and reducing missed updates in downstream services.

Closes OSIDB-4284