### PR TITLE
OSIDB-4956: Fix check parser replaces spaces with underscores in equality check values

### DIFF
--- a/apps/sla/tests/test_models.py
+++ b/apps/sla/tests/test_models.py
@@ -992,6 +992,112 @@ class TestSLOPolicy:
                 == accepted
             )
 
+        @pytest.mark.parametrize(
+            "true_case, false_case",
+            [
+                ("Red Hat Enterprise Linux", "Red_Hat_Enterprise_Linux"),
+                ("Red_Hat_Enterprise_Linux", "Red Hat Enterprise Linux"),
+                ("Red_Hat Enterprise_Linux", "Red Hat_Enterprise Linux"),
+                ("Red Hat_Enterprise_Linux", "Red_Hat_Enterprise_Linux"),
+            ],
+        )
+        def test_policy_with_spaces(self, true_case, false_case):
+            """
+            Test the SLA policy with multi-word product name
+            (regression test for OSIDB-4956)
+
+            This mirrors and actually policy from ps-constants with spaces in the value:
+            """
+            policy_desc = {
+                "name": "testCase",
+                "description": "Magical test case",
+                "conditions": {
+                    "affect": [
+                        f"PS product is {true_case}",
+                        "PS component is magic",
+                    ],
+                },
+                "slo": None,  # Exclusion policy - no SLO applies
+            }
+
+            policy = SLOPolicy.create_from_description(policy_desc)
+
+            ps_product = PsProductFactory(short_name="rhel", name=true_case)
+            ps_module = PsModuleFactory(bts_name="bugzilla", ps_product=ps_product)
+            ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+            flaw = FlawFactory(embargoed=False)
+
+            # Test 1: Affect that SHOULD match the policy (Magic on RHEL)
+            magic_affect = AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
+                ps_module=ps_module.name,
+                ps_component="magic",
+                ps_update_stream=ps_update_stream.name,
+                impact=Impact.MODERATE,
+            )
+            magic_tracker = TrackerFactory(
+                affects=[magic_affect],
+                embargoed=flaw.embargoed,
+                ps_update_stream=ps_update_stream.name,
+                type=Tracker.BTS2TYPE[ps_module.bts_name],
+            )
+
+            # Should accept because both conditions match
+            assert policy.accepts(
+                TemporalContext(flaw=flaw, affect=magic_affect, tracker=magic_tracker)
+            ), f"Ps product is {true_case} should match component"
+
+            # Test 2: Affect that should NOT match (different component)
+            other_affect = AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
+                ps_module=ps_module.name,
+                ps_component="kernel",
+                ps_update_stream=ps_update_stream.name,
+                impact=Impact.MODERATE,
+            )
+            other_tracker = TrackerFactory(
+                affects=[other_affect],
+                embargoed=flaw.embargoed,
+                ps_update_stream=ps_update_stream.name,
+                type=Tracker.BTS2TYPE[ps_module.bts_name],
+            )
+
+            # Should NOT accept because component doesn't match
+            assert not policy.accepts(
+                TemporalContext(flaw=flaw, affect=other_affect, tracker=other_tracker)
+            ), "Magic policy should not match non-magic components"
+
+            # Test 3: Affect on different product (magic but not RHEL)
+            other_product = PsProductFactory(short_name="fedora", name=false_case)
+            other_ps_module = PsModuleFactory(
+                bts_name="bugzilla", ps_product=other_product
+            )
+            other_ps_update_stream = PsUpdateStreamFactory(ps_module=other_ps_module)
+            fedora_affect = AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
+                ps_module=other_ps_module.name,
+                ps_component="magic",  # Same component
+                ps_update_stream=other_ps_update_stream.name,
+                impact=Impact.MODERATE,
+            )
+            fedora_tracker = TrackerFactory(
+                affects=[fedora_affect],
+                embargoed=flaw.embargoed,
+                ps_update_stream=other_ps_update_stream.name,
+                type=Tracker.BTS2TYPE[other_ps_module.bts_name],
+            )
+
+            # Should NOT accept because product doesn't match
+            assert not policy.accepts(
+                TemporalContext(flaw=flaw, affect=fedora_affect, tracker=fedora_tracker)
+            ), "Magic policy should not match kpatch on non-RHEL products"
+
     class TestContext:
         """
         test SLOPolicy context determination

--- a/apps/sla/tests/test_models.py
+++ b/apps/sla/tests/test_models.py
@@ -943,8 +943,12 @@ class TestSLOPolicy:
             [
                 ("in", "kpatch", True),
                 ("in", "coffee", False),
+                ("in", "red hat", True),
+                ("in", "red_hat", False),
                 ("not in", "kpatch", False),
                 ("not in", "coffee", True),
+                ("not in", "red hat", False),
+                ("not in", "red_hat", True),
             ],
         )
         def test_in_condition(self, operator, component, accepted):
@@ -956,7 +960,14 @@ class TestSLOPolicy:
                 "description": "Test for the in/not in operator",
                 "conditions": {
                     "affect": [
-                        {f"PS component {operator}": ["kpatch", "kmatch", "kcatch"]}
+                        {
+                            f"PS component {operator}": [
+                                "kpatch",
+                                "kmatch",
+                                "kcatch",
+                                "red hat",
+                            ]
+                        }
                     ],
                 },
                 "slo": {
@@ -993,7 +1004,14 @@ class TestSLOPolicy:
             )
 
         @pytest.mark.parametrize(
-            "true_case, false_case",
+            "operator, accepted",
+            [
+                ("is", True),
+                ("is not", False),
+            ],
+        )
+        @pytest.mark.parametrize(
+            "valid_case, invalid_case",
             [
                 ("Red Hat Enterprise Linux", "Red_Hat_Enterprise_Linux"),
                 ("Red_Hat_Enterprise_Linux", "Red Hat Enterprise Linux"),
@@ -1001,20 +1019,17 @@ class TestSLOPolicy:
                 ("Red Hat_Enterprise_Linux", "Red_Hat_Enterprise_Linux"),
             ],
         )
-        def test_policy_with_spaces(self, true_case, false_case):
+        def test_policy_with_spaces(self, operator, accepted, valid_case, invalid_case):
             """
             Test the SLA policy with multi-word product name
             (regression test for OSIDB-4956)
