### PR TITLE
OSIDB-4878: Automate package discovery and affect creation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -249,7 +249,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 134,
         "is_secret": false
       }
     ],
@@ -445,6 +445,58 @@
         "is_secret": false
       }
     ],
+    "osidb/tests/fixtures/newcli_openssl_hummingbird1.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_openssl_hummingbird1.json",
+        "hashed_secret": "c8d65f58fe3508fe2d57617b782806fc2c9e204b",
+        "is_verified": false,
+        "line_number": 37,
+        "is_secret": false
+      }
+    ],
+    "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json",
+        "hashed_secret": "c8d65f58fe3508fe2d57617b782806fc2c9e204b",
+        "is_verified": false,
+        "line_number": 37,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json",
+        "hashed_secret": "2f691bd4a49ed97be2097dff949ea55753b8add0",
+        "is_verified": false,
+        "line_number": 74,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json",
+        "hashed_secret": "1e78d90ecc8d40309bef3beab6794b26f797d64c",
+        "is_verified": false,
+        "line_number": 111,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json",
+        "hashed_secret": "e232187ccab2c7c8d513d0b40bd76e2d07175720",
+        "is_verified": false,
+        "line_number": 148,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json",
+        "hashed_secret": "7b44c3c4edf9acb71bd59108e57c8eb4d48e18bb",
+        "is_verified": false,
+        "line_number": 185,
+        "is_secret": false
+      }
+    ],
     "perf/main.py": [
       {
         "type": "Secret Keyword",
@@ -474,5 +526,5 @@
       }
     ]
   },
-  "generated_at": "2026-03-31T11:50:37Z"
+  "generated_at": "2026-04-10T12:29:07Z"
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,25 @@ RUN uv sync --frozen --no-dev && \
     rm -f /opt/app-root/src/pyproject.toml && \ 
     rm -f /opt/app-root/src/uv.lock
 
+# Optional: GitLab HTTPS clone URL for the newtopia-cli monorepo; when set, install in-repo
+# deptopia_client first, then newtopia_cli (PyPI has no deptopia_client).
+# Optional: branch, tag, or commit for both installs (omit for the remote default branch).
+ARG NEWCLI_REPO_URL=""
+ARG NEWCLI_EXPERIMENTAL_BRANCH=""
+RUN if [ -n "$NEWCLI_REPO_URL" ]; then \
+        if [ -n "$NEWCLI_EXPERIMENTAL_BRANCH" ]; then \
+            uv pip install --no-cache --python "$UV_PROJECT_ENVIRONMENT/bin/python" \
+                "git+${NEWCLI_REPO_URL}@${NEWCLI_EXPERIMENTAL_BRANCH}#subdirectory=python/deptopia-client" && \
+            uv pip install --no-cache --python "$UV_PROJECT_ENVIRONMENT/bin/python" \
+                "git+${NEWCLI_REPO_URL}@${NEWCLI_EXPERIMENTAL_BRANCH}#egg=newtopia_cli&subdirectory=python/newtopia_cli"; \
+        else \
+            uv pip install --no-cache --python "$UV_PROJECT_ENVIRONMENT/bin/python" \
+                "git+${NEWCLI_REPO_URL}#subdirectory=python/deptopia-client" && \
+            uv pip install --no-cache --python "$UV_PROJECT_ENVIRONMENT/bin/python" \
+                "git+${NEWCLI_REPO_URL}#egg=newtopia_cli&subdirectory=python/newtopia_cli"; \
+        fi; \
+    fi
+
 # Copy the project into the image
 COPY . /opt/app-root/src
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import json
 import re
+from copy import deepcopy
+from pathlib import Path
 
 import pytest
 from django.conf import settings
@@ -247,6 +249,37 @@ def bypass_rls(db, request):
     if "enable_rls" in request.keywords:
         return
     set_user_acls(settings.ALL_GROUPS)
