### PR TITLE
Fix API schema

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -11416,6 +11416,7 @@ components:
           allOf:
           - $ref: '#/components/schemas/Tracker'
           readOnly: true
+          nullable: true
         delegated_resolution:
           type: string
           readOnly: true
@@ -11466,6 +11467,7 @@ components:
       - delegated_not_affected_justification
       - delegated_resolution
       - embargoed
+      - flaw
       - ps_product
       - ps_update_stream
       - resolved_dt
@@ -11531,6 +11533,7 @@ components:
             it is used to detect mit-air collisions.
       required:
       - embargoed
+      - flaw
       - ps_update_stream
       - updated_dt
       - uuid
@@ -11772,6 +11775,7 @@ components:
             access to the resource.
       required:
       - embargoed
+      - flaw
       - ps_update_stream
     AffectReportData:
       type: object
@@ -11841,6 +11845,7 @@ components:
             it is used to detect mit-air collisions.
       required:
       - embargoed
+      - flaw
       - ps_update_stream
       - updated_dt
     AffectV1:

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -1164,7 +1164,7 @@ class AffectSerializer(
         "resolution",
     )
 
-    tracker = serializers.SerializerMethodField()
+    tracker = serializers.SerializerMethodField(allow_null=True)
     meta_attr = serializers.SerializerMethodField()
     cvss_scores = AffectCVSSSerializer(many=True, read_only=True)
     # at least one of ps_component or purl is required


### PR DESCRIPTION
This PR:
* allows nullable `tracker` field for `AffectSerializer`
* additionally adds required `flaw` field to all affect related serializes, this is change which was not done by this PR but apparently the schema was not correctly updated