### PR TITLE
OSIDB-4367: Relax PURL and ps_component mismatch validation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Emit a warning instead of an error when the PURL-derived PsComponent doesn't
+  match a user-provided PsComponent (OSIDB-4367)
 
 ## [4.14.0] - 2025-07-23
 ### Added


### PR DESCRIPTION
In the context of backfilling PURLs into OSIDB, it may happen that ps_components extrapolated from PURLs may not match the originally provided ps_component.

This could be due to an error in the assigned ps_component or in the PURL parsing, however this should not be a blocker for such an automatic or pseudo-automatic operation.

This relaxation also allows users to override the ps_component when the PURL parsing does not work properly.

Closes OSIDB-4367