### PR TITLE
Fix regex used to match new modular component name convention

### DIFF
--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -570,7 +570,7 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         Check if the component matches the pattern module:stream/package
         and extracts the package part, otherwise returns None.
         """
-        match = re.match(r"^[\w-]+:[\w-]+\/([\w-]+)$", self.ps_component)
+        match = re.match(r"^[\w-]+:[^/]+\/([\w-]+)$", self.ps_component)
         if match:
             return match.group(1)
         return None

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -836,6 +836,7 @@ class TestBothNewOldTrackerJiraQueryBuilder:
             ("fooproj", True, "barfoo", None, "foobar", False),
             ("fooproj", True, "imaginary", None, "imaginary", True),
             ("fooproj", True, "mod:compo/nent", None, "nent", False),
+            ("fooproj", True, "mod:10.4/component", None, "component", False),
             ("fooproj", True, "compo/nent", None, "compo/nent", False),
             ("fooproj", True, "comp/onent", None, "comp/onent", True),
             ("fooproj", False, "comp/onent", None, "comp/onent", False),

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Deprecate `team` field from PsProduct (OSIDB-4319)
 
+### Fixed
+- Fix regex used to match new modular component name convention (OSIDB-4369)
+
 ### Removed
 - Remove CVE Severity usage for tracker filing (OSIDB-3840)
 


### PR DESCRIPTION
This PR changes the regex in order to also match numeric-only streams used in the new modular naming convention for RHEL.

Closes OSIDB-4369.