### PR TITLE
OSIDB-2995-update drf-spectacular to generate OpenAPI 3.1 schema

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -304,6 +304,7 @@ SPECTACULAR_SETTINGS = {
     },
     "ENUM_GENERATE_CHOICE_DESCRIPTION": False,
     "COMPONENT_SPLIT_REQUEST": True,
+    "OAS_VERSION": "3.1.0",
 }
 
 # Execute once a day by default

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improve resilience, error-reporting and performance of /bulk create
   affects endpoint (OSIDB-4748)
+- Update drf-spectacular to generate OpenAPI 3.1 schema(OSIDB-2995)
 
 ## [5.9.0] - 2026-04-09
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,7 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve resilience, error-reporting and performance of /bulk create
   affects endpoint (OSIDB-4748)
 - Replace JiraUserMapping with direct Jira API user lookup and cache in Profile model(OSIDB-4865)
-
+- Update drf-spectacular to generate OpenAPI 3.1 schema(OSIDB-2995)
 
 ## [5.9.0] - 2026-04-09
 ### Fixed

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: OSIDB API
   version: 5.9.0
@@ -14002,19 +14002,19 @@ components:
           type: string
           readOnly: true
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
-          maxLength: 255
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         tracker:
-          allOf:
+          oneOf:
           - $ref: '#/components/schemas/Tracker'
+          - type: 'null'
           readOnly: true
-          nullable: true
         delegated_resolution:
           type: string
           readOnly: true
@@ -14024,8 +14024,9 @@ components:
             $ref: '#/components/schemas/AffectCVSS'
           readOnly: true
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14041,10 +14042,11 @@ components:
           - $ref: '#/components/schemas/DelegatedNotAffectedJustificationEnum'
           - $ref: '#/components/schemas/BlankEnum'
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         labels:
           type: array
           items:
@@ -14128,17 +14130,18 @@ components:
           type: string
           minLength: 1
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
-          maxLength: 255
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14172,8 +14175,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -14233,8 +14237,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -14268,8 +14273,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -14327,8 +14333,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -14349,8 +14356,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -14391,17 +14399,18 @@ components:
           type: string
           minLength: 1
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
-          maxLength: 255
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14460,17 +14469,18 @@ components:
           type: string
           minLength: 1
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
-          maxLength: 255
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14504,9 +14514,10 @@ components:
           format: uuid
           readOnly: true
         flaw:
-          type: string
+          type:
+          - string
+          - 'null'
           format: uuid
-          nullable: true
         affectedness:
           oneOf:
           - $ref: '#/components/schemas/AffectednessEnum'
@@ -14552,10 +14563,11 @@ components:
           type: string
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -14683,14 +14695,17 @@ components:
           description: The object model.
           maxLength: 64
         pgh_obj_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           description: The primary key of the object.
         pgh_label:
           type: string
           description: The event label.
         pgh_context:
-          nullable: true
+          oneOf:
+          - {}
+          - type: 'null'
           description: The context associated with the event.
         pgh_diff:
           description: The diff between the previous event of the same label.
@@ -14805,10 +14820,11 @@ components:
           type: string
           readOnly: true
         shipped_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         created_dt:
           type: string
           format: date-time
@@ -14831,9 +14847,10 @@ components:
           type: string
           maxLength: 50
         date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         source:
           $ref: '#/components/schemas/ExploitOnlyReportDataSourceEnum'
         reference:
@@ -14867,8 +14884,9 @@ components:
           format: uuid
           readOnly: true
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -14902,17 +14920,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -14920,9 +14940,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -15006,9 +15027,10 @@ components:
           type: string
           maxLength: 60
         task_key:
-          type: string
+          type:
+          - string
+          - 'null'
           readOnly: true
-          nullable: true
         team_id:
           type: string
           readOnly: true
@@ -15188,8 +15210,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15246,8 +15269,9 @@ components:
       description: FlawCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15272,8 +15296,9 @@ components:
       description: FlawCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15307,8 +15332,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15342,8 +15368,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15401,8 +15428,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -15423,8 +15451,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -15714,8 +15743,9 @@ components:
       description: serialize flaw model
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -15739,17 +15769,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -15758,9 +15790,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -15787,8 +15820,9 @@ components:
           format: uuid
           readOnly: true
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -15822,17 +15856,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -15841,9 +15877,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -15927,9 +15964,10 @@ components:
           type: string
           maxLength: 60
         task_key:
-          type: string
+          type:
+          - string
+          - 'null'
           readOnly: true
-          nullable: true
         team_id:
           type: string
           readOnly: true
@@ -16104,8 +16142,9 @@ components:
       type: object
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         affects:
           type: array
           items:
@@ -16115,8 +16154,9 @@ components:
       description: serialize flaw model
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -16140,17 +16180,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -16158,9 +16200,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16295,8 +16338,9 @@ components:
           format: uuid
           readOnly: true
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -16330,17 +16374,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -16348,9 +16394,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16434,9 +16481,10 @@ components:
           type: string
           maxLength: 60
         task_key:
-          type: string
+          type:
+          - string
+          - 'null'
           readOnly: true
-          nullable: true
         team_id:
           type: string
           readOnly: true
@@ -16473,8 +16521,9 @@ components:
       type: object
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         affects:
           type: array
           items:
@@ -16484,8 +16533,9 @@ components:
       description: Serializer for the flaw model adapted to affects v1
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -16509,17 +16559,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -16527,9 +16579,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16595,11 +16648,13 @@ components:
       type: object
       properties:
         jira:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         bugzilla:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
       required:
       - bugzilla
       - jira
@@ -17395,21 +17450,25 @@ components:
         sync_id:
           type: string
         last_scheduled_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_started_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_finished_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_failed_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_consecutive_failures:
           type: integer
           maximum: 2147483647
@@ -17417,9 +17476,10 @@ components:
         permanently_failed:
           type: boolean
         last_rescheduled_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_consecutive_reschedules:
           type: integer
           maximum: 2147483647
@@ -17528,10 +17588,11 @@ components:
             $ref: '#/components/schemas/SpecialHandlingEnum'
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -17618,10 +17679,11 @@ components:
             $ref: '#/components/schemas/SpecialHandlingEnum'
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -17828,10 +17890,11 @@ components:
             $ref: '#/components/schemas/SpecialHandlingEnum'
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as

--- a/openapi.yml
+++ b/openapi.yml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: OSIDB API
   version: 5.11.1
@@ -14086,8 +14086,9 @@ components:
           type: string
           readOnly: true
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
           maxLength: 255
         impact:
@@ -14095,10 +14096,10 @@ components:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         tracker:
-          allOf:
+          oneOf:
           - $ref: '#/components/schemas/Tracker'
+          - type: 'null'
           readOnly: true
-          nullable: true
         delegated_resolution:
           type: string
           readOnly: true
@@ -14108,8 +14109,9 @@ components:
             $ref: '#/components/schemas/AffectCVSS'
           readOnly: true
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14125,10 +14127,11 @@ components:
           - $ref: '#/components/schemas/DelegatedNotAffectedJustificationEnum'
           - $ref: '#/components/schemas/BlankEnum'
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         labels:
           type: array
           items:
@@ -14141,7 +14144,9 @@ components:
           type: string
           readOnly: true
         assist_meta:
-          nullable: true
+          oneOf:
+          - {}
+          - type: 'null'
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -14222,8 +14227,9 @@ components:
           type: string
           minLength: 1
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
           maxLength: 255
         impact:
@@ -14231,8 +14237,9 @@ components:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14243,7 +14250,9 @@ components:
           - $ref: '#/components/schemas/NotAffectedJustificationEnum'
           - $ref: '#/components/schemas/BlankEnum'
         assist_meta:
-          nullable: true
+          oneOf:
+          - {}
+          - type: 'null'
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -14268,8 +14277,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -14329,8 +14339,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -14364,8 +14375,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -14423,8 +14435,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -14445,8 +14458,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -14487,8 +14501,9 @@ components:
           type: string
           minLength: 1
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
           maxLength: 255
         impact:
@@ -14496,8 +14511,9 @@ components:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14508,7 +14524,9 @@ components:
           - $ref: '#/components/schemas/NotAffectedJustificationEnum'
           - $ref: '#/components/schemas/BlankEnum'
         assist_meta:
-          nullable: true
+          oneOf:
+          - {}
+          - type: 'null'
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -14558,8 +14576,9 @@ components:
           type: string
           minLength: 1
         ps_component:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
           maxLength: 255
         impact:
@@ -14567,8 +14586,9 @@ components:
           - $ref: '#/components/schemas/ImpactEnum'
           - $ref: '#/components/schemas/BlankEnum'
         purl:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           default: ''
         subpackage_purls:
           type: array
