### PR TITLE
OSIDB-4985: Fix revert issues.

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Exclude streams with no offer from tracker suggestions response (OSIDB-4977)
+- Refresh Flaws in signal to avoid revert issues (OSIDB-4985)
 
 ## [5.10.3] - 2026-05-06
 ### Fixed

--- a/osidb/signals.py
+++ b/osidb/signals.py
@@ -126,6 +126,8 @@ def update_flaw_fields(sender, instance, **kwargs):
 @receiver(post_save, sender=FlawCollaborator)
 @receiver(post_save, sender=FlawCVSS)
 def flaw_dependant_update_local_updated_dt(sender, instance, **kwargs):
+    if isinstance(instance, Affect):
+        instance.flaw.refresh_from_db()
     instance.flaw.save(auto_timestamps=False, raise_validation_error=False)
 
 
@@ -140,6 +142,7 @@ def update_local_updated_dt_tracker(sender, instance, **kwargs):
         for affect in instance.affects.all():
             flaws.add(affect.flaw)
     for flaw in list(flaws):
+        flaw.refresh_from_db()
         flaw.save(
             auto_timestamps=False,
             no_alerts=True,  # recreating alerts from nested entities can cause deadlocks
@@ -149,6 +152,7 @@ def update_local_updated_dt_tracker(sender, instance, **kwargs):
 
 @receiver(post_save, sender=AffectCVSS)
 def updated_local_updated_dt_affectcvss(sender, instance, **kwargs):
+    instance.affect.flaw.refresh_from_db()
     instance.affect.flaw.save(auto_timestamps=False, raise_validation_error=False)
 
 

--- a/osidb/tests/test_flaw_revert_bug.py
+++ b/osidb/tests/test_flaw_revert_bug.py
@@ -1,0 +1,116 @@
+"""
+Test to reproduce OSIDB-4985: Flaw fields revert after PUT with many affects
+"""
+
+import pytest
+from django.db.models import Prefetch
+
+from osidb.models import Affect, Flaw, Tracker
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+    TrackerFactory,
+)
+
+
+@pytest.mark.enable_signals
+class TestFlawRevertBug:
+    """
+    Reproduce the bug where flaw.statement reverts to empty string
+    after a PUT request with many affects.
+
+    Based on real-world evidence from CVE-2026-39892:
+    - PUT with 152 affects
+    - statement changes from '' to 'In default configurations...'
+    - ~400ms-1.2s later, statement reverts to ''
+    - pg_history shows revert with no user/path (internal operation)
+    """
+
+    def _create_flaw_and_affects(self) -> Flaw:
+        # Create initial flaw
+        flaw = FlawFactory(
+            cve_id="CVE-2026-39892",
+            statement="",
+            impact="IMPORTANT",
+        )
+
+        # Create affects (fewer for faster test, but same pattern)
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        for i in range(2):
+            affect = AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                ps_module=ps_update_stream.ps_module.name,
+                ps_update_stream=ps_update_stream.name,
+                ps_component=f"component-{i}",
+            )
+            tracker = TrackerFactory(
+                affects=(affect,),
+                ps_update_stream=ps_update_stream.name,
+                type=Tracker.TrackerType.JIRA,
+                embargoed=flaw.embargoed,
+            )
+            tracker.save()
+        return flaw
+
+    def test_affect_does_not_revert_statement(self):
+        """
+        Test that affect saves do not revert the flaw statement when saved on signals.
+        """
+        # Simulate what happens when Django processes a nested serializer update:
+        # 1. Affects are loaded (they have references to the OLD flaw)
+        flaw = self._create_flaw_and_affects()
+        loaded_affects = list(Affect.objects.filter(flaw=flaw).select_related("flaw"))
+
+        # 2. Flaw is updated
+        new_statement = "This is the new statement that should not revert"
+        flaw.statement = new_statement
+        flaw.save()
+        flaw.refresh_from_db()
+        assert flaw.statement == new_statement
+        assert loaded_affects[0].flaw.statement == ""
+
+        for affect in loaded_affects:
+            affect.save()
+
+        # 4. Check if statement reverted
+        flaw.refresh_from_db()
+
+        assert flaw.statement == new_statement, (
+            "Statement reverted when affects were saved!"
+        )
+
+    def test_tracker_does_not_revert_statement(self):
+        """
+        Test that tracker saves do not revert the flaw statement when saved on signals.
+        """
+        # Simulate what happens when Django processes a nested serializer update:
+        # 1. Trackers are loaded (they have references to the OLD flaw)
+        flaw = self._create_flaw_and_affects()
+        loaded_trackers = list(
+            Tracker.objects.filter(affects__flaw__uuid=flaw.uuid)
+            .prefetch_related(
+                Prefetch("affects", queryset=Affect.objects.select_related("flaw"))
+            )
+            .distinct()
+        )
+        # 2. Flaw is updated
+        new_statement = "This is the new statement that should not revert"
+        flaw.statement = new_statement
+        flaw.save()
+        flaw.refresh_from_db()
+        assert flaw.statement == new_statement
+        assert loaded_trackers[0].affects.first().flaw.statement == ""
+
+        for tracker in loaded_trackers:
+            tracker.save()
+
+        flaw.refresh_from_db()
+        # 4. Check if statement reverted
+        assert flaw.statement == new_statement, (
+            "Statement reverted when affects were saved"
+        )


### PR DESCRIPTION
Fix the revert Flaw fields issue by refreshing the Flaw instance before re saving the flaw. 


The rever can happen when someone updates a tracker for a flaw and then saves the Flaw while the tracker process is happening with a stale version of the flaw.. 

1. User Adds/updates The tracker TA of Flaw F1 on any of this API endpoints. 

    -  Tracker API — create/update via TrackerSerializer
    -  Flaw API — when flaw fields change (CVE, embargo, impact, components, etc.), related Jira trackers may be re-pushed
    - . Affect API — e.g. promotion from NEW regenerates the Jira tracker
    - . Affect / Flaw CVSS API — sync_to_trackers() → tracker.save(jira_token=...)
    -  Flaw reference API — sync_reference() adds/updates links on the Jira issue (not a full tracker field sync)

2. The change triggers an update on Jira  TA because TRACKERS_SYNC_TO_JIRA is true. 
3. Jira is updated (and updates its last changed date for TA)
4. User runs updates on flaw F1 (To change FA to FB) 
5. a minute later the JiraTrackerCollector process TA because it has a newer date
6. At some point [(maybe here) ](https://github.com/RedHatProductSecurity/osidb/blob/0a8720f512a0c55c5c4c9f3caba7933b34369198/osidb/signals.py#L132-L147) it gets flaw F1 with  FA 
7. User from point 4 finish the process saving the F1 with FB
8. Process from point 6 runs a save F1 with FA causing the revert. 

Possible Catalysts: 

- Many trackers for the flaw 
- Multi flaw trackers



## Attachments & Links:
[Logs digested](https://docs.google.com/spreadsheets/d/1VoPxcqZBaCPBy9wCG0fKLLJZ-wUV7yg9c5DtdOLSB8k/edit?usp=sharing) that show the overriding case

[Jira ticket ](https://redhat.atlassian.net/browse/OSIDB-4985) 
