### PR TITLE
[WIP] Affects v2 alternative approach 

### DIFF
--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -621,6 +621,24 @@ class AffectFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilte
     order = OrderingFilter(fields=order_fields)
 
 
+class AffectV2Filter(AffectFilter):
+    """
+    Extends the AffectFilter to include ps_update_stream which is necessary for affects v2.
+    """
+
+    class Meta(AffectFilter.Meta):
+        fields = AffectFilter.Meta.fields.copy()
+        fields["ps_update_stream"] = ["exact"]
+
+    order_fields = [
+        "cvss_scores__cvss_version",
+        "embargoed",
+        "flaw__embargoed",
+        "trackers__embargoed",
+    ] + list(Meta.fields.keys())
+    order = OrderingFilter(fields=order_fields)
+
+
 class TrackerFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilterSet):
 
     DISTINCT_FIELDS_PREFIXES = ("affects__",)

--- a/osidb/migrations/0192_affects_v2.py
+++ b/osidb/migrations/0192_affects_v2.py
@@ -1,0 +1,108 @@
+from django.conf import settings
+from django.db import migrations, models
+from osidb.core import set_user_acls
+import pgtrigger.compiler
+import pgtrigger.migrations
+
+
+BATCH_SIZE = 1000
+
+
+def initial_populate_ps_update_stream(apps, schema_editor):
+    # Populate ps_update_stream fields for current affects (which will be the v1 affects after the
+    # data migration) with its own UUID. This is a hack to avoid errors due to empty or duplicate
+    # ps_update_stream, this field is not used by v1 affects anyway.
+    set_user_acls(settings.ALL_GROUPS)
+    Affect = apps.get_model("osidb", "Affect")
+    update_batch = []
+    for affect in Affect.objects.all():
+        affect.ps_update_stream = str(affect.uuid)
+        update_batch.append(affect)
+        if len(update_batch) >= BATCH_SIZE:
+            Affect.objects.bulk_update(update_batch, ["ps_update_stream"])
+            update_batch.clear()
+    if update_batch:
+        Affect.objects.bulk_update(update_batch, ["ps_update_stream"])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('osidb', '0191_cisa_cvss_data_migration'),
+    ]
+
+    operations = [
+        pgtrigger.migrations.RemoveTrigger(
+            model_name='affect',
+            name='insert_insert',
+        ),
+        pgtrigger.migrations.RemoveTrigger(
+            model_name='affect',
+            name='update_update',
+        ),
+        pgtrigger.migrations.RemoveTrigger(
+            model_name='affect',
+            name='delete_delete',
+        ),
+        migrations.RemoveIndex(
+            model_name='affect',
+            name='osidb_affec_flaw_id_1a7b76_idx',
+        ),
+        migrations.AlterUniqueTogether(
+            name='affect',
+            unique_together=set(),
+        ),
+        migrations.AddField(
+            model_name='affect',
+            name='affect_v1',
+            field=models.ForeignKey(blank=True, null=True, on_delete=models.deletion.SET_NULL, related_name='affects_v2', to='osidb.affect'),
+        ),
+        migrations.AddField(
+            model_name='affect',
+            name='ps_update_stream',
+            field=models.CharField(default='', max_length=100),
+            preserve_default=False,
+        ),
+        migrations.AlterField(
+            model_name='affect',
+            name='ps_module',
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+        migrations.AlterField(
+            model_name='affectaudit',
+            name='ps_module',
+            field=models.CharField(blank=True, max_length=100, null=True),
+        ),
+        migrations.AddField(
+            model_name='affectaudit',
+            name='affect_v1',
+            field=models.ForeignKey(blank=True, db_constraint=False, null=True, on_delete=models.deletion.DO_NOTHING, related_name='+', related_query_name='+', to='osidb.affect'),
+        ),
+        migrations.AddField(
+            model_name='affectaudit',
+            name='ps_update_stream',
+            field=models.CharField(default='', max_length=100),
+            preserve_default=False,
+        ),
+        migrations.RunPython(initial_populate_ps_update_stream, migrations.RunPython.noop),
+        migrations.AddIndex(
+            model_name='affect',
+            index=models.Index(fields=['flaw', 'ps_update_stream'], name='osidb_affec_flaw_id_72f059_idx'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='affect',
+            unique_together={('flaw', 'ps_update_stream', 'ps_component')},
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name='affect',
+            trigger=pgtrigger.compiler.Trigger(name='insert_insert', sql=pgtrigger.compiler.UpsertTriggerSql(func='INSERT INTO "osidb_affectaudit" ("acl_read", "acl_write", "affect_v1_id", "affectedness", "created_dt", "flaw_id", "impact", "last_validated_dt", "not_affected_justification", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "ps_component", "ps_module", "ps_update_stream", "purl", "resolution", "resolved_dt", "updated_dt", "uuid") VALUES (NEW."acl_read", NEW."acl_write", NEW."affect_v1_id", NEW."affectedness", NEW."created_dt", NEW."flaw_id", NEW."impact", NEW."last_validated_dt", NEW."not_affected_justification", _pgh_attach_context(), NOW(), \'insert\', NEW."uuid", NEW."ps_component", NEW."ps_module", NEW."ps_update_stream", NEW."purl", NEW."resolution", NEW."resolved_dt", NEW."updated_dt", NEW."uuid"); RETURN NULL;', hash='25ccad7f89a855c4a83e78ecf7acf66c8b41134f', operation='INSERT', pgid='pgtrigger_insert_insert_0d1b1', table='osidb_affect', when='AFTER')),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name='affect',
+            trigger=pgtrigger.compiler.Trigger(name='update_update', sql=pgtrigger.compiler.UpsertTriggerSql(condition='WHEN (OLD."acl_read" IS DISTINCT FROM (NEW."acl_read") OR OLD."acl_write" IS DISTINCT FROM (NEW."acl_write") OR OLD."affect_v1_id" IS DISTINCT FROM (NEW."affect_v1_id") OR OLD."affectedness" IS DISTINCT FROM (NEW."affectedness") OR OLD."created_dt" IS DISTINCT FROM (NEW."created_dt") OR OLD."flaw_id" IS DISTINCT FROM (NEW."flaw_id") OR OLD."impact" IS DISTINCT FROM (NEW."impact") OR OLD."last_validated_dt" IS DISTINCT FROM (NEW."last_validated_dt") OR OLD."not_affected_justification" IS DISTINCT FROM (NEW."not_affected_justification") OR OLD."ps_component" IS DISTINCT FROM (NEW."ps_component") OR OLD."ps_module" IS DISTINCT FROM (NEW."ps_module") OR OLD."ps_update_stream" IS DISTINCT FROM (NEW."ps_update_stream") OR OLD."purl" IS DISTINCT FROM (NEW."purl") OR OLD."resolution" IS DISTINCT FROM (NEW."resolution") OR OLD."resolved_dt" IS DISTINCT FROM (NEW."resolved_dt") OR OLD."updated_dt" IS DISTINCT FROM (NEW."updated_dt") OR OLD."uuid" IS DISTINCT FROM (NEW."uuid"))', func='INSERT INTO "osidb_affectaudit" ("acl_read", "acl_write", "affect_v1_id", "affectedness", "created_dt", "flaw_id", "impact", "last_validated_dt", "not_affected_justification", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "ps_component", "ps_module", "ps_update_stream", "purl", "resolution", "resolved_dt", "updated_dt", "uuid") VALUES (NEW."acl_read", NEW."acl_write", NEW."affect_v1_id", NEW."affectedness", NEW."created_dt", NEW."flaw_id", NEW."impact", NEW."last_validated_dt", NEW."not_affected_justification", _pgh_attach_context(), NOW(), \'update\', NEW."uuid", NEW."ps_component", NEW."ps_module", NEW."ps_update_stream", NEW."purl", NEW."resolution", NEW."resolved_dt", NEW."updated_dt", NEW."uuid"); RETURN NULL;', hash='54c82f489964fa66d8704794e4bb97e7053cd8e7', operation='UPDATE', pgid='pgtrigger_update_update_fdef6', table='osidb_affect', when='AFTER')),
+        ),
+        pgtrigger.migrations.AddTrigger(
+            model_name='affect',
+            trigger=pgtrigger.compiler.Trigger(name='delete_delete', sql=pgtrigger.compiler.UpsertTriggerSql(func='INSERT INTO "osidb_affectaudit" ("acl_read", "acl_write", "affect_v1_id", "affectedness", "created_dt", "flaw_id", "impact", "last_validated_dt", "not_affected_justification", "pgh_context_id", "pgh_created_at", "pgh_label", "pgh_obj_id", "ps_component", "ps_module", "ps_update_stream", "purl", "resolution", "resolved_dt", "updated_dt", "uuid") VALUES (OLD."acl_read", OLD."acl_write", OLD."affect_v1_id", OLD."affectedness", OLD."created_dt", OLD."flaw_id", OLD."impact", OLD."last_validated_dt", OLD."not_affected_justification", _pgh_attach_context(), NOW(), \'delete\', OLD."uuid", OLD."ps_component", OLD."ps_module", OLD."ps_update_stream", OLD."purl", OLD."resolution", OLD."resolved_dt", OLD."updated_dt", OLD."uuid"); RETURN NULL;', hash='2aab5f842ee51cd16fb38be896c133ab246543eb', operation='DELETE', pgid='pgtrigger_delete_delete_cc8c5', table='osidb_affect', when='AFTER')),
+        ),
+    ]

--- a/osidb/migrations/0193_affects_v2_data_migration.py
+++ b/osidb/migrations/0193_affects_v2_data_migration.py
@@ -1,0 +1,139 @@
+from django.conf import settings
+from django.db import migrations
+from osidb.core import set_user_acls
+
+BATCH_SIZE = 1000
+
+
+def migrate_trackers(apps, schema_editor):
+    """
+    Iterate over the existing trackers, migrating them to a v2 affect with
+    its corresponding ps_update_stream if it exists.
+    """
+    Affect = apps.get_model("osidb", "Affect")
+    Tracker = apps.get_model("osidb", "Tracker")
+    
+    print("\nStarting tracker migration...")
+    for tracker in Tracker.objects.all().prefetch_related("affects"):
+        current_affects = list(tracker.affects.all())
+        for affect_v1 in current_affects:
+            affects_v2 = Affect.objects.filter(
+                affect_v1=affect_v1, ps_update_stream=tracker.ps_update_stream
+            )
+            if affects_v2.exists():
+                tracker.affects.add(*affects_v2)
+
+def forwards_func(apps, schema_editor):
+    """
+    Generate affects v2 from affects v1, by expanding the ps_modules into the available
+    ps_update_streams.
+    """
+    set_user_acls(settings.ALL_GROUPS)
+
+    Affect = apps.get_model("osidb", "Affect")
+    PsModule = apps.get_model("osidb", "PsModule")
+
+    v1_affects_processed = 0
+    v2_affects_created_total = 0
+    v2_affects_skipped_total = 0
+
+    create_batch = []
+
+    affects_v1 = Affect.objects.all()
+    for affect in affects_v1:
+        v1_affects_processed += 1
+
+        try:
+            ps_module = PsModule.objects.get(name=affect.ps_module)
+        except PsModule.DoesNotExist:
+            print(
+                f"[Warning] Affect {affect.uuid} has no existing PsModule '{affect.ps_module}'."
+            )
+            continue
+
+        ps_update_streams = ps_module.ps_update_streams.all()
+        trackers = affect.trackers.all()
+        if trackers.exists():
+            # If trackers exist, only create those for existing trackers, otherwise expand to all streams
+            ps_update_streams = ps_module.ps_update_streams.filter(
+                name__in=trackers.values_list("ps_update_stream", flat=True)
+            )
+
+        v2_skipped_iter = 0
+        for ps_update_stream in ps_update_streams:
+            # Check if it already exists
+            if Affect.objects.filter(
+                flaw=affect.flaw,
+                ps_update_stream=ps_update_stream.name,
+                ps_component=affect.ps_component,
+            ).exists():
+                v2_skipped_iter += 1
+                continue
+
+            try:
+                # Create a new affect v2 for each stream, linking back to the original v1 affect
+                affect_v2 = Affect(
+                    affect_v1=affect,
+                    flaw=affect.flaw,
+                    ps_update_stream=ps_update_stream.name,
+                    ps_module=ps_module.name,
+                    ps_component=affect.ps_component,
+                    affectedness=affect.affectedness,
+                    resolution=affect.resolution,
+                    purl=affect.purl,
+                    impact=affect.impact,
+                    not_affected_justification=affect.not_affected_justification,
+                    resolved_dt=affect.resolved_dt,
+                    meta_attr=affect.meta_attr or {},
+                    created_dt=affect.created_dt,
+                    updated_dt=affect.updated_dt,
+                    acl_read=affect.acl_read,
+                    acl_write=affect.acl_write,
+                )
+                create_batch.append(affect_v2)
+            except Exception as e:
+                print(
+                    f"[ERROR] creating AffectV2 for Affect {affect.uuid}, Stream {ps_update_stream.name}: {e}"
+                )
+                v2_skipped_iter += 1
+
+            if len(create_batch) >= BATCH_SIZE:
+                Affect.objects.bulk_create(create_batch)
+                v2_affects_created_total += len(create_batch)
+                v2_affects_skipped_total += v2_skipped_iter
+                create_batch.clear()
+                print(
+                    f"Processed {v1_affects_processed} affects. Total V2 created: {v2_affects_created_total}, Total skipped: {v2_affects_skipped_total}"
+                )
+
+    # Create/update any remaining affects in the batch
+    if create_batch:
+        Affect.objects.bulk_create(create_batch)
+        v2_affects_created_total += len(create_batch)
+        create_batch.clear()
+
+    print(f"Affects Processed: {v1_affects_processed}")
+    print(f"Total V2 Affects Created: {v2_affects_created_total}")
+    print(
+        f"Total V2 Affects Skipped (already existed or error): {v2_affects_skipped_total}"
+    )
+
+    migrate_trackers(apps, schema_editor)
+
+
+def backwards_func(apps, schema_editor):
+    # Get affects v2 that come from a v1 affect and delete all but the first one
+    Affect = apps.get_model("osidb", "Affect")
+    deleted_count, _ = Affect.objects.filter(affect_v1__isnull=False).delete()
+    print(f"Deleted {deleted_count} Affect V2 objects that were linked to a v1 affect.")
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("osidb", "0192_affects_v2"),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards_func, reverse_code=backwards_func),
+    ]

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -11,6 +11,7 @@ from osidb.helpers import get_execution_env
 
 from .api_views import (
     AffectCVSSView,
+    AffectV2View,
     AffectView,
     AlertView,
     AuditView,
@@ -23,11 +24,13 @@ from .api_views import (
     FlawPackageVersionView,
     FlawReferenceView,
     FlawSuggestionsView,
+    FlawV2View,
     FlawView,
     JiraStageForwarderView,
     LabelView,
     ManifestView,
     StatusView,
+    TrackerV2View,
     TrackerView,
     healthy,
     integration_tokens,
@@ -76,6 +79,11 @@ vnext_router = routers.DefaultRouter(trailing_slash=False)
 vnext_router.register(
     r"flaws/(?P<flaw_id>[^/.]+)/cvss-scores", FlawCVSSV2View, basename="flawcvssv2"
 )
+# Views adapted for affects v2
+vnext_router.register(r"flaws", FlawV2View)
+vnext_router.register(r"affects", AffectV2View, basename="affectsv2")
+vnext_router.register(r"trackers", TrackerV2View)
+
 
 urlpatterns = [
     path("healthy", healthy),


### PR DESCRIPTION
# Affects V2 - an alternative approach
## Justification
The initial plan for affects v2 involved creating a new affect model based on `ps_update_stream` rather than `ps_module`. During the transition, we would migrate v1 affects by expanding them into multiple v2 affects - one for each stream associated to the affect's module. To maintain backward compatibility, both V1 and V2 models would need to coexist and be synchronized, introducing significant complexity until V1 affects can be fully deleted. Furthermore, this approach requires updating all areas of the codebase that interact with affects to make them use the new model.

This PR aims to propose an alternative strategy that simplifies the database architecture and isolates compatibility concerns at the API level. We will modify the existing Affect model to serve both v1 and v2 affects. While this will introduce more complex logic into our views and serializers, I believe it is a more manageable solution than maintaining two separate, synchronized database models.

## Summary of changes
The original `Affect` model will serve both as v1 and v2 data. The distinction between the two versions is established through a new many-to-one relationship, managed by an `affect_v1` field:
- Affects v1 serve as a "parent" object, they will have this set to `None`, but will have the reverse relation `affects_v2` filled.
- Affects v2 represent the more granular affects based on streams. Each v2 affect will link to the "parent" v1 affect via this field.

Affects now also have the `ps_update_stream` field which should be filled with an appropriate stream for affects v2, and contain junk for v1 as it is not used there.

## Proof of concept
A proof of concept has been implemented to demonstrate the migration process and the separation of logic at the API layer.

Consider the following example. In a database before the changes in this PR, I have created this simple flaw with 3 affects, for modules `rhel-8`, `rhel-9` and `fedora-42`. We have 3 trackers for 3 different streams of `rhel-8`.
```
{
  "uuid": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
  "cve_id": "CVE-2026-123456",
  "trackers": [
    "RHEL-82942",
    "RHEL-82941",
    "RHEL-82940"
  ],
  "affects": [
    {
      "uuid": "108830d7-f6cd-4595-b206-5622147ad420",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": []
    },
    {
      "uuid": "bd3429ce-4f1a-453e-baca-7fbc4fac8744",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "AFFECTED",
      "resolution": "DELEGATED",
      "ps_module": "rhel-8",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "pam",
      "impact": "",
      "trackers": [
        {
          "affects": [
            "bd3429ce-4f1a-453e-baca-7fbc4fac8744"
          ],
          "external_system_id": "RHEL-82940",
          "ps_update_stream": "rhel-8.6.0.z",
          "status": "New",
          "resolution": "",
          "type": "JIRA",
          "uuid": "9d59f4f2-920b-4924-beff-aca993d1b12d"
        },
        {
          "affects": [
            "bd3429ce-4f1a-453e-baca-7fbc4fac8744"
          ],
          "external_system_id": "RHEL-82941",
          "ps_update_stream": "rhel-8.10.z",
          "status": "New",
          "resolution": "",
          "type": "JIRA",
          "uuid": "477ac895-971b-4ce5-b45f-da4ea11413d3"
        },
        {
          "affects": [
            "bd3429ce-4f1a-453e-baca-7fbc4fac8744"
          ],
          "external_system_id": "RHEL-82942",
          "ps_update_stream": "rhel-8.4.0.z",
          "status": "New",
          "resolution": "",
          "type": "JIRA",
          "uuid": "ef275e4e-987c-4fea-ad88-982c6fb792f6"
        }
      ]
    },
    {
      "uuid": "80431d90-be5f-4e60-a7fe-0a3d3be65661",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "AFFECTED",
      "resolution": "DELEGATED",
      "ps_module": "fedora-42",
      "ps_product": "Community Projects",
      "ps_component": "atuin",
      "impact": "",
      "trackers": []
    }
  ]
}
```

If we now migrate to affects v2 and make the same query (for `v1` of the API), we get the same result. However, if we fetch the `v2beta` version of the API, we get

```
{
  "uuid": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
  "cve_id": "CVE-2026-123456",
  "trackers": [
    "RHEL-82941",
    "RHEL-82942",
    "RHEL-82940"
  ],
  "affects": [
    {
      "uuid": "054876d3-b6a4-4095-a8f3-4b75710a2c18",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.6.z"
    },
    {
      "uuid": "176228ed-cf05-4c3a-8bc1-38419ef41303",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9"
    },
    {
      "uuid": "289853e0-576f-4252-9894-a1e0ebb353aa",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.4.z"
    },
    {
      "uuid": "4499d5bf-f3bd-49d9-b9ce-c3470cd79e3b",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.3.0"
    },
    {
      "uuid": "6fbeeb9a-cea1-486a-ad5a-47469972f363",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.5"
    },
    {
      "uuid": "a1b876b6-1540-4da0-a921-e5884c4202a6",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.1.0.z"
    },
    {
      "uuid": "abcab09a-78f0-4840-91fb-97e0fae2ff55",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.2.0.z"
    },
    {
      "uuid": "aee1b1d7-64cb-431e-b85b-d33552420411",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.1.0"
    },
    {
      "uuid": "b2d962c9-363c-4fb9-a4d8-4f2752ddc9ff",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.2.0"
    },
    {
      "uuid": "b75c83e6-e1c6-4b0a-aac9-017aa76fae97",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.7"
    },
    {
      "uuid": "d0ec1d24-fb62-4899-af2c-931fc1f836b3",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.6"
    },
    {
      "uuid": "d23b6908-b87f-4384-b0ef-76895d219ccd",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.3.0.z"
    },
    {
      "uuid": "d6309d98-078b-42d8-a2c7-9e08424bb381",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.0.0.z"
    },
    {
      "uuid": "e580225b-e7ea-4c60-8905-281812e6a653",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.0"
    },
    {
      "uuid": "e739cb49-7c2b-44cc-ace3-0f61e52f383c",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.5.z"
    },
    {
      "uuid": "ee153561-6927-4a52-8bdd-8a6137b6c975",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "NEW",
      "resolution": "",
      "ps_module": "rhel-9",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "kernel",
      "impact": "CRITICAL",
      "trackers": [],
      "ps_update_stream": "rhel-9.4.0"
    },
    {
      "uuid": "1b680aa2-3e91-408e-8165-8d7b918bbd52",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "AFFECTED",
      "resolution": "DELEGATED",
      "ps_module": "rhel-8",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "pam",
      "impact": "",
      "trackers": [
        {
          "affects": [
            "bd3429ce-4f1a-453e-baca-7fbc4fac8744"
          ],
          "errata": [],
          "external_system_id": "RHEL-82942",
          "ps_update_stream": "rhel-8.4.0.z",
          "status": "New",
          "resolution": "",
          "not_affected_justification": "",
          "type": "JIRA",
          "uuid": "ef275e4e-987c-4fea-ad88-982c6fb792f6",
          "special_handling": [],
          "resolved_dt": null,
          "embargoed": false,
          "alerts": [],
          "created_dt": "2025-06-18T08:25:50.328000Z",
          "updated_dt": "2025-06-18T08:25:51.378000Z"
        }
      ],
      "ps_update_stream": "rhel-8.4.0.z"
    },
    {
      "uuid": "5ae28306-1dfb-431e-83fb-bb5d00fc1153",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "AFFECTED",
      "resolution": "DELEGATED",
      "ps_module": "rhel-8",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "pam",
      "impact": "",
      "trackers": [
        {
          "affects": [
            "bd3429ce-4f1a-453e-baca-7fbc4fac8744"
          ],
          "errata": [],
          "external_system_id": "RHEL-82940",
          "ps_update_stream": "rhel-8.6.0.z",
          "status": "New",
          "resolution": "",
          "not_affected_justification": "",
          "type": "JIRA",
          "uuid": "9d59f4f2-920b-4924-beff-aca993d1b12d",
          "special_handling": [],
          "resolved_dt": null,
          "embargoed": false,
          "alerts": [],
          "created_dt": "2025-06-18T08:25:39.291000Z",
          "updated_dt": "2025-06-18T08:25:40.525000Z"
        }
      ],
      "ps_update_stream": "rhel-8.6.0.z"
    },
    {
      "uuid": "b66e11c9-e1ac-415c-ab72-5bc37261ab24",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "AFFECTED",
      "resolution": "DELEGATED",
      "ps_module": "rhel-8",
      "ps_product": "Red Hat Enterprise Linux",
      "ps_component": "pam",
      "impact": "",
      "trackers": [
        {
          "affects": [
            "bd3429ce-4f1a-453e-baca-7fbc4fac8744"
          ],
          "errata": [],
          "external_system_id": "RHEL-82941",
          "ps_update_stream": "rhel-8.10.z",
          "status": "New",
          "resolution": "",
          "not_affected_justification": "",
          "type": "JIRA",
          "uuid": "477ac895-971b-4ce5-b45f-da4ea11413d3",
          "special_handling": [],
          "resolved_dt": null,
          "embargoed": false,
          "alerts": [],
          "created_dt": "2025-06-18T08:25:44.518000Z",
          "updated_dt": "2025-06-18T08:25:47.352000Z"
        }
      ],
      "ps_update_stream": "rhel-8.10.z"
    },
    {
      "uuid": "2e99a1dc-72b0-46e3-aa21-9be4524f51bd",
      "flaw": "0dbd37ec-dec2-41b4-8cf0-8f9fa9dff214",
      "affectedness": "AFFECTED",
      "resolution": "DELEGATED",
      "ps_module": "fedora-42",
      "ps_product": "Community Projects",
      "ps_component": "atuin",
      "impact": "",
      "trackers": [],
      "ps_update_stream": "fedora-42"
    }
  ]
}
```

Note how the affects are now different, they contain the `ps_update_stream` field, and the trackers are related to the affect with the corresponding `ps_update_stream`, so we have one tracker per affect while in `v1` we had 3 trackers in a single affect.

If we take a look at the same thing from a shell:
```py
In [3]: affect_v2 = Affect.objects.get(uuid="b66e11c9-e1ac-415c-ab72-5bc37261ab24")

# Affect v2 has one tracker with the same stream
In [4]: affect_v2.trackers.all()
Out[4]: <QuerySet [<Tracker: 477ac895-971b-4ce5-b45f-da4ea11413d3>]>

# Affect v1 has all three trackers
In [5]: affect_v2.affect_v1.trackers.all()
Out[5]: <QuerySet [<Tracker: 9d59f4f2-920b-4924-beff-aca993d1b12d>, <Tracker: 477ac895-971b-4ce5-b45f-da4ea11413d3>, <Tracker: ef275e4e-987c-4fea-ad88-982c6fb792f6>]>

```

This demonstrates how we can transition from v1 to v2 without significant changes to the database, and preserving compatibility for v1 consumers. Note that there is still a lot of work to be done here, including affect and tracker creation/update/deletion for each version, making sure all the business logic keeps working for both versions, adapting tests, etc, but this example showcases the main idea.
