### PR TITLE
OSIDB-4923 - Add helper function to pull cpe list

### DIFF
--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -70,7 +70,7 @@ class NVDQuerier:
             Return a list of CPEs from the CVE `data`
             """
             cpe_list = []
-            if "cpe" in data and len(data.cpe) > 0:
+            if hasattr(data, "cpe"):
                 for entry in data.cpe:
                     cpe_list.append(entry.criteria)
 

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from typing import List, Union
 
 import nvdlib
 from celery.utils.log import get_task_logger
@@ -65,7 +65,7 @@ class NVDQuerier:
         filtering out everything unnecessary and simplifying
         """
 
-        def get_cpe_list(data: CVE) -> Optional[List[str]]:
+        def get_cpe_list(data: CVE) -> List[str]:
             """
             Return a list of CPEs from the CVE `data`
             """

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import List, Optional, Union
 
 import nvdlib
 from celery.utils.log import get_task_logger
@@ -65,6 +65,20 @@ class NVDQuerier:
         filtering out everything unnecessary and simplifying
         """
 
+        def get_cpe_list(data: CVE) -> Optional[List[str]]:
+            """
+            Return a list of CPEs from the CVE `data`
+            """
+            cpe_list = []
+            if "cpe" in data and len(data.cpe) > 0:
+                for entry in data.cpe:
+                    cpe_list.append(entry.criteria)
+
+            if len(cpe_list) > 0:
+                return cpe_list
+            else:
+                return None
+
         def get_cvss_metric(data: CVE, version: str) -> Union[dict, None]:
             """
             Return CVSS metric from `data` for the given `version`.
@@ -104,6 +118,7 @@ class NVDQuerier:
                             ],
                         )
                     ),
+                    "nvd_cpes": get_cpe_list(vulnerability),
                 }
             )
 

--- a/collectors/nvd/collectors.py
+++ b/collectors/nvd/collectors.py
@@ -74,10 +74,7 @@ class NVDQuerier:
                 for entry in data.cpe:
                     cpe_list.append(entry.criteria)
 
-            if len(cpe_list) > 0:
-                return cpe_list
-            else:
-                return None
+            return cpe_list
 
         def get_cvss_metric(data: CVE, version: str) -> Union[dict, None]:
             """

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -236,6 +236,20 @@ class TestNVDCollector:
         flaw = Flaw.objects.get(cve_id=cve_id)
         assert flaw.cvss_scores.filter(version=FlawCVSS.CVSSVersion.VERSION4)
 
+    @pytest.mark.vcr
+    def test_cpe_load(self):
+        """
+        Test that CPE values are correctly loaded in the Flaw model.
+        """
+        cve_id = "CVE-2020-1234"
+        FlawFactory(cve_id=cve_id)
+
+        nvdc = NVDCollector()
+        nvdc.collect(cve_id)
+
+        flaw = Flaw.objects.get(cve_id=cve_id)
+        assert len(flaw.nvd_cpes) > 0
+
     @pytest.mark.parametrize(
         "old_flag,new_flag",
         [
@@ -257,20 +271,6 @@ class TestNVDCollector:
             ),
         ],
     )
-    @pytest.mark.vcr
-    def test_cpe_load(self):
-        """
-        Test that CPE values are correctly loaded in the Flaw model.
-        """
-        cve_id = "CVE-2020-1234"
-        FlawFactory(cve_id=cve_id)
-
-        nvdc = NVDCollector()
-        nvdc.collect(cve_id)
-
-        flaw = Flaw.objects.get(cve_id=cve_id)
-        assert hasattr(flaw, "cpe")
-        assert False
 
     def test_reset_flag_on_removal(self, old_flag, new_flag):
         """

--- a/collectors/nvd/tests/test_collectors.py
+++ b/collectors/nvd/tests/test_collectors.py
@@ -257,6 +257,21 @@ class TestNVDCollector:
             ),
         ],
     )
+    @pytest.mark.vcr
+    def test_cpe_load(self):
+        """
+        Test that CPE values are correctly loaded in the Flaw model.
+        """
+        cve_id = "CVE-2020-1234"
+        FlawFactory(cve_id=cve_id)
+
+        nvdc = NVDCollector()
+        nvdc.collect(cve_id)
+
+        flaw = Flaw.objects.get(cve_id=cve_id)
+        assert hasattr(flaw, "cpe")
+        assert False
+
     def test_reset_flag_on_removal(self, old_flag, new_flag):
         """
         test that NIST CVSS validation flag is correctly adjusted when NVD CVSSv3 is removed


### PR DESCRIPTION
Adds a helper function to extract nvd cpe data and adds it to the list of data returned Partial implementation for OSIDB-4923

I didn't see where the function `response2result` is being tested, so I didn't add a test, but happy to do so if that can be pointed out.

This PR does not store the data elsewhere. The eventual location will be one of the new fields discussed in OSIDB-4923