### PR TITLE
Use internal ACLs for new flaws

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix FlawSource enum reference in OpenAPI schema (OSIDB-4401)
 - Fix the available-flaws API giving a 404 on non-existent flaws instead of 204 (OSIDB-4397).
+- Prevent emails from being sent for *rejected* critical flaws (OSIDB-4274)
 
 ### Changed
 - Emit a warning instead of an error when the PURL-derived PsComponent doesn't
   match a user-provided PsComponent (OSIDB-4367)
+- Initialize ACLs as internal (OSIDB-4274)
 
 ## [4.14.0] - 2025-07-23
 ### Added

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -553,13 +553,13 @@ class Flaw(
 
     def _validate_public_unembargo_date(self, **kwargs):
         """
-        Check that an unembargo date (public date) exists and is in the past if the Flaw is public
+        Check that an unembargo date (public date) exists and is in the past if the Flaw is not embargoed
         """
         if not self.is_embargoed:
             if self.unembargo_dt is None:
-                raise ValidationError("Public flaw has an empty unembargo_dt")
+                raise ValidationError("Non-embargoed flaw has an empty unembargo_dt")
             if self.unembargo_dt > timezone.now():
-                raise ValidationError("Public flaw has a future unembargo_dt")
+                raise ValidationError("Non-embargoed flaw has a future unembargo_dt")
 
     def _validate_future_unembargo_date(self, **kwargs):
         """

--- a/osidb/tests/endpoints/test_endpoints.py
+++ b/osidb/tests/endpoints/test_endpoints.py
@@ -157,7 +157,7 @@ class TestEndpointsACLs:
     @pytest.mark.parametrize(
         "embargoed,acl_read,acl_write",
         [
-            (False, settings.PUBLIC_READ_GROUPS, settings.PUBLIC_WRITE_GROUP),
+            (False, settings.INTERNAL_READ_GROUP, settings.INTERNAL_WRITE_GROUP),
             (True, settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP),
         ],
     )

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1577,8 +1577,12 @@ class TestFlawValidators:
     @pytest.mark.parametrize(
         "embargoed,unembargo_date,error_str",
         [
-            (False, None, "Public flaw has an empty unembargo_dt"),
-            (False, tzdatetime(2022, 11, 22), "Public flaw has a future unembargo_dt"),
+            (False, None, "Non-embargoed flaw has an empty unembargo_dt"),
+            (
+                False,
+                tzdatetime(2022, 11, 22),
+                "Non-embargoed flaw has a future unembargo_dt",
+            ),
             (False, tzdatetime(2021, 11, 22), None),
             (True, None, None),
             (


### PR DESCRIPTION
There are still considerable logic that uses the PUBLIC groups, and conceivably those will need to be adapted. Is it necessary to change to use `settings.INTERNAL_`{READ/WRITE}`_GROUP` everywhere? It seems like it would but it certainly seems to enlarge the impact and scope of this change. Should I abort this approach to preventing the emails? I wonder if there is a more granular, well-scoped approach.

Closes OSIDB-4274