### PR TITLE
OSIDB-4965: Include builds in auto-created affects

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -455,6 +455,34 @@
         "is_secret": false
       }
     ],
+    "osidb/tests/fixtures/newcli_openssl_multi_builds.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_openssl_multi_builds.json",
+        "hashed_secret": "e7f3b88a7f4fa56dff903493e42b2ef061a1edb6",
+        "is_verified": false,
+        "line_number": 106,
+        "is_secret": false
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_openssl_multi_builds.json",
+        "hashed_secret": "6dc49d64a0c9e0d968540021e8546499512c83bd",
+        "is_verified": false,
+        "line_number": 143,
+        "is_secret": false
+      }
+    ],
+    "osidb/tests/fixtures/newcli_ostree_hummingbird1.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "osidb/tests/fixtures/newcli_ostree_hummingbird1.json",
+        "hashed_secret": "e7f3b88a7f4fa56dff903493e42b2ef061a1edb6",
+        "is_verified": false,
+        "line_number": 49,
+        "is_secret": false
+      }
+    ],
     "osidb/tests/fixtures/newcli_urllib3_hummingbird1.json": [
       {
         "type": "Hex High Entropy String",
@@ -526,5 +554,5 @@
       }
     ]
   },
-  "generated_at": "2026-04-10T12:29:07Z"
+  "generated_at": "2026-05-05T19:47:10Z"
 }

--- a/conftest.py
+++ b/conftest.py
@@ -283,6 +283,41 @@ def newcli_openssl_hummingbird1_json():
 
 
 @pytest.fixture
