### PR TITLE
Unblock edits on flaws w/o affects

### DIFF
--- a/apps/workflows/workflows/default.yml
+++ b/apps/workflows/workflows/default.yml
@@ -29,7 +29,7 @@ states:
     jira_state: To Do
     jira_resolution: null
     requirements:
-      - has affects
+      # - has affects
       - has source
       - has title
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add query for finding flaw whose non-community affects are missing trackers (OSIDB-4104)
 
+### Changed
+- Don't block affectless flaws from being promoted or changing impact, CVSS, or text fields (OSIDB-4463)
+
 ## [4.16.0] - 2025-09-16
 ### Fixed
 - Fix `owner` update in Jira not reflected in OSIDB (OSIDB-4306)

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -726,21 +726,13 @@ class Flaw(
             return
 
         if not Affect.objects.filter(flaw=self).exists():
-            err = ValidationError("Flaw does not contain any affects.")
-            # When a flaw without state or in a "new" workflow state is modified, allow saving
-            # with no affects but issue an alert
-            if self.workflow_state in {
-                WorkflowModel.WorkflowState.NOVALUE,
-                WorkflowModel.WorkflowState.NEW,
-            }:
-                self.alert(
-                    "_validate_flaw_without_affect",
-                    err.message,
-                    alert_type=Alert.AlertType.ERROR,
-                    **kwargs,
-                )
-            else:
-                raise err
+            # When a flaw without afects is saved, issue an alert
+            self.alert(
+                "_validate_flaw_without_affect",
+                "Flaw does not contain any affects.",
+                alert_type=Alert.AlertType.ERROR,
+                **kwargs,
+            )
 
     def _validate_nonempty_components(self, **kwargs):
         """

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -1982,17 +1982,15 @@ class TestFlawValidators:
 
     def test_validate_flaw_without_affect(self):
         """
-        test that flaws without affect raises an error on editing,
-        unless it is in a new workflow state
+        test that flaws without affect raises an error-level alert on editing
         """
         flaw1 = FlawFactory()
         AffectFactory(flaw=flaw1)
         assert flaw1.save() is None
 
         flaw2 = FlawFactory(workflow_state=WorkflowModel.WorkflowState.TRIAGE)
-        with pytest.raises(ValidationError) as e:
-            flaw2.save()
-        assert "Flaw does not contain any affects." in str(e)
+        assert flaw2.save() is None
+        assert flaw2.valid_alerts.filter(name="_validate_flaw_without_affect").exists()
 
         # Flaws in the 'new' state can be edited without any affects, but
         # an alert is raised


### PR DESCRIPTION
With this PR, OSIDB would permit:
1. Flaws to be promoted past Triage without affects (not sure if this makes sense)
2. Changing CVSS score, impact, text field, etc
3. Instead raising a validation error, an alert is created for Flaws without affects, regardless of workflow state.

Closes OSIDB-4463
Closes OSIDB-4310