### PR TITLE
OSIDB-4977: Fix tracker suggestions with empty offer

### DIFF
--- a/apps/trackers/api.py
+++ b/apps/trackers/api.py
@@ -198,6 +198,9 @@ class TrackerFileSuggestionView(TrackerFileSuggestionV1View):
                 exclude_existing_trackers=exclude_existing_trackers,
             )
 
+            if offer is None:
+                continue
+
             targets[key] = {
                 "affect": affect,
                 "ps_update_stream": affect.ps_update_stream,

--- a/apps/trackers/product_definition_handlers/base.py
+++ b/apps/trackers/product_definition_handlers/base.py
@@ -24,7 +24,7 @@ class ProductDefinitionRules:
         impact: Impact,
         ps_update_stream: PsUpdateStream,
         exclude_existing_trackers=False,
-    ):
+    ) -> dict | None:
         # Only generate offers for active streams
         if not ps_update_stream.is_active:
             return None

--- a/apps/trackers/tests/test_file_offer.py
+++ b/apps/trackers/tests/test_file_offer.py
@@ -1357,17 +1357,51 @@ class TestTrackerSuggestions:
         )
         res = response.json()
 
-        assert len(res["streams_components"]) == 2
+        assert len(res["streams_components"]) == expected_total
         available_streams = [
-            stream["ps_update_stream"]
-            for stream in res["streams_components"]
-            if stream["offer"]
+            stream["ps_update_stream"] for stream in res["streams_components"]
         ]
 
-        # Check expectations
-        assert len(available_streams) == expected_total
         assert (stream1.name in available_streams) == expected_stream_1
         assert (stream2.name in available_streams) == expected_stream_2
+
+    def test_no_null_offers_in_suggestions(self, auth_client, test_app_api_uri):
+        """
+        Test that streams_components never contains entries with a null offer
+        """
+        flaw = FlawFactory(embargoed=False, impact=Impact.CRITICAL)
+        ps_module = PsModuleFactory()
+
+        active_stream = PsUpdateStreamFactory(
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+            default_to_ps_module=ps_module,
+        )
+        inactive_stream = PsUpdateStreamFactory(
+            ps_module=ps_module,
+            active_to_ps_module=None,
+        )
+
+        for stream in [active_stream, inactive_stream]:
+            AffectFactory(
+                flaw=flaw,
+                affectedness=Affect.AffectAffectedness.AFFECTED,
+                resolution=Affect.AffectResolution.DELEGATED,
+                ps_component="component",
+                ps_update_stream=stream.name,
+            )
+
+        headers = {"HTTP_JiraAuthentication": "SECRET"}
+        response = auth_client().post(
+            f"{test_app_api_uri}/file",
+            data={"flaw_uuids": [flaw.uuid]},
+            format="json",
+            **headers,
+        )
+        res = response.json()
+
+        assert len(res["streams_components"]) == 1
+        assert all(stream["offer"] is not None for stream in res["streams_components"])
 
 
 class TestDefaultHandler:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Automatic affectedness and resolution determination based on product
   definitions (OSIDB-4938)
 
+### Fixed
+- Exclude streams with no offer from tracker suggestions response (OSIDB-4977)
+
 ## [5.10.3] - 2026-05-06
 ### Fixed
 - Include builds during affect auto-creation (OSIDB-4965)


### PR DESCRIPTION
This PR fixes trackers suggestions for affects v2. Currently there was a problem that if the affect was not eligible to receive a tracker `offer` field in the tracker suggestions response had `null` (`None`) value, which however is in contradict of what the OpenAPI schema says as this field is not nullable.