-
-            This mirrors and actually policy from ps-constants with spaces in the value:
             """
             policy_desc = {
                 "name": "testCase",
                 "description": "Magical test case",
                 "conditions": {
                     "affect": [
-                        f"PS product is {true_case}",
-                        "PS component is magic",
+                        f"PS product {operator} {valid_case}",
                     ],
                 },
                 "slo": None,  # Exclusion policy - no SLO applies
@@ -1022,13 +1037,13 @@ class TestSLOPolicy:
 
             policy = SLOPolicy.create_from_description(policy_desc)
 
-            ps_product = PsProductFactory(short_name="rhel", name=true_case)
+            ps_product = PsProductFactory(short_name="valid", name=valid_case)
             ps_module = PsModuleFactory(bts_name="bugzilla", ps_product=ps_product)
             ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             flaw = FlawFactory(embargoed=False)
 
             # Test 1: Affect that SHOULD match the policy (Magic on RHEL)
-            magic_affect = AffectFactory(
+            valid_affect = AffectFactory(
                 flaw=flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
@@ -1037,66 +1052,62 @@ class TestSLOPolicy:
                 ps_update_stream=ps_update_stream.name,
                 impact=Impact.MODERATE,
             )
-            magic_tracker = TrackerFactory(
-                affects=[magic_affect],
+            valid_tracker = TrackerFactory(
+                affects=[valid_affect],
                 embargoed=flaw.embargoed,
                 ps_update_stream=ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 
-            # Should accept because both conditions match
-            assert policy.accepts(
-                TemporalContext(flaw=flaw, affect=magic_affect, tracker=magic_tracker)
-            ), f"Ps product is {true_case} should match component"
+            # Should accept because condition match
+            assert (
+                policy.accepts(
+                    TemporalContext(
+                        flaw=flaw, affect=valid_affect, tracker=valid_tracker
+                    )
+                )
+                is accepted
+            ), f"Ps product is {valid_case} should match component"
 
             # Test 2: Affect that should NOT match (different component)
-            other_affect = AffectFactory(
-                flaw=flaw,
+            invalid_ps_product = PsProductFactory(
+                short_name="invalid", name=invalid_case
+            )
+            invalid_ps_module = PsModuleFactory(
+                bts_name="bugzilla", ps_product=invalid_ps_product
+            )
+            invalid_ps_update_stream = PsUpdateStreamFactory(
+                ps_module=invalid_ps_module
+            )
+
+            invalid_flaw = FlawFactory(embargoed=False)
+            invalid_affect = AffectFactory(
+                flaw=invalid_flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,
                 resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=ps_module.name,
+                ps_module=invalid_ps_module.name,
                 ps_component="kernel",
-                ps_update_stream=ps_update_stream.name,
+                ps_update_stream=invalid_ps_update_stream.name,
                 impact=Impact.MODERATE,
             )
-            other_tracker = TrackerFactory(
-                affects=[other_affect],
-                embargoed=flaw.embargoed,
-                ps_update_stream=ps_update_stream.name,
+            invalid_tracker = TrackerFactory(
+                affects=[invalid_affect],
+                embargoed=invalid_flaw.embargoed,
+                ps_update_stream=invalid_ps_update_stream.name,
                 type=Tracker.BTS2TYPE[ps_module.bts_name],
             )
 
             # Should NOT accept because component doesn't match
-            assert not policy.accepts(
-                TemporalContext(flaw=flaw, affect=other_affect, tracker=other_tracker)
-            ), "Magic policy should not match non-magic components"
-
-            # Test 3: Affect on different product (magic but not RHEL)
-            other_product = PsProductFactory(short_name="fedora", name=false_case)
-            other_ps_module = PsModuleFactory(
-                bts_name="bugzilla", ps_product=other_product
-            )
-            other_ps_update_stream = PsUpdateStreamFactory(ps_module=other_ps_module)
-            fedora_affect = AffectFactory(
-                flaw=flaw,
-                affectedness=Affect.AffectAffectedness.AFFECTED,
-                resolution=Affect.AffectResolution.DELEGATED,
-                ps_module=other_ps_module.name,
-                ps_component="magic",  # Same component
-                ps_update_stream=other_ps_update_stream.name,
-                impact=Impact.MODERATE,
-            )
-            fedora_tracker = TrackerFactory(
-                affects=[fedora_affect],
-                embargoed=flaw.embargoed,
-                ps_update_stream=other_ps_update_stream.name,
-                type=Tracker.BTS2TYPE[other_ps_module.bts_name],
-            )
-
-            # Should NOT accept because product doesn't match
-            assert not policy.accepts(
-                TemporalContext(flaw=flaw, affect=fedora_affect, tracker=fedora_tracker)
-            ), "Magic policy should not match kpatch on non-RHEL products"
+            assert (
+                policy.accepts(
+                    TemporalContext(
+                        flaw=invalid_flaw,
+                        affect=invalid_affect,
+                        tracker=invalid_tracker,
+                    )
+                )
+                is not accepted
+            ), f"Ps product is {valid_case} should not match component {invalid_case}"
 
     class TestContext:
         """

