### PR TITLE
OSIDB-4906: pghistory performance improvements

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Make HashiCorp Vault integration credential-based opt-in (OSIDB-5108)
+- Performance improvements for pghistory-related queries (OSIDB-4906)
 
 ### Fixed
 - Fix FieldDoesNotExist being raised for non-DB declared filters (OSIDB-4734)

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -2,8 +2,10 @@
 implement osidb rest api views
 """
 
+import json
 import logging
 from datetime import datetime
+from functools import cache
 from importlib.metadata import distributions
 from typing import Any, Type, cast
 from urllib.parse import urljoin
@@ -11,9 +13,11 @@ from uuid import uuid4
 
 import pghistory
 import requests
+from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied, ValidationError
+from django.db.models import Q
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django_filters.rest_framework import DjangoFilterBackend
@@ -42,6 +46,7 @@ from rest_framework.status import (
     HTTP_404_NOT_FOUND,
     HTTP_503_SERVICE_UNAVAILABLE,
 )
+from rest_framework.utils.urls import remove_query_param, replace_query_param
 from rest_framework.views import APIView
 from rest_framework.viewsets import (
     ModelViewSet,
@@ -134,6 +139,64 @@ from .serializer import (
     TrackerV1Serializer,
     UserSerializer,
 )
+
+
+def _normalize_pgh_context(value):
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode()
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _pgh_data_from_row(audit_table, row):
+    excluded = {"acl_read", "acl_write", "pgh_context", "pgh_context_id"}
+    return {
+        column: row[column]
+        for column in audit_table["columns"]
+        if not column.startswith("pgh_") and column not in excluded
+    }
+
+
+def _pgh_diff(previous_data, pgh_data):
+    diff = {}
+    for key, value in pgh_data.items():
+        if previous_data.get(key) != value:
+            diff[key] = [previous_data.get(key), value]
+    return diff
+
+
+_PREVIOUS_ROW_NOT_LOADED = object()
+
+
+@cache
+def _registered_audit_tables():
+    audit_tables = []
+    for model in apps.get_models():
+        fields = {field.attname for field in model._meta.fields}
+        if not {"pgh_id", "pgh_obj_id", "pgh_created_at"}.issubset(fields):
+            continue
+        if not model._meta.object_name.endswith("Audit"):
+            continue
+        try:
+            object_label = model._meta.get_field(
+                "pgh_obj"
+            ).remote_field.model._meta.label
+        except Exception:
+            object_label = model._meta.label.removesuffix("Audit")
+        audit_tables.append(
+            {
+                "model": model,
+                "audit_label": model._meta.label,
+                "object_label": object_label,
+                "columns": [field.attname for field in model._meta.concrete_fields],
+            }
+        )
+    return tuple(audit_tables)
+
 
 # Use only for RudimentaryUserPathLoggingMixin
 api_logger = logging.getLogger("api_req")
@@ -1986,6 +2049,256 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
     # allow dots and colons in pgh_slug (e.g. "osidb.FlawAudit:2035413"); default [^/.]+
     # would only capture up to the first dot.
     lookup_value_regex = "[^/]+"
+
+    def list(self, request, *args, **kwargs):
+        limit = self._get_limit(request)
+        offset = self._get_offset(request)
+        count = self._audit_count(request.query_params)
+        rows = self._audit_rows(request.query_params, limit, offset)
+        previous_rows = self._previous_rows_for_rows(rows)
+        events = [
+            self._event_from_row(
+                audit_table,
+                row,
+                previous_rows.get((audit_table["audit_label"], row["pgh_id"])),
+            )
+            for audit_table, row in rows
+        ]
+
+        return Response(
+            {
+                "count": count,
+                "next": self._get_next_link(request, limit, offset, count),
+                "previous": self._get_previous_link(request, limit, offset),
+                "results": events,
+            }
+        )
+
+    def retrieve(self, request, *args, **kwargs):
+        event = self._event_by_slug(kwargs[self.lookup_field])
+        if event is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        return Response(event)
+
+    def _get_limit(self, request):
+        default_limit = settings.REST_FRAMEWORK.get("PAGE_SIZE") or 100
+        hard_limit = settings.REST_FRAMEWORK.get("MAX_PAGE_SIZE") or default_limit
+        try:
+            limit = int(request.query_params.get("limit", default_limit))
+        except (TypeError, ValueError):
+            limit = default_limit
+        return max(0, min(limit, hard_limit))
+
+    def _get_offset(self, request):
+        try:
+            return max(0, int(request.query_params.get("offset", 0)))
+        except (TypeError, ValueError):
+            return 0
+
+    def _get_next_link(self, request, limit, offset, count):
+        if not limit or offset + limit >= count:
+            return None
+
+        url = request.build_absolute_uri()
+        url = replace_query_param(url, "limit", limit)
+        return replace_query_param(url, "offset", offset + limit)
+
+    def _get_previous_link(self, request, limit, offset):
+        if not limit or offset <= 0:
+            return None
+
+        url = request.build_absolute_uri()
+        url = replace_query_param(url, "limit", limit)
+        previous_offset = max(offset - limit, 0)
+        if previous_offset == 0:
+            return remove_query_param(url, "offset")
+        return replace_query_param(url, "offset", previous_offset)
+
+    def _audit_count(self, params):
+        pgh_slug = params.get("pgh_slug")
+        if pgh_slug:
+            return 1 if self._row_by_slug(pgh_slug, params) else 0
+
+        count = 0
+        for audit_table in self._audit_tables():
+            if (
+                params.get("pgh_obj_model")
+                and params["pgh_obj_model"] != audit_table["object_label"]
+            ):
+                continue
+            # Exact counts on unfiltered audit feeds are expensive on large audit tables,
+            # but are preserved for API compatibility with the existing /audit contract.
+            count += self._audit_queryset(audit_table, params).count()
+        return count
+
+    def _audit_rows(self, params, limit, offset):
+        rows = []
+        pgh_slug = params.get("pgh_slug")
+        if pgh_slug:
+            if not limit or offset:
+                return []
+            event = self._row_by_slug(pgh_slug, params)
+            return [event] if event else []
+
+        for audit_table in self._audit_tables():
+            if (
+                params.get("pgh_obj_model")
+                and params["pgh_obj_model"] != audit_table["object_label"]
+            ):
+                continue
+
+            window = limit + offset
+            if not window:
+                continue
+
+            rows.extend(
+                (audit_table, row)
+                for row in self._audit_rows_with_context(
+                    self._audit_queryset(audit_table, params).order_by("-pgh_id")[
+                        :window
+                    ],
+                    audit_table,
+                )
+            )
+
+        rows.sort(key=lambda item: item[1]["pgh_created_at"], reverse=True)
+        return rows[offset : offset + limit]
+
+    def _audit_queryset(self, audit_table, params):
+        filters = {}
+        if params.get("pgh_label"):
+            filters["pgh_label"] = params["pgh_label"]
+        if params.get("pgh_obj_id"):
+            filters["pgh_obj_id"] = params["pgh_obj_id"]
+        if params.get("pgh_created_at"):
+            filters["pgh_created_at"] = params["pgh_created_at"]
+        return audit_table["model"].objects.filter(**filters)
+
+    def _event_by_slug(self, pgh_slug):
+        row = self._row_by_slug(pgh_slug)
+        if row is None:
+            return None
+        return self._event_from_row(*row)
+
+    def _row_by_slug(self, pgh_slug, params=None):
+        if ":" not in pgh_slug:
+            return None
+
+        audit_label, pgh_id = pgh_slug.rsplit(":", 1)
+        try:
+            pgh_id = int(pgh_id)
+        except ValueError:
+            return None
+
+        for audit_table in self._audit_tables():
+            if audit_table["audit_label"] != audit_label:
+                continue
+            if (
+                params
+                and params.get("pgh_obj_model")
+                and params["pgh_obj_model"] != audit_table["object_label"]
+            ):
+                return None
+
+            row = next(
+                self._audit_rows_with_context(
+                    self._audit_queryset(audit_table, params or {}).filter(
+                        pgh_id=pgh_id
+                    )[:1],
+                    audit_table,
+                ),
+                None,
+            )
+            if row is None:
+                return None
+            return audit_table, row
+        return None
+
+    def _event_from_row(self, audit_table, row, previous=_PREVIOUS_ROW_NOT_LOADED):
+        pgh_data = self._pgh_data(audit_table, row)
+        if previous is _PREVIOUS_ROW_NOT_LOADED:
+            previous = self._previous_row(audit_table, row)
+        previous_data = self._pgh_data(audit_table, previous) if previous else {}
+
+        return {
+            "pgh_created_at": row["pgh_created_at"],
+            "pgh_slug": f"{audit_table['audit_label']}:{row['pgh_id']}",
+            "pgh_obj_model": audit_table["object_label"],
+            "pgh_obj_id": row["pgh_obj_id"],
+            "pgh_label": row["pgh_label"],
+            "pgh_context": _normalize_pgh_context(row.get("pgh_context")),
+            "pgh_diff": self._pgh_diff(previous_data, pgh_data),
+            "pgh_data": pgh_data,
+        }
+
+    def _previous_row(self, audit_table, row):
+        """pg_diff is not physically stored, previous edit on field is needed for that"""
+        return (
+            audit_table["model"]
+            .objects.filter(pgh_obj_id=row["pgh_obj_id"], pgh_id__lt=row["pgh_id"])
+            .order_by("-pgh_id")
+            .values(*audit_table["columns"])
+            .first()
+        )
+
+    def _previous_rows_for_rows(self, rows):
+        rows_by_audit_label = defaultdict(list)
+        audit_tables_by_label = {}
+        for audit_table, row in rows:
+            audit_label = audit_table["audit_label"]
+            audit_tables_by_label[audit_label] = audit_table
+            rows_by_audit_label[audit_label].append(row)
+
+        previous_rows = {}
+        for audit_label, audit_rows in rows_by_audit_label.items():
+            audit_table = audit_tables_by_label[audit_label]
+            max_pgh_id_by_obj_id = defaultdict(int)
+            for row in audit_rows:
+                max_pgh_id_by_obj_id[row["pgh_obj_id"]] = max(
+                    max_pgh_id_by_obj_id[row["pgh_obj_id"]], row["pgh_id"]
+                )
+
+            filters = Q()
+            for pgh_obj_id, pgh_id in max_pgh_id_by_obj_id.items():
+                filters |= Q(pgh_obj_id=pgh_obj_id, pgh_id__lt=pgh_id)
+
+            candidates_by_obj_id = defaultdict(list)
+            for previous in (
+                audit_table["model"]
+                .objects.filter(filters)
+                .order_by("pgh_obj_id", "-pgh_id")
+                .values(*audit_table["columns"])
+            ):
+                candidates_by_obj_id[previous["pgh_obj_id"]].append(previous)
+
+            for row in audit_rows:
+                previous = next(
+                    (
+                        candidate
+                        for candidate in candidates_by_obj_id[row["pgh_obj_id"]]
+                        if candidate["pgh_id"] < row["pgh_id"]
+                    ),
+                    None,
+                )
+                if previous:
+                    previous_rows[(audit_label, row["pgh_id"])] = previous
+
+        return previous_rows
+
+    def _pgh_data(self, audit_table, row):
+        return _pgh_data_from_row(audit_table, row)
+
+    def _pgh_diff(self, previous_data, pgh_data):
+        return _pgh_diff(previous_data, pgh_data)
+
+    def _audit_tables(self):
+        return _registered_audit_tables()
+
+    def _audit_rows_with_context(self, queryset, audit_table):
+        rows = queryset.values(*audit_table["columns"], "pgh_context__metadata")
+        for row in rows:
+            row["pgh_context"] = row.pop("pgh_context__metadata")
+            yield row
 
 
 # NOTE: Purpose of this custom class is for Kerberos authenticated

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -2,18 +2,17 @@
 implement osidb rest api views
 """
 
