### PR TITLE
OSIDB-4738: Add context to async process in history.

### DIFF
--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -72,12 +72,14 @@ class TrackingMixin(models.Model):
             # updated_dt should never change from the DB version
             # otherwise assume that there was a conflicting parallel change
             if db_self is not None and db_self.updated_dt != self.updated_dt:
-                raise DataInconsistencyException(
-                    "Save operation based on an outdated model instance: "
-                    f"Updated datetime in the request {self.updated_dt} "
-                    f"differes from the DB {db_self.updated_dt}. "
-                    "You need to refresh."
+                actual_event_user = self._get_actual_user()
+
+                message = (
+                    f"Save operation based on an outdated model instance by "
+                    f"{actual_event_user} with updated_dt {self.updated_dt} "
+                    f"differs from the DB {db_self.updated_dt} check in history for details."
                 )
+                raise DataInconsistencyException(f"{message} You need to refresh.")
 
             # auto-set updated_dt as now on any change
             # cut off the microseconds to allow mid-air
@@ -85,6 +87,13 @@ class TrackingMixin(models.Model):
             self.updated_dt = timezone.now().replace(microsecond=0)
 
         super().save(*args, **kwargs)
+
+    def _get_actual_user(self):
+        ctx = getattr(
+            pghistory.runtime._tracker, "value", None
+        )  # active context for this thread, if any
+        actual_user = (ctx.metadata.get("user") if ctx else None) or "unknown"
+        return actual_user
 
 
 class TrackingMixinManager(models.Manager):

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -1,7 +1,9 @@
 import json
+from contextlib import contextmanager
 from datetime import timedelta
-from typing import Optional, Type
+from typing import Any, Iterator, Optional, Type
 
+import pghistory
 from celery.exceptions import Ignore
 from celery.utils.log import get_task_logger
 from django.conf import settings
@@ -13,6 +15,22 @@ from config.celery import app
 from osidb.core import set_user_acls
 
 logger = get_task_logger(__name__)
+
+
+@contextmanager
+def pghistory_context(
+    action: str,
+    celery_task_id: str,
+    *,
+    source: str = "celery",
+    user: str = "celery_task",
+    **extra_context: Any,
+) -> Iterator[None]:
+    ctx = {"source": source, "user": user, "action": action, **extra_context}
+    if celery_task_id:
+        ctx["celery_task_id"] = celery_task_id
+    with pghistory.context(**ctx):
+        yield
 
 
 class SyncManager(models.Model):
@@ -486,7 +504,7 @@ class BZTrackerDownloadManager(SyncManager):
         return result
 
     @staticmethod
-    def link_tracker_with_affects(tracker_id):
+    def link_tracker_with_affects(tracker_id, task="UNKNOWN"):
         # Code adapted from collectors.bzimport.convertors.BugzillaTrackerConvertor.affects
 
         from osidb.models import Affect, Flaw, Tracker
@@ -561,9 +579,13 @@ class BZTrackerDownloadManager(SyncManager):
         affects = list(set(affects))
 
         with transaction.atomic():
-            tracker.affects.clear()
-            tracker.affects.add(*affects)
-            tracker.save(raise_validation_error=False, auto_timestamps=False)
+            with pghistory_context(
+                action="link_tracker_with_affects",
+                celery_task_id=getattr(getattr(task, "request", None), "id", None),
+            ):
+                tracker.affects.clear()
+                tracker.affects.add(*affects)
+                tracker.save(raise_validation_error=False, auto_timestamps=False)
 
         return affects, failed_flaws, failed_affects
 
@@ -580,7 +602,9 @@ class BZTrackerDownloadManager(SyncManager):
         collector = collectors.BugzillaTrackerCollector()
         try:
             collector.sync_tracker(tracker_id)
-            result = BZTrackerDownloadManager.link_tracker_with_affects(tracker_id)
+            result = BZTrackerDownloadManager.link_tracker_with_affects(
+                tracker_id, task
+            )
             # Handle link failures
             affects, failed_flaws, failed_affects = result
             if failed_flaws:
@@ -819,8 +843,12 @@ class JiraTaskSyncManager(SyncManager):
         set_user_acls(settings.ALL_GROUPS)
 
         try:
-            flaw = Flaw.objects.get(uuid=flaw_id)
-            flaw._create_or_update_task()
+            with pghistory_context(
+                action="jira_task_sync",
+                celery_task_id=getattr(getattr(task, "request", None), "id", None),
+            ):
+                flaw = Flaw.objects.get(uuid=flaw_id)
+                flaw._create_or_update_task()
 
         except Exception as e:
             JiraTaskSyncManager.failed(flaw_id, e)
@@ -869,8 +897,12 @@ class JiraTaskTransitionManager(SyncManager):
         set_user_acls(settings.ALL_GROUPS)
 
         try:
-            flaw = Flaw.objects.get(uuid=flaw_id)
-            flaw._transition_task()
+            with pghistory_context(
+                action="jira_task_transition",
+                celery_task_id=getattr(getattr(task, "request", None), "id", None),
+            ):
+                flaw = Flaw.objects.get(uuid=flaw_id)
+                flaw._transition_task()
 
         except Exception as e:
             JiraTaskTransitionManager.failed(flaw_id, e)
@@ -990,7 +1022,11 @@ class JiraTrackerDownloadManager(SyncManager):
             tracker_data = JiraQuerier().get_issue(tracker_id)
             tracker = JiraTrackerConvertor(tracker_data).tracker
             if tracker:
-                tracker.save()
+                with pghistory_context(
+                    action="jira_tracker_download",
+                    celery_task_id=getattr(getattr(task, "request", None), "id", None),
+                ):
+                    tracker.save()
 
             # Link this Jira tracker to OSIDB Affects as part of the sync process.
             result = JiraTrackerDownloadManager.link_tracker_with_affects(tracker_id)


### PR DESCRIPTION
This PR adds a bit more context for the async tasks in async manager. The idea is to have a better view on events conflicts. 

It also adds more contexts into the history for the sync_manager making easier to understand if a celery process did a change. 

Example of how context looks (First lines are empty because Flaw was created with custom code) 

```
 - 2026-02-27 16:42:00.664918+00:00
 - 2026-02-27 16:42:00.806890+00:00
**************************************************
None
**************************************************
 - 2026-02-27 16:42:00.890381+00:00
**************************************************
None
**************************************************
 - 2026-02-27 16:43:06.290773+00:00
**************************************************
{'path': '/osidb/api/v2/flaws/4b32861b-6271-4e35-a0a0-fb991cf3e8bd', 'user': 'monke@banana.com'}
**************************************************
 - 2026-02-27 16:43:06.915591+00:00
**************************************************
{'path': '/osidb/api/v1/flaws/CVE-2026-10007/promote', 'user': 'monke@banana.com'}
**************************************************
 - 2026-02-27 16:43:07.542939+00:00
**************************************************
{'path': '/osidb/api/v2/flaws/4b32861b-6271-4e35-a0a0-fb991cf3e8bd', 'user': 'monke@banana.com'}
**************************************************
OSIM-74136 - 2026-02-27 16:43:10.760294+00:00
**************************************************
{'action': 'jira_task_sync', 'source': 'celery', 'flaw_uuid': '4b32861b-6271-4e35-a0a0-fb991cf3e8bd', 'celery_task_id': '1ff25c35-c5be-47a2-a036-8e43592aefbc'}
**************************************************
OSIM-74137 - 2026-02-27 16:43:12.808267+00:00
**************************************************
{'action': 'jira_task_sync', 'source': 'celery', 'flaw_uuid': '4b32861b-6271-4e35-a0a0-fb991cf3e8bd', 'celery_task_id': '48b5b426-1d9e-4ecb-8443-b63248f22580'}
**************************************************
OSIM-74138 - 2026-02-27 16:43:16.493056+00:00
**************************************************
{'action': 'jira_task_sync', 'source': 'celery', 'flaw_uuid': '4b32861b-6271-4e35-a0a0-fb991cf3e8bd', 'celery_task_id': 'c21c62d2-c6c9-462d-8d9e-5f62d1c65cc6'}
**************************************************
OSIM-74138 - 2026-02-27 16:43:33.640337+00:00
**************************************************
{'path': '/osidb/api/v2/flaws/4b32861b-6271-4e35-a0a0-fb991cf3e8bd', 'user': 'monke@banana.com'}
**************************************************
OSIM-74138 - 2026-02-27 16:43:34.152565+00:00
**************************************************
{'path': '/osidb/api/v1/flaws/CVE-2026-10007/promote', 'user': 'monke@banana.com'}
**************************************************
```


Closes OSIDB-4738