### PR TITLE
Adapt integration tests to use affects v2 and v2 API

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -144,7 +144,7 @@
         "filename": "apps/bbsync/tests/test_integration.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 891,
+        "line_number": 940,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-08-25T09:58:18Z"
+  "generated_at": "2025-09-08T17:12:18Z"
 }

--- a/apps/taskman/tests/conftest.py
+++ b/apps/taskman/tests/conftest.py
@@ -3,7 +3,7 @@ import uuid
 import pytest
 from django.conf import settings
 
-from osidb.constants import OSIDB_API_VERSION
+from osidb.constants import OSIDB_API_VERSION, OSIDB_API_VERSION_NEXT
 from taskman.constants import TASKMAN_API_VERSION
 
 
@@ -72,10 +72,10 @@ def test_osidb_scheme_host():
 
 
 @pytest.fixture
-def osidb_api_version():
-    return OSIDB_API_VERSION
+def test_osidb_api_uri(test_osidb_scheme_host):
+    return f"{test_osidb_scheme_host}/api/{OSIDB_API_VERSION}"
 
 
 @pytest.fixture
-def test_osidb_api_uri(test_osidb_scheme_host, osidb_api_version):
-    return f"{test_osidb_scheme_host}/api/{osidb_api_version}"
+def test_osidb_api_v2_uri(test_osidb_scheme_host):
+    return f"{test_osidb_scheme_host}/api/{OSIDB_API_VERSION_NEXT}"

--- a/apps/taskman/tests/test_flaw_model_integration.py
+++ b/apps/taskman/tests/test_flaw_model_integration.py
@@ -97,7 +97,7 @@ class TestFlawModelIntegration(object):
         assert flaw.save() is None
         assert sync_count == 1
 
-    def test_create_api(self, monkeypatch, auth_client, test_osidb_api_uri):
+    def test_create_api(self, monkeypatch, auth_client, test_osidb_api_v2_uri):
         sync_count = 0
 
         def mock_create_or_update_task(self, flaw):
