### PR TITLE
OSIDB-4875- remove owner and qe_owner parsing from Jira tracker and task download

### DIFF
--- a/collectors/jiraffe/constants.py
+++ b/collectors/jiraffe/constants.py
@@ -32,7 +32,6 @@ JIRA_METADATA_COLLECTOR_ENABLED = get_env(
 )
 
 TASK_CHANGELOG_FIELD_MAPPING = {
-    "assignee": ["owner"],
     "status": ["workflow_name", "workflow_state"],
     "resolution": ["workflow_name", "workflow_state"],
 }

--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -14,7 +14,6 @@ from django.db import transaction
 from apps.workflows.workflow import WorkflowFramework
 from osidb.core import generate_acls, set_user_acls
 from osidb.models import Flaw, Tracker
-from osidb.models.jira_user_mapping import JiraUserMapping
 from osidb.validators import CVE_RE_STR
 
 from ..utils import (
@@ -65,14 +64,10 @@ class JiraTaskConvertor:
         status = self.get_field_attr(self._raw, "status", "name")
         resolution = self.get_field_attr(self._raw, "resolution", "name")
         workflow, state = WorkflowFramework().jira_to_state(status, resolution)
-        assignee_cloud_id = self.get_field_attr(self._raw, "assignee", "accountId")
 
         return {
             "external_system_id": self._raw.key,
             "labels": self._raw.fields.labels,
-            "owner": f"{JiraUserMapping.cloud_id_to_kerberos(assignee_cloud_id)}@redhat.com"
-            if assignee_cloud_id
-            else "",
             "jira_status": status,
             "jira_resolution": resolution,
             "workflow_state": state,
@@ -180,7 +175,6 @@ class JiraTaskSaver:
         task_attributes = [
             "task_key",
             "task_updated_dt",
-            "owner",
             # the ACLs are not really directly fetched but can
             # get modified due to state or resolution changes
             "acl_read",
@@ -423,23 +417,10 @@ class JiraTrackerConvertor(TrackerConvertor):
                 self._raw.fields.resolutiondate, JIRA_DT_FULL_FMT
             )
 
-        assignee_cloud_id = self.get_field_attr(self._raw, "assignee", "accountId")
-        qe_cloud_id = self.get_field_attr(
-            self._raw, "customfield_12316243", "accountId"
-        )
-
         return {
             "jira_issuetype": self.get_field_attr(self._raw, "issuetype", "name"),
             "external_system_id": self._raw.key,
             "labels": json.dumps(self._raw.fields.labels),
-            "owner": JiraUserMapping.cloud_id_to_kerberos(assignee_cloud_id)
-            if assignee_cloud_id
-            else "",
-            # QE Assignee corresponds to customfield_12316243
-            # in RH Jira which is a field of schema type user
-            "qe_owner": JiraUserMapping.cloud_id_to_kerberos(qe_cloud_id)
-            if qe_cloud_id
-            else "",
             "ps_module": ps_module,
             "ps_component": ps_component,
             "ps_update_stream": ps_update_stream,

--- a/collectors/jiraffe/tests/test_collectors.py
+++ b/collectors/jiraffe/tests/test_collectors.py
@@ -25,7 +25,6 @@ from osidb.models import Affect, Flaw, Impact, Tracker
 from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
-    JiraUserMappingFactory,
     PsModuleFactory,
     PsUpdateStreamFactory,
     TrackerFactory,
@@ -121,8 +120,6 @@ class TestJiraTaskCollector:
 
     @pytest.mark.vcr
     def test_link_on_cve(self):
-        # some random UUID
-        JiraUserMappingFactory(atlassian_cloud_id="test-cloud-id")
         flaw = FlawFactory(cve_id="CVE-2024-34703")
         # this is super-unprobable to happen but based
         # on the review feedback I am adding the assert
@@ -568,7 +565,6 @@ class TestMetadataCollector:
         Regression: when Jira tracker data is up-to-date (convertor returns None),
         sync_task should still link affects for an existing tracker.
         """
-        JiraUserMappingFactory(atlassian_cloud_id="test-cloud-id")
         tracker_id = "RHEL-159920"
         ps_module = PsModuleFactory(name="module", bts_name="jboss")
         ps_update_stream = PsUpdateStreamFactory(name="stream", ps_module=ps_module)

--- a/collectors/jiraffe/tests/test_convertors.py
+++ b/collectors/jiraffe/tests/test_convertors.py
@@ -13,7 +13,6 @@ from osidb.models import Affect, Flaw, Tracker
 from osidb.tests.factories import (
     AffectFactory,
     FlawFactory,
-    JiraUserMappingFactory,
     PsModuleFactory,
     PsUpdateStreamFactory,
 )
@@ -392,9 +391,6 @@ class TestJiraTrackerConvertor:
         mock_issue.fields.created = "2026-01-01T00:00:00.000+0000"
         mock_issue.fields.updated = "2026-01-01T00:00:00.000+0000"
         mock_issue.fields.resolutiondate = None
-        mock_issue.fields.assignee = None
-        mock_issue.fields.customfield_12316243 = None
-
         convertor = JiraTrackerConvertor(mock_issue)
 
         assert convertor.ps_update_stream == "test-stream"
@@ -414,7 +410,6 @@ class TestJiraTaskConvertor:
         """
         test that the convertor works
         """
-        mapping = JiraUserMappingFactory(atlassian_cloud_id="test-cloud-id")
         task_data = JiraQuerier().get_issue(self.task_id, expand="changelog")
         task_convertor = JiraTaskConvertor(task_data)
 
@@ -442,4 +437,3 @@ class TestJiraTaskConvertor:
         )
         assert flaw.workflow_name == "DEFAULT"
         assert flaw.workflow_state == "TRIAGE"
-        assert flaw.owner == f"{mapping.associate_kerberos_id}@redhat.com"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Affect(s) can be automatically created and assigned to Flaw(s) for
   specific products (OSIDB-4878)
 
+### Removed
+- Remove `owner` and `qe_owner` parsing from Jira Tracker and Task download to prevent tracker sync failure(OSIDB-4875)
+
 ## [5.9.0] - 2026-04-09
 ### Fixed
 - Fix invalid `in` field in kerberos OpenAPI security scheme (OSIDB-1590)


### PR DESCRIPTION
Remove `owner` and `qe_owner` parsing from Jira tracker download.
These fields used `JiraUserMapping.cloud_id_to_kerberos` which fails for service accounts and deactivated users.
-convertors.py - Removed `owner` and `qe_owner` parsing from JiraTrackerConvertor and JiraTaskConvertor.
-constants.py - Removed `assignee: ["owner"]` .
-test_convertors.py - Updated tests accordingly.
-CHANGELOG.md - Added entry.
Closes: OSIDB - 4875