--- a/apps/workflows/checks.py
+++ b/apps/workflows/checks.py
@@ -159,15 +159,13 @@ class CheckParser:
         """
         attribute to literal value equality check
 
-        currently only supports string attributes
-        which values do not contain any spaces
+        supports string attributes including those with spaces in values
         """
         if check_desc.count("_is_") == 1:
             attr, value = check_desc.split("_is_")
             attr = self.sanitize_attribute(attr)
 
             if hasattr(self.model, attr):
-                doc = f"check that {self.model.__name__} attribute {attr} has a value equal to {value}"
 
                 def choices_field(model, name):
                     """
@@ -184,6 +182,11 @@ class CheckParser:
                     or attr in self.TEXT_CHOICES_PROPERTIES
                 ):
                     value = value.upper()
+                else:
+                    # For non-choices fields, restore spaces that were replaced with underscores
+                    value = value.replace("_", " ")
+
+                doc = f"check that {self.model.__name__} attribute {attr} has a value equal to {value}"
 
                 def compare_element(instance):
                     field = getattr(instance, attr)

--- a/apps/workflows/checks.py
+++ b/apps/workflows/checks.py
@@ -68,6 +68,7 @@ class CheckParser:
         return self._parse_string(check_desc)
 
     def _parse_string(self, check_desc):
+        original_check_desc = check_desc
         check_desc = check_desc.replace(" ", "_")
         # enable more human-readable negation
         if check_desc.startswith("is_not_"):
@@ -84,7 +85,7 @@ class CheckParser:
             self.desc2equals,
             self.desc2in,
         ]:
-            result = func(check_desc)
+            result = func(check_desc, original_check_desc=original_check_desc)
             if result is not None:
                 return result
 
@@ -109,7 +110,7 @@ class CheckParser:
             f"Unknown or incorrect check definition: {statement} {', '.join(values)}"
         )
 
-    def desc2property(self, check_desc):
+    def desc2property(self, check_desc, **kwargs):
         """native property check"""
         check_desc = self.sanitize_attribute(check_desc)
         if hasattr(self.model, check_desc):
@@ -121,7 +122,7 @@ class CheckParser:
 
             return (inspect.getdoc(func), get_element)
 
-    def desc2not_property(self, check_desc):
+    def desc2not_property(self, check_desc, **kwargs):
         """negative native property check"""
         if check_desc.startswith("not_"):
             attr = self.sanitize_attribute(check_desc[4:])
@@ -135,7 +136,7 @@ class CheckParser:
                     lambda instance: not func(instance),
                 )
 
-    def desc2non_empty(self, check_desc):
+    def desc2non_empty(self, check_desc, **kwargs):
         """attribute non-emptiness check"""
         if check_desc.startswith("has_"):
             attr = self.sanitize_attribute(check_desc[4:])
@@ -155,7 +156,19 @@ class CheckParser:
 
                 return (doc, has_element)
 
-    def desc2equals(self, check_desc):
+    def get_original_check_description(
+        self, check_desc_after_underscore, original_check_desc
+    ):
+        total_chars = len(check_desc_after_underscore) * -1
+        original_check_desc = original_check_desc[total_chars:]
+        return original_check_desc
+
+    def desc2equals(
+        self,
+        check_desc,
+        original_check_desc=None,
+        **kwargs,
+    ):
         """
         attribute to literal value equality check
 
