### PR TITLE
[OSIDB-3835] Add link to Vuln Mgmt documentation in tracker description

### DIFF
--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -7,7 +7,11 @@ from urllib.parse import urljoin
 
 from apps.bbsync.constants import MAX_SUMMARY_LENGTH, MULTIPLE_DESCRIPTIONS_SUBSTITUTION
 from apps.bbsync.query import summary_shorten
-from apps.trackers.constants import KERNEL_PACKAGES, VIRTUALIZATION_PACKAGES
+from apps.trackers.constants import (
+    KERNEL_PACKAGES,
+    VIRTUALIZATION_PACKAGES,
+    VULN_MGMT_INFO_URL,
+)
 from apps.trackers.jira.constants import TRACKER_FEEDBACK_FORM_URL
 from collectors.bzimport.constants import BZ_URL
 from osidb.helpers import cve_id_comparator
@@ -199,11 +203,14 @@ class TrackerQueryBuilder:
         if self.ps_component in KERNEL_PACKAGES:
             description_parts.extend(TrackerQueryBuilder._description_kernel())
 
-        # 5) Tracker feedback form for Jira
+        # 5) Link to vulnerability management information
+        description_parts.extend(self._description_vuln_mgmt_info())
+
+        # 6) Tracker feedback form for Jira
         if self.tracker.type == Tracker.TrackerType.JIRA:
             description_parts.extend(self._description_feedback_form())
 
-        # 6) join the parts by empty lines
+        # 7) join the parts by empty lines
         return "\n\n".join(description_parts)
 
     def _description_bugzilla_footer(self):
@@ -366,3 +373,15 @@ class TrackerQueryBuilder:
         if TRACKER_FEEDBACK_FORM_URL is None:
             return []
         return [f"Tracker accuracy feedback form: {TRACKER_FEEDBACK_FORM_URL}"]
+
+    def _description_vuln_mgmt_info(self):
+        """
+        generate vulnerability management link and text
+        """
+        if VULN_MGMT_INFO_URL is None:
+            return []
+        return [
+            "The following link provides references to all essential vulnerability management information. "
+            "If something is wrong or missing, please contact a member of PSIRT.\n"
+            f"{VULN_MGMT_INFO_URL}"
+        ]

--- a/apps/trackers/constants.py
+++ b/apps/trackers/constants.py
@@ -12,3 +12,6 @@ SYNC_TO_JIRA = get_env("TRACKERS_SYNC_TO_JIRA", default="False", is_bool=True)
 # tracker description constants
 KERNEL_PACKAGES = {"kernel", "realtime-kernel", "kernel-rt", "kernel-alt"}
 VIRTUALIZATION_PACKAGES = {"xen", "kvm", "kernel-xen"}
+
+# link to essential Vuln Mgmt documentation
+VULN_MGMT_INFO_URL = get_env("VULN_MGMT_INFO_URL", default=None)

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -691,6 +691,40 @@ class TestTrackerQueryBuilderDescription:
             else:
                 assert "feedback form" not in tqb.description
 
+    @pytest.mark.parametrize("info_url", [None, "https://example.doc.com"])
+    def test_vuln_mgmt_link(self, info_url):
+        """
+        test that the link to vunerability management documentation is included in the description
+        if the env variable is set
+        """
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+        flaw = FlawFactory()
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_module=ps_module.name,
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=affect.flaw.embargoed,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.JIRA,
+        )
+
+        with patch("apps.trackers.common.VULN_MGMT_INFO_URL", info_url):
+            tqb = TrackerQueryBuilder()
+            tqb.instance = tracker
+
+            if info_url is not None:
+                assert info_url in tqb.description
+            else:
+                assert (
+                    "essential vulnerability management information"
+                    not in tqb.description
+                )
+
     def test_triage(self):
         """
         test triage tracker description generation

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Trigger Jira tracker sync when Red Hat's CVSS change (OSIDB-4186)
 - Extend `Special Handling` tracker values (OSIDB-4337)
+- Add vuln mgmt documentation link to tracker description (OSIDB-3835)
 
 ### Fixed
 - CVE.org and CISA CVSS correctly recalculate and persist the numeric


### PR DESCRIPTION
Uses the same logic as the code for OSIDB-4095. A link to Vulnerability Management documentation will be attached to trackers during creation if the environment variable, `VULN_MGMT_INFO_URL`, is defined.

Closes OSIDB-3835.