### PR TITLE
Add .venv directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,7 +30,7 @@ testrun.ini
 tests/htmlcov
 .tox/
 /venv
-/.venv
+.venv
 .vscode/
 *.db.gz
 osidb_data_backup_dump*


### PR DESCRIPTION
After switching from pyenv to uv, git started picking up the .venv directory as containing changes. This directory should be ignored.