### PR TITLE
[OSIDB-4371] Use full component name for CC lists

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix `owner` update in Jira not reflected in OSIDB (OSIDB-4306)
 - Fix not affected justifications from Jira not being collected by OSIDB (OSIDB-4418)
+- Fix use full component name for CC lists (OSIDB-4371)
 
 ### Changed
 - Make `affect` model's `flaw` field un-nullable (OSIDB-4202)

--- a/osidb/cc.py
+++ b/osidb/cc.py
@@ -240,6 +240,16 @@ class JiraAffectCCBuilder(BaseAffectCCBuilder):
         else:
             self.bz_component = self.ps_component
 
+    def component_cc(self):
+        # exact match
+        for key in [
+            self.ps_component,
+            self.ps_component.split(":")[-1],
+        ]:
+            if key in self.ps_module_obj.component_cc:
+                return self.ps_module_obj.component_cc[key]
+        return super().component_cc()
+
 
 class BugzillaAffectCCBuilder(BaseAffectCCBuilder):
     """


### PR DESCRIPTION
Updated component parsing for CC list creation to use the full component name instead of only the module.

I saw this code that has similar logic, should be updated as well?https://github.com/RedHatProductSecurity/osidb/blob/30dd1c180b77d4c98459cf0cca635f128c8c1892/osidb/cc.py#L292-L293

Closes OSIDB-4371