### PR TITLE
OSIDB-4992 - Fix inconsistent transactions

### DIFF
--- a/apps/bbsync/tests/conftest.py
+++ b/apps/bbsync/tests/conftest.py
@@ -1,9 +1,5 @@
-import uuid
-
 import pytest
-from django.conf import settings
 
-from osidb.core import generate_acls
 from osidb.tests.factories import FlawFactory
 
 
@@ -20,13 +16,3 @@ def test_flaw():
 @pytest.fixture
 def sentinel_err_message():
     return "400 Client Error: Bad Request"
-
-
-@pytest.fixture
-def internal_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
-
-
-@pytest.fixture
-def internal_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]

--- a/apps/taskman/tests/conftest.py
+++ b/apps/taskman/tests/conftest.py
@@ -1,7 +1,4 @@
-import uuid
-
 import pytest
-from django.conf import settings
 
 from osidb.constants import OSIDB_API_VERSION, OSIDB_API_VERSION_NEXT
 from taskman.constants import TASKMAN_API_VERSION
@@ -46,24 +43,6 @@ def auto_enable_jira_task_sync(enable_jira_task_sync) -> None:
     the tests should be immune to what .env you build the testrunner with
     """
     pass
-
-
-@pytest.fixture
-def acl_read():
-    return [
-        uuid.uuid5(uuid.NAMESPACE_URL, f"https://osidb.prod.redhat.com/ns/acls#{group}")
-        for group in settings.PUBLIC_READ_GROUPS
-    ]
-
-
-@pytest.fixture
-def acl_write():
-    return [
-        uuid.uuid5(
-            uuid.NAMESPACE_URL,
-            f"https://osidb.prod.redhat.com/ns/acls#{settings.PUBLIC_WRITE_GROUP}",
-        )
-    ]
 
 
 @pytest.fixture

--- a/apps/taskman/tests/test_flaw_model_integration.py
+++ b/apps/taskman/tests/test_flaw_model_integration.py
@@ -74,7 +74,7 @@ class TestFlawModelIntegration(object):
         # flaws without task_key were created by collectors should not sync in jira
         assert sync_count == 1
 
-    def test_syncing(self, monkeypatch, acl_read, acl_write):
+    def test_syncing(self, monkeypatch, public_read_groups, public_write_groups):
         sync_count = 0
 
         def mock_create_or_update_task(self, flaw):
@@ -89,8 +89,8 @@ class TestFlawModelIntegration(object):
         flaw = Flaw(
             cve_id="CVE-2020-8004",
             title="CVE-2020-8004 kernel: some description",
-            acl_read=acl_read,
-            acl_write=acl_write,
+            acl_read=public_read_groups,
+            acl_write=public_write_groups,
             comment_zero="Comment zero",
             components=["component"],
             impact=Impact.LOW,
@@ -313,7 +313,12 @@ class TestFlawModelIntegration(object):
 
     @pytest.mark.vcr
     def test_token_validation(
-        self, monkeypatch, acl_read, acl_write, jira_token, jira_email
+        self,
+        monkeypatch,
+        public_read_groups,
+        public_write_groups,
+        jira_token,
+        jira_email,
     ):
         """
         Test that service is able validate user authentication and raise errors
