### PR TITLE
Adapt sla module tests to affects v2

### DIFF
--- a/apps/sla/tests/test_framework.py
+++ b/apps/sla/tests/test_framework.py
@@ -259,13 +259,13 @@ sla: null
             """
             flaw = FlawFactory(embargoed=False)
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
@@ -332,20 +332,20 @@ sla:
                 reported_dt=make_aware(reported_dt2),
             )
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect1 = AffectFactory(
                 flaw=flaw1,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
             )
             affect2 = AffectFactory(
                 flaw=flaw2,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 ps_component=affect1.ps_component,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect1, affect2],
                 embargoed=flaw1.embargoed,
@@ -426,20 +426,20 @@ sla:
                 major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
             )
             ps_module = PsModuleFactory(name="ps-module")
-            affect = AffectFactory(
-                flaw=flaw,
-                impact=Impact.MODERATE,
-                affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
-                ps_component="component-1",
-            )
             PsUpdateStream(
                 name="upd-stream-1",
                 ps_module=ps_module,
                 active_to_ps_module=ps_module,
                 unacked_to_ps_module=ps_module,
             ).save()
+            affect = AffectFactory(
+                flaw=flaw,
+                impact=Impact.MODERATE,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
+                ps_update_stream="upd-stream-1",
+                ps_component="component-1",
+            )
             status = "CLOSED" if is_closed else "NEW"
             tracker = TrackerFactory(
                 affects=[affect],
@@ -528,15 +528,15 @@ sla:
                 major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
             )
             ps_module = PsModuleFactory(name="rhel-8")
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 ps_component=component,
                 impact=Impact.LOW,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,

--- a/apps/sla/tests/test_models.py
+++ b/apps/sla/tests/test_models.py
@@ -326,13 +326,13 @@ class TestSLA:
             for attribute, value in context.get("flaw", {}):
                 setattr(flaw, attribute, make_aware(value))
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
@@ -757,14 +757,14 @@ class TestSLAPolicy:
             )
             ps_product = PsProductFactory(business_unit="Community")
             ps_module = PsModuleFactory(ps_product=ps_product)
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 impact=Impact.MODERATE,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
@@ -823,11 +823,12 @@ class TestSLAPolicy:
             )
             ps_product = PsProductFactory(business_unit="Community")
             ps_module = PsModuleFactory(ps_product=ps_product)
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect1 = AffectFactory(
                 flaw=flaw1,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 ps_component="dnf",
                 impact=Impact.MODERATE,
             )
@@ -835,11 +836,10 @@ class TestSLAPolicy:
                 flaw=flaw2,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 ps_component="dnf",
                 impact=Impact.LOW,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect1, affect2],
                 embargoed=flaw1.embargoed,
@@ -897,15 +897,15 @@ class TestSLAPolicy:
 
             flaw = FlawFactory()
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 impact=Impact.MODERATE,
                 ps_component=component,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
@@ -948,13 +948,13 @@ class TestSLAPolicy:
                 embargoed=False,
             )
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect],
                 embargoed=flaw.embargoed,
@@ -1006,21 +1006,21 @@ class TestSLAPolicy:
                 unembargo_dt=make_aware(datetime(2020, 1, 1)),
             )
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect1 = AffectFactory(
                 flaw=flaw1,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 ps_component="dnf",
             )
             affect2 = AffectFactory(
                 flaw=flaw2,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_update_stream=ps_update_stream.name,
                 ps_component="dnf",
             )
-            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             tracker = TrackerFactory(
                 affects=[affect1, affect2],
                 embargoed=flaw1.embargoed,
@@ -1079,14 +1079,14 @@ class TestSLAPolicy:
                 embargoed=False,
             )
             ps_module = PsModuleFactory()
+            ps_update_stream = PsUpdateStreamFactory(
+                ps_module=ps_module, rhsa_sla_applicable=False
+            )
             affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
-            )
-            ps_update_stream = PsUpdateStreamFactory(
-                ps_module=ps_module, rhsa_sla_applicable=False
+                ps_update_stream=ps_update_stream.name,
             )
             tracker = TrackerFactory(
                 affects=[affect],


### PR DESCRIPTION
No real change to the sla module is required as it works in an abstract way with both v1 and v2 affects. Only the tests need to be adapted.

Closes OSIDB-4047.