### PR TITLE
Group v1 affects by flaw, module and component

### DIFF
--- a/osidb/migrations/0202_affect_v1_view.py
+++ b/osidb/migrations/0202_affect_v1_view.py
@@ -12,7 +12,7 @@ WITH ranked_affects AS (
     SELECT
         *,
         ROW_NUMBER() OVER (
-            PARTITION BY flaw_id, ps_module
+            PARTITION BY flaw_id, ps_module, ps_component
             ORDER BY
                 -- Affected affects take priority
                 CASE WHEN affectedness = 'NOTAFFECTED' THEN 2 ELSE 1 END,


### PR DESCRIPTION
Before this commit the v1 affects which were fabricated from v2 affects were grouped by flaw and module. This leads to a few missing affects in the v1 endpoint when a flaw has more than one affect for the same module, but a different component.