@@ -14579,7 +14599,9 @@ components:
           - $ref: '#/components/schemas/NotAffectedJustificationEnum'
           - $ref: '#/components/schemas/BlankEnum'
         assist_meta:
-          nullable: true
+          oneOf:
+          - {}
+          - type: 'null'
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -14604,9 +14626,10 @@ components:
           format: uuid
           readOnly: true
         flaw:
-          type: string
+          type:
+          - string
+          - 'null'
           format: uuid
-          nullable: true
         affectedness:
           oneOf:
           - $ref: '#/components/schemas/AffectednessEnum'
@@ -14652,10 +14675,11 @@ components:
           type: string
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -14783,14 +14807,17 @@ components:
           description: The object model.
           maxLength: 64
         pgh_obj_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
           description: The primary key of the object.
         pgh_label:
           type: string
           description: The event label.
         pgh_context:
-          nullable: true
+          oneOf:
+          - {}
+          - type: 'null'
           description: The context associated with the event.
         pgh_diff:
           description: The diff between the previous event of the same label.
@@ -14905,10 +14932,11 @@ components:
           type: string
           readOnly: true
         shipped_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         created_dt:
           type: string
           format: date-time
@@ -14931,9 +14959,10 @@ components:
           type: string
           maxLength: 50
         date:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date
-          nullable: true
         source:
           $ref: '#/components/schemas/ExploitOnlyReportDataSourceEnum'
         reference:
@@ -14967,8 +14996,9 @@ components:
           format: uuid
           readOnly: true
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -15002,17 +15032,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -15020,9 +15052,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -15111,9 +15144,10 @@ components:
           type: string
           maxLength: 60
         task_key:
-          type: string
+          type:
+          - string
+          - 'null'
           readOnly: true
-          nullable: true
         team_id:
           type: string
           readOnly: true
@@ -15294,8 +15328,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15352,8 +15387,9 @@ components:
       description: FlawCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15378,8 +15414,9 @@ components:
       description: FlawCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15413,8 +15450,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15448,8 +15486,9 @@ components:
           type: string
           format: uuid
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         issuer:
@@ -15507,8 +15546,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -15529,8 +15569,9 @@ components:
       description: Abstract serializer for FlawCVSS and AffectCVSS serializer
       properties:
         comment:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         cvss_version:
           $ref: '#/components/schemas/CvssVersionEnum'
         vector:
@@ -15822,8 +15863,9 @@ components:
       description: serialize flaw model
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -15847,17 +15889,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -15866,9 +15910,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -15895,8 +15940,9 @@ components:
           format: uuid
           readOnly: true
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -15930,17 +15976,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -15949,9 +15997,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16040,9 +16089,10 @@ components:
           type: string
           maxLength: 60
         task_key:
-          type: string
+          type:
+          - string
+          - 'null'
           readOnly: true
-          nullable: true
         team_id:
           type: string
           readOnly: true
@@ -16218,8 +16268,9 @@ components:
       type: object
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         affects:
           type: array
           items:
@@ -16229,8 +16280,9 @@ components:
       description: serialize flaw model
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -16254,17 +16306,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -16272,9 +16326,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16409,8 +16464,9 @@ components:
           format: uuid
           readOnly: true
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -16444,17 +16500,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -16462,9 +16520,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16553,9 +16612,10 @@ components:
           type: string
           maxLength: 60
         task_key:
-          type: string
+          type:
+          - string
+          - 'null'
           readOnly: true
-          nullable: true
         team_id:
           type: string
           readOnly: true
@@ -16593,8 +16653,9 @@ components:
       type: object
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         affects:
           type: array
           items:
@@ -16604,8 +16665,9 @@ components:
       description: Serializer for the flaw model adapted to affects v1
       properties:
         cve_id:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         impact:
           oneOf:
           - $ref: '#/components/schemas/ImpactEnum'
@@ -16629,17 +16691,19 @@ components:
           type: string
           maxLength: 255
         unembargo_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         source:
           oneOf:
           - $ref: '#/components/schemas/FlawSource'
           - $ref: '#/components/schemas/BlankEnum'
         reported_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         mitigation:
           type: string
         major_incident_state:
@@ -16647,9 +16711,10 @@ components:
           - $ref: '#/components/schemas/MajorIncidentStateEnum'
           - $ref: '#/components/schemas/BlankEnum'
         major_incident_start_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         nist_cvss_validation:
           oneOf:
           - $ref: '#/components/schemas/NistCvssValidationEnum'
