### PR TITLE
persist tracker id on creation

### DIFF
--- a/apps/trackers/tests/test_integration.py
+++ b/apps/trackers/tests/test_integration.py
@@ -238,9 +238,9 @@ class TestTrackerAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-        # 4) the tracker is not stored to DB as it happens async
-        #    so check that there is no tracker relic stored
-        assert not Tracker.objects.count()
+        # 4) the tracker has been created with an external id
+        assert Tracker.objects.count() == 1
+        assert Tracker.objects.first().external_system_id
 
         # 5) so check at least the response
         #    even though it is not complete
@@ -399,9 +399,9 @@ class TestTrackerAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-        # 4) the tracker is not stored to DB as it happens async
-        #    so check that there is no tracker relic stored
-        assert not Tracker.objects.count()
+        # 4) the tracker has been created with an external id
+        assert Tracker.objects.count() == 1
+        assert Tracker.objects.first().external_system_id
 
         # 5) so check at least the response
         #    even though it is not complete
@@ -676,9 +676,9 @@ class TestTrackerAPI:
 
         assert response.status_code == status.HTTP_201_CREATED
 
-        # 4) the tracker is not stored to DB as it happens async
-        #    so check that there is no tracker relic stored
-        assert not Tracker.objects.count()
+        # 4) the tracker has been created with an external id
+        assert Tracker.objects.count() == 1
+        assert Tracker.objects.first().external_system_id
 
         # 5) so check at least the response
         #    even though it is not complete
@@ -704,7 +704,7 @@ class TestTrackerAPI:
         assert Affect.objects.count() == 1
         assert Flaw.objects.first().affects.count() == 1
         assert flaw.affects.count() == 1
-        assert Tracker.objects.count() == 0
+        assert Tracker.objects.count() == 1
         assert Affect.objects.first() == affect
         assert affect.flaw == flaw
 

--- a/collectors/bzimport/collectors.py
+++ b/collectors/bzimport/collectors.py
@@ -15,7 +15,7 @@ from django.utils import timezone
 from apps.bbsync.models import BugzillaComponent, BugzillaProduct
 from collectors.bzimport.convertors import BugzillaTrackerConvertor
 from collectors.framework.models import Collector
-from osidb.models import Flaw, PsModule
+from osidb.models import Flaw, PsModule, Tracker
 from osidb.sync_manager import (
     BZTrackerDownloadManager,
 )
@@ -367,8 +367,14 @@ class BugzillaTrackerCollector(Collector):
         BZTrackerDownloadManager.check_for_reschedules()
 
         tracker_ids = self.get_batch()
+        existing_trackers = Tracker.objects.filter(
+            external_system_id__in=tracker_ids
+        ).values_list("external_system_id", flat=True)
         for tracker_id, _ in tracker_ids:
-            BZTrackerDownloadManager.schedule(tracker_id)
+            # if tracker doesn't exist on db yet it may have been manually created on Jira or is being
+            # collected it too early, we delay the scheduling to avoid a writing race on the later
+            opt = {"countdown": 0 if tracker_id in existing_trackers else 30}
+            BZTrackerDownloadManager.schedule(tracker_id, schedule_options=opt)
             successes.append(tracker_id)
 
         complete = bool(self.is_complete or len(tracker_ids) < self.BATCH_SIZE)

--- a/collectors/jiraffe/collectors.py
+++ b/collectors/jiraffe/collectors.py
@@ -16,7 +16,7 @@ from jira.exceptions import JIRAError
 from apps.taskman.service import JiraTaskmanQuerier
 from apps.trackers.models import JiraProjectFields
 from collectors.framework.models import Collector
-from osidb.models import PsModule
+from osidb.models import PsModule, Tracker
 from osidb.sync_manager import (
     JiraTaskDownloadManager,
     JiraTrackerDownloadManager,
@@ -198,9 +198,16 @@ class JiraTrackerCollector(Collector):
             else "No Jira trackers were updated."
         )
 
+        existing_trackers = Tracker.objects.filter(
+            external_system_id__in=updated_trackers
+        ).values_list("external_system_id", flat=True)
+
         # schedule data sync
         for tracker_key in updated_trackers:
