### PR TITLE
Fix logic for available-flaws to match the original spec

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Emit a warning instead of an error when the PURL-derived PsComponent doesn't
   match a user-provided PsComponent (OSIDB-4367)
 
+### Fixed
+- Fix the available-flaws API giving a 404 on non-existent flaws instead of 204 (OSIDB-4397).
+
 ## [4.14.0] - 2025-07-23
 ### Added
 - Add endpoint that checks if flaw is public or has its work completed (OSIDB-4328)

--- a/openapi.yml
+++ b/openapi.yml
@@ -2526,9 +2526,9 @@ paths:
       description: |-
         Report whether a flaw is available for public consumption purposes
         based on the following criteria:
-        1) The work on the flaw is done, or the flaw is public:
+        1) The work on the flaw is done, or the flaw is public, or the flaw doesn't exist in the DB:
             - 204 status (yes, flaw is available for public consumption)
-        2) The work on the flaw is not done yet, or the flaw doesn't exist in the DB:
+        2) The work on the flaw is not done yet:
             - 404 status (no, flaw is unavailable for public consumption)
         3) Invalid CVE ID:
             - 400 status
@@ -2542,6 +2542,18 @@ paths:
         page, or not?") most likely doesn't change. So this is to prevent public confusion
         during the early stages of security analysis where the preliminary analysis might
         switch between "this CVE affects our products" and "this CVE doesn't affect our products".
+
+        Also an important point is that the client processes CVEs that never get saved to OSIDB's
+        DB (because of internal function `should_create_snippet`), yet the client must
+        publish information about all CVEs. By returning 204 when the flaw doesn't exist in OSIDB's
+        DB, it allows the client to take the output of this API endpoint as actionable advice:
+        When 204, publish the CVE page (either using OSIDB data or using other data), when
+        404, do not publish the CVE page (because the Vulnerability Management team still works
+        on the CVE).
+
+        That also means the client that uses this API endpoint must implement a grace period
+        to allow OSIDB to ingest the CVE and decide whether to save it to the DB, to prevent
+        the client publishing a CVE sooner than OSIDB processes it and potentially returns 404 for it.
       parameters:
       - in: path
         name: cve_id

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -830,9 +830,9 @@ def flaw_available(request: Request, *args, **kwargs) -> Response:
     """
     Report whether a flaw is available for public consumption purposes
     based on the following criteria:
-    1) The work on the flaw is done, or the flaw is public:
+    1) The work on the flaw is done, or the flaw is public, or the flaw doesn't exist in the DB:
         - 204 status (yes, flaw is available for public consumption)
-    2) The work on the flaw is not done yet, or the flaw doesn't exist in the DB:
+    2) The work on the flaw is not done yet:
         - 404 status (no, flaw is unavailable for public consumption)
     3) Invalid CVE ID:
         - 400 status
@@ -846,6 +846,18 @@ def flaw_available(request: Request, *args, **kwargs) -> Response:
     page, or not?") most likely doesn't change. So this is to prevent public confusion
     during the early stages of security analysis where the preliminary analysis might
     switch between "this CVE affects our products" and "this CVE doesn't affect our products".
+
+    Also an important point is that the client processes CVEs that never get saved to OSIDB's
+    DB (because of internal function `should_create_snippet`), yet the client must
+    publish information about all CVEs. By returning 204 when the flaw doesn't exist in OSIDB's
+    DB, it allows the client to take the output of this API endpoint as actionable advice:
+    When 204, publish the CVE page (either using OSIDB data or using other data), when
+    404, do not publish the CVE page (because the Vulnerability Management team still works
+    on the CVE).
+
+    That also means the client that uses this API endpoint must implement a grace period
+    to allow OSIDB to ingest the CVE and decide whether to save it to the DB, to prevent
+    the client publishing a CVE sooner than OSIDB processes it and potentially returns 404 for it.
     """
 
     cve_id = kwargs["cve_id"]
@@ -858,7 +870,7 @@ def flaw_available(request: Request, *args, **kwargs) -> Response:
         set_user_acls([])
     except Flaw.DoesNotExist:
         set_user_acls([])
-        return Response(status=HTTP_404_NOT_FOUND)
+        return Response(status=HTTP_204_NO_CONTENT)
 
     if (
         flaw.is_public

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -1856,8 +1856,8 @@ class TestEndpointsFlaws:
         Test that API endpoint reports whether a flaw is available
         based on the following criteria:
 
-        1) Public or work on flaw is done: 204 status
-        2) Not public and work not done / flaw does not exist: 404 status
+        1) Public or work on flaw is done / flaw does not exist: 204 status
+        2) Not public and work not done: 404 status
         3) CVE ID is not valid: 400 status
         """
 
@@ -1886,9 +1886,9 @@ class TestEndpointsFlaws:
         else:
             assert response.status_code == 404
 
-        # check for non-existent flaw (should be the same as criterion (2))
+        # check for non-existent flaw
         response = client.get(f"{test_api_uri}/available-flaws/CVE-2999-9999")
-        assert response.status_code == 404
+        assert response.status_code == 204
         assert response.data is None
 
         # check for invalid flaw id


### PR DESCRIPTION
Followup to https://github.com/RedHatProductSecurity/osidb/pull/999/files#r2245509506

Sorry for the misunderstanding.

There's a lot of CVEs that don't exist in OSIDB, I presume because some sort of automatic filtering doesn't let them through to VM. For very random examples, CVE-2024-46451 or CVE-2025-2691. The goal is that these CVEs get processed as "unaffected" ones by the API consumer. Without this PR, the consumer gets no useful information from the API.

Closes OSIDB-4397