+
+
+_NEWCLI_FIXTURE_DIR = Path(__file__).resolve().parent / "osidb" / "tests" / "fixtures"
+
+
+def _load_newcli_json_fixture(filename: str) -> dict:
+    path = _NEWCLI_FIXTURE_DIR / filename
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def newcli_urllib3_hummingbird1_json():
+    """
+    Pretty-printed sample of ``newcli -s urllib3 --include hummingbird-1 --json``.
+
+    Source: ``osidb/tests/fixtures/newcli_urllib3_hummingbird1.json`` (multiple ``deps`` for
+    multi-affect tests).
+    """
+    return deepcopy(_load_newcli_json_fixture("newcli_urllib3_hummingbird1.json"))
+
+
+@pytest.fixture
+def newcli_openssl_hummingbird1_json():
+    """
+    Pretty-printed sample of ``newcli -s openssl --include hummingbird-1 --json`` (openssl /
+    cargo dependency shape; single ``deps`` entry).
+
+    Source: ``osidb/tests/fixtures/newcli_openssl_hummingbird1.json``.
+    """
+    return deepcopy(_load_newcli_json_fixture("newcli_openssl_hummingbird1.json"))
 
 
 @pytest.fixture

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,8 @@ services:
         args:
           RH_CERT_URL: ${RH_CERT_URL}
           PYPI_MIRROR: ${PIP_INDEX_URL}
+          NEWCLI_REPO_URL: ${NEWCLI_REPO_URL}
+          NEWCLI_EXPERIMENTAL_BRANCH: ${NEWCLI_EXPERIMENTAL_BRANCH}
       image: localhost/osidb-service
       pull_policy: never
       stdin_open: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Add schema validation to PURLs (OSIDB-4910)
+- Affect(s) can be automatically created and assigned to Flaw(s) for
+  specific products (OSIDB-4878)
 
 ## [5.9.0] - 2026-04-09
 ### Fixed
@@ -120,7 +122,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [5.2.2] - 2025-12-04
 ### Added
-- support for multiple endings 
+- support for multiple endings
 - new ending type "no shutdown" [christmas + new year + from jan 2 to jan 7]
 
 ## [5.2.1] - 2025-11-13
@@ -165,7 +167,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix PUT request being allowed for `AuditView` endpoint (OSIDB-4428)
 - Fix creation of related objects for public flaws having internal visibility (OSIDB-4552)
-- Fix CVE_id parsing for OSV in linux DB (OSIDB-4548) 
+- Fix CVE_id parsing for OSV in linux DB (OSIDB-4548)
 - Prevent unintended publicizing flaws when workflow state has unexpected value during sync tasks (OSIDB-4446)
 - Fix changing flaw's severity making trackers to temporarily disappear (OSIDB-4069)
 
@@ -175,7 +177,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add filter and Djangoql field for multi-label flaws (OSIDB-4531)
 
 ### Changed
-- Adjust `unembargo_dt` validation for embargoed flaws to only trigger when 
+- Adjust `unembargo_dt` validation for embargoed flaws to only trigger when
   `unembargo_dt` is changed (OSIDB-4296)
 - Improve performance in Alerts and ACL serialization (OSIDB-4313)
 - Implement affects v2 (OSIDB-4023)
@@ -186,7 +188,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Require an internal comment on incident request (OSIDB-3852)
 
 ### Removed
-- Remove deprecated fields/models: `PsProduct`'s `team`, `FlawComment`'s `order` 
+- Remove deprecated fields/models: `PsProduct`'s `team`, `FlawComment`'s `order`
   and models in `package_versions.py` (OSIDB-3552)
 
 ## [4.16.1] - 2025-10-01
@@ -282,7 +284,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   don't meet Moderate and CVSS score >= 7.0 criteria (OSIDB-4199)
 
 ### Fixed
-- Prevent running multiple Jira transition managers at the same time (OSIDB-4175) 
+- Prevent running multiple Jira transition managers at the same time (OSIDB-4175)
 
 ## [4.10.1] - 2025-04-30
 ### Added
