### PR TITLE
[OSIDB-4328]  Add available-flaws endpoint

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -372,7 +372,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_flaws.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 1344,
+        "line_number": 1345,
         "is_secret": false
       }
     ],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Filter affects based on absence/presence of related trackers (OSIDB-3893)
 - Allow excluding streams with existing trackers from tracker file offer (OSIDB-3893)
 - Add `cve_id` to affect and trackers endpoints (OSIDB-4293)
+- Add endpoint that checks if flaw is public or has its work completed (OSIDB-4328)
 
 ### Fixed
 - CVE.org and CISA CVSS correctly recalculate and persist the numeric

--- a/openapi.yml
+++ b/openapi.yml
@@ -2520,6 +2520,88 @@ paths:
                     version:
                       type: string
           description: ''
+  /osidb/api/v1/available-flaws/{cve_id}:
+    get:
+      operationId: osidb_api_v1_available_flaws_retrieve
+      description: |-
+        Report whether a flaw is available for public consumption purposes
+        based on the following criteria:
+        1) The work on the flaw is done, or the flaw is public:
+            - 204 status (yes, flaw is available for public consumption)
+        2) The work on the flaw is not done yet, or the flaw doesn't exist in the DB:
+            - 404 status (no, flaw is unavailable for public consumption)
+        3) Invalid CVE ID:
+            - 400 status
+
+        The intention is that this API is consumed by an agent that publishes pages
+        with information about individual CVEs. As long as this API returns 404,
+        the agent waits and doesn't publish the CVE page. Once this API first returns 204,
+        the agent stops polling this API and publishes the CVE page. The consumers of such
+        CVE pages are then informed about the CVE in such a way that the general affectedness
+        ("Does the CVE affect products shipped by the organization that publishes the CVE
+        page, or not?") most likely doesn't change. So this is to prevent public confusion
+        during the early stages of security analysis where the preliminary analysis might
+        switch between "this CVE affects our products" and "this CVE doesn't affect our products".
+      parameters:
+      - in: path
+        name: cve_id
+        schema:
+          type: string
+        required: true
+      tags:
+      - osidb
+      security:
+      - OsidbTokenAuthentication: []
+      - {}
+      responses:
+        '204':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+          description: ''
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+          description: ''
+        '404':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+          description: ''
   /osidb/api/v1/flaws:
     get:
       operationId: osidb_api_v1_flaws_list

--- a/osidb/urls.py
+++ b/osidb/urls.py
@@ -30,6 +30,7 @@ from .api_views import (
     ManifestView,
     StatusView,
     TrackerView,
+    flaw_available,
     healthy,
     integration_tokens,
     whoami,
@@ -87,6 +88,11 @@ urlpatterns = [
     path("healthy", healthy),
     path("whoami", whoami),
     path("integrations", integration_tokens),
+    re_path(
+        rf"^api/{OSIDB_API_VERSION}/available-flaws/(?P<cve_id>[^/.]+)",
+        flaw_available,
+        name="flawavailable",
+    ),
     re_path(
         rf"^api/{OSIDB_API_VERSION}/flaws/(?P<flaw_id>[^/.]+)/promote$",
         promote.as_view(),


### PR DESCRIPTION
The endpoint takes in a CVE ID (.../osidb/api/v1/available/flaw-id) and returns a response based on the following criteria:
1) Public / work on flaw is done 
     => 204 No Content
2) Not public and work not done / flaw does not exist
     => 404 Not Found 

Closes OSIDB-4328.