@@ -16715,11 +16780,13 @@ components:
       type: object
       properties:
         jira:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
         bugzilla:
-          type: string
-          nullable: true
+          type:
+          - string
+          - 'null'
       required:
       - bugzilla
       - jira
@@ -17515,21 +17582,25 @@ components:
         sync_id:
           type: string
         last_scheduled_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_started_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_finished_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_failed_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_consecutive_failures:
           type: integer
           maximum: 2147483647
@@ -17537,9 +17608,10 @@ components:
         permanently_failed:
           type: boolean
         last_rescheduled_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
-          nullable: true
         last_consecutive_reschedules:
           type: integer
           maximum: 2147483647
@@ -17648,10 +17720,11 @@ components:
             $ref: '#/components/schemas/SpecialHandlingEnum'
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -17738,10 +17811,11 @@ components:
             $ref: '#/components/schemas/SpecialHandlingEnum'
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as
@@ -17948,10 +18022,11 @@ components:
             $ref: '#/components/schemas/SpecialHandlingEnum'
           readOnly: true
         resolved_dt:
-          type: string
+          type:
+          - string
+          - 'null'
           format: date-time
           readOnly: true
-          nullable: true
         embargoed:
           type: boolean
           description: The embargoed boolean attribute is technically read-only as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "djangorestframework-csv>=3.0.2",
     "djangorestframework-simplejwt>=5.3.1",
     "djangorestframework-xml>=2.0.0",
-    "drf-spectacular>=0.27.2",
+    "drf-spectacular==0.29.0",
     "flower>=2.0.1",
     "gunicorn[gevent,setproctitle]>=23.0.0",
     "hvac>=2.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -595,7 +595,7 @@ wheels = [
 
 [[package]]
 name = "drf-spectacular"
-version = "0.27.2"
+version = "0.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "django" },
@@ -605,9 +605,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "uritemplate" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/c9/55311dcbdae9a437eeb8f898f8421a6a3eabf08725c23ddf458cf2479b78/drf-spectacular-0.27.2.tar.gz", hash = "sha256:a199492f2163c4101055075ebdbb037d59c6e0030692fc83a1a8c0fc65929981", size = 235131, upload-time = "2024-04-01T18:00:21.171Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/0e/a4f50d83e76cbe797eda88fc0083c8ca970cfa362b5586359ef06ec6f70a/drf_spectacular-0.29.0.tar.gz", hash = "sha256:0a069339ea390ce7f14a75e8b5af4a0860a46e833fd4af027411a3e94fc1a0cc", size = 241722, upload-time = "2025-11-02T03:40:26.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/cd/84c44a5d435f6544e58a9b138305f59bca232157ae4ecb658f9787f87d1c/drf_spectacular-0.27.2-py3-none-any.whl", hash = "sha256:b1c04bf8b2fbbeaf6f59414b4ea448c8787aba4d32f76055c3b13335cf7ec37b", size = 102930, upload-time = "2024-04-01T18:00:17.937Z" },
+    { url = "https://files.pythonhosted.org/packages/32/d9/502c56fc3ca960075d00956283f1c44e8cafe433dada03f9ed2821f3073b/drf_spectacular-0.29.0-py3-none-any.whl", hash = "sha256:d1ee7c9535d89848affb4427347f7c4a22c5d22530b8842ef133d7b72e19b41a", size = 105433, upload-time = "2025-11-02T03:40:24.823Z" },
 ]
 
 [[package]]
@@ -1146,7 +1146,7 @@ requires-dist = [
     { name = "djangorestframework-csv", specifier = ">=3.0.2" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.3.1" },
     { name = "djangorestframework-xml", specifier = ">=2.0.0" },
-    { name = "drf-spectacular", specifier = ">=0.27.2" },
+    { name = "drf-spectacular", specifier = "==0.29.0" },
     { name = "flower", specifier = ">=2.0.1" },
     { name = "gunicorn", extras = ["gevent", "setproctitle"], specifier = ">=23.0.0" },
     { name = "hvac", specifier = ">=2.3.0" },


### PR DESCRIPTION
Update drf-spectacular to generate OPenAPI 3.1 schema.
-Added OAS version to SPECTACULAR_SETTINGS to enable OpenAPI 3.1 schema generation.
-Regenerated openapi.yml
Closes:OSIDB-2995