### PR TITLE
OSIDB-4776: Include comment_zero in community tracker description

### DIFF
--- a/apps/trackers/common.py
+++ b/apps/trackers/common.py
@@ -263,6 +263,8 @@ class TrackerQueryBuilder:
             "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
             "affects their package, before starting the update process."
         )
+        for flaw in self.flaws:
+            description_parts.append(flaw.comment_zero)
         return description_parts
 
     def _description_embargoed(self):

--- a/apps/trackers/tests/test_common.py
+++ b/apps/trackers/tests/test_common.py
@@ -476,7 +476,9 @@ class TestTrackerQueryBuilderDescription:
 
         affects = []
 
-        flaw = FlawFactory()
+        flaw = FlawFactory(
+            comment_zero="this is the community flaw description",
+        )
         embargoed = flaw.embargoed
 
         affects.append(
@@ -506,6 +508,7 @@ class TestTrackerQueryBuilderDescription:
             "Disclaimer: Community trackers are created by Red Hat Product Security team on a "
             "best effort basis. Package maintainers are required to ascertain if the flaw indeed "
             "affects their package, before starting the update process."
+            "\n\nthis is the community flaw description"
         )
 
     def test_jira_basic(self):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `bu_labels` label type (OSIDB-4982)
 - Auditing and tracking of tool-assisted and auto-created affects (OSIDB-4951, OSIDB-4978)
 - Add UpstreamData model with upstream purl field and collection (OSIDB-4923)
+- Add comment_zero in the description of community trackers (OSIDB-4776)
 
 ### Changed
 - Allow adding labels to flaws in any workflow state, including DONE (OSIDB-4986)


### PR DESCRIPTION
Add comment_zero to the community tracker template. 
-Appended flaw title and `comment_zero` for each flaw in `common.py`
-Updated `test_common.py `
Closes:OSIDB-4776

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Community tracker descriptions now include additional flaw comments, providing users with more comprehensive context about tracked issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->