### PR TITLE
Ps constants default to empty list

### DIFF
--- a/collectors/ps_constants/core.py
+++ b/collectors/ps_constants/core.py
@@ -76,21 +76,23 @@ def sync_cveorg_keywords(source: dict) -> None:
     """
     Sync CVEorg keywords in the database
     """
-    try:
-        keywords = [
-            (Keyword.Type.ALLOWLIST, source["allowlist"]),
-            (Keyword.Type.ALLOWLIST_SPECIAL_CASE, source["allowlist_special_cases"]),
-            (Keyword.Type.BLOCKLIST, source["blocklist"]),
-            (Keyword.Type.BLOCKLIST_SPECIAL_CASE, source["blocklist_special_cases"]),
-            (
-                Keyword.Type.ASSIGNER_ORG_ID_BLOCKLIST,
-                source.get("assigner_org_id_blocklist", []),  # default to empty list
-            ),
-        ]
-    except KeyError:
-        raise KeyError(
-            "The ps-constants repository does not contain the expected CVEorg keyword sections."
-        )
+    # Try to get keywords and default to an empty list
+    keywords = [
+        (Keyword.Type.ALLOWLIST, source.get("allowlist", [])),
+        (
+            Keyword.Type.ALLOWLIST_SPECIAL_CASE,
+            source.get("allowlist_special_cases", []),
+        ),
+        (Keyword.Type.BLOCKLIST, source.get("blocklist", [])),
+        (
+            Keyword.Type.BLOCKLIST_SPECIAL_CASE,
+            source.get("blocklist_special_cases", []),
+        ),
+        (
+            Keyword.Type.ASSIGNER_ORG_ID_BLOCKLIST,
+            source.get("assigner_org_id_blocklist", []),
+        ),
+    ]
 
     # Delete and recreate keywords
     Keyword.objects.all().delete()

--- a/collectors/ps_constants/tests/test_core.py
+++ b/collectors/ps_constants/tests/test_core.py
@@ -102,19 +102,3 @@ class TestPsConstantsCollection:
             Keyword.objects.filter(type=Keyword.Type.ASSIGNER_ORG_ID_BLOCKLIST).count()
             == 1
         )
-
-    def test_failed_sync_cveorg_keywords(self):
-        """
-        Test that CVEorg keywords without expected groups raise an error.
-        """
-        mock_keywords = {
-            "allowlist": ["kernel"],
-            "allowlist_special_cases": [r"(?:\W|^)\.NET\b"],
-            "blocklist": [".*plugin.*for WordPress", "Cisco", "IBM Tivoli", "iTunes"],
-            # "blocklist_special_cases" is missing
-        }
-
-        with pytest.raises(KeyError):
-            sync_cveorg_keywords(mock_keywords)
-
-        assert Keyword.objects.count() == 0


### PR DESCRIPTION
Following up on PR https://github.com/RedHatProductSecurity/osidb/pull/1012 provide a default for all keywords. I'd love a second set of eyes given the test removal. I'm also happy to rewrite that test if that's preferred.