-import json
 import logging
+from collections import defaultdict
 from datetime import datetime
-from functools import cache
 from importlib.metadata import distributions
+from types import SimpleNamespace
 from typing import Any, Type, cast
 from urllib.parse import urljoin
 from uuid import uuid4
 
 import pghistory
 import requests
-from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied, ValidationError
@@ -68,6 +67,16 @@ from osidb.models import (
     FlawLabel,
     PsUpdateStream,
     Tracker,
+)
+from osidb.models.audit_history import (
+    audit_rows_with_context,
+    audit_table_for_model,
+    normalize_pgh_context,
+    pgh_data_from_row,
+    registered_audit_tables,
+)
+from osidb.models.audit_history import (
+    pgh_diff as build_pgh_diff,
 )
 from osidb.models.flaw.comment import FlawComment
 from osidb.models.flaw.cvss import FlawCVSS
@@ -130,6 +139,7 @@ from .serializer import (
     FlawReferenceSerializer,
     FlawSerializer,
     FlawV1Serializer,
+    HistoryMixinSerializer,
     IncidentRequestSerializer,
     IntegrationTokenGetSerializer,
     IntegrationTokenPatchSerializer,
@@ -140,62 +150,7 @@ from .serializer import (
     UserSerializer,
 )
 
-
-def _normalize_pgh_context(value):
-    if isinstance(value, (bytes, bytearray)):
-        value = value.decode()
-    if isinstance(value, str):
-        try:
-            return json.loads(value)
-        except json.JSONDecodeError:
-            return value
-    return value
-
-
-def _pgh_data_from_row(audit_table, row):
-    excluded = {"acl_read", "acl_write", "pgh_context", "pgh_context_id"}
-    return {
-        column: row[column]
-        for column in audit_table["columns"]
-        if not column.startswith("pgh_") and column not in excluded
-    }
-
-
-def _pgh_diff(previous_data, pgh_data):
-    diff = {}
-    for key, value in pgh_data.items():
-        if previous_data.get(key) != value:
-            diff[key] = [previous_data.get(key), value]
-    return diff
-
-
 _PREVIOUS_ROW_NOT_LOADED = object()
-
-
-@cache
-def _registered_audit_tables():
-    audit_tables = []
-    for model in apps.get_models():
-        fields = {field.attname for field in model._meta.fields}
-        if not {"pgh_id", "pgh_obj_id", "pgh_created_at"}.issubset(fields):
-            continue
-        if not model._meta.object_name.endswith("Audit"):
-            continue
-        try:
-            object_label = model._meta.get_field(
-                "pgh_obj"
-            ).remote_field.model._meta.label
-        except Exception:
-            object_label = model._meta.label.removesuffix("Audit")
-        audit_tables.append(
-            {
-                "model": model,
-                "audit_label": model._meta.label,
-                "object_label": object_label,
-                "columns": [field.attname for field in model._meta.concrete_fields],
-            }
-        )
-    return tuple(audit_tables)
 
 
 # Use only for RudimentaryUserPathLoggingMixin
@@ -634,14 +589,170 @@ class BulkHistoryMixin(ReadOnlyModelViewSet):
         history_map = {}
 
         if objects:
-            all_history_events = Events.objects.references(*objects)
-            for event in all_history_events:
-                key = f"{event.pgh_obj_model}:{event.pgh_obj_id}"
-                if key not in history_map:
-                    history_map[key] = []
-                history_map[key].append(event)
+            history_map = self._build_concrete_history_cache(objects)
+            if history_map is None:
+                history_map = {}
+                all_history_events = Events.objects.references(*objects)
+                for event in all_history_events:
+                    key = f"{event.pgh_obj_model}:{event.pgh_obj_id}"
+                    if key not in history_map:
+                        history_map[key] = []
+                    history_map[key].append(event)
 
         return history_map
+
+    def _build_concrete_history_cache(self, objects):
+        """
+        Build history for serializers that expose HistoryMixinSerializer.
+
+        Serializer declarations decide which nested serializers can expose
+        history. Reading concrete audit tables keeps the API shape while
+        avoiding the broad pghistory references aggregate.
+        """
+        serializer_class = self.get_serializer_class()
+        objects_by_model = defaultdict(list)
+        include_fields, include_nested = self._history_requested_fields(
+            "include_fields"
+        )
+        exclude_fields, exclude_nested = self._history_requested_fields(
+            "exclude_fields", default_empty=True
+        )
+
+        if not self._collect_history_objects(
+            serializer_class,
+            objects,
+            objects_by_model,
+            include_fields,
+            include_nested,
+            exclude_fields,
+            exclude_nested,
+        ):
+            return None
+
+        history_map = {}
+        for model_class, model_objects in objects_by_model.items():
+            self._add_model_history(history_map, model_class, model_objects)
+        return history_map
+
+    def _collect_history_objects(
+        self,
+        serializer_class,
+        objects,
+        objects_by_model,
+        include_fields,
+        include_nested,
+        exclude_fields,
+        exclude_nested,
+    ):
+        if not issubclass(serializer_class, HistoryMixinSerializer):
+            return False
+
+        object_list = list(objects)
+        objects_by_model[serializer_class.get_history_model()].extend(object_list)
+
+        for relation in serializer_class.get_history_relations():
+            if not self._history_field_included(
+                relation.field_name, include_fields, exclude_fields
+            ):
+                continue
+
+            related_objects = []
+            for obj in object_list:
+                related_objects.extend(relation.accessor(obj))
+
+            child_include_fields, child_include_nested = self._history_child_fields(
+                relation.field_name, include_nested, default_empty=False
+            )
+            child_exclude_fields, child_exclude_nested = self._history_child_fields(
+                relation.field_name, exclude_nested, default_empty=True
+            )
+            self._collect_history_objects(
+                relation.serializer_class,
+                related_objects,
+                objects_by_model,
+                child_include_fields,
+                child_include_nested,
+                child_exclude_fields,
+                child_exclude_nested,
+            )
+
+        return True
+
+    def _history_requested_fields(self, param_name, default_empty=False):
+        request = getattr(self, "request", None)
+        if request is None:
+            return (set() if default_empty else None), {}
+
+        raw = request.query_params.get(param_name)
+        if not raw:
+            return (set() if default_empty else None), {}
+
+        fields = set()
+        nested = defaultdict(list)
+        for item in raw.split(","):
+            item = item.strip()
+            if not item:
+                continue
+            field_name, separator, child_field = item.partition(".")
+            fields.add(field_name)
+            if separator:
+                nested[field_name].append(child_field)
+        return fields, nested
+
+    def _history_child_fields(self, field_name, nested_fields, default_empty=False):
+        child_values = nested_fields.get(field_name, [])
+        if not child_values:
+            return (set() if default_empty else None), {}
+
+        fields = set()
+        nested = defaultdict(list)
+        for item in child_values:
+            child_name, separator, grandchild = item.partition(".")
+            fields.add(child_name)
+            if separator:
+                nested[child_name].append(grandchild)
+        return fields, nested
+
+    def _history_field_included(self, field_name, include_fields, exclude_fields):
+        # Explicit includes take precedence over excludes.
+        if include_fields is not None and field_name not in include_fields:
+            return False
+        return not (
+            field_name in exclude_fields
+            and (include_fields is None or field_name not in include_fields)
+        )
+
+    def _add_model_history(self, history_map, model_class, objects):
+        object_ids = [obj.pk for obj in objects if obj.pk is not None]
+        if not object_ids:
+            return
+
+        audit_table = audit_table_for_model(model_class)
+        if audit_table is None:
+            return
+
+        rows = audit_rows_with_context(
+            audit_table["model"]
+            .objects.filter(pgh_obj_id__in=object_ids)
+            .order_by("pgh_obj_id", "pgh_id"),
+            audit_table,
+        )
+
+        previous_data_by_obj_id = {}
+        for row in rows:
+            key = f"{audit_table['object_label']}:{row['pgh_obj_id']}"
+            pgh_data = pgh_data_from_row(audit_table, row)
+            previous_data = previous_data_by_obj_id.get(row["pgh_obj_id"], {})
+            history_map.setdefault(key, []).append(
+                SimpleNamespace(
+                    pgh_created_at=row["pgh_created_at"],
+                    pgh_slug=f"{audit_table['audit_label']}:{row['pgh_id']}",
+                    pgh_label=row["pgh_label"],
+                    pgh_context=normalize_pgh_context(row.get("pgh_context")),
+                    pgh_diff=build_pgh_diff(previous_data, pgh_data),
+                )
+            )
+            previous_data_by_obj_id[row["pgh_obj_id"]] = pgh_data
 
     def list(self, request, *args, **kwargs):
         # Override list to bulk-fetch history for all objects.
@@ -2120,7 +2231,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             return 1 if self._row_by_slug(pgh_slug, params) else 0
 
         count = 0
-        for audit_table in self._audit_tables():
+        for audit_table in registered_audit_tables():
             if (
                 params.get("pgh_obj_model")
                 and params["pgh_obj_model"] != audit_table["object_label"]
@@ -2140,7 +2251,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             event = self._row_by_slug(pgh_slug, params)
             return [event] if event else []
 
-        for audit_table in self._audit_tables():
+        for audit_table in registered_audit_tables():
             if (
                 params.get("pgh_obj_model")
                 and params["pgh_obj_model"] != audit_table["object_label"]
@@ -2153,7 +2264,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
 
             rows.extend(
                 (audit_table, row)
-                for row in self._audit_rows_with_context(
+                for row in audit_rows_with_context(
                     self._audit_queryset(audit_table, params).order_by("-pgh_id")[
                         :window
                     ],
@@ -2190,7 +2301,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
         except ValueError:
             return None
 
-        for audit_table in self._audit_tables():
+        for audit_table in registered_audit_tables():
             if audit_table["audit_label"] != audit_label:
                 continue
             if (
@@ -2201,7 +2312,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
                 return None
 
             row = next(
-                self._audit_rows_with_context(
+                audit_rows_with_context(
                     self._audit_queryset(audit_table, params or {}).filter(
                         pgh_id=pgh_id
                     )[:1],
@@ -2215,10 +2326,10 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
         return None
 
     def _event_from_row(self, audit_table, row, previous=_PREVIOUS_ROW_NOT_LOADED):
-        pgh_data = self._pgh_data(audit_table, row)
+        pgh_data = pgh_data_from_row(audit_table, row)
         if previous is _PREVIOUS_ROW_NOT_LOADED:
             previous = self._previous_row(audit_table, row)
-        previous_data = self._pgh_data(audit_table, previous) if previous else {}
+        previous_data = pgh_data_from_row(audit_table, previous) if previous else {}
 
         return {
             "pgh_created_at": row["pgh_created_at"],
@@ -2226,8 +2337,8 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             "pgh_obj_model": audit_table["object_label"],
             "pgh_obj_id": row["pgh_obj_id"],
             "pgh_label": row["pgh_label"],
-            "pgh_context": _normalize_pgh_context(row.get("pgh_context")),
-            "pgh_diff": self._pgh_diff(previous_data, pgh_data),
+            "pgh_context": normalize_pgh_context(row.get("pgh_context")),
+            "pgh_diff": build_pgh_diff(previous_data, pgh_data),
             "pgh_data": pgh_data,
         }
 
@@ -2284,21 +2395,6 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
                     previous_rows[(audit_label, row["pgh_id"])] = previous
 
         return previous_rows
-
-    def _pgh_data(self, audit_table, row):
-        return _pgh_data_from_row(audit_table, row)
-
-    def _pgh_diff(self, previous_data, pgh_data):
-        return _pgh_diff(previous_data, pgh_data)
-
-    def _audit_tables(self):
-        return _registered_audit_tables()
-
-    def _audit_rows_with_context(self, queryset, audit_table):
-        rows = queryset.values(*audit_table["columns"], "pgh_context__metadata")
-        for row in rows:
-            row["pgh_context"] = row.pop("pgh_context__metadata")
-            yield row
 
 
 # NOTE: Purpose of this custom class is for Kerberos authenticated

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -6,7 +6,6 @@ from itertools import batched, chain
 
 import pghistory
 import pgtrigger
-from django.apps import apps
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
@@ -17,6 +16,7 @@ from django.db import IntegrityError, models, transaction
 from django.utils import timezone
 
 from osidb.exceptions import DataInconsistencyException
+from osidb.models.audit_history import audit_model_for_model
 
 from .core import generate_acls
 
@@ -615,17 +615,33 @@ class ACLMixin(models.Model):
         """
         set the history to public
         """
-        refs = pghistory.models.Events.objects.tracks(self).all()
-        for ref in refs:
-            model_audit = apps.get_model(ref.pgh_model).objects.filter(
-                pgh_id=ref.pgh_id
-            )
+        self._set_history_public_for_model(type(self), [self.pk])
 
-            with pgtrigger.ignore(f"{ref.pgh_model}:append_only"):
-                model_audit.update(
-                    acl_read=list(self.acls_public_read),
-                    acl_write=list(self.acls_public_write),
-                )
+    @classmethod
+    def _set_history_public_for_model(cls, model_class, object_ids):
+        """
+        Set history ACLs in one update per concrete audit table.
+        """
+        object_ids = [object_id for object_id in object_ids if object_id is not None]
+        if not object_ids:
+            return
+
+        audit_model = audit_model_for_model(model_class)
+        if audit_model is None:
+            return
+
+        public_acl_read = [
+            uuid.UUID(acl) for acl in generate_acls(settings.PUBLIC_READ_GROUPS)
+        ]
+        public_acl_write = [
+            uuid.UUID(acl) for acl in generate_acls([settings.PUBLIC_WRITE_GROUP])
+        ]
+
+        with pgtrigger.ignore(f"{audit_model._meta.label}:append_only"):
+            audit_model.objects.filter(pgh_obj_id__in=object_ids).update(
+                acl_read=public_acl_read,
+                acl_write=public_acl_write,
+            )
 
     def unembargo(self):
         """
@@ -722,8 +738,8 @@ class ACLMixin(models.Model):
             for pk_chunk in batched(object_ids, max_chunk_size):
                 model_class.objects.filter(pk__in=pk_chunk).update(**update_kwargs)
 
-            for pk in object_ids:
-                model_class(pk=pk).set_history_public()
+            for pk_chunk in batched(object_ids, max_chunk_size):
+                self._set_history_public_for_model(model_class, pk_chunk)
 
     def _collect_objects_for_public_update(self, objects_to_update, visited):
         """

--- a/osidb/models/audit_history.py
+++ b/osidb/models/audit_history.py
@@ -1,5 +1,93 @@
+import json
+from functools import cache
+
+from django.apps import apps
 from django.db import models
 from pghistory import models as pg_models
+
+
+def normalize_pgh_context(value):
+    if isinstance(value, (bytes, bytearray)):
+        value = value.decode()
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def pgh_data_from_row(audit_table, row):
+    excluded = {"acl_read", "acl_write", "pgh_context", "pgh_context_id"}
+    return {
+        column: row[column]
+        for column in audit_table["columns"]
+        if not column.startswith("pgh_") and column not in excluded
+    }
+
+
+def pgh_diff(previous_data, pgh_data):
+    diff = {}
+    for key, value in pgh_data.items():
+        if previous_data.get(key) != value:
+            diff[key] = [previous_data.get(key), value]
+    return diff
+
+
+def audit_model_for_model(model_class):
+    try:
+        return apps.get_model(
+            model_class._meta.app_label,
+            f"{model_class._meta.object_name}Audit",
+        )
+    except LookupError:
+        return None
+
+
+def audit_table_for_model(model_class):
+    audit_model = audit_model_for_model(model_class)
+    if audit_model is None:
+        return None
+
+    return {
+        "model": audit_model,
+        "audit_label": audit_model._meta.label,
+        "object_label": model_class._meta.label,
+        "columns": [field.attname for field in audit_model._meta.concrete_fields],
+    }
+
+
+@cache
+def registered_audit_tables():
+    audit_tables = []
+    for model in apps.get_models():
+        fields = {field.attname for field in model._meta.fields}
+        if not {"pgh_id", "pgh_obj_id", "pgh_created_at"}.issubset(fields):
+            continue
+        if not model._meta.object_name.endswith("Audit"):
+            continue
+        try:
+            object_label = model._meta.get_field(
+                "pgh_obj"
+            ).remote_field.model._meta.label
+        except Exception:
+            object_label = model._meta.label.removesuffix("Audit")
+        audit_tables.append(
+            {
+                "model": model,
+                "audit_label": model._meta.label,
+                "object_label": object_label,
+                "columns": [field.attname for field in model._meta.concrete_fields],
+            }
+        )
+    return tuple(audit_tables)
+
+
+def audit_rows_with_context(queryset, audit_table):
+    rows = queryset.values(*audit_table["columns"], "pgh_context__metadata")
+    for row in rows:
+        row["pgh_context"] = row.pop("pgh_context__metadata")
+        yield row
 
 
 class CustomHistoryBase(pg_models.Event):

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -5,7 +5,8 @@ serialize flaw model
 import logging
 import uuid
 from collections import defaultdict
-from typing import Dict, List, Tuple
+from dataclasses import dataclass
+from typing import Any, Callable, Dict, Iterable, List, Tuple, Type
 
 import pghistory
 from django.conf import settings
@@ -680,8 +681,24 @@ class HistoricalEventSerializer(serializers.ModelSerializer):
         return representation
 
 
+@dataclass(frozen=True)
+class HistoryRelation:
+    field_name: str
+    serializer_class: Type[serializers.Serializer]
+    accessor: Callable[[Any], Iterable[Any]]
+
+
 class HistoryMixinSerializer(serializers.ModelSerializer):
+    history_relations: Tuple[HistoryRelation, ...] = ()
     history = serializers.SerializerMethodField()
+
+    @classmethod
+    def get_history_model(cls):
+        return cls.Meta.model
+
+    @classmethod
+    def get_history_relations(cls):
+        return cls.history_relations
 
     def __init__(self, *args, **kwargs):
         # Instantiate the superclass normally
@@ -1490,12 +1507,16 @@ class AffectV1Serializer(
         # Use pre-queried list when present
         tracker_list = self.context.get("tracker_list_by_uuid")
         if tracker_list is not None:
-            uuids = (
-                Affect.objects.filter(uuid=obj.uuid)
-                .exclude(tracker__isnull=True)
-                .values_list("tracker__uuid", flat=True)
-                .distinct()
-            )
+            tracker_uuids_by_affect = self.context.get("tracker_uuids_by_affect")
+            if tracker_uuids_by_affect is not None:
+                uuids = tracker_uuids_by_affect.get(str(obj.uuid), [])
+            else:
+                uuids = (
+                    Affect.objects.filter(uuid=obj.uuid)
+                    .exclude(tracker__isnull=True)
+                    .values_list("tracker__uuid", flat=True)
+                    .distinct()
+                )
             return [
                 tracker_list[str(uuid)] for uuid in uuids if str(uuid) in tracker_list
             ]
@@ -2209,6 +2230,14 @@ class FlawSerializer(
 ):
     """serialize flaw model"""
 
+    history_relations = (
+        HistoryRelation(
+            field_name="affects",
+            serializer_class=AffectSerializer,
+            accessor=lambda flaw: flaw.affects.all(),
+        ),
+    )
+
     # All currently used keys in Flaw.meta_attr used for SwaggerUI population,
     # whenever we introduce new key, which users might be interested in, we should
     # add it to this tuple.
@@ -2531,6 +2560,14 @@ class FlawPutSerializer(FlawSerializer):
 class FlawV1Serializer(FlawSerializer):
     """Serializer for the flaw model adapted to affects v1"""
 
+    history_relations = (
+        HistoryRelation(
+            field_name="affects",
+            serializer_class=AffectV1Serializer,
+            accessor=lambda flaw: AffectV1.objects.filter(flaw=flaw),
+        ),
+    )
+
     @extend_schema_field(AffectV1Serializer(many=True))
     def get_affects(self, obj):
         # Query the AffectV1 read-only model instead of the original Affect model.
@@ -2612,6 +2649,7 @@ class FlawV1Serializer(FlawSerializer):
 
         tracker_uuid_set = set()
         affects_by_tracker = defaultdict(list)
+        tracker_uuids_by_affect = defaultdict(list)
 
         if affects:
             for affect_uuid, tracker_uuid in (
@@ -2622,6 +2660,7 @@ class FlawV1Serializer(FlawSerializer):
             ):
                 tracker_uuid_set.add(tracker_uuid)
                 affects_by_tracker[tracker_uuid].append(affect_uuid)
+                tracker_uuids_by_affect[str(affect_uuid)].append(str(tracker_uuid))
 
         # Fetch and serialize each tracker
         tracker_list = {}
@@ -2660,6 +2699,7 @@ class FlawV1Serializer(FlawSerializer):
 
         # Pass down caches
         context["tracker_list_by_uuid"] = tracker_list
+        context["tracker_uuids_by_affect"] = tracker_uuids_by_affect
         context["cvss_list_by_uuid"] = cvss_list
 
         return AffectV1Serializer(

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -2122,6 +2122,32 @@ class TestEndpointsFlaws:
             assert flaw_json["history"][1]["pgh_diff"]
             assert "last_validated_dt" not in flaw_json["history"][1]["pgh_diff"]
 
+    def test_flaw_history_schema(self, auth_client, test_api_v2_uri):
+        with pghistory.context(source="schema-test"):
+            flaw = FlawFactory()
+
+        response = auth_client().get(
+            f"{test_api_v2_uri}/flaws?cve_id={flaw.cve_id}&include_history=True"
+        )
+
+        assert response.status_code == 200
+        flaw_json = response.json()["results"][0]
+        history = flaw_json["history"]
+
+        assert len(history) == 1
+        assert set(history[0]) == {
+            "pgh_created_at",
+            "pgh_slug",
+            "pgh_label",
+            "pgh_context",
+            "pgh_diff",
+        }
+        assert history[0]["pgh_created_at"]
+        assert history[0]["pgh_slug"].startswith("osidb.FlawAudit:")
+        assert history[0]["pgh_label"] == "insert"
+        assert history[0]["pgh_context"] == {"source": "schema-test"}
+        assert isinstance(history[0]["pgh_diff"], dict)
+
     def test_flaw_history_no_history(self, auth_client, test_api_v2_uri):
         with pghistory.context(disable=True):
             flaw = FlawFactory()

--- a/osidb/tests/endpoints/test_audit.py
+++ b/osidb/tests/endpoints/test_audit.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pghistory
 import pytest
 
@@ -87,6 +89,22 @@ class TestEndpointsAudit:
         assert "pgh_created_at" in body
         assert "pgh_label" in body
         assert "pgh_data" in body
+
+        response_filtered = auth_client().get(
+            f"{test_api_uri}/audit?pgh_slug={pgh_slug}&pgh_obj_id={body['pgh_obj_id']}"
+        )
+        assert response_filtered.status_code == 200
+        filtered_body = response_filtered.json()
+        assert filtered_body["count"] == 1
+        assert filtered_body["results"][0]["pgh_slug"] == pgh_slug
+
+        response_mismatch = auth_client().get(
+            f"{test_api_uri}/audit?pgh_slug={pgh_slug}&pgh_obj_id={uuid4()}"
+        )
+        assert response_mismatch.status_code == 200
+        mismatch_body = response_mismatch.json()
+        assert mismatch_body["count"] == 0
+        assert mismatch_body["results"] == []
 
     def test_audit_list_filter_by_pgh_obj_id(self, auth_client, test_api_uri):
         """GET /audit?pgh_obj_id=<uuid> returns only events for that object."""

--- a/osidb/tests/test_query_regresion.py
+++ b/osidb/tests/test_query_regresion.py
@@ -122,7 +122,7 @@ class TestQuerySetRegression:
             response = auth_client().get(f"{test_api_v2_uri}/flaws/{flaw.uuid}")
             assert response.status_code == 200
 
-    @pytest.mark.parametrize("embargoed,query_count", [(False, 63), (True, 63)])
+    @pytest.mark.parametrize("embargoed,query_count", [(False, 67), (True, 67)])
     def test_flaw_with_affects_history(
         self, auth_client, test_api_v2_uri, embargoed, query_count
     ):
@@ -266,7 +266,7 @@ class TestQuerySetRegression:
             response = auth_client().get(f"{test_api_v2_uri}/affects")
             assert response.status_code == 200
 
-    @pytest.mark.parametrize("embargoed,query_count", [(False, 55), (True, 55)])
+    @pytest.mark.parametrize("embargoed,query_count", [(False, 56), (True, 56)])
     def test_affect_list_history(
         self, auth_client, test_api_v2_uri, embargoed, query_count
     ):


### PR DESCRIPTION
This PR improves pghistory-related performance in three areas: `/audit`, `/flaws?include_history=true`, and history ACL publication.

This PR changes the `/audit` endpoint to query concrete audit tables directly instead of using pghistory's aggregate `Events` model. The response shape is preserved, including pagination links, `pgh_slug`, `pgh_context`, `pgh_data`, and `pgh_diff`.

This PR also changes `include_history` to fetch only the history needed by the serializer. Instead of loading broad pghistory references for many related models, it collects the root and nested objects that can actually expose history and reads their concrete audit tables directly. This keeps the API schema compatible while reducing the history-cache cost.

This PR also updates history ACL publication to bulk-update generated audit models when objects become public. This avoids per-event pghistory lookups and keeps historical ACLs physically synchronized with the live object ACLs.

Local benchmark results from a stage-sized dump showed:
- `/audit?pgh_obj_id=...`: ~51s -> ~94ms
- `/audit/{pgh_slug}`: ~22s -> ~40-50ms
- `/audit?limit=100`: ~30s -> ~16ms
- `/flaws?include_history=true`: ~8.9s -> ~2.6s
- `include_history` history-cache phase: ~6.4s -> ~210ms
- ACL publication (1 flaw + 1000 affects + 22k events): ~31s -> ~4s

One remaining caveat is unfiltered `/audit` pagination. The endpoint still returns an exact `count` for compatibility, and that count remains expensive on large audit tables. Removing or relaxing that count would provide another large improvement, but would be an API compatibility decision.

Closes OSIDB-4906.