### PR TITLE
[OSIDB-4287] Remove dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-
-updates:
-  - package-ecosystem: "uv"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
Adjustment to [PR 1013](https://github.com/RedHatProductSecurity/osidb/pull/1013) to stop dependabot from automatically making PRs for updating packages that are not security updates.