@@ -826,7 +828,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed OSIM module to Workflows (OSIDB-1395)
 - Change settings to allow regex in CORS policy in stage environment (OSIDB-1737)
 - Enhanced prefetches on Flaw, Affect, and Tracker api querysets
-- Change default pg configs 
+- Change default pg configs
 - Adjust CONN_MAX_AGE and CONN_MAX_CONNS to maintain a minimal pool of idle db conns (OSIDB-1620)
 - Tracker status field is read-only (OSIDB-1780)
 - Change Bugzilla collector and Flaw model to allow multiple components in bz_summary (OSIDB-1420)

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -50,8 +50,7 @@ from rest_framework_simplejwt.views import TokenObtainPairView
 
 from apps.workflows.workflow import WorkflowModel
 from collectors.jiraffe.constants import HTTPS_PROXY, JIRA_SERVER
-from osidb.core import set_user_acls
-from osidb.helpers import get_bugzilla_api_key, get_flaw_or_404
+from osidb.helpers import bypass_rls, get_bugzilla_api_key, get_flaw_or_404
 from osidb.integrations import IntegrationRepository, IntegrationSettings
 from osidb.models import Affect, AffectCVSS, AffectV1, Flaw, FlawLabel, Tracker
 from osidb.models.flaw.comment import FlawComment
@@ -1007,6 +1006,7 @@ class FlawCVSSV2View(
 )
 @api_view(["GET"])
 @permission_classes([IsAuthenticatedOrReadOnly])
+@bypass_rls
 def flaw_available(request: Request, *args, **kwargs) -> Response:
     """
     Report whether a flaw is available for public consumption purposes
@@ -1044,14 +1044,11 @@ def flaw_available(request: Request, *args, **kwargs) -> Response:
     cve_id = kwargs["cve_id"]
 
     try:
-        set_user_acls(settings.ALL_GROUPS)
         flaw = Flaw.objects.get_by_identifier(cve_id)
     except Flaw.DoesNotExist:
         return Response(status=HTTP_204_NO_CONTENT)
     except ValidationError:
         return Response(status=HTTP_400_BAD_REQUEST)
-    finally:
-        set_user_acls([])
 
     if (
         flaw.is_public

--- a/osidb/core.py
+++ b/osidb/core.py
@@ -25,6 +25,39 @@ def generate_acls(groups):
     )
 
 
+def snapshot_user_acl_session() -> dict[str, str | None]:
+    """
+    Read ``osidb.acl`` from each open DB connection (``None`` if unset).
+    """
+    snapshot: dict[str, str | None] = {}
+    try:
+        for db_alias in connections:
+            with connections[db_alias].cursor() as cursor:
+                cursor.execute("SELECT current_setting('osidb.acl', true)")
+                raw = cursor.fetchone()[0]
+                snapshot[db_alias] = None if raw in (None, "") else raw
+    except Exception:
+        raise OSIDBException("Cannot snapshot user acl session")
+    return snapshot
+
+
+def restore_user_acl_session(snapshot: dict[str, str | None]) -> None:
+    """
+    Restore ``osidb.acl`` on each connection from a :func:`snapshot_user_acl_session` value.
+    """
+    try:
+        for db_alias, raw in snapshot.items():
+            if db_alias not in connections:
+                continue
+            with connections[db_alias].cursor() as cursor:
+                if raw is None:
+                    cursor.execute("RESET osidb.acl")
+                else:
+                    cursor.execute("SET osidb.acl = %s", [raw])
+    except Exception:
+        raise OSIDBException("Cannot restore user acl session")
+
+
 def set_user_acls(groups) -> None:
     """
     set user acls

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -2,6 +2,7 @@
 Helpers for direct or development shell usage
 """
 
+import functools
 import json
 import logging
 import logging.handlers
@@ -22,7 +23,11 @@ from requests.models import Response
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
-from osidb.core import set_user_acls
+from osidb.core import (
+    restore_user_acl_session,
+    set_user_acls,
+    snapshot_user_acl_session,
+)
 from osidb.validators import CVE_RE_STR, restrict_regex
 
 from .exceptions import OSIDBException
@@ -348,6 +353,8 @@ def bypass_rls(f: Callable) -> Callable:
 
     When a callable is decorated with this helper, the ACLs will be set to
     ALL_GROUPS, effectively bypassing Row-Level Security / Authorization.
+    After the callable returns, the previous ``osidb.acl`` session values per
+    connection are restored (same as before the decorator ran), not cleared.
 
     Be aware of the implications of bypassing RLS, namely that any actions
     that depend on a user's permissions will not work correctly if executed
@@ -359,10 +366,14 @@ def bypass_rls(f: Callable) -> Callable:
         * Non user-driven processes
     """
 
