### PR TITLE
[OSIDB-3766] Allow case insensitive CVE ID flaw queries

### DIFF
--- a/apps/workflows/api.py
+++ b/apps/workflows/api.py
@@ -13,10 +13,10 @@ from rest_framework.viewsets import ModelViewSet
 
 from apps.taskman.service import JiraTaskmanQuerier
 from osidb.api_views import RudimentaryUserPathLoggingMixin, get_valid_http_methods
-from osidb.helpers import get_bugzilla_api_key, get_jira_api_key
+from osidb.helpers import get_bugzilla_api_key, get_flaw_or_404, get_jira_api_key
 
 from .exceptions import WorkflowsException
-from .helpers import get_flaw_or_404, str2bool
+from .helpers import str2bool
 from .serializers import (
     ClassificationWorkflowSerializer,
     RejectSerializer,

--- a/apps/workflows/helpers.py
+++ b/apps/workflows/helpers.py
@@ -2,26 +2,7 @@
 various helper functions
 """
 
-import re
-
-from django.http import Http404
-
-from osidb.validators import CVE_RE_STR
-
 from .exceptions import APIError
-
-
-def get_flaw_or_404(pk):
-    """get flaw instance or raise HTTP 404 error"""
-    # import here to prevent cycle
-    from osidb.models import Flaw
-
-    try:
-        if re.match(CVE_RE_STR, pk):
-            return Flaw.objects.get(cve_id=pk)
-        return Flaw.objects.get(pk=pk)
-    except Flaw.DoesNotExist as e:
-        raise Http404 from e
 
 
 # singleton wrapper based on the following docs

--- a/apps/workflows/views.py
+++ b/apps/workflows/views.py
@@ -7,7 +7,8 @@ import logging
 from django.shortcuts import render
 from django.views.generic import ListView
 
-from .helpers import get_flaw_or_404
+from osidb.helpers import get_flaw_or_404
+
 from .models import Workflow
 from .serializers import ClassificationWorkflowSerializer, WorkflowSerializer
 from .workflow import WorkflowFramework

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - Remove deprecated fields/models: `PsProduct`'s `team`, `FlawComment`'s `order` 
   and models in `package_versions.py` (OSIDB-3552)
+- Make CVE ID case insensitive for flaw queries (OSIDB-3766)
 
 ## [4.16.0] - 2025-09-16
 ### Fixed

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -71,6 +71,20 @@ def filter_cves(strings, inverse=False):
     )
 
 
+def get_flaw_or_404(pk, queryset=None):
+    """
+    get flaw instance or raise HTTP 404 error
+    """
+    from django.http import Http404
+
+    from osidb.models import Flaw
+
+    try:
+        return Flaw.objects.get_by_identifier(pk, queryset=queryset)
+    except Flaw.DoesNotExist as e:
+        raise Http404 from e
+
+
 # Replaces strtobool from the deprecated distutils library
 def strtobool(val: str):
     val = val.lower()

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -89,6 +89,29 @@ class FlawManager(ACLMixinManager, TrackingMixinManager, WorkflowModelManager):
         # Search default Flaw fields (title, comment_zero, cve_description, statement) with default weights
         # If search has no results, this will now return an empty queryset
 
+    @staticmethod
+    def get_by_identifier(id, queryset=None):
+        """
+        Get a flaw by its identifier: CVE ID or UUID.
+        Match CVE ID case-insensitively and default to UUID if CVE does not match.
+
+        Optionally accepts a custom Flaw queryset to fetch from.
+        """
+        from osidb.validators import CVE_RE_STR
+
+        if queryset is None:
+            queryset = Flaw.objects
+        elif queryset.model != Flaw:
+            raise ValidationError("queryset must be a Flaw queryset")
+
+        id_upper = id.upper()
+        cve_match = CVE_RE_STR.match(id_upper)
+
+        if cve_match:
+            return queryset.get(cve_id=id_upper)
+
+        return queryset.get(pk=id)
+
 
 @pghistory.track(
     pghistory.InsertEvent(),

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -1954,3 +1954,19 @@ class TestEndpointsFlaws:
         response = client.get(f"{test_api_uri}/available-flaws/not-an-id")
         assert response.status_code == 400
         assert response.data is None
+
+    def test_cve_id_case_insensitive(self, auth_client, test_api_uri):
+        """
+        Test that the API endpoint is case-insensitive when matching CVE IDs
+        """
+
+        flaw = FlawFactory(cve_id="CVE-2999-9999")
+
+        response = auth_client().get(f"{test_api_uri}/flaws/{flaw.cve_id}")
+        assert response.status_code == 200
+
+        response = auth_client().get(f"{test_api_uri}/flaws/{flaw.cve_id.lower()}")
+        assert response.status_code == 200
+
+        response = auth_client().get(f"{test_api_uri}/flaws/CvE-2999-9999")
+        assert response.status_code == 200


### PR DESCRIPTION
This PR adds a new helper function to match string with CVE ID regex in a case insensitive manner.

The function is used to make CVE ID queries for flaws case insensitive.

Closes OSIDB-3766