### PR TITLE
Add is_hummingbird flag for new SLA policy

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Add is_hummingbird flag for new SLA policy (OSIDB-4884)
 
 ## [5.10.0] - 2026-05-04
 ### Added

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -852,6 +852,12 @@ class Affect(
             name=self.ps_module, ps_product__business_unit="Community"
         ).exists()
 
+    def is_hummingbird(self) -> bool:
+        """
+        check and return whether the given affect is targeting HUM project
+        """
+        return PsModule.objects.filter(name=self.ps_module, bts_key="HUM").exists()
+
     @property
     def is_notaffected(self) -> bool:
         """


### PR DESCRIPTION
This PR add is_hummingbird flag for affects for the condition on the new 1-day SLA policy.

Closes OSIDB-4884.