+    @functools.wraps(f)
     def wrapped(*args, **kwargs):
+        previous_acl = snapshot_user_acl_session()
         set_user_acls(settings.ALL_GROUPS)
-        f(*args, **kwargs)
-        set_user_acls([])
+        try:
+            return f(*args, **kwargs)
+        finally:
+            restore_user_acl_session(previous_acl)
 
     return wrapped
 

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -10,6 +10,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from psqlextra.fields import HStoreField
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from apps.bbsync.constants import RHSCL_BTS_KEY
@@ -42,6 +43,10 @@ class AffectSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OSIDB_AFFECTS_")
 
     require_purl_for_middleware: bool = False
+    auto_create: bool = False
+    auto_create_ps_modules: list[str] = Field(
+        default_factory=lambda: ["hummingbird-1"],
+    )
 
 
 class NotAffectedJustification(models.TextChoices):

--- a/osidb/signals.py
+++ b/osidb/signals.py
@@ -2,6 +2,7 @@ import logging
 
 from bugzilla import Bugzilla
 from django.contrib.auth.models import User
+from django.db import transaction
 from django.db.models.signals import post_delete, post_save, pre_save
 from django.dispatch import receiver
 from django.template.loader import render_to_string
@@ -24,10 +25,11 @@ from osidb.models import (
     PsUpdateStream,
     Tracker,
 )
+from osidb.models.affect import AffectSettings
 from osidb.models.flaw.acknowledgment import FlawAcknowledgment
 from osidb.models.flaw.comment import FlawComment
 from osidb.models.flaw.reference import FlawReference
-from osidb.tasks import async_send_email
+from osidb.tasks import async_send_email, sync_flaw_affects_from_newcli
 
 logger = logging.getLogger(__name__)
 
@@ -111,6 +113,49 @@ def auto_create_profile(sender, instance, created, **kwargs):
 @receiver(pre_save, sender=AffectCVSS)
 def populate_cvss_score(sender, instance, **kwargs):
     instance.score = float(instance.cvss_object.base_score)
+
+
+@receiver(pre_save, sender=Flaw)
+def schedule_sync_flaw_affects_on_components_change(sender, instance, **kwargs) -> None:
+    """
+    When :attr:`Flaw.components` is set or updated and the flaw has at least one
+    non-empty component, register :func:`osidb.tasks.sync_flaw_affects_from_newcli`
+    to run after the current DB transaction commits (via :func:`django.db.transaction.on_commit`).
+
+    Gated by :attr:`osidb.models.affect.AffectSettings.auto_create`
+    (``OSIDB_AFFECTS_AUTO_CREATE``, default false).
+    """
+    if not AffectSettings().auto_create:
+        return
+
+    if kwargs.get("raw"):
+        return
+
+    update_fields = kwargs.get("update_fields")
+    if update_fields is not None and "components" not in update_fields:
+        return
+
+    new_list = list(instance.components or [])
+
+    if instance._state.adding:
+        components_changed = True
+    else:
+        old_list = list(Flaw.objects.get(pk=instance.pk).components or [])
+        components_changed = old_list != new_list
+
+    if not components_changed:
+        return
+
+    if not any(c and str(c).strip() for c in new_list):
+        return
+
+    flaw_id = str(instance.uuid)
+
+    def enqueue_sync() -> None:
+        # Celery adds .delay at import time; static checkers do not see it
+        sync_flaw_affects_from_newcli.delay(flaw_id)  # type: ignore[attr-defined]
+
+    transaction.on_commit(enqueue_sync)
 
 
 @receiver(pre_save, sender=Flaw)

