### PR TITLE
Add OSIDB version update of uv.lock to update_release.sh

### DIFF
--- a/scripts/update_release.sh
+++ b/scripts/update_release.sh
@@ -12,6 +12,9 @@ if [[ $1 =~ [0-9]*\.[0-9]*\.[0-9]* ]]; then
     echo "Replacing version in pyproject.toml"
     sed -i 's/version = "[0-9]*\.[0-9]*\.[0-9]*"/version = "'$1'"/g' pyproject.toml
 
+    echo "Replacing version in uv.lock"
+    sed -i '/^name = "osidb"$/,/^$/ s/version = "[0-9]*\.[0-9]*\.[0-9]*"/version = "'$1'"/' uv.lock
+
     echo "Replacing version in openapi.yml"
     ./scripts/schema-check.sh
 

--- a/uv.lock
+++ b/uv.lock
@@ -1034,7 +1034,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/bf/61/395013f4378b12f47
 
 [[package]]
 name = "osidb"
-version = "4.15.0"
+version = "4.16.0"
 source = { virtual = "." }
 dependencies = [
     { name = "backoff" },


### PR DESCRIPTION
The OSIDB version inside of uv.lock was not updated when running the update_release.sh script. The OSIDB version would  only update from pyproject.toml after running uv lock/sync (or manually changed).

This PR adds the missing uv.lock update to the version update script.