### PR TITLE
Tighten public logic on workflow change

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -432,7 +432,7 @@
         "filename": "osidb/tests/endpoints/test_endpoints.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 185,
+        "line_number": 186,
         "is_secret": false
       }
     ],
@@ -475,5 +475,5 @@
       }
     ]
   },
-  "generated_at": "2025-09-30T11:23:14Z"
+  "generated_at": "2025-10-08T21:07:11Z"
 }

--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -389,13 +389,14 @@ class WorkflowModel(models.Model):
     def adjust_acls(self, save=True):
         # a flaw can have internal ACLs before the triage is
         # completed or if it was rejected during the triage
-        internal_supported = [
-            WorkflowModel.WorkflowState.NEW,
-            WorkflowModel.WorkflowState.TRIAGE,
-            WorkflowModel.WorkflowState.REJECTED,
+
+        public_stages = [
+            WorkflowModel.WorkflowState.PRE_SECONDARY_ASSESSMENT,
+            WorkflowModel.WorkflowState.SECONDARY_ASSESSMENT,
+            WorkflowModel.WorkflowState.DONE,
         ]
 
-        if self.workflow_state not in internal_supported and self.is_internal:
+        if self.is_internal and self.workflow_state in public_stages:
             self.set_public()
             # updates ACLs of all related objects except for snippets
             self.set_public_nested()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Fixed
 - Fix PUT request being allowed for `AuditView` endpoint (OSIDB-4428)
+- Prevent unintended publicizing flaws when workflow state has unexpected value during sync tasks (OSIDB-4446)
 
 ### Added
 - Add query for finding flaw whose non-community affects are missing trackers (OSIDB-4104)


### PR DESCRIPTION
Closes OSIDB-4446

As far I can tell, the current logic in `def adjust_acls`  seems ambiguous enough to account for flaws unexpectedly becoming public in some scenarios (where `workflow_state` would be momentarily an unexpected value, probably during a sync task), but I'm still unclear on how `workflow_state` would be `None` or `""` in the cases documented in the ticket.