@@ -182,9 +195,10 @@ class CheckParser:
                     or attr in self.TEXT_CHOICES_PROPERTIES
                 ):
                     value = value.upper()
-                else:
-                    # For non-choices fields, restore spaces that were replaced with underscores
-                    value = value.replace("_", " ")
+                elif original_check_desc:
+                    value = self.get_original_check_description(
+                        value, original_check_desc
+                    )
 
                 doc = f"check that {self.model.__name__} attribute {attr} has a value equal to {value}"
 
@@ -194,17 +208,14 @@ class CheckParser:
 
                 return (doc, compare_element)
 
-    def desc2not_equals(self, check_desc):
-        """
-        negative attribute to literal value comparison check
-
-        currently only supports string attributes
-        which values do not contain any spaces
-        """
+    def desc2not_equals(self, check_desc, original_check_desc=None, **kwargs):
+        """negative attribute to literal value comparison check"""
         if check_desc.count("_not_is_") == 1:
             check_desc = check_desc.replace("_not_is_", "_is_")
 
-            result = self.desc2equals(check_desc)
+            result = self.desc2equals(
+                check_desc, original_check_desc=original_check_desc, **kwargs
+            )
 
             if result is not None:
                 doc, func = result
@@ -213,7 +224,7 @@ class CheckParser:
                     lambda instance: not func(instance),
                 )
 
-    def desc2in(self, statement, values):
+    def desc2in(self, statement, values, **kwargs):
         if statement.count("_in") == 1:
             attr = self.sanitize_attribute(statement[:-3])
 
@@ -226,7 +237,7 @@ class CheckParser:
 
                 return (doc, check_inclusion)
 
-    def desc2not_in(self, statement, values):
+    def desc2not_in(self, statement, values, **kwargs):
         if statement.count("_not_in") == 1:
             statement = statement.replace("_not_in", "_in")
             result = self.desc2in(statement, values)

--- a/apps/workflows/tests/test_models.py
+++ b/apps/workflows/tests/test_models.py
@@ -24,6 +24,7 @@ from osidb.tests.factories import (
     FlawReferenceFactory,
     PackageFactory,
     PsModuleFactory,
+    PsProductFactory,
     PsUpdateStreamFactory,
     TrackerFactory,
 )
@@ -346,6 +347,39 @@ class TestCheck:
             affect.tracker = tracker
             affect.save(raise_validation_error=False)
             assert check(flaw)
+
+    def test_equals_with_spaces(self):
+        """
+        test that equality checks work correctly for values containing spaces
+        (regression test for OSIDB-4956)
+        """
+        ps_product = PsProductFactory(
+            short_name="rhel", name="Red Hat Enterprise Linux"
+        )
+        ps_module = PsModuleFactory(
+            bts_name="bugzilla", name="rhel-8", ps_product=ps_product
+        )
+        ps_update_stream = PsUpdateStreamFactory(
+            ps_module=ps_module, name="rhel-8.10.0"
+        )
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_component="kpatch",
+            ps_update_stream=ps_update_stream.name,
+        )
+
+        check = Check("PS product is Red Hat Enterprise Linux", cls=Affect)
+
+        assert check.name == "PS product is Red Hat Enterprise Linux"
+        assert (
+            check.description
+            == "check that Affect attribute ps_product has a value equal to Red Hat Enterprise Linux"
+        )
+
+        # The check should pass when ps_product matches
+        assert check(affect), f"Check failed: {check.name}"
 
 
 class TestCondition:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Exclude streams with no offer from tracker suggestions response (OSIDB-4977)
 
+### Fixed
+- Fix check parser replaces spaces with underscores in equality check values (OSIDB-4956)
+
+
 ## [5.10.3] - 2026-05-06
 ### Fixed
 - Include builds during affect auto-creation (OSIDB-4965)


### PR DESCRIPTION
### problem 
CheckParser replaced all spaces with underscores, causing equality checks with multi-word values to fail. 

For example, "PS product is Red Hat Enterprise Linux" compared "Red_Hat_Enterprise_Linux"
  instead of "Red Hat Enterprise Linux".

  Impact: SLA exclusion policies (like Kpatch) and workflow conditions with multi-word values silently failed to match.

### solution
Modified desc2equals() to restore spaces in values for non-choices fields while preserving uppercase transformation for enum fields.


Closes OSIDB-4956