### PR TITLE
Remove CVE severity usage for tracker filing

### DIFF
--- a/apps/trackers/tests/conftest.py
+++ b/apps/trackers/tests/conftest.py
@@ -73,8 +73,8 @@ def clean_policies():
     SLAPolicy.objects.all().delete()
 
 
-def jira_vulnissuetype_fields_setup_without_severity_versions():
-    # CVE Severity field and Affects Versions field not set up here so that tests can customize it
+def jira_vulnissuetype_fields_setup_without_versions():
+    # Affects Versions field not set up here so that tests can customize it
     JiraProjectFields(
         project_key="FOOPROJECT",
         field_id="customfield_12324746",
@@ -137,10 +137,25 @@ def jira_vulnissuetype_fields_setup_without_severity_versions():
         ],
     ).save()
 
+    JiraProjectFields(
+        project_key="FOOPROJECT",
+        field_id="customfield_12316142",
+        field_name="Severity",
+        allowed_values=[
+            "Critical",
+            "Important",
+            "Moderate",
+            "Low",
+            "unexpected mess here",
+            "Informational",
+            "None",
+        ],
+    ).save()
+
 
 @pytest.fixture()
 def setup_vulnerability_issue_type_fields() -> None:
-    jira_vulnissuetype_fields_setup_without_severity_versions()
+    jira_vulnissuetype_fields_setup_without_versions()
 
 
 @pytest.fixture

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -792,17 +792,6 @@ class TestTrackerQueryBuilderSLA:
             type=Tracker.TrackerType.JIRA,
         )
 
-        JiraProjectFields(
-            project_key="FOOPROJECT",
-            field_id="customfield_123",
-            field_name="CVE Severity",
-            allowed_values=[
-                "Critical",
-                "Important",
-                "Moderate",
-                "Low",
-            ],
-        ).save()
         target_start_id = "customfield_12313941"
         JiraProjectFields(
             project_key=ps_module2.bts_key,

--- a/conftest.py
+++ b/conftest.py
@@ -605,19 +605,6 @@ def setup_sample_external_resources():
             "KEV (active exploit case)",
         ],
     ).save()
-    JiraProjectFields(
-        project_key=ps_module.bts_key,
-        field_id="customfield_12324940",
-        field_name="CVE Severity",
-        allowed_values=[
-            "Critical",
-            "Important",
-            "Moderate",
-            "Low",
-            "An Irrelevant Value To Be Ignored",
-            "None",
-        ],
-    ).save()
     JiraBugIssuetype(project=ps_module.bts_key).save()
 
     # 4) list some valid components accepeted for the

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Deprecate `team` field from PsProduct (OSIDB-4319)
 
+### Removed
+- Remove CVE Severity usage for tracker filing (OSIDB-3840)
+
 ## [4.13.0] - 2025-07-14
 ### Added
 - Trigger Jira tracker sync when Red Hat's CVSS change (OSIDB-4186)


### PR DESCRIPTION
This PR:
* removes the usage of CVE severity for the purpose of tracker filing and standardize the filing logic on using the Severity instead

Closes OSIDB-3840