+def newcli_openssl_multi_builds_json():
+    """
+    Fixture with multiple ``builds`` entries across different streams, including one genuine
+    duplicate (rhel-9.8.z / openssl appears twice with different NVRs — same ps_update_stream
+    and ps_component, so the second must be skipped as already existing).
+
+    Layout:
+    - builds[0]: hummingbird-1 / openssl            → unique
+    - builds[1]: rhel-9.8.z   / openssl (3.5.1-7)  → unique  (first encounter)
+    - builds[2]: rhel-9.8.z   / openssl (3.5.5-1)  → duplicate of builds[1] → skipped_existing
+    - builds[3]: rhel-8.8.0.z / openssl (1.1.1k)   → unique
+    - deps[0]:   hummingbird-1 / bootc              → unique
+    - deps[1]:   hummingbird-1 / chunkah            → unique
+
+    Expected on first sync: created=5, skipped=0, skipped_existing=1.
+
+    Source: ``osidb/tests/fixtures/newcli_openssl_multi_builds.json``.
+    """
+    return deepcopy(_load_newcli_json_fixture("newcli_openssl_multi_builds.json"))
+
+
+@pytest.fixture
+def newcli_ostree_hummingbird1_json():
+    """
+    Pretty-printed sample of ``newcli -s ostree --include hummingbird-1 --json``.
+
+    Contains one ``builds`` entry (ostree, the searched component) and one ``deps`` entry
+    (bootc, which bundles ostree as a cargo dependency).
+
+    Source: ``osidb/tests/fixtures/newcli_ostree_hummingbird1.json``.
+    """
+    return deepcopy(_load_newcli_json_fixture("newcli_ostree_hummingbird1.json"))
+
+
+@pytest.fixture
 def enable_bz_sync(monkeypatch) -> None:
     """
     enable the sync of trackers and flaw to Bugzilla

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Include builds during affect auto-creation (OSIDB-4965)
 
 ## [5.10.2] - 2026-05-05
 ### Added

--- a/osidb/tasks.py
+++ b/osidb/tasks.py
@@ -60,27 +60,35 @@ def _run_newcli_deps_json(flaw_component: str) -> dict[str, Any]:
     return json.loads(result.stdout or "{}")
 
 
-def _sync_affects_from_newcli_deps(
+def _sync_affects_from_newcli_payload(
     flaw: Flaw, payload: dict[str, Any]
 ) -> dict[str, int]:
+    """Process both ``builds`` and ``deps`` entries from a newcli JSON payload.
+
+    ``builds`` contains the directly-searched component (e.g. ostree itself),
+    while ``deps`` contains packages that bundle it as a dependency (e.g. bootc).
+    Both result in new affects on the flaw.
+    """
+    builds = payload.get("builds") or []
     deps = payload.get("deps") or []
+    entries = list(builds) + list(deps)
     created = 0
     skipped = 0
     skipped_existing = 0
 
     with transaction.atomic():
-        for dep in deps:
-            if not isinstance(dep, dict):
+        for entry in entries:
+            if not isinstance(entry, dict):
                 skipped += 1
                 continue
-            ps_update_stream = dep.get("ps_update_stream") or dep.get("ps_module")
-            purls = dep.get("purls") or []
+            ps_update_stream = entry.get("ps_update_stream") or entry.get("ps_module")
+            purls = entry.get("purls") or []
             purl_str = purls[0] if purls else None
 
             if not ps_update_stream or not purl_str:
                 logger.warning(
-                    "Skipping newcli dep missing ps_update_stream or purls: %s",
-                    dep.get("build_nvr"),
+                    "Skipping newcli entry missing ps_update_stream or purls: %s",
+                    entry.get("build_nvr"),
                 )
                 skipped += 1
                 continue
@@ -232,7 +240,7 @@ def sync_flaw_affects_from_newcli(flaw_id: str) -> dict[str, Any]:
     totals: dict[str, int] = {"created": 0, "skipped": 0, "skipped_existing": 0}
     for flaw_component in components:
         payload = _run_newcli_deps_json(flaw_component)
-        stats = _sync_affects_from_newcli_deps(flaw, payload)
+        stats = _sync_affects_from_newcli_payload(flaw, payload)
         for key in totals:
             totals[key] += stats[key]
     logger.info(

--- a/osidb/tests/fixtures/newcli_openssl_multi_builds.json
+++ b/osidb/tests/fixtures/newcli_openssl_multi_builds.json
@@ -1,0 +1,157 @@
+{
+  "builds": [
+    {
+      "build_id": null,
+      "build_name": "openssl",
+      "build_nvr": "openssl-3.5.6-0.1.hum1",
+      "build_repo": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/openssl",
+      "build_type": "rpm",
+      "eol": null,
+      "inactive": false,
+      "is_scl": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "scl": null,
+      "scl_build_ids": null,
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:rpm/redhat/openssl@3.5.6-0.1.hum1?arch=src"
+      ]
+    },
+    {
+      "build_id": 264607,
+      "build_name": "openssl",
+      "build_nvr": "openssl-3.5.1-7.el9_7",
+      "build_repo": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#9ddb40dcc20bfd97e8e1363829d9c3ea4ed4138f",
+      "build_type": "rpm",
+      "eol": false,
+      "inactive": null,
+      "is_scl": null,
+      "modules": [],
+      "ps_module": "rhel-9",
+      "ps_update_stream": "rhel-9.8.z",
+      "scl": null,
+      "scl_build_ids": null,
+      "manifest_source": "deptopia",
+      "purls": [
+        "pkg:rpm/redhat/openssl@3.5.1-7.el9_7?arch=src"
+      ]
+    },
+    {
+      "build_id": 264620,
+      "build_name": "openssl",
+      "build_nvr": "openssl-3.5.5-1.el9",
+      "build_repo": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+      "build_type": "rpm",
+      "eol": false,
+      "inactive": null,
+      "is_scl": null,
+      "modules": [],
+      "ps_module": "rhel-9",
+      "ps_update_stream": "rhel-9.8.z",
+      "scl": null,
+      "scl_build_ids": null,
+      "manifest_source": "deptopia",
+      "purls": [
+        "pkg:rpm/redhat/openssl@3.5.5-1.el9?arch=src"
+      ]
+    },
+    {
+      "build_id": 266670,
+      "build_name": "openssl",
+      "build_nvr": "openssl-1.1.1k-15.el8_6",
+      "build_repo": "git+https://pkgs.devel.redhat.com/git/rpms/openssl#939904bc141acc8f33f0a9a7fc06ca3524c5c2ef",
+      "build_type": "rpm",
+      "eol": false,
+      "inactive": null,
+      "is_scl": null,
+      "modules": [],
+      "ps_module": "rhel-8",
+      "ps_update_stream": "rhel-8.8.0.z",
+      "scl": null,
+      "scl_build_ids": null,
+      "manifest_source": "deptopia",
+      "purls": [
+        "pkg:rpm/redhat/openssl@1.1.1k-15.el8_6?arch=src"
+      ]
+    }
+  ],
+  "deps": [
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "bootc",
+      "build_nvr": "bootc-1.14.0-0.1.1.hum1",
+      "build_repo": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/bootc",
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "cargo",
+              "id": null,
+              "name": "openssl",
+              "nvr": "openssl-0.10.75",
+              "version": "0.10.75"
+            }
+          ],
+          "hash": "695c7f05e95e98aa0c39ec51e42aa3a0c4a1d684",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/bootc",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:rpm/redhat/bootc@1.14.0-0.1.1.hum1?arch=src"
+      ]
+    },
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "chunkah",
+      "build_nvr": "chunkah-0.4.0-1.hum1",
+      "build_repo": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/chunkah",
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "cargo",
+              "id": null,
+              "name": "openssl",
+              "nvr": "openssl-0.10.75",
+              "version": "0.10.75"
+            }
+          ],
+          "hash": "2397124c09a393e6d6dbdb484ff274b20099c038",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/chunkah",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:rpm/redhat/chunkah@0.4.0-1.hum1?arch=src"
+      ]
+    }
+  ],
+  "params": null
+}

--- a/osidb/tests/fixtures/newcli_ostree_hummingbird1.json
+++ b/osidb/tests/fixtures/newcli_ostree_hummingbird1.json
@@ -1,0 +1,63 @@
+{
+  "builds": [
+    {
+      "build_id": null,
+      "build_name": "ostree",
+      "build_nvr": "ostree-2026.1-2.hum1",
+      "build_repo": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/ostree",
+      "build_type": "rpm",
+      "eol": null,
+      "inactive": false,
+      "is_scl": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "scl": null,
+      "scl_build_ids": null,
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:rpm/redhat/ostree@2026.1-2.hum1?arch=src"
+      ]
+    }
+  ],
+  "deps": [
+    {
+      "build_id": null,
+      "build_is_scl": null,
+      "build_name": "bootc",
+      "build_nvr": "bootc-1.14.0-0.1.1.hum1",
+      "build_repo": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/bootc",
+      "build_scl": null,
+      "build_scl_build_ids": null,
+      "build_type": "rpm",
+      "inactive": null,
+      "modules": null,
+      "ps_module": "hummingbird-1",
+      "ps_update_stream": "hummingbird-1",
+      "sources": [
+        {
+          "dependencies": [
+            {
+              "dev": 0,
+              "ecosystem": "cargo",
+              "id": null,
+              "name": "ostree",
+              "nvr": "ostree-0.20.5",
+              "version": "0.20.5"
+            }
+          ],
+          "hash": "695c7f05e95e98aa0c39ec51e42aa3a0c4a1d684",
+          "id": null,
+          "provenance": null,
+          "source": "git+https://gitlab.com/redhat/hummingbird/rpms.git#rpms/bootc",
+          "type": null
+        }
+      ],
+      "manifest_source": "konflux",
+      "purls": [
+        "pkg:rpm/redhat/bootc@1.14.0-0.1.1.hum1?arch=src"
+      ]
+    }
+  ],
+  "params": null
+}

--- a/osidb/tests/test_sync_flaw_affects_from_newcli.py
+++ b/osidb/tests/test_sync_flaw_affects_from_newcli.py
@@ -12,7 +12,9 @@ pytestmark = pytest.mark.unit
 
 
 def _purls_from_newcli_payload(payload: dict) -> set[str]:
-    return {dep["purls"][0] for dep in payload["deps"]}
+    """Return the first PURL from every entry in both ``builds`` and ``deps``."""
+    entries = list(payload.get("builds") or []) + list(payload.get("deps") or [])
+    return {entry["purls"][0] for entry in entries if entry.get("purls")}
 
 
 def test_sync_flaw_affects_from_newcli_creates_one_affect_per_dep(
@@ -135,6 +137,116 @@ def test_sync_flaw_affects_from_newcli_no_components_raises(monkeypatch):
 
     with pytest.raises(ValueError, match="no non-empty components"):
         sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+
+def test_sync_flaw_affects_from_newcli_includes_build_as_affect(
+    newcli_ostree_hummingbird1_json, monkeypatch
+):
+    """
+    When newcli returns a non-empty ``builds`` list, an affect is created for each build entry
+    in addition to any ``deps`` entries.
+
+    For ``newcli -s ostree --include hummingbird-1``, the payload contains:
+    - one ``builds`` entry: ostree (the searched component itself)
+    - one ``deps`` entry: bootc (which bundles ostree as a cargo dependency)
+
+    Both should result in separate affects on the flaw.
+    """
+    flaw = FlawFactory(components=["ostree"])
+
+    def fake_run(cmd, **kwargs):
+        assert cmd == [
+            "newcli",
+            "-s",
+            "ostree",
+            "--include",
+            "hummingbird-1",
+            "--json",
+        ]
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(newcli_ostree_hummingbird1_json),
+            stderr="",
+        )
+
+    monkeypatch.setattr("osidb.tasks.subprocess.run", fake_run)
+
+    n_builds = len(newcli_ostree_hummingbird1_json["builds"])  # 1 (ostree)
+    n_deps = len(newcli_ostree_hummingbird1_json["deps"])  # 1 (bootc)
+    expected_total = n_builds + n_deps  # 2
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats == {"created": expected_total, "skipped": 0, "skipped_existing": 0}
+    assert flaw.affects.count() == expected_total
+
+    stored = {
+        str(a.purl) for a in flaw.affects.filter(ps_update_stream="hummingbird-1")
+    }
+    expected_purls = _purls_from_newcli_payload(newcli_ostree_hummingbird1_json)
+    normalized_expected = {
+        PackageURL.from_string(p).to_string() for p in expected_purls
+    }
+    assert stored == normalized_expected
+
+
+def test_sync_flaw_affects_from_newcli_multi_builds_with_duplicate(
+    newcli_openssl_multi_builds_json, monkeypatch
+):
+    """
+    Multiple ``builds`` entries across different streams, including a same-stream duplicate,
+    are all processed correctly.
+
+    Fixture layout (4 builds + 2 deps):
+    - builds[0]: hummingbird-1 / openssl            → created
+    - builds[1]: rhel-9.8.z   / openssl (3.5.1-7)  → created  (first encounter)
+    - builds[2]: rhel-9.8.z   / openssl (3.5.5-1)  → skipped_existing (same stream+component)
+    - builds[3]: rhel-8.8.0.z / openssl (1.1.1k)   → created
+    - deps[0]:   hummingbird-1 / bootc              → created
+    - deps[1]:   hummingbird-1 / chunkah            → created
+
+    Expected: created=5, skipped=0, skipped_existing=1.
+    Running a second time should mark all 5 as skipped_existing.
+    """
+    flaw = FlawFactory(components=["openssl"])
+
+    def fake_run(cmd, **kwargs):
+        return subprocess.CompletedProcess(
+            args=cmd,
+            returncode=0,
+            stdout=json.dumps(newcli_openssl_multi_builds_json),
+            stderr="",
+        )
+
+    monkeypatch.setattr("osidb.tasks.subprocess.run", fake_run)
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+    assert stats == {"created": 5, "skipped": 0, "skipped_existing": 1}
+    assert flaw.affects.count() == 5
+
+    # Group stored components by stream to allow multiple affects per stream
+    from collections import defaultdict
+
+    stored_by_stream = defaultdict(set)
+    for a in flaw.affects.all():
+        stored_by_stream[a.ps_update_stream].add(
+            PackageURL.from_string(str(a.purl)).name
+        )
+
+    # hummingbird-1: one build (openssl) + two deps (bootc, chunkah)
+    assert stored_by_stream["hummingbird-1"] == {"openssl", "bootc", "chunkah"}
+    # rhel-9.8.z: only the first openssl build (duplicate skipped)
+    assert stored_by_stream["rhel-9.8.z"] == {"openssl"}
+    # rhel-8.8.0.z: one openssl build
+    assert stored_by_stream["rhel-8.8.0.z"] == {"openssl"}
+
+    # Second run: all 6 raw entries (4 builds + 2 deps) find existing affects.
+    # The duplicate rhel-9.8.z build also matches the affect created by the first encounter,
+    # so skipped_existing is 6, not 5.
+    stats2 = sync_flaw_affects_from_newcli(str(flaw.uuid))
+    assert stats2 == {"created": 0, "skipped": 0, "skipped_existing": 6}
+    assert flaw.affects.count() == 5
 
 
 def test_sync_flaw_affects_from_newcli_include_modules_from_env(


### PR DESCRIPTION
Before this commit, auto-creation of affects by querying newcli would only take into account the dependencies of the search term but not the search term itself.

E.g. when creating affects for the component ostree, the bootc component would be created (dependency) but not ostree (build).

This commit includes the builds when auto-creating affects.