@@ -325,8 +330,8 @@ class TestFlawModelIntegration(object):
         reported_dt = make_aware(datetime.now())
         flaw = Flaw(
             uuid=uuid1,
-            acl_read=acl_read,
-            acl_write=acl_write,
+            acl_read=public_read_groups,
+            acl_write=public_write_groups,
             cwe_id="CWE-1",
             impact="LOW",
             components=["kernel"],
@@ -344,8 +349,8 @@ class TestFlawModelIntegration(object):
 
         flaw = Flaw(
             uuid=uuid2,
-            acl_read=acl_read,
-            acl_write=acl_write,
+            acl_read=public_read_groups,
+            acl_write=public_write_groups,
             cwe_id="CWE-1",
             impact="LOW",
             components=["kernel"],
@@ -375,7 +380,11 @@ class TestFlawModelIntegration(object):
             flaw.save(jira_token=jira_token, jira_email=jira_email)
 
     def test_tasksync_conditions(
-        self, acl_read, acl_write, enable_jira_task_sync, monkeypatch
+        self,
+        public_read_groups,
+        public_write_groups,
+        enable_jira_task_sync,
+        monkeypatch,
     ):
         """
         test that tasksync conditional branching leands where it is supposed to

--- a/apps/workflows/tests/conftest.py
+++ b/apps/workflows/tests/conftest.py
@@ -1,13 +1,10 @@
 import os
-import uuid
 from unittest.mock import MagicMock
 
 import pytest
-from django.conf import settings
 
 from apps.workflows.constants import WORKFLOWS_API_VERSION
 from apps.workflows.workflow import WorkflowFramework
-from osidb.core import generate_acls
 from osidb.helpers import get_env
 
 
@@ -37,36 +34,6 @@ def ldap_test_username():
 @pytest.fixture
 def ldap_test_password():
     return "password"
-
-
-@pytest.fixture
-def public_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)]
-
-
-@pytest.fixture
-def public_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])]
-
-
-@pytest.fixture
-def internal_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
-
-
-@pytest.fixture
-def internal_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]
-
-
-@pytest.fixture
-def embargo_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])]
-
-
-@pytest.fixture
-def embargo_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])]
 
 
 @pytest.fixture

--- a/collectors/bzimport/tests/conftest.py
+++ b/collectors/bzimport/tests/conftest.py
@@ -1,10 +1,6 @@
-import uuid
-
 import pytest
-from django.conf import settings
 
 from collectors.bzimport.collectors import BugzillaTrackerCollector
-from osidb.core import generate_acls
 
 
 @pytest.fixture(autouse=True)
@@ -54,33 +50,3 @@ def bz_tracker_id():
 @pytest.fixture
 def bz_tracker_collector():
     return BugzillaTrackerCollector()
-
-
-@pytest.fixture
-def public_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)]
-
-
-@pytest.fixture
-def embargoed_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])]
-
-
-@pytest.fixture
-def internal_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
-
-
-@pytest.fixture
-def public_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])]
-
-
-@pytest.fixture
-def embargoed_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])]
-
-
-@pytest.fixture
-def internal_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]

--- a/collectors/jiraffe/convertors.py
+++ b/collectors/jiraffe/convertors.py
@@ -160,7 +160,6 @@ class JiraTaskConvertor:
 
             for field in changed_fields:
                 setattr(flaw, field, self.task_data[field])
-            flaw.adjust_acls(save=False)
             return JiraTaskSaver(flaw)
         return None
 
@@ -184,17 +183,20 @@ class JiraTaskSaver:
             "workflow_name",
             "workflow_state",
         ]
-        kwargs = {}
-        # set only existing values
-        for attribute in task_attributes:
-            value = getattr(self.flaw, attribute)
-            if value is not None:
-                kwargs[attribute] = value
+        with transaction.atomic():
+            self.flaw.adjust_acls(save=False)
 
-        Flaw.objects.filter(uuid=self.flaw.uuid).update(
-            auto_timestamps=False,  # we do not want to touch updated_dt
-            **kwargs,
-        )
+            kwargs = {}
+            # set only existing values
+            for attribute in task_attributes:
+                value = getattr(self.flaw, attribute)
+                if value is not None:
+                    kwargs[attribute] = value
+
+            Flaw.objects.filter(uuid=self.flaw.uuid).update(
+                auto_timestamps=False,  # we do not want to touch updated_dt
+                **kwargs,
+            )
 
 
 class TrackerSaver:

--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,6 @@
 import json
 import re
+import uuid
 
 import pytest
 from django.conf import settings
@@ -15,7 +16,7 @@ from rest_framework.test import APIClient
 
 from apps.trackers.models import JiraBugIssuetype, JiraProjectFields
 from osidb.constants import OSIDB_API_VERSION
-from osidb.core import set_user_acls
+from osidb.core import generate_acls, set_user_acls
 from osidb.exceptions import InvalidTestEnvironmentException
 from osidb.models import PsModule, PsUpdateStream
 from osidb.tests.factories import PsModuleFactory, PsProductFactory
@@ -683,3 +684,39 @@ def setup_sample_external_resources():
         "jboss_components": ["kernel", "kernel-rt"],
         "bz_components": ["redhat-certification", "openssl"],
     }
+
+
+@pytest.fixture
+def public_read_groups():
+    """Public read ACL groups (multiple groups for public read access)."""
+    return [uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)]
+
+
+@pytest.fixture
+def embargoed_read_groups():
+    """Embargoed read ACL group (restricted to embargo group)."""
+    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])]
+
+
+@pytest.fixture
+def internal_read_groups():
+    """Internal read ACL group (restricted to internal group)."""
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
+
+
+@pytest.fixture
+def public_write_groups():
+    """Public write ACL group."""
+    return [uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])]
+
+
+@pytest.fixture
+def embargoed_write_groups():
+    """Embargoed write ACL group."""
+    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])]
+
+
+@pytest.fixture
+def internal_write_groups():
+    """Internal write ACL group."""
+    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix FieldDoesNotExist being raised for non-DB declared filters (OSIDB-4734)
 - Wrap external errors with affect context for bulk PUT endpoint (OSIDB-5038)
+- Wrapped bulk ACL updates in a transaction to prevent them from auto-committing outside the request transaction (OSIDB-4992)
 
 ## [5.11.1] - 2026-06-10
 ### Fixed

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -641,44 +641,45 @@ class ACLMixin(models.Model):
         if isnt_embargoed or cant_unembargo:
             return
 
-        # unembargo
-        self.set_public()
-        self.set_history_public()
+        with transaction.atomic():
+            # unembargo
+            self.set_public()
+            self.set_history_public()
 
-        kwargs = {}
-        if issubclass(type(self), AlertMixin):
-            # suppress the validation errors as we expect that during
-            # the update the parent and child ACLs will not equal
-            kwargs["raise_validation_error"] = False
-        if issubclass(type(self), TrackingMixin):
-            # do not auto-update the updated_dt timestamp as the
-            # followup update would fail on a mid-air collision
-            kwargs["auto_timestamps"] = False
+            kwargs = {}
+            if issubclass(type(self), AlertMixin):
+                # suppress the validation errors as we expect that during
+                # the update the parent and child ACLs will not equal
+                kwargs["raise_validation_error"] = False
+            if issubclass(type(self), TrackingMixin):
+                # do not auto-update the updated_dt timestamp as the
+                # followup update would fail on a mid-air collision
+                kwargs["auto_timestamps"] = False
 
-        self.save(**kwargs)
+            self.save(**kwargs)
 
-        # chain all the related instances in reverse relationships (o2m, m2m)
-        # as we only care for the ACLs which are unified
-        for related_instance in chain.from_iterable(
-            getattr(self, name).all()
-            for name in [
-                related.related_name
-                for related in self._meta.related_objects
-                # only the models with ACLs are subject of this
-                if issubclass(related.related_model, ACLMixin)
-            ]
-        ):
-            # continue deeper into the related context
-            related_instance.unembargo()
+            # chain all the related instances in reverse relationships (o2m, m2m)
+            # as we only care for the ACLs which are unified
+            for related_instance in chain.from_iterable(
+                getattr(self, name).all()
+                for name in [
+                    related.related_name
+                    for related in self._meta.related_objects
+                    # only the models with ACLs are subject of this
+                    if issubclass(related.related_model, ACLMixin)
+                ]
+            ):
+                # continue deeper into the related context
+                related_instance.unembargo()
 
-        # chain related instances in forward relationships (m2o, o2o)
-        for field in self._meta.concrete_fields:
-            if isinstance(
-                field, (models.ForeignKey, models.OneToOneField)
-            ) and issubclass(field.related_model, ACLMixin):
-                related_instance = getattr(self, field.name)
-                if related_instance:
-                    related_instance.unembargo()
+            # chain related instances in forward relationships (m2o, o2o)
+            for field in self._meta.concrete_fields:
+                if isinstance(
+                    field, (models.ForeignKey, models.OneToOneField)
+                ) and issubclass(field.related_model, ACLMixin):
+                    related_instance = getattr(self, field.name)
+                    if related_instance:
+                        related_instance.unembargo()
 
     def set_public_nested(self, max_chunk_size=5000):
         """

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -9,7 +9,7 @@ import pghistory
 from django.contrib.postgres import fields
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
-from django.db import models
+from django.db import models, transaction
 from django.db.models import JSONField, Q
 from django.utils import timezone
 from psqlextra.fields import HStoreField
@@ -1112,35 +1112,36 @@ class Flaw(
             return
 
         # switch of sync/async processing
-        if JIRA_TASKMAN_ASYNCHRONOUS_SYNC:
-            if update_task:
-                JiraTaskSyncManager.check_for_reschedules()
-                JiraTaskSyncManager.schedule(str(self.uuid))
+        with transaction.atomic():
+            if JIRA_TASKMAN_ASYNCHRONOUS_SYNC:
+                if update_task:
+                    JiraTaskSyncManager.check_for_reschedules()
+                    JiraTaskSyncManager.schedule(str(self.uuid))
 
-            if transition_task:
-                # workflow transition may result in ACL change
-                self.adjust_acls(save=False)
-                Flaw.objects.filter(uuid=self.uuid).update(
-                    acl_read=self.acl_read,
-                    acl_write=self.acl_write,
-                )
+                if transition_task:
+                    # workflow transition may result in ACL change
+                    self.adjust_acls(save=False)
+                    Flaw.objects.filter(uuid=self.uuid).update(
+                        acl_read=self.acl_read,
+                        acl_write=self.acl_write,
+                    )
 
-                JiraTaskTransitionManager.check_for_reschedules()
-                JiraTaskTransitionManager.schedule(str(self.uuid))
+                    JiraTaskTransitionManager.check_for_reschedules()
+                    JiraTaskTransitionManager.schedule(str(self.uuid))
 
-        else:
-            if update_task:
-                self._create_or_update_task(jira_token, jira_email)
+            else:
+                if update_task:
+                    self._create_or_update_task(jira_token, jira_email)
 
-            if transition_task:
-                # workflow transition may result in ACL change
-                self.adjust_acls(save=False)
-                Flaw.objects.filter(uuid=self.uuid).update(
-                    acl_read=self.acl_read,
-                    acl_write=self.acl_write,
-                )
+                if transition_task:
+                    # workflow transition may result in ACL change
+                    self.adjust_acls(save=False)
+                    Flaw.objects.filter(uuid=self.uuid).update(
+                        acl_read=self.acl_read,
+                        acl_write=self.acl_write,
+                    )
 
-                self._transition_task(jira_token, jira_email)
+                    self._transition_task(jira_token, jira_email)
 
     def _create_or_update_task(self, jira_token=None, jira_email=None):
         """

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -1,12 +1,9 @@
 import os
-import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
-from django.conf import settings
 
-from osidb.core import generate_acls
 from osidb.helpers import get_env
 from osidb.integrations import IntegrationRepository, IntegrationSettings
 from osidb.models import FlawSource
@@ -57,36 +54,6 @@ def good_cve_id():
 @pytest.fixture
 def good_cve_id2():
     return "CVE-2021-999999"
-
-
-@pytest.fixture
-def public_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)]
-
-
-@pytest.fixture
-def embargoed_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_READ_GROUP])]
-
-
-@pytest.fixture
-def internal_read_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_READ_GROUP])]
-
-
-@pytest.fixture
-def public_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])]
-
-
-@pytest.fixture
-def embargoed_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.EMBARGO_WRITE_GROUP])]
-
-
-@pytest.fixture
-def internal_write_groups():
-    return [uuid.UUID(acl) for acl in generate_acls([settings.INTERNAL_WRITE_GROUP])]
 
 
 @pytest.fixture

--- a/osidb/tests/test_acl_consistency.py
+++ b/osidb/tests/test_acl_consistency.py
@@ -1,0 +1,159 @@
+"""
+Test ACL consistency and propagation.
+
+Django's ATOMIC_REQUESTS=True ensures that all HTTP requests are atomic.
+These tests verify that ACL updates propagate correctly to all nested entities.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+
+from osidb.models import Affect, Flaw, Tracker
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+    TrackerFactory,
+)
+
+
+class TestAtomicRollbackOnFailure:
+    """Verify transactions rollback correctly when failures occur during ACL updates."""
+
+    @pytest.mark.django_db
+    def test_rollback_when_recursive_unembargo_fails(
+        self,
+        embargoed_read_groups,
+        embargoed_write_groups,
+    ):
+        """When recursive unembargo of nested entity fails, all changes rollback."""
+        ps_module = PsModuleFactory()
+        ps_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        flaw = FlawFactory(
+            embargoed=True,
+            acl_read=embargoed_read_groups,
+            acl_write=embargoed_write_groups,
+        )
+
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_update_stream=ps_stream.name,
+            ps_component="test-component",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            acl_read=embargoed_read_groups,
+            acl_write=embargoed_write_groups,
+        )
+
+        tracker = TrackerFactory(
+            affects=[affect],
+            embargoed=True,
+            ps_update_stream=ps_stream.name,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+            acl_read=embargoed_read_groups,
+            acl_write=embargoed_write_groups,
+        )
+
+        original_flaw_acls = (list(flaw.acl_read), list(flaw.acl_write))
+        original_affect_acls = (list(affect.acl_read), list(affect.acl_write))
+        original_tracker_acls = (list(tracker.acl_read), list(tracker.acl_write))
+        original_unembargo = Affect.unembargo
+
+        def failing_unembargo_on_affect(self):
+            # Fail when unembargo is called on an Affect
+            if isinstance(self, Affect):
+                raise Exception("Simulated failure during recursive unembargo")
+            return original_unembargo(self)
+
+        with patch.object(Affect, "unembargo", failing_unembargo_on_affect):
+            with pytest.raises(Exception, match="Simulated failure during recursive"):
+                flaw.unembargo_dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+                flaw.unembargo()
+
+        # Refresh from database
+        flaw.refresh_from_db()
+        affect.refresh_from_db()
+        tracker.refresh_from_db()
+
+        # All should still be embargoed (entire operation rolled back)
+        assert (list(flaw.acl_read), list(flaw.acl_write)) == original_flaw_acls
+        assert (list(affect.acl_read), list(affect.acl_write)) == original_affect_acls
+        assert (
+            list(tracker.acl_read),
+            list(tracker.acl_write),
+        ) == original_tracker_acls
+
+    @pytest.mark.django_db
+    def test_set_history_public_failure_during_workflow_transition(
+        self,
+        internal_read_groups,
+        internal_write_groups,
+    ):
+        """When flaw ACL update fails during workflow transition, all changes rollback."""
+
+        ps_module = PsModuleFactory()
+        ps_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        # Create INTERNAL flaw for workflow transition test
+        flaw = FlawFactory(
+            embargoed=False,
+            unembargo_dt=datetime(2000, 1, 1, tzinfo=timezone.utc),
+            task_key="TASK-1",
+            workflow_state=Flaw.WorkflowState.TRIAGE,
+            acl_read=internal_read_groups,
+            acl_write=internal_write_groups,
+        )
+
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_update_stream=ps_stream.name,
+            ps_component="test-component",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            acl_read=internal_read_groups,
+            acl_write=internal_write_groups,
+        )
+
+        # Verify flaw is internal
+        assert flaw.is_internal
+
+        original_flaw_acls = (list(flaw.acl_read), list(flaw.acl_write))
+        original_affect_acls = (list(affect.acl_read), list(affect.acl_write))
+
+        flaw_queryset_class = Flaw.objects.get_queryset().__class__
+        original_update = flaw_queryset_class.update
+
+        # Inject failure at the call-site level, after nested ACLs were updated
+        # and before the flaw-row ACL update can commit.
+        def failing_flaw_acl_update(self, *args, **kwargs):
+            if self.model is Flaw and "acl_read" in kwargs and "acl_write" in kwargs:
+                raise Exception("Simulated failure during flaw ACL update")
+            return original_update(self, *args, **kwargs)
+
+        with patch.object(flaw_queryset_class, "update", failing_flaw_acl_update):
+            with pytest.raises(Exception, match="Simulated failure during flaw ACL"):
+                flaw.workflow_state = Flaw.WorkflowState.PRE_SECONDARY_ASSESSMENT
+                flaw.tasksync(
+                    jira_token=None,
+                    jira_email=None,
+                    diff={
+                        "workflow_state": {
+                            "old": Flaw.WorkflowState.TRIAGE,
+                            "new": Flaw.WorkflowState.PRE_SECONDARY_ASSESSMENT,
+                        },
+                    },
+                )
+
+        # Refresh from database
+        flaw.refresh_from_db()
+        affect.refresh_from_db()
+
+        # ACLs should be unchanged (rollback occurred)
+        assert (list(flaw.acl_read), list(flaw.acl_write)) == original_flaw_acls
+        assert (list(affect.acl_read), list(affect.acl_write)) == original_affect_acls
+        # Workflow state should also be unchanged
+        assert flaw.workflow_state == Flaw.WorkflowState.TRIAGE


### PR DESCRIPTION
This PR asserts atomic changes on ACLs preventing inconsistencies.
This PR also centralize ACLs fixture to root conftest so we don't have duplicated fixtures across the codebase.

Note that I've separated the cleanup from this task, now it's mapped on OSIDB-5037 and the perfomance issues, that is on OSIDB-4999.

Closes OSIDB-4992.