-            JiraTrackerDownloadManager.schedule(tracker_key)
+            # if tracker doesn't exist on db yet it may have been manually created on Jira or is being
+            # collected it too early, we delay the scheduling to avoid a writing race on the later
+            opt = {"countdown": 0 if tracker_key in existing_trackers else 30}
+            JiraTrackerDownloadManager.schedule(tracker_key, schedule_options=opt)
 
         # when we get to the future with the period end
         # the initial sync is done and the data are complete

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adjust Jira tracker sync to use `Update Stream` field and `ps_component` label (OSIDB-3830)
 - make purl_ps_component_mismatch an error instead of an alert (OSIDB-4830)
 - Allow empty components in empty workflow state (OSIDB-4857)
+- Trackers will save external id on first creation before async get (OSIDB-4872)
 
 ### Fixed
 - Fix JiraTrackerCollector not linking affect when OSIDB updated_dt was newer that jira updated_dt (OSIDB-4864)

--- a/osidb/models/tracker.py
+++ b/osidb/models/tracker.py
@@ -24,10 +24,6 @@ from osidb.mixins import (
 )
 from osidb.models.affect import Affect, NotAffectedJustification
 from osidb.models.fields import CVEIDField
-from osidb.sync_manager import (
-    BZTrackerDownloadManager,
-    JiraTrackerDownloadManager,
-)
 
 from .ps_module import PsModule
 from .ps_update_stream import PsUpdateStream
@@ -209,11 +205,10 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
         ):
             # sync to Bugzilla
             tracker_instance = TrackerSaver(self, bz_api_key=bz_api_key).save()
-            # no save or fetch to prevent collisions
-            # only schedule an asynchronous sync
-            BZTrackerDownloadManager.schedule(tracker_instance.external_system_id)
-            # at the end delete the temporary empty tracker
-            Tracker.objects.filter(external_system_id="").delete()
+
+            # skip alerts as the tracker has already being validated on first creation save
+            # skip timestamp generation as it should be updated soon with external timestamp
+            tracker_instance.save(no_alerts=True, auto_timestamps=False)
 
         # check Jira conditions are met
         elif (
@@ -240,11 +235,10 @@ class Tracker(AlertMixin, TrackingMixin, NullStrFieldsMixin, ACLMixin):
                 jira_token=jira_token,
                 jira_issuetype=actual_jira_issuetype,
             ).save()
-            # no save or fetch to prevent collisions
-            # only schedule an asynchronous sync
-            JiraTrackerDownloadManager.schedule(tracker_instance.external_system_id)
-            # at the end delete the temporary empty tracker
-            Tracker.objects.filter(external_system_id="").delete()
+
+            # skip alerts as the tracker has already being validated on first creation save
+            # skip timestamp generation as it should be updated soon with external timestamp
+            tracker_instance.save(no_alerts=True, auto_timestamps=False)
 
         # regular save otherwise
         else:

--- a/osidb/tests/endpoints/flaws/test_update_trackers.py
+++ b/osidb/tests/endpoints/flaws/test_update_trackers.py
@@ -305,7 +305,9 @@ class TestEndpointsFlawsUpdateTrackers:
             "updated_dt": flaw.updated_dt,
         }
 
-        monkeypatch.setattr(BZTrackerDownloadManager, "schedule", lambda x: None)
+        monkeypatch.setattr(
+            BZTrackerDownloadManager, "schedule", lambda *args, **kwargs: None
+        )
         # enable autospec to get self as part of the method call args
         with patch.object(BugzillaSaver, "save", autospec=True) as mock_save:
             response = auth_client().put(


### PR DESCRIPTION
This PR changes the tracker saving logic so we have a tracker instance with the id created on external BTS.

Due to performance issues, postponing the tracker instance creation on OSIDB can cause confusion on users and allow them to schedule duplicated trackers, this PR saves the actual external system id on creation without metadatas and schedule the collector in the future for complete metadata on trackers.

Closes OSIDB-4872.