### PR TITLE
Adapt exploits module to use affects v2

### DIFF
--- a/apps/exploits/query_sets.py
+++ b/apps/exploits/query_sets.py
@@ -1,5 +1,3 @@
-from django.db import models
-
 from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .constants import FIXED_AND_UNFIXABLE_TRACKER_RESOLUTIONS, UNSUPPORTED_PRODUCTS
@@ -35,29 +33,22 @@ class AffectQuerySetExploitExtension(CustomQuerySetUpdatedDt):
 
     def unfixed_in_delegate(self):
         """
-        Exclude all affects which have resolution DELEGATED and all associated trackers are either
+        Exclude all affects which have resolution DELEGATED and the associated tracker is either
         in fixed state, or are not fixable, e.g. duplicate, EOL.
         """
         from osidb.models import Affect
 
-        unfixed_trackers = models.Count(
-            "trackers",
-            filter=~models.Q(
-                trackers__resolution__in=FIXED_AND_UNFIXABLE_TRACKER_RESOLUTIONS
-            ),
-        )
         q = self
-        q = q.annotate(unfixed_trackers=unfixed_trackers)
         q = q.exclude(
             resolution=Affect.AffectResolution.DELEGATED,
-            unfixed_trackers=0,
+            tracker__resolution__in=FIXED_AND_UNFIXABLE_TRACKER_RESOLUTIONS,
         )
         return q
 
     def unfixed(self):
         """
         Exclude all affects which either have resolution FIX or have resolution DELEGATED and
-        associated trackers allow us to treat it as fixed (see "unfixed_in_delegate" above).
+        associated tracker allow us to treat it as fixed (see "unfixed_in_delegate" above).
         """
         from osidb.models import Affect
 

--- a/apps/exploits/serializers.py
+++ b/apps/exploits/serializers.py
@@ -29,11 +29,11 @@ class TrackerReportDataSerializer(serializers.ModelSerializer):
 
 
 class AffectReportDataSerializer(serializers.ModelSerializer):
-    trackers = TrackerReportDataSerializer(many=True, required=False)
+    tracker = TrackerReportDataSerializer(required=False)
 
     class Meta:
         model = Affect
-        fields = ["ps_module", "ps_component", "affectedness", "resolution", "trackers"]
+        fields = ["ps_module", "ps_component", "affectedness", "resolution", "tracker"]
 
 
 class FlawReportDataSerializer(serializers.ModelSerializer):

--- a/apps/exploits/tests/test_api.py
+++ b/apps/exploits/tests/test_api.py
@@ -46,33 +46,41 @@ def load_data():
         cve_id="CVE-2222-9999",
     )
 
+    ps_module = PsModuleFactory(name="ps-module-1")
+    ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
     a1 = AffectFactory(
         resolution=Affect.AffectResolution.DELEGATED,
         affectedness=Affect.AffectAffectedness.AFFECTED,
         flaw=f1,
-        ps_module="ps-module-1",
         ps_component="ps-component-1",
+        ps_update_stream=ps_update_stream.name,
     )
+    ps_module = PsModuleFactory(name="ps-module-2")
+    ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
     AffectFactory(
         resolution=Affect.AffectResolution.WONTFIX,
         affectedness=Affect.AffectAffectedness.AFFECTED,
         flaw=f2,
-        ps_module="ps-module-2",
         ps_component="ps-component-2",
+        ps_update_stream=ps_update_stream.name,
     )
+    ps_module = PsModuleFactory(name="rhel-6")
+    ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
     AffectFactory(
         resolution=Affect.AffectResolution.WONTFIX,
         affectedness=Affect.AffectAffectedness.AFFECTED,
         flaw=f3,
-        ps_module="rhel-6",
         ps_component="firefox",
+        ps_update_stream=ps_update_stream.name,
     )
+    ps_module = PsModuleFactory(name="rhel-5")
+    ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
     AffectFactory(
         resolution=Affect.AffectResolution.WONTFIX,
         affectedness=Affect.AffectAffectedness.AFFECTED,
         flaw=f4,
-        ps_module="rhel-5",
         ps_component="kernel",
+        ps_update_stream=ps_update_stream.name,
     )
 
     # Affect with tracker
@@ -86,7 +94,8 @@ def load_data():
     # validation error but we ignore it here
     t1.save(raise_validation_error=False)
 
-    a1.trackers.add(t1)
+    a1.tracker = t1
+    a1.save()
 
     with open(CISA_TEST_FILE) as f:
         objects = process_data(json.load(f))
@@ -323,14 +332,12 @@ class TestAPI(object):
                         "ps_component": "ps-component-1",
                         "affectedness": "AFFECTED",
                         "resolution": "DELEGATED",
-                        "trackers": [
-                            {
-                                "type": "BUGZILLA",
-                                "external_system_id": "12345678",
-                                "status": "CLOSED",
-                                "resolution": "ERRATA",
-                            },
-                        ],
+                        "tracker": {
+                            "type": "BUGZILLA",
+                            "external_system_id": "12345678",
+                            "status": "CLOSED",
+                            "resolution": "ERRATA",
+                        },
                     },
                 ],
             },
@@ -342,7 +349,7 @@ class TestAPI(object):
                         "ps_component": "ps-component-2",
                         "affectedness": "AFFECTED",
                         "resolution": "WONTFIX",
-                        "trackers": [],
+                        "tracker": None,
                     }
                 ],
             },
@@ -354,7 +361,7 @@ class TestAPI(object):
                         "ps_component": "firefox",
                         "affectedness": "AFFECTED",
                         "resolution": "WONTFIX",
-                        "trackers": [],
+                        "tracker": None,
                     }
                 ],
             },
@@ -366,7 +373,7 @@ class TestAPI(object):
                         "ps_component": "kernel",
                         "affectedness": "AFFECTED",
                         "resolution": "WONTFIX",
-                        "trackers": [],
+                        "tracker": None,
                     }
                 ],
             },

--- a/openapi.yml
+++ b/openapi.yml
@@ -11545,10 +11545,8 @@ components:
           oneOf:
           - $ref: '#/components/schemas/ResolutionEnum'
           - $ref: '#/components/schemas/BlankEnum'
-        trackers:
-          type: array
-          items:
-            $ref: '#/components/schemas/TrackerReportData'
+        tracker:
+          $ref: '#/components/schemas/TrackerReportData'
       required:
       - ps_component
     AffectRequest:


### PR DESCRIPTION
This PR changes the exploits module to filter and perform serialization on a single tracker rather than a list as of the affects v2 update. The tests has also be adapted to use affects v2.

I believe that exploits API might need to be updated too (flaws will get more affects but the exploits API currently only outputs ps_module/product for these affects). Leaving this update for the larger v1 to v2 migration at the suggestion of @dmonzonis.