--- a/osidb/tasks.py
+++ b/osidb/tasks.py
@@ -1,17 +1,23 @@
+import json
+import subprocess  # nosec: B404
 from time import time
+from typing import Any
 
 from celery.utils.log import get_task_logger
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.mail.message import EmailMultiAlternatives
-from django.db import OperationalError, connection
+from django.db import OperationalError, connection, transaction
 from django.db.models import OuterRef, Q, Subquery
 from django.db.models.functions import Cast
 
 from config.celery import app
 from config.settings import EmailSettings
 from osidb.core import set_user_acls
+from osidb.helpers import bypass_rls
 from osidb.mixins import Alert
+from osidb.models import Flaw
+from osidb.models.affect import Affect, AffectSettings
 from osidb.sync_manager import (
     BZSyncManager,
     JiraTaskSyncManager,
@@ -19,6 +25,97 @@ from osidb.sync_manager import (
 )
 
 logger = get_task_logger(__name__)
+
+
+def _newcli_include_modules_csv() -> str:
+    return ",".join(AffectSettings().auto_create_ps_modules)
+
+
+def _flaw_components_for_newcli(flaw: Flaw) -> list[str]:
+    components = [c for c in (flaw.components or []) if c and str(c).strip()]
+    if not components:
+        raise ValueError(f"Flaw {flaw.uuid} has no non-empty components for newcli -s")
+    return components
+
+
+def _run_newcli_deps_json(flaw_component: str) -> dict[str, Any]:
+    cmd = [
+        "newcli",
+        "-s",
+        flaw_component,
+        "--include",
+        _newcli_include_modules_csv(),
+        "--json",
+    ]
+    result = subprocess.run(  # noqa: S603
+        cmd,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"newcli failed (exit {result.returncode}): {result.stderr or result.stdout}"
+        )
+    return json.loads(result.stdout or "{}")
+
+
+def _sync_affects_from_newcli_deps(
+    flaw: Flaw, payload: dict[str, Any]
+) -> dict[str, int]:
+    deps = payload.get("deps") or []
+    created = 0
+    skipped = 0
+    skipped_existing = 0
+
+    with transaction.atomic():
+        for dep in deps:
+            if not isinstance(dep, dict):
+                skipped += 1
+                continue
+            ps_update_stream = dep.get("ps_update_stream") or dep.get("ps_module")
+            purls = dep.get("purls") or []
+            purl_str = purls[0] if purls else None
+
+            if not ps_update_stream or not purl_str:
+                logger.warning(
+                    "Skipping newcli dep missing ps_update_stream or purls: %s",
+                    dep.get("build_nvr"),
+                )
+                skipped += 1
+                continue
+
+            ps_component = Affect(purl=purl_str).ps_component_from_purl()
+
+            if (
+                ps_component
+                and Affect.objects.filter(
+                    flaw=flaw,
+                    ps_update_stream=ps_update_stream,
+                    ps_component=ps_component,
+                ).exists()
+            ):
+                skipped_existing += 1
+                continue
+
+            affect = Affect(
+                flaw=flaw,
+                ps_update_stream=ps_update_stream,
+                purl=purl_str,
+                acl_read=flaw.acl_read,
+                acl_write=flaw.acl_write,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
+                impact=flaw.impact,
+            )
+            affect.save(raise_validation_error=False)
+            created += 1
+
+    return {
+        "created": created,
+        "skipped": skipped,
+        "skipped_existing": skipped_existing,
+    }
 
 
 @app.task
@@ -111,6 +208,40 @@ def refresh_affect_v1_view():
         message = f'Could not refresh "affect_v1" (likely already in progress): {e}'
         logger.warning(message)
         return message
+
+
+@app.task
+@bypass_rls
+def sync_flaw_affects_from_newcli(flaw_id: str) -> dict[str, Any]:
+    """
+    For each entry in ``Flaw.components``, run ``newcli`` and create affects for each
+    ``deps`` row: ``ps_update_stream`` from the payload, ``purl`` from the first ``purls``
+    entry. Existing affects for the same flaw, stream, and ``ps_component`` (inferred from
+    the purl) are left unchanged.
+
+    ``newcli --include`` is built from :attr:`osidb.models.affect.AffectSettings.auto_create_ps_modules`
+    (``OSIDB_AFFECTS_AUTO_CREATE_PS_MODULES``, JSON list; default ``["hummingbird-1"]``).
+
+    When :attr:`osidb.models.affect.AffectSettings.auto_create` is true
+    (``OSIDB_AFFECTS_AUTO_CREATE``), changes to :attr:`~osidb.models.flaw.flaw.Flaw.components`
+    register this task on :func:`django.db.transaction.on_commit` from a ``pre_save`` signal
+    on :class:`~osidb.models.flaw.flaw.Flaw`.
+    """
+    flaw = Flaw.objects.get(uuid=flaw_id)
+    components = _flaw_components_for_newcli(flaw)
+    totals: dict[str, int] = {"created": 0, "skipped": 0, "skipped_existing": 0}
+    for flaw_component in components:
+        payload = _run_newcli_deps_json(flaw_component)
+        stats = _sync_affects_from_newcli_deps(flaw, payload)
+        for key in totals:
+            totals[key] += stats[key]
+    logger.info(
+        "sync_flaw_affects_from_newcli flaw=%s components=%s %s",
+        flaw_id,
+        components,
+        totals,
+    )
+    return totals
 
 
 @app.task

--- a/osidb/tests/fixtures/newcli_openssl_hummingbird1.json
+++ b/osidb/tests/fixtures/newcli_openssl_hummingbird1.json
@@ -1,0 +1,51 @@
+{
+  "builds": [],
+  "deps": [
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "python-cryptography",
+      "build_nvr": "python-cryptography-46.0.6-1.hum1",
+      "build_repo": null,
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "cargo",
+              "id": null,
+              "name": "openssl",
+              "nvr": "openssl-0.10.73",
+              "version": "0.10.73"
+            },
+            {
+              "dev": 0,
+              "ecosystem": "cargo",
+              "id": null,
+              "name": "openssl",
+              "nvr": "openssl-0.10.74",
+              "version": "0.10.74"
+            }
+          ],
+          "hash": "7bca1d9029f834712ccb75ae70e72a46cab54361",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/python-cryptography",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:oci/python-cryptography?repository_url=registry.redhat.io/python-cryptography"
+      ]
+    }
+  ],
+  "params": null
+}

