### PR TITLE
Fix FlawSource enum in OpenAPI

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -291,6 +291,7 @@ SPECTACULAR_SETTINGS = {
         "osidb.hooks.response_metadata_postprocess_hook",
     ],
     "ENUM_NAME_OVERRIDES": {
+        "FlawSource": "osidb.models.flaw.source.FlawSource",
         "FlawReferenceType": "osidb.models.flaw.reference.FlawReference.FlawReferenceType",
         "TrackerType": "osidb.models.Tracker.TrackerType",
     },

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix FlawSource enum reference in OpenAPI schema (OSIDB-4401)
+
 ### Changed
 - Emit a warning instead of an error when the PURL-derived PsComponent doesn't
   match a user-provided PsComponent (OSIDB-4367)

--- a/openapi.yml
+++ b/openapi.yml
@@ -9049,7 +9049,7 @@ components:
           nullable: true
         source:
           oneOf:
-          - $ref: '#/components/schemas/SourceBe0Enum'
+          - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
           type: string
@@ -9831,7 +9831,7 @@ components:
           nullable: true
         source:
           oneOf:
-          - $ref: '#/components/schemas/SourceBe0Enum'
+          - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
           type: string
@@ -10050,7 +10050,7 @@ components:
           nullable: true
         source:
           oneOf:
-          - $ref: '#/components/schemas/SourceBe0Enum'
+          - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
           type: string
@@ -10094,6 +10094,98 @@ components:
       - embargoed
       - title
       - updated_dt
+    FlawSource:
+      enum:
+      - ADOBE
+      - APPLE
+      - ASF
+      - BIND
+      - BK
+      - BUGTRAQ
+      - BUGZILLA
+      - CERT
+      - CERTIFI
+      - CORELABS
+      - CUSTOMER
+      - CVE
+      - CVEORG
+      - DAILYDAVE
+      - DEBIAN
+      - DISTROS
+      - FEDORA
+      - FETCHMAIL
+      - FREEDESKTOP
+      - FREERADIUS
+      - FRSIRT
+      - FULLDISCLOSURE
+      - GAIM
+      - GENTOO
+      - GENTOOBZ
+      - GIT
+      - GNOME
+      - GNUPG
+      - GOOGLE
+      - HP
+      - HW_VENDOR
+      - IBM
+      - IDEFENSE
+      - INTERNET
+      - ISC
+      - ISEC
+      - IT
+      - JBOSS
+      - JPCERT
+      - KERNELBUGZILLA
+      - KERNELSEC
+      - LKML
+      - LWN
+      - MACROMEDIA
+      - MAGEIA
+      - MAILINGLIST
+      - MILW0RM
+      - MIT
+      - MITRE
+      - MOZILLA
+      - MUTTDEV
+      - NETDEV
+      - NISCC
+      - NVD
+      - OCERT
+      - OPENOFFICE
+      - OPENSSL
+      - OPENSUSE
+      - ORACLE
+      - OSS
+      - OSSSECURITY
+      - OSV
+      - PHP
+      - PIDGIN
+      - POSTGRESQL
+      - PRESS
+      - REAL
+      - REDHAT
+      - RESEARCHER
+      - RT
+      - SAMBA
+      - SECALERT
+      - SECUNIA
+      - SECURITYFOCUS
+      - SKO
+      - SQUID
+      - SQUIRRELMAIL
+      - SUN
+      - SUNSOLVE
+      - SUSE
+      - TWITTER
+      - UBUNTU
+      - UPSTREAM
+      - VENDORSEC
+      - VULNWATCH
+      - WIRESHARK
+      - XCHAT
+      - XEN
+      - XPDF
+      type: string
     FlawUUIDListRequest:
       type: object
       properties:
@@ -10767,98 +10859,6 @@ components:
       - OOSS
       - DELEGATED
       - WONTREPORT
-      type: string
-    SourceBe0Enum:
-      enum:
-      - ADOBE
-      - APPLE
-      - ASF
-      - BIND
-      - BK
-      - BUGTRAQ
-      - BUGZILLA
-      - CERT
-      - CERTIFI
-      - CORELABS
-      - CUSTOMER
-      - CVE
-      - CVEORG
-      - DAILYDAVE
-      - DEBIAN
-      - DISTROS
-      - FEDORA
-      - FETCHMAIL
-      - FREEDESKTOP
-      - FREERADIUS
-      - FRSIRT
-      - FULLDISCLOSURE
-      - GAIM
-      - GENTOO
-      - GENTOOBZ
-      - GIT
-      - GNOME
-      - GNUPG
-      - GOOGLE
-      - HP
-      - HW_VENDOR
-      - IBM
-      - IDEFENSE
-      - INTERNET
-      - ISC
-      - ISEC
-      - IT
-      - JBOSS
-      - JPCERT
-      - KERNELBUGZILLA
-      - KERNELSEC
-      - LKML
-      - LWN
-      - MACROMEDIA
-      - MAGEIA
-      - MAILINGLIST
-      - MILW0RM
-      - MIT
-      - MITRE
-      - MOZILLA
-      - MUTTDEV
-      - NETDEV
-      - NISCC
-      - NVD
-      - OCERT
-      - OPENOFFICE
-      - OPENSSL
-      - OPENSUSE
-      - ORACLE
-      - OSS
-      - OSSSECURITY
-      - OSV
-      - PHP
-      - PIDGIN
-      - POSTGRESQL
-      - PRESS
-      - REAL
-      - REDHAT
-      - RESEARCHER
-      - RT
-      - SAMBA
-      - SECALERT
-      - SECUNIA
-      - SECURITYFOCUS
-      - SKO
-      - SQUID
-      - SQUIRRELMAIL
-      - SUN
-      - SUNSOLVE
-      - SUSE
-      - TWITTER
-      - UBUNTU
-      - UPSTREAM
-      - VENDORSEC
-      - VULNWATCH
-      - WIRESHARK
-      - XCHAT
-      - XEN
-      - XPDF
       type: string
     SpecialHandlingEnum:
       enum:


### PR DESCRIPTION
This PR:
* fixes the FlawSource enum in OpenAPI schema so its name is fixed rather then being always produced by drf-spectacular name collision resolver, this will help clients like `osidb-bindings` to rely on the enum naming


Closes OSIDB-4401