### PR TITLE
trigger tracker save on cvss change

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -362,7 +362,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_cvss_scores.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 141,
         "is_secret": false
       }
     ],
@@ -422,7 +422,7 @@
         "filename": "osidb/tests/endpoints/test_affects.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 74,
+        "line_number": 75,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-17T07:59:59Z"
+  "generated_at": "2025-06-18T19:08:07Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Trigger Jira tracker syunc when Red Hat's CVSS change (OSIDB-4186)
 
 ## [4.12.0] - 2025-06-18
 ### Added

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -801,6 +801,18 @@ class AffectCVSS(CVSS):
         # AffectCVSS needs to be synced through affect
         self.affect.save(*args, **kwargs)
 
+    def sync_to_trackers(self, jira_token):
+        """Sync this CVSS in the related Jira trackers."""
+        from osidb.models.tracker import Tracker
+
+        if self.affect.is_community:
+            return
+
+        for tracker in self.affect.trackers.all():
+            if not tracker.is_closed and tracker.type == Tracker.TrackerType.JIRA:
+                # default save already sync with Jira when needed
+                tracker.save(jira_token=jira_token)
+
 
 # List of all states an Affect is considered open/not resolved
 AFFECTEDNESS_UNRESOLVED_RESOLUTIONS = {

--- a/osidb/models/flaw/cvss.py
+++ b/osidb/models/flaw/cvss.py
@@ -69,3 +69,16 @@ class FlawCVSS(CVSS):
                 raise ValidationError(
                     "RH CVSSv3 score must be zero if flaw impact is not set."
                 )
+
+    def sync_to_trackers(self, jira_token):
+        """Sync this CVSS in the related Jira trackers."""
+        from osidb.models.tracker import Tracker
+
+        for affect in self.flaw.affects.all():
+            if affect.is_community:
+                continue
+
+            for tracker in affect.trackers.all():
+                if not tracker.is_closed and tracker.type == Tracker.TrackerType.JIRA:
+                    # default save already sync with Jira when needed
+                    tracker.save(jira_token=jira_token)

--- a/osidb/tests/endpoints/test_affects.py
+++ b/osidb/tests/endpoints/test_affects.py
@@ -3,7 +3,8 @@ from unittest.mock import patch
 import pytest
 from rest_framework import status
 
-from osidb.models import Affect, AffectCVSS, Tracker
+from apps.trackers.save import TrackerJiraSaver
+from osidb.models import Affect, AffectCVSS, PsUpdateStream, Tracker
 from osidb.tests.factories import (
     AffectCVSSFactory,
     AffectFactory,
@@ -337,6 +338,76 @@ class TestEndpointsAffects:
         )
         assert response.status_code == status.HTTP_200_OK
         assert response.data["issuer"] == AffectCVSS.CVSSIssuer.REDHAT
+
+    @pytest.mark.enable_signals
+    def test_affectcvss_update_tracker(
+        self,
+        monkeypatch,
+        enable_jira_tracker_sync,
+        setup_sample_external_resources,
+        auth_client,
+        test_api_uri,
+    ):
+        """Test that changes in AffectCVSS API triggers a sync with Jira trackers related"""
+        save_performed = False
+
+        def mock_save(self):
+            nonlocal save_performed
+            save_performed = True
+            return self.tracker
+
+        monkeypatch.setattr(TrackerJiraSaver, "save", mock_save)
+
+        ps_update_stream = (
+            PsUpdateStream.objects.filter(active_to_ps_module__bts_name="jboss")
+            .order_by("name")
+            .first()
+        )
+        ps_module = ps_update_stream.active_to_ps_module
+        ps_component = setup_sample_external_resources["jboss_components"][0]
+
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.NEW,
+            ps_module=ps_module.name,
+            ps_component=ps_component,
+        )
+        TrackerFactory(
+            affects=[affect],
+            type=Tracker.TrackerType.JIRA,
+            ps_update_stream=ps_update_stream.name,
+        )
+        cvss = AffectCVSSFactory(
+            affect=affect,
+            issuer=AffectCVSS.CVSSIssuer.REDHAT,
+            comment="",
+            vector="CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            version=AffectCVSS.CVSSVersion.VERSION3,
+        )
+
+        response = auth_client().get(
+            f"{test_api_uri}/affects/{str(affect.uuid)}/cvss_scores/{cvss.uuid}"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["issuer"] == AffectCVSS.CVSSIssuer.REDHAT
+        assert response.data["score"] == 8.1
+
+        updated_data = response.json().copy()
+        updated_data["vector"] = "CVSS:3.1/AV:L/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H"
+
+        # Tests "PUT" on affects/{uuid}/cvss_scores/{uuid}
+        response = auth_client().put(
+            f"{test_api_uri}/affects/{str(affect.uuid)}/cvss_scores/{cvss.uuid}",
+            data=updated_data,
+            format="json",
+            HTTP_BUGZILLA_API_KEY="SECRET",
+            HTTP_JIRA_API_KEY="SECRET",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["issuer"] == AffectCVSS.CVSSIssuer.REDHAT
+        assert response.data["score"] == 7.8
+        assert save_performed
 
     @pytest.mark.enable_signals
     def test_affectcvss_delete(self, auth_client, test_api_uri):


### PR DESCRIPTION
This PR modifies the CVSS serializer for flaws and affects in order to trigger Jira trackers to be re-synced.

Closes OSIDB-4186.