--- a/osidb/tests/fixtures/newcli_urllib3_hummingbird1.json
+++ b/osidb/tests/fixtures/newcli_urllib3_hummingbird1.json
@@ -1,0 +1,199 @@
+{
+  "builds": [],
+  "deps": [
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "python-cryptography",
+      "build_nvr": "python-cryptography-46.0.6-1.hum1",
+      "build_repo": null,
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "pypi",
+              "id": null,
+              "name": "urllib3",
+              "nvr": "urllib3-2.2.3",
+              "version": "2.2.3"
+            },
+            {
+              "dev": 0,
+              "ecosystem": "pypi",
+              "id": null,
+              "name": "urllib3",
+              "nvr": "urllib3-2.5.0",
+              "version": "2.5.0"
+            }
+          ],
+          "hash": "7bca1d9029f834712ccb75ae70e72a46cab54361",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/python-cryptography",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:oci/python-cryptography?repository_url=registry.redhat.io/python-cryptography"
+      ]
+    },
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "python-jsonschema",
+      "build_nvr": "python-jsonschema-4.26.0-5.hum1",
+      "build_repo": null,
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "pypi",
+              "id": null,
+              "name": "urllib3",
+              "nvr": "urllib3-2.6.2",
+              "version": "2.6.2"
+            }
+          ],
+          "hash": "bc1a8d94133f7ad6751b1f20f2a291ce8cda5374",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/python-jsonschema",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:oci/python-jsonschema?repository_url=registry.redhat.io/python-jsonschema"
+      ]
+    },
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "python-jsonschema-specifications",
+      "build_nvr": "python-jsonschema-specifications-2025.9.1-1.hum1",
+      "build_repo": null,
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "pypi",
+              "id": null,
+              "name": "urllib3",
+              "nvr": "urllib3-2.5.0",
+              "version": "2.5.0"
+            }
+          ],
+          "hash": "2d8731d4847f06881c0429a07d11af4b1ecc2717",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/python-jsonschema-specifications",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:oci/python-jsonschema-specifications?repository_url=registry.redhat.io/python-jsonschema-specifications"
+      ]
+    },
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "python-sentry-sdk",
+      "build_nvr": "python-sentry-sdk-2.48.0-4.hum1",
+      "build_repo": null,
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "pypi",
+              "id": null,
+              "name": "urllib3",
+              "nvr": "urllib3-2.3.0",
+              "version": "2.3.0"
+            }
+          ],
+          "hash": "5a521129e6bdb2b5c8e07606ebf01b169fe8c208",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/python-sentry-sdk",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:oci/python-sentry-sdk?repository_url=registry.redhat.io/python-sentry-sdk"
+      ]
+    },
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "python3.11",
+      "build_nvr": "python3.11-3.11.15-2.hum1",
+      "build_repo": null,
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "pypi",
+              "id": null,
+              "name": "urllib3",
+              "nvr": "urllib3-2.0.7",
+              "version": "2.0.7"
+            }
+          ],
+          "hash": "28ff09b9483630aefb06151b503a4cfa10c8ab77",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/python3.11",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:oci/python3.11?repository_url=registry.redhat.io/python3.11"
+      ]
+    }
+  ],
+  "params": null
+}

