### PR TITLE
Change validation handling of zero CVSS score / flaw impact to alerts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CVE.org and CISA CVSS correctly recalculate and persist the numeric
   score on update (OSIDB-4326)
 - Properly handle scheduled tasks collision in Jira Downloader (OSIDB-3846)
+- Swap from exceptions to alerts to resolve RH CVSS and flaw impact deadlock (OSIDB-4332)
 
 ## [4.12.0] - 2025-06-18
 ### Added

--- a/osidb/models/flaw/cvss.py
+++ b/osidb/models/flaw/cvss.py
@@ -1,8 +1,6 @@
-from decimal import Decimal
-
 import pghistory
 from django.contrib.postgres.indexes import GinIndex
-from django.core.exceptions import ObjectDoesNotExist, ValidationError
+from django.core.exceptions import ObjectDoesNotExist
 from django.db import models
 
 from osidb.mixins import ACLMixinManager, TrackingMixin, TrackingMixinManager
@@ -50,25 +48,6 @@ class FlawCVSS(CVSS):
         indexes = TrackingMixin.Meta.indexes + [
             GinIndex(fields=["acl_read"]),
         ]
-
-    def _validate_rh_cvss3_and_impact(self, **kwargs):
-        """
-        Validate that flaw's RH CVSSv3 score and impact comply with the following:
-        * RH CVSSv3 score is not zero and flaw impact is set
-        * RH CVSSv3 score is zero and flaw impact is not set
-        """
-        if (
-            self.issuer == self.CVSSIssuer.REDHAT
-            and self.version == self.CVSSVersion.VERSION3
-        ):
-            if self.flaw.impact and self.cvss_object.base_score == Decimal("0.0"):
-                raise ValidationError(
-                    "RH CVSSv3 score must not be zero if flaw impact is set."
-                )
-            if not self.flaw.impact and self.cvss_object.base_score != Decimal("0.0"):
-                raise ValidationError(
-                    "RH CVSSv3 score must be zero if flaw impact is not set."
-                )
 
     def sync_to_trackers(self, jira_token):
         """Sync this CVSS in the related Jira trackers."""

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -470,12 +470,16 @@ class Flaw(
 
         if rh_cvss3:
             if rh_cvss3.cvss_object.base_score == Decimal("0.0") and self.impact:
-                raise ValidationError(
-                    "Flaw impact must not be set if RH CVSSv3 score is zero."
+                self.alert(
+                    "set_impact_with_zero_CVSSv3_score",
+                    "Flaw impact must not be set if RH CVSSv3 score is zero.",
+                    **kwargs,
                 )
             if rh_cvss3.cvss_object.base_score != Decimal("0.0") and not self.impact:
-                raise ValidationError(
-                    "Flaw impact must be set if RH CVSSv3 score is not zero."
+                self.alert(
+                    "unset_impact_with_nonzero_CVSSv3_score",
+                    "Flaw impact must be set if RH CVSSv3 score is not zero.",
+                    **kwargs,
                 )
 
     def _validate_cve_description_and_requires_cve_description(self, **kwargs):


### PR DESCRIPTION
Removes the deadlock when writing zero/empty values in either the RH CVSS score or the impact. New behavior now produces alerts rather than exceptions.

Closes OSIDB-4332