### PR TITLE
OSIDB-4293: Add flaw `cve_id` to affect endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -442,7 +442,7 @@
         "filename": "osidb/tests/endpoints/test_trackers.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 47,
+        "line_number": 48,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-06-18T19:08:07Z"
+  "generated_at": "2025-07-10T13:01:45Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filter affects based on flaw workflow state (OSIDB-3893)
 - Filter affects based on absence/presence of related trackers (OSIDB-3893)
 - Allow excluding streams with existing trackers from tracker file offer (OSIDB-3893)
+- Add `cve_id` to affect and trackers endpoints (OSIDB-4293)
 
 ### Fixed
 - CVE.org and CISA CVSS correctly recalculate and persist the numeric

--- a/openapi.yml
+++ b/openapi.yml
@@ -760,6 +760,10 @@ paths:
           type: string
           format: date-time
       - in: query
+        name: cve_id
+        schema:
+          type: string
+      - in: query
         name: cvss_scores__comment
         schema:
           type: string
@@ -1217,6 +1221,7 @@ paths:
             enum:
             - -affectedness
             - -created_dt
+            - -cve_id
             - -cvss_scores__comment
             - -cvss_scores__created_dt
             - -cvss_scores__cvss_version
@@ -1254,6 +1259,7 @@ paths:
             - -uuid
             - affectedness
             - created_dt
+            - cve_id
             - cvss_scores__comment
             - cvss_scores__created_dt
             - cvss_scores__cvss_version
@@ -6677,6 +6683,10 @@ paths:
           type: string
           format: date-time
       - in: query
+        name: cve_id
+        schema:
+          type: string
+      - in: query
         name: embargoed
         schema:
           type: boolean
@@ -6754,6 +6764,7 @@ paths:
             - -affects__updated_dt
             - -affects__uuid
             - -created_dt
+            - -cve_id
             - -embargoed
             - -external_system_id
             - -ps_update_stream
@@ -6783,6 +6794,7 @@ paths:
             - affects__updated_dt
             - affects__uuid
             - created_dt
+            - cve_id
             - embargoed
             - external_system_id
             - ps_update_stream
@@ -8132,6 +8144,9 @@ components:
         ps_module:
           type: string
           maxLength: 100
+        cve_id:
+          type: string
+          readOnly: true
         ps_product:
           type: string
           readOnly: true
@@ -8193,6 +8208,7 @@ components:
       required:
       - alerts
       - created_dt
+      - cve_id
       - cvss_scores
       - delegated_not_affected_justification
       - delegated_resolution
@@ -10848,6 +10864,9 @@ components:
           items:
             type: string
             format: uuid
+        cve_id:
+          type: string
+          readOnly: true
         errata:
           type: array
           items:
@@ -10910,6 +10929,7 @@ components:
       required:
       - alerts
       - created_dt
+      - cve_id
       - embargoed
       - errata
       - external_system_id
@@ -10930,6 +10950,9 @@ components:
           items:
             type: string
             format: uuid
+        cve_id:
+          type: string
+          readOnly: true
         errata:
           type: array
           items:
@@ -10989,6 +11012,7 @@ components:
       required:
       - alerts
       - created_dt
+      - cve_id
       - embargoed
       - errata
       - not_affected_justification

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -575,6 +575,7 @@ class AffectFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilte
             + LT_GT_LOOKUP_EXPRS
             + LTE_GTE_LOOKUP_EXPRS
             + DATE_LOOKUP_EXPRS,
+            "cve_id": ["exact"],
             "updated_dt": ["exact"]
             + LT_GT_LOOKUP_EXPRS
             + LTE_GTE_LOOKUP_EXPRS
@@ -663,6 +664,7 @@ class TrackerFilter(DistinctFilterSet, IncludeFieldsFilterSet, ExcludeFieldsFilt
             + LT_GT_LOOKUP_EXPRS
             + LTE_GTE_LOOKUP_EXPRS
             + DATE_LOOKUP_EXPRS,
+            "cve_id": ["exact"],
             "updated_dt": ["exact"]
             + LT_GT_LOOKUP_EXPRS
             + LTE_GTE_LOOKUP_EXPRS

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -676,6 +676,7 @@ class TrackerSerializer(
     )
     errata = serializers.SerializerMethodField()
     meta_attr = serializers.SerializerMethodField()
+    cve_id = serializers.CharField(allow_blank=True, read_only=True)
 
     @extend_schema_field(ErratumSerializer(many=True))
     def get_errata(self, obj):
@@ -706,6 +707,7 @@ class TrackerSerializer(
         fields = (
             [
                 "affects",
+                "cve_id",
                 "errata",
                 "external_system_id",
                 "meta_attr",
@@ -1123,6 +1125,7 @@ class AffectSerializer(
     META_ATTR_KEYS = (
         "affectedness",
         "component",
+        "cve_id",
         "impact",
         "module_name",
         "module_stream",
@@ -1141,6 +1144,7 @@ class AffectSerializer(
     )
     purl = serializers.CharField(allow_blank=True, allow_null=True, required=False)
     resolved_dt = serializers.DateTimeField(read_only=True, allow_null=True)
+    cve_id = serializers.CharField(allow_blank=True, read_only=True)
 
     @extend_schema_field(
         {
@@ -1176,6 +1180,7 @@ class AffectSerializer(
                 "affectedness",
                 "resolution",
                 "ps_module",
+                "cve_id",
                 "ps_product",
                 "ps_component",
                 "impact",


### PR DESCRIPTION
Added `cve_id` field to the affect serializer, this allows OSIM to fetch related flaws from the `/affects` endpoint, improving performance, it was also recently asked by VM team.

Queryset regression grew by 1 as the `flaw` was added to the `prefetch_required` in the view, without this each affect would have added an extra query for the flaw

Closes OSIDB-4293