### PR TITLE
OSIDB-3704: Supply PURL for middleware engineering trackers if available

### DIFF
--- a/apps/trackers/jira/constants.py
+++ b/apps/trackers/jira/constants.py
@@ -1,6 +1,8 @@
 """
 Jira specific tracker constants
 """
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
 from osidb.helpers import get_env
 
 JIRA_SERVER = get_env("JIRA_URL", default="https://issues.redhat.com")
@@ -19,3 +21,11 @@ PS_ADDITIONAL_FIELD_TO_JIRA = {
     "target_release": "customfield_12311240",
     "target_version": "customfield_12319940",
 }
+
+
+class TrackersAppSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="OSIDB_TRACKERS_")
+
+    # whether PURLs should be used for the downstream component field when
+    # creating JIRA engineering trackers
+    prefer_purls: bool = True

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CVE.org and CISA CVSS correctly recalculate and persist the numeric
   score on update (OSIDB-4326)
 
+### Changed
+- Provide PURLs for Middleware engineering trackers when available (OSIDB-3704)
+
 ## [4.12.0] - 2025-06-18
 ### Added
 - Workaround for parsing modular components from PURLs (OSIDB-4292)

--- a/osidb/models/ps_product.py
+++ b/osidb/models/ps_product.py
@@ -21,8 +21,12 @@ class PsProduct(models.Model):
     business_unit = models.CharField(max_length=50)
 
     @property
-    def is_community(self):
+    def is_community(self) -> bool:
         """
         is community boolean property
         """
         return self.business_unit == "Community"
+
+    @property
+    def is_middleware(self) -> bool:
+        return self.business_unit == "Core Middleware"


### PR DESCRIPTION
For engineering trackers targeting middleware PsModules we want to populate the JIRA "Downstream component" field with PURLs if available and ps_component otherwise, for middleware the ps_component usually doesn't tell engineering teams much and they desperately need PURLs in order to more efficiently do their job.

Since their dependence on ps_component low, we can safely assume this change won't bring many downsides to them.

Other categories of PsModules may implement the change further down the line.

Closes OSIDB-3704