### PR TITLE
Fix not affected justifications from Jira not being collected by OSIDB 

### DIFF
--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -430,7 +430,7 @@ class JiraTrackerConvertor(TrackerConvertor):
             "status": self.get_field_attr(self._raw, "status", "name"),
             "resolution": self.get_field_attr(self._raw, "resolution", "name"),
             "not_affected_justification": self.get_field_attr(
-                self._raw, "customfield_12326140", "value"
+                self._raw, "customfield_12325940", "value"
             ),
             "special_handling": self.get_array_field_attr(
                 self._raw, "customfield_12324753", "value"

--- a/collectors/jiraffe/tests/cassettes/test_convertors/TestJiraTrackerConvertor.test_convert_not_affected_justification.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_convertors/TestJiraTrackerConvertor.test_convert_not_affected_justification.yaml
@@ -68,7 +68,7 @@ interactions:
         "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
         null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
         null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
-        null, "customfield_12317313": null, "customfield_12326140": {"self": "https://example.com/rest/api/2/customFieldOption/41651",
+        null, "customfield_12317313": null, "customfield_12325940": {"self": "https://example.com/rest/api/2/customFieldOption/41651",
         "value": "Inline Mitigations already Exist", "id": "41651", "disabled": false},
         "customfield_12321540": null, "customfield_12323840": null, "customfield_12325740":
         null, "creator": {"self": "https://example.com/rest/api/2/user?username=rh-ee-dmonzoni",

--- a/collectors/jiraffe/tests/cassettes/test_convertors/TestJiraTrackerConvertor.test_convert_special_handling.yaml
+++ b/collectors/jiraffe/tests/cassettes/test_convertors/TestJiraTrackerConvertor.test_convert_special_handling.yaml
@@ -67,7 +67,7 @@ interactions:
         "id": "12370079", "name": "kernel / Other", "description": " Other"}], "customfield_12320841":
         null, "customfield_12314040": null, "customfield_12320844": null, "archiveddate":
         null, "customfield_12320842": null, "customfield_12310243": null, "aggregatetimeestimate":
-        null, "customfield_12317313": null, "customfield_12326140": null, "customfield_12321540":
+        null, "customfield_12317313": null, "customfield_12325940": null, "customfield_12321540":
         null, "customfield_12323840": null, "customfield_12325740": null, "creator":
         {"self": "https://example.com/rest/api/2/user?username=rh-ee-dmonzoni", "name":
         "rh-ee-dmonzoni", "key": "JIRAUSER227953", "emailAddress": "dmonzoni+stage@redhat.com",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fix `owner` update in Jira not reflected in OSIDB (OSIDB-4306)
+- Fix not affected justifications from Jira not being collected by OSIDB (OSIDB-4418)
 
 ### Changed
 - Make `affect` model's `flaw` field un-nullable (OSIDB-4202)


### PR DESCRIPTION
The ID of the field has changed within Jira at some point. This commit updates the ID in OSIDB so that it is correctly collected from Jira.

Closes OSIDB-4418.