@@ -121,7 +121,7 @@ class TestFlawModelIntegration(object):
             "embargoed": False,
         }
         response = auth_client().post(
-            f"{test_osidb_api_uri}/flaws",
+            f"{test_osidb_api_v2_uri}/flaws",
             flaw_data,
             format="json",
             HTTP_BUGZILLA_API_KEY="SECRET",
@@ -130,7 +130,7 @@ class TestFlawModelIntegration(object):
         assert response.status_code == 201
         assert sync_count == 1
 
-    def test_update_api(self, monkeypatch, auth_client, test_osidb_api_uri):
+    def test_update_api(self, monkeypatch, auth_client, test_osidb_api_v2_uri):
         sync_count = 0
 
         def mock(self, flaw):
@@ -145,11 +145,11 @@ class TestFlawModelIntegration(object):
         AffectFactory(flaw=flaw)
         flaw.task_key = "TASK-123"
         flaw.save()
-        response = auth_client().get(f"{test_osidb_api_uri}/flaws/{flaw.uuid}")
+        response = auth_client().get(f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}")
         assert response.status_code == 200
 
         response = auth_client().put(
-            f"{test_osidb_api_uri}/flaws/{flaw.uuid}",
+            f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}",
             {
                 "uuid": flaw.uuid,
                 "cve_id": flaw.cve_id,
@@ -170,7 +170,7 @@ class TestFlawModelIntegration(object):
 
         flaw = Flaw.objects.get(uuid=flaw.uuid)
         response = auth_client().put(
-            f"{test_osidb_api_uri}/flaws/{flaw.uuid}",
+            f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}",
             {
                 "uuid": flaw.uuid,
                 "cve_id": flaw.cve_id,
@@ -189,7 +189,9 @@ class TestFlawModelIntegration(object):
         # changes require sync
         assert sync_count == 1
 
-    def test_create_jira_task_param(self, monkeypatch, auth_client, test_osidb_api_uri):
+    def test_create_jira_task_param(
+        self, monkeypatch, auth_client, test_osidb_api_v2_uri
+    ):
         def mock_create_or_update_task(self, flaw):
             flaw.task_key = "TASK-123"
             return "TASK-123"
@@ -206,7 +208,7 @@ class TestFlawModelIntegration(object):
         # Update flaw with no task without using the create_jira_task param:
         # it should not create any task
         response = auth_client().put(
-            f"{test_osidb_api_uri}/flaws/{flaw.uuid}",
+            f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}",
             {
                 "uuid": flaw.uuid,
                 "cve_id": flaw.cve_id,
@@ -228,7 +230,7 @@ class TestFlawModelIntegration(object):
         # it should not create any task
         flaw = Flaw.objects.get(uuid=flaw.uuid)
         response = auth_client().put(
-            f"{test_osidb_api_uri}/flaws/{flaw.uuid}",
+            f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}",
             {
                 "uuid": flaw.uuid,
                 "cve_id": flaw.cve_id,
@@ -250,7 +252,7 @@ class TestFlawModelIntegration(object):
         # Now use the create_jira_task to force the creation of a task for the flaw
         flaw = Flaw.objects.get(uuid=flaw.uuid)
         response = auth_client().put(
-            f"{test_osidb_api_uri}/flaws/{flaw.uuid}?create_jira_task=1",
+            f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}?create_jira_task=1",
             {
                 "uuid": flaw.uuid,
                 "cve_id": flaw.cve_id,

--- a/apps/workflows/tests/test_integration.py
+++ b/apps/workflows/tests/test_integration.py
@@ -94,7 +94,7 @@ class TestIntegration(object):
             "Content-type: application/json",
             "-H",
             f"Authorization: Bearer {tokens['access']}",
-            f"{live_server.url}/osidb/api/v1/flaws?limit=1&include_fields=uuid",
+            f"{live_server.url}/osidb/api/v2beta/flaws?limit=1&include_fields=uuid",
         ]
         curl_result = subprocess.run(
             cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE

--- a/osidb/tests/test_integration.py
+++ b/osidb/tests/test_integration.py
@@ -14,58 +14,38 @@ pytestmark = pytest.mark.integration
 
 
 class TestIntegration(object):
+    def _test_with_curl(self, command_curl, live_server, endpoint):
+        cmd = [
+            command_curl,
+            "-v",
+            "-H",
+            "Content-type: application/json",
+            f"{live_server.url}/osidb/{endpoint}",
+        ]
+
+        curl_result = subprocess.run(
+            cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE
+        )
+
+        assert curl_result.returncode == 0
+        return json.loads(curl_result.stdout)
+
     def test_healthy_with_curl(self, command_curl, live_server):
         """access healthy using curl"""
-        cmd = [
-            command_curl,
-            "-v",
-            "-H",
-            "Content-type: application/json",
-            f"{live_server.url}/osidb/healthy",
-        ]
-        curl_result = subprocess.run(
-            cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE
-        )
-        assert curl_result.returncode == 0
-        json_body = json.loads(curl_result.stdout)
+        json_body = self._test_with_curl(command_curl, live_server, "healthy")
         assert json_body["env"] == "local"
 
-    def test_status_with_curl(
-        self,
-        command_curl,
-        live_server,
-    ):
+    def test_status_with_curl(self, command_curl, live_server):
         """access status api using curl"""
-        cmd = [
-            command_curl,
-            "-v",
-            "-H",
-            "Content-type: application/json",
-            f"{live_server.url}/osidb/api/v1/status",
-        ]
-        curl_result = subprocess.run(
-            cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE
-        )
-        assert curl_result.returncode == 0
-        json_body = json.loads(curl_result.stdout)
+        json_body = self._test_with_curl(command_curl, live_server, "api/v1/status")
         assert json_body["env"] == "local"
 
-    def test_flaws_with_curl(
-        self,
-        command_curl,
-        live_server,
-    ):
-        """access status api using curl"""
-        cmd = [
-            command_curl,
-            "-v",
-            "-H",
-            "Content-type: application/json",
-            f"{live_server.url}/osidb/api/v1/flaws",
-        ]
-        curl_result = subprocess.run(
-            cmd, stderr=subprocess.PIPE, stdout=subprocess.PIPE
-        )
-        assert curl_result.returncode == 0
-        json_body = json.loads(curl_result.stdout)
+    def test_flaws_with_curl(self, command_curl, live_server):
+        """access flaw api v1 using curl"""
+        json_body = self._test_with_curl(command_curl, live_server, "api/v1/flaws")
+        assert "count" in json_body
+
+    def test_flaws_with_curl_v2(self, command_curl, live_server):
+        """access flaw api v2 using curl"""
+        json_body = self._test_with_curl(command_curl, live_server, "api/v2beta/flaws")
         assert "count" in json_body


### PR DESCRIPTION
For this PR I have adjusted the integration tests to use affects v2 and the associated v2 API endpoints. 

I have changed the update function since I was running into an issue saving the affects. The original logic was that the affects were removed from the trackers and the respective change would be propagated to the affects. The new logic does the removal from the affect side.

Closes OSIDB-4041