--- a/osidb/tests/test_sync_flaw_affects_from_newcli.py
+++ b/osidb/tests/test_sync_flaw_affects_from_newcli.py
@@ -1,0 +1,164 @@
+import json
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+from packageurl import PackageURL
+
+from osidb.tasks import sync_flaw_affects_from_newcli
+from osidb.tests.factories import FlawFactory
+
+pytestmark = pytest.mark.unit
+
+
+def _purls_from_newcli_payload(payload: dict) -> set[str]:
+    return {dep["purls"][0] for dep in payload["deps"]}
+
+
+def test_sync_flaw_affects_from_newcli_creates_one_affect_per_dep(
+    newcli_urllib3_hummingbird1_json, monkeypatch
+):
+    flaw = FlawFactory(components=["urllib3"])
+    expected_purls = _purls_from_newcli_payload(newcli_urllib3_hummingbird1_json)
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == [
+            "newcli",
+            "-s",
+            "urllib3",
+            "--include",
+            "hummingbird-1",
+            "--json",
+        ]
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(newcli_urllib3_hummingbird1_json),
+            stderr="",
+        )
+
+    monkeypatch.setattr("osidb.tasks.subprocess.run", fake_run)
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    n_deps = len(newcli_urllib3_hummingbird1_json["deps"])
+    assert stats == {"created": n_deps, "skipped": 0, "skipped_existing": 0}
+    assert flaw.affects.count() == n_deps
+
+    stored = {
+        str(a.purl) for a in list(flaw.affects.filter(ps_update_stream="hummingbird-1"))
+    }
+    normalized_expected = {
+        PackageURL.from_string(p).to_string() for p in expected_purls
+    }
+    assert stored == normalized_expected
+
+
+def test_sync_flaw_affects_from_newcli_runs_newcli_per_flaw_component(
+    newcli_urllib3_hummingbird1_json,
+    newcli_openssl_hummingbird1_json,
+    monkeypatch,
+):
+    """
+    Each flaw component gets its own ``newcli -s <component>`` call; payloads are merged into
+    one set of affects. The openssl sample repeats the python-cryptography PURL from urllib3,
+    so that row is skipped as already existing.
+    """
+    flaw = FlawFactory(components=["urllib3", "openssl"])
+    newcli_s_order = []
+
+    def fake_run(cmd, **kwargs):
+        component = cmd[2]
+        newcli_s_order.append(component)
+        if component == "urllib3":
+            payload = newcli_urllib3_hummingbird1_json
+        elif component == "openssl":
+            payload = newcli_openssl_hummingbird1_json
+        else:
+            raise AssertionError(f"unexpected newcli -s {component!r}")
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+
+    monkeypatch.setattr("osidb.tasks.subprocess.run", fake_run)
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert newcli_s_order == ["urllib3", "openssl"]
+    n_urllib3 = len(newcli_urllib3_hummingbird1_json["deps"])
+    assert stats == {
+        "created": n_urllib3,
+        "skipped": 0,
+        "skipped_existing": 1,
+    }
+    assert flaw.affects.count() == n_urllib3
+
+
+def test_sync_flaw_affects_from_newcli_skips_existing(
+    newcli_urllib3_hummingbird1_json, monkeypatch
+):
+    flaw = FlawFactory(components=["urllib3"])
+    n_deps = len(newcli_urllib3_hummingbird1_json["deps"])
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(newcli_urllib3_hummingbird1_json),
+            stderr="",
+        )
+
+    monkeypatch.setattr("osidb.tasks.subprocess.run", fake_run)
+
+    assert sync_flaw_affects_from_newcli(str(flaw.uuid)) == {
+        "created": n_deps,
+        "skipped": 0,
+        "skipped_existing": 0,
+    }
+    assert sync_flaw_affects_from_newcli(str(flaw.uuid)) == {
+        "created": 0,
+        "skipped": 0,
+        "skipped_existing": n_deps,
+    }
+
+
+def test_sync_flaw_affects_from_newcli_no_components_raises(monkeypatch):
+    flaw = FlawFactory(components=[])
+
+    monkeypatch.setattr(
+        "osidb.tasks.subprocess.run",
+        MagicMock(side_effect=AssertionError("newcli should not run")),
+    )
+
+    with pytest.raises(ValueError, match="no non-empty components"):
+        sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+
+def test_sync_flaw_affects_from_newcli_include_modules_from_env(
+    newcli_urllib3_hummingbird1_json, monkeypatch
+):
+    monkeypatch.setenv(
+        "OSIDB_AFFECTS_AUTO_CREATE_PS_MODULES",
+        '["hummingbird-1","rhel-9"]',
+    )
+    flaw = FlawFactory(components=["urllib3"])
+
+    seen_include = []
+
+    def fake_run(cmd, **kwargs):
+        seen_include.append(cmd[4])
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(newcli_urllib3_hummingbird1_json),
+            stderr="",
+        )
+
+    monkeypatch.setattr("osidb.tasks.subprocess.run", fake_run)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert seen_include == ["hummingbird-1,rhel-9"]


### PR DESCRIPTION
This experimental feature provisions `newcli` within OSIDB in certain environments.

Whenever a new Flaw is assigned components or its components are changed, newcli is invoked asynchronously in order to find affected packages and streams and then the relevant affects are created and added to the Flaw automatically.

As of this time, the feature is limited to the hummingbird-1 ps_module but can be easily expanded to other ps_modules and enabled/disabled independently thanks to feature flags.