### PR TITLE
OSIDB-5031: Base auto-affect determination on upstream affected versions

### DIFF
--- a/apps/ace/constants.py
+++ b/apps/ace/constants.py
@@ -1,0 +1,17 @@
+# OSV ecosystem strings to normalized ecosystem identifiers
+OSV_ECOSYSTEM_MAP: dict[str, str] = {
+    "maven": "maven",
+    "pypi": "pypi",
+    "npm": "npm",
+    "crates.io": "cargo",
+    "go": "golang",
+    "rubygems": "gem",
+    "nuget": "nuget",
+    "packagist": "generic",
+    "hex": "generic",
+    "pub": "generic",
+    "hackage": "generic",
+    "bioconductor": "generic",
+    "cran": "generic",
+    "github actions": "generic",
+}

--- a/apps/ace/osv_ranges.py
+++ b/apps/ace/osv_ranges.py
@@ -1,0 +1,153 @@
+"""
+osv_ranges.py — Match Flaw components to OSV upstream version ranges.
+
+Adapts the OsvPackageInfo / _extract_osv_packages logic from vulncli/intake.py
+to work directly on the upstream_purls list stored in UpstreamData (no HTTP
+fetch needed — the data is already present in the database).
+
+Depends on apps/ace/version.py for version comparison.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from packageurl import PackageURL
+
+from apps.ace.constants import OSV_ECOSYSTEM_MAP
+
+log = logging.getLogger(__name__)
+
+# Only SEMVER and ECOSYSTEM range types yield meaningful version bounds.
+# GIT ranges (commit hashes) are skipped — version comparison is not possible.
+_RANGE_TYPES = {"semver", "ecosystem"}
+
+
+@dataclass
+class OsvPackageInfo:
+    """A single package entry extracted from an OSV upstream_purls record."""
+
+    name: str
+    ecosystem: str  # normalised (e.g. "cargo", "maven", "rpm")
+    purl: str
+    introduced: str  # "" means "from the beginning"
+    fixed: str  # "" means "no fix yet / unknown"
+    last_affected: str  # alternative to fixed (inclusive upper bound)
+
+    def affected_range(self) -> str | None:
+        """
+        Convert OSV events to a version.py range expression string.
+
+        Returns ``None`` when no meaningful range can be expressed (no fixed/last_affected
+        events were present in the OSV record).
+
+        Examples:
+          introduced="0",       fixed="2.15.0"           →  "< 2.15.0"
+          introduced="2.0-b9",  fixed="2.15.0"           →  ">= 2.0-b9, < 2.15.0"
+          introduced="0.1.0",   last_affected="0.10.65"  →  ">= 0.1.0, <= 0.10.65"
+          (no events)                                     →  None
+        """
+        parts = []
+        intro = self.introduced.strip()
+        fixed = self.fixed.strip()
+        last = self.last_affected.strip()
+
+        if intro and intro not in ("0", "0.0", "0.0.0", ""):
+            parts.append(f">= {intro}")
+
+        if fixed:
+            parts.append(f"< {fixed}")
+        elif last:
+            parts.append(f"<= {last}")
+
+        return ", ".join(parts) or None
+
+
+def osv_entry_to_package_info(entry: dict) -> OsvPackageInfo:
+    """
+    Convert one upstream_purls dict entry to an OsvPackageInfo.
+
+    upstream_purls entries are produced by the OSV collector
+    (collectors/osv/collectors.py::get_upstream_purls) and have the shape:
+      {
+        "purl":      "pkg:nuget/Magick.NET-Q16-AnyCPU",
+        "name":      "Magick.NET-Q16-AnyCPU",
+        "ecosystem": "NuGet",
+        "ranges":    [{"type": "ECOSYSTEM", "events": [...]}],
+        "versions":  ["10.0.0", ...],
+      }
+    """
+    raw_eco = (entry.get("ecosystem") or "").lower()
+    ecosystem = OSV_ECOSYSTEM_MAP.get(raw_eco, raw_eco)
+
+    introduced = ""
+    fixed = ""
+    last_affected = ""
+
+    for r in entry.get("ranges", []):
+        if r.get("type", "").lower() not in _RANGE_TYPES:
+            continue
+        for evt in r.get("events", []):
+            if "introduced" in evt and not introduced:
+                introduced = evt["introduced"]
+            if "fixed" in evt and not fixed:
+                fixed = evt["fixed"]
+            if "last_affected" in evt and not last_affected:
+                last_affected = evt["last_affected"]
+
+    return OsvPackageInfo(
+        name=entry.get("name", ""),
+        ecosystem=ecosystem,
+        purl=entry.get("purl", ""),
+        introduced=introduced,
+        fixed=fixed,
+        last_affected=last_affected,
+    )
+
+
+def match_component_to_upstream(
+    component: str,
+    upstream_purls: list[dict],
+    ecosystem: str = "",
+) -> OsvPackageInfo | None:
+    """
+    Find the upstream_purls entry whose package name matches ``component``.
+
+    When ``ecosystem`` is provided, only entries whose PURL type matches the
+    ecosystem are considered. This prevents selecting the wrong OSV range when
+    the same component exists in multiple ecosystems.
+
+    Matching is case-insensitive and tries two strategies in order:
+      1. ``entry["name"]`` directly
+      2. The ``name`` part of ``entry["purl"]`` (via PackageURL)
+
+    Returns the first matching OsvPackageInfo, or None if no entry matches.
+    """
+    needle = component.strip().lower()
+    if not needle:
+        return None
+
+    for entry in upstream_purls or []:
+        purl_str = entry.get("purl") or ""
+        parsed_purl = None
+        if purl_str:
+            try:
+                parsed_purl = PackageURL.from_string(purl_str)
+            except Exception:
+                log.debug("Skipping malformed upstream PURL %r", purl_str)
+                continue
+
+        if ecosystem:
+            purl_type = parsed_purl.type if parsed_purl else ""
+            if purl_type != ecosystem:
+                continue
+
+        entry_name = (entry.get("name") or "").strip().lower()
+        if entry_name and entry_name == needle:
+            return osv_entry_to_package_info(entry)
+
+        if parsed_purl and parsed_purl.name.lower() == needle:
+            return osv_entry_to_package_info(entry)
+
+    return None

--- a/apps/ace/tasks.py
+++ b/apps/ace/tasks.py
@@ -3,11 +3,19 @@ from typing import Any
 
 from celery.utils.log import get_task_logger
 from django.db import transaction
+from packageurl import PackageURL
 
+from apps.ace.osv_ranges import OsvPackageInfo, match_component_to_upstream
+from apps.ace.version import (
+    OsvStatus,
+    determine_status,
+    extract_upstream_version,
+    parse_version_range_or,
+)
 from config.celery import app
 from osidb.helpers import bypass_rls
 from osidb.models import Flaw
-from osidb.models.affect import Affect, AffectSettings
+from osidb.models.affect import Affect, AffectSettings, NotAffectedJustification
 from osidb.models.flaw.upstream import UpstreamData
 
 logger = get_task_logger(__name__)
@@ -51,23 +59,69 @@ def _ace_tool_name() -> str:
         return f"osidb {osidb_version}"
 
 
+def _osv_version_status(
+    purl_str: str,
+    pkg_info: OsvPackageInfo | None,
+) -> tuple[OsvStatus, str | None, str | None]:
+    """
+    Determine the OSV affectedness status for a single lib_newtopia result purl.
+
+    Returns ``(status, range_str, version_checked)`` where:
+      - ``status`` is an :class:`OsvStatus` member
+      - ``range_str`` is the range expression derived from upstream_purls, or ``None``
+        when no range could be determined (NO_MATCH / NO_RANGE)
+      - ``version_checked`` is the upstream version extracted from the result purl, or
+        ``None`` when no version was available (NO_MATCH / NO_RANGE / NO_VERSION)
+    """
+    if pkg_info is None:
+        return OsvStatus.NO_MATCH, None, None
+
+    range_str = pkg_info.affected_range()
+    if range_str is None:
+        return OsvStatus.NO_RANGE, None, None
+
+    try:
+        purl_version = PackageURL.from_string(purl_str).version
+    except Exception:
+        purl_version = None
+
+    upstream_version = extract_upstream_version(purl_version, pkg_info.ecosystem)
+    if upstream_version is None:
+        return OsvStatus.NO_VERSION, range_str, None
+
+    status = determine_status(
+        upstream_version, parse_version_range_or(range_str, pkg_info.ecosystem)
+    )
+    return status, range_str, upstream_version
+
+
 def _sync_affects_from_results(
     flaw: Flaw,
     results: list,
     flaw_component: str = "",
     ps_modules: list[str] | None = None,
     ecosystem: str = "",
+    upstream_purls: list[dict] | None = None,
 ) -> dict[str, int]:
     """Create affects on ``flaw`` for each entry in ``results``.
 
     Each entry is a ``NewcliBuildResult`` or ``NewcliDepResult`` from lib_newtopia.
     Existing affects matching ``(flaw, ps_update_stream, ps_component)`` are skipped.
+
+    When ``upstream_purls`` is provided (from ``UpstreamData``), each result's purl
+    version is checked against the OSV version range for the matched component.
+    Results whose version falls outside the range are created as NOTAFFECTED affects.
     """
     created = 0
     skipped = 0
     skipped_existing = 0
+    marked_notaffected = 0
     flaw_has_high_cvss_score = flaw.has_high_cvss_score
     tool_name = _ace_tool_name()
+
+    pkg_info = match_component_to_upstream(
+        flaw_component, upstream_purls or [], ecosystem=ecosystem
+    )
 
     with transaction.atomic():
         for result in results:
@@ -96,6 +150,10 @@ def _sync_affects_from_results(
                 skipped_existing += 1
                 continue
 
+            osv_status, range_str, version_checked = _osv_version_status(
+                purl_str, pkg_info
+            )
+
             affect = Affect(
                 flaw=flaw,
                 ps_update_stream=ps_update_stream,
@@ -115,9 +173,22 @@ def _sync_affects_from_results(
                     "tool_trigger": (
                         f"flaw.components updated (component: {flaw_component!r})"
                     ),
+                    "osv_range_used": range_str,
+                    "osv_version_checked": version_checked,
+                    "osv_status": osv_status.value,
                 },
             )
-            affect.auto_resolve(flaw_has_high_cvss_score=flaw_has_high_cvss_score)
+
+            if osv_status is OsvStatus.NOT_AFFECTED:
+                affect.affectedness = Affect.AffectAffectedness.NOTAFFECTED
+                affect.resolution = Affect.AffectResolution.NOVALUE
+                affect.not_affected_justification = (
+                    NotAffectedJustification.VULN_CODE_NOT_PRESENT
+                )
+                marked_notaffected += 1
+            else:
+                affect.auto_resolve(flaw_has_high_cvss_score=flaw_has_high_cvss_score)
+
             affect.save(raise_validation_error=False)
             created += 1
 
@@ -125,6 +196,7 @@ def _sync_affects_from_results(
         "created": created,
         "skipped": skipped,
         "skipped_existing": skipped_existing,
+        "marked_notaffected": marked_notaffected,
     }
 
 
@@ -161,17 +233,28 @@ def sync_flaw_affects_from_newcli(flaw_id: str) -> dict[str, Any]:
     flaw = Flaw.objects.get(uuid=flaw_id)
     components = _flaw_components(flaw)
     ps_modules = AffectSettings().auto_create_ps_modules
-    totals: dict[str, int] = {"created": 0, "skipped": 0, "skipped_existing": 0}
+    totals: dict[str, int] = {
+        "created": 0,
+        "skipped": 0,
+        "skipped_existing": 0,
+        "marked_notaffected": 0,
+    }
 
     osv_data = flaw.upstream_data.filter(source=UpstreamData.Source.OSV).first()
+    upstream_purls: list[dict] = osv_data.upstream_purls if osv_data else []
     component_ecosystems = osv_data.component_ecosystems if osv_data else {}
 
     for flaw_component in components:
-        ecosystems = component_ecosystems.get(flaw_component, [""])
+        ecosystems = component_ecosystems.get(flaw_component.strip().lower(), [""])
         for ecosystem in ecosystems:
             results = _query_newtopia(flaw_component, ps_modules, ecosystem=ecosystem)
             stats = _sync_affects_from_results(
-                flaw, results, flaw_component, ps_modules, ecosystem=ecosystem
+                flaw,
+                results,
+                flaw_component,
+                ps_modules,
+                ecosystem=ecosystem,
+                upstream_purls=upstream_purls,
             )
             for key in totals:
                 totals[key] += stats[key]

--- a/apps/ace/tests/conftest.py
+++ b/apps/ace/tests/conftest.py
@@ -13,6 +13,12 @@ def _result(ps_update_stream: str, purl: str) -> SimpleNamespace:
     )
 
 
+@pytest.fixture
+def result():
+    """Return the _result factory so tests can call ``result(stream, purl)``."""
+    return _result
+
+
 def _make_mock_querier(results_by_component: dict) -> MagicMock:
     """Return a NewtopiaQuerier mock whose .search().filter().all() returns
     the list mapped to each component key in *results_by_component*."""
@@ -97,3 +103,41 @@ def mock_querier():
 def ace_enabled(monkeypatch):
     """Patch HAS_LIB_NEWTOPIA=True so the task does not short-circuit."""
     monkeypatch.setattr("apps.ace.tasks.HAS_LIB_NEWTOPIA", True)
+
+
+@pytest.fixture
+def upstream_purls_openssl_rpm():
+    """OSV upstream_purls entry for openssl (RPM ecosystem, fixed at 3.0.9)."""
+    return [
+        {
+            "purl": "pkg:rpm/redhat/openssl",
+            "name": "openssl",
+            "ecosystem": "Linux",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "3.0.9"}],
+                }
+            ],
+            "versions": [],
+        }
+    ]
+
+
+@pytest.fixture
+def upstream_purls_nuget():
+    """OSV upstream_purls entry for Magick.NET (NuGet ecosystem, fixed at 14.10.3)."""
+    return [
+        {
+            "purl": "pkg:nuget/Magick.NET-Q16-AnyCPU",
+            "name": "Magick.NET-Q16-AnyCPU",
+            "ecosystem": "NuGet",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "14.10.3"}],
+                }
+            ],
+            "versions": [],
+        }
+    ]

--- a/apps/ace/tests/test_osv_ranges.py
+++ b/apps/ace/tests/test_osv_ranges.py
@@ -1,0 +1,255 @@
+"""Tests for apps.ace.osv_ranges."""
+
+import pytest
+
+from apps.ace.osv_ranges import (
+    OsvPackageInfo,
+    match_component_to_upstream,
+    osv_entry_to_package_info,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── osv_entry_to_package_info ─────────────────────────────────────────────────
+
+
+def test_entry_to_package_info_basic():
+    entry = {
+        "purl": "pkg:nuget/Magick.NET-Q16-AnyCPU",
+        "name": "Magick.NET-Q16-AnyCPU",
+        "ecosystem": "NuGet",
+        "ranges": [
+            {
+                "type": "ECOSYSTEM",
+                "events": [{"introduced": "0"}, {"fixed": "14.10.3"}],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.name == "Magick.NET-Q16-AnyCPU"
+    assert info.ecosystem == "nuget"
+    assert info.introduced == "0"
+    assert info.fixed == "14.10.3"
+    assert info.last_affected == ""
+
+
+def test_entry_to_package_info_last_affected():
+    entry = {
+        "purl": "pkg:pypi/vllm",
+        "name": "vllm",
+        "ecosystem": "PyPI",
+        "ranges": [
+            {
+                "type": "ECOSYSTEM",
+                "events": [{"introduced": "0.1.0"}, {"last_affected": "0.10.65"}],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.introduced == "0.1.0"
+    assert info.fixed == ""
+    assert info.last_affected == "0.10.65"
+
+
+def test_entry_to_package_info_git_range_skipped():
+    # GIT ranges must be ignored — no meaningful version bounds
+    entry = {
+        "purl": "pkg:golang/example.com/foo",
+        "name": "foo",
+        "ecosystem": "Go",
+        "ranges": [
+            {
+                "type": "GIT",
+                "events": [{"introduced": "abc123"}, {"fixed": "def456"}],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.introduced == ""
+    assert info.fixed == ""
+
+
+def test_entry_to_package_info_empty_ranges():
+    entry = {
+        "purl": "pkg:rpm/redhat/openssl",
+        "name": "openssl",
+        "ecosystem": "Linux",
+        "ranges": [],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.affected_range() is None
+
+
+# ── OsvPackageInfo.affected_range ─────────────────────────────────────────────
+
+
+def test_affected_range_introduced_zero_fixed():
+    info = OsvPackageInfo(
+        name="x",
+        ecosystem="nuget",
+        purl="",
+        introduced="0",
+        fixed="14.10.3",
+        last_affected="",
+    )
+    assert info.affected_range() == "< 14.10.3"
+
+
+def test_affected_range_introduced_nonzero_fixed():
+    info = OsvPackageInfo(
+        name="x",
+        ecosystem="maven",
+        purl="",
+        introduced="2.0-b9",
+        fixed="2.15.0",
+        last_affected="",
+    )
+    assert info.affected_range() == ">= 2.0-b9, < 2.15.0"
+
+
+def test_affected_range_last_affected():
+    info = OsvPackageInfo(
+        name="x",
+        ecosystem="pypi",
+        purl="",
+        introduced="0.1.0",
+        fixed="",
+        last_affected="0.10.65",
+    )
+    assert info.affected_range() == ">= 0.1.0, <= 0.10.65"
+
+
+def test_affected_range_no_events():
+    info = OsvPackageInfo(
+        name="x", ecosystem="rpm", purl="", introduced="", fixed="", last_affected=""
+    )
+    assert info.affected_range() is None
+
+
+# ── match_component_to_upstream ───────────────────────────────────────────────
+
+
+def _make_upstream_purls():
+    return [
+        {
+            "purl": "pkg:nuget/Magick.NET-Q16-AnyCPU",
+            "name": "Magick.NET-Q16-AnyCPU",
+            "ecosystem": "NuGet",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "14.10.3"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:rpm/redhat/openssl",
+            "name": "openssl",
+            "ecosystem": "Linux",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "3.0.9"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+
+
+def test_match_by_name_exact():
+    result = match_component_to_upstream("openssl", _make_upstream_purls())
+    assert result is not None
+    assert result.name == "openssl"
+    assert result.fixed == "3.0.9"
+
+
+def test_match_by_name_case_insensitive():
+    result = match_component_to_upstream("OpenSSL", _make_upstream_purls())
+    assert result is not None
+    assert result.name == "openssl"
+
+
+def test_match_by_purl_name():
+    upstream_purls = _make_upstream_purls()
+    upstream_purls[0]["name"] = "different-display-name"
+    result = match_component_to_upstream("Magick.NET-Q16-AnyCPU", upstream_purls)
+    assert result is not None
+    assert result.fixed == "14.10.3"
+
+
+def test_no_match_returns_none():
+    result = match_component_to_upstream("nonexistent-package", _make_upstream_purls())
+    assert result is None
+
+
+def test_empty_upstream_purls_returns_none():
+    result = match_component_to_upstream("openssl", [])
+    assert result is None
+
+
+def test_empty_component_returns_none():
+    result = match_component_to_upstream("", _make_upstream_purls())
+    assert result is None
+
+
+# ── match_component_to_upstream ecosystem filtering ─────────────────────────
+
+
+def _make_multi_ecosystem_purls():
+    return [
+        {
+            "purl": "pkg:npm/redis",
+            "name": "redis",
+            "ecosystem": "npm",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "5.0.0"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:pypi/redis",
+            "name": "redis",
+            "ecosystem": "PyPI",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "4.0.0"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+
+
+def test_match_filters_by_ecosystem():
+    purls = _make_multi_ecosystem_purls()
+    npm_result = match_component_to_upstream("redis", purls, ecosystem="npm")
+    assert npm_result is not None
+    assert npm_result.fixed == "5.0.0"
+
+    pypi_result = match_component_to_upstream("redis", purls, ecosystem="pypi")
+    assert pypi_result is not None
+    assert pypi_result.fixed == "4.0.0"
+
+
+def test_match_no_ecosystem_returns_first():
+    purls = _make_multi_ecosystem_purls()
+    result = match_component_to_upstream("redis", purls)
+    assert result is not None
+    assert result.fixed == "5.0.0"
+
+
+def test_match_unknown_ecosystem_returns_none():
+    purls = _make_multi_ecosystem_purls()
+    result = match_component_to_upstream("redis", purls, ecosystem="maven")
+    assert result is None

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -14,7 +14,12 @@ import pytest
 from packageurl import PackageURL
 
 from apps.ace.tasks import sync_flaw_affects_from_newcli
-from osidb.tests.factories import FlawFactory, UpstreamDataFactory
+from osidb.models.affect import Affect
+from osidb.tests.factories import (
+    FlawFactory,
+    PsUpdateStreamFactory,
+    UpstreamDataFactory,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -34,7 +39,12 @@ def test_sync_creates_one_affect_per_result(
     stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
 
     n = len(urllib3_results)
-    assert stats == {"created": n, "skipped": 0, "skipped_existing": 0}
+    assert stats == {
+        "created": n,
+        "skipped": 0,
+        "skipped_existing": 0,
+        "marked_notaffected": 0,
+    }
     assert flaw.affects.count() == n
     assert {
         str(a.purl) for a in flaw.affects.filter(ps_update_stream="hummingbird-1")
@@ -68,7 +78,12 @@ def test_sync_runs_query_per_flaw_component(
 
     assert querier_calls == ["urllib3", "openssl"]
     n_urllib3 = len(urllib3_results)
-    assert stats == {"created": n_urllib3, "skipped": 0, "skipped_existing": 1}
+    assert stats == {
+        "created": n_urllib3,
+        "skipped": 0,
+        "skipped_existing": 1,
+        "marked_notaffected": 0,
+    }
     assert flaw.affects.count() == n_urllib3
 
 
@@ -85,8 +100,18 @@ def test_sync_skips_existing_on_second_run(
     first = sync_flaw_affects_from_newcli(str(flaw.uuid))
     second = sync_flaw_affects_from_newcli(str(flaw.uuid))
 
-    assert first == {"created": n, "skipped": 0, "skipped_existing": 0}
-    assert second == {"created": 0, "skipped": 0, "skipped_existing": n}
+    assert first == {
+        "created": n,
+        "skipped": 0,
+        "skipped_existing": 0,
+        "marked_notaffected": 0,
+    }
+    assert second == {
+        "created": 0,
+        "skipped": 0,
+        "skipped_existing": n,
+        "marked_notaffected": 0,
+    }
 
 
 def test_sync_no_components_raises(monkeypatch, ace_enabled):
@@ -108,7 +133,12 @@ def test_sync_includes_builds_as_affects(
 
     stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
 
-    assert stats == {"created": 2, "skipped": 0, "skipped_existing": 0}
+    assert stats == {
+        "created": 2,
+        "skipped": 0,
+        "skipped_existing": 0,
+        "marked_notaffected": 0,
+    }
     assert flaw.affects.count() == 2
 
     expected = {PackageURL.from_string(r.purls[0]).to_string() for r in ostree_results}
@@ -142,7 +172,12 @@ def test_sync_multi_stream_with_duplicate(
 
     stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
 
-    assert stats == {"created": 5, "skipped": 0, "skipped_existing": 1}
+    assert stats == {
+        "created": 5,
+        "skipped": 0,
+        "skipped_existing": 1,
+        "marked_notaffected": 0,
+    }
     assert flaw.affects.count() == 5
 
     stored_by_stream = defaultdict(set)
@@ -157,7 +192,12 @@ def test_sync_multi_stream_with_duplicate(
 
     # Second run: all 6 entries find existing affects; duplicate also matches → 6 skipped
     stats2 = sync_flaw_affects_from_newcli(str(flaw.uuid))
-    assert stats2 == {"created": 0, "skipped": 0, "skipped_existing": 6}
+    assert stats2 == {
+        "created": 0,
+        "skipped": 0,
+        "skipped_existing": 6,
+        "marked_notaffected": 0,
+    }
     assert flaw.affects.count() == 5
 
 
@@ -235,6 +275,189 @@ def test_sync_respects_ps_modules_setting(monkeypatch, ace_enabled, urllib3_resu
     sync_flaw_affects_from_newcli(str(flaw.uuid))
 
     assert seen_filter_products == [["hummingbird-1", "rhel-9"]]
+
+
+# ── Version-range / OSV upstream_purls integration tests ─────────────────────
+
+
+def test_sync_marks_notaffected_when_version_outside_range(
+    monkeypatch, ace_enabled, mock_querier, result, upstream_purls_openssl_rpm
+):
+    """
+    lib_newtopia returns openssl@3.5.1 but the OSV range says fixed at 3.0.9.
+    The created affect must be NOTAFFECTED.
+    """
+    flaw = FlawFactory(components=["openssl"])
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/openssl@3.5.1-7.el9_7?arch=src"),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["created"] == 1
+    assert stats["marked_notaffected"] == 1
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.NOTAFFECTED
+
+
+def test_sync_creates_affected_when_version_in_range(
+    monkeypatch, ace_enabled, mock_querier, result, upstream_purls_openssl_rpm
+):
+    """
+    lib_newtopia returns openssl@3.0.7 which is inside the OSV range (< 3.0.9).
+    The created affect must be AFFECTED (auto_resolve applies).
+    """
+    PsUpdateStreamFactory(name="rhel-9.8.z")
+    flaw = FlawFactory(components=["openssl"])
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/openssl@3.0.7-18.el9_2?arch=src"),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["created"] == 1
+    assert stats["marked_notaffected"] == 0
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
+
+
+def test_sync_creates_affected_when_no_upstream_match(
+    monkeypatch, ace_enabled, mock_querier, result
+):
+    """
+    No upstream_purls entry matches the component name.
+    Falls back to AFFECTED (current behaviour preserved).
+    """
+    PsUpdateStreamFactory(name="rhel-9.8.z")
+    flaw = FlawFactory(components=["curl"])
+    UpstreamDataFactory(
+        flaw=flaw,
+        upstream_purls=[
+            {
+                "purl": "pkg:rpm/redhat/openssl",
+                "name": "openssl",
+                "ecosystem": "Linux",
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": "0"}, {"fixed": "3.0.9"}],
+                    }
+                ],
+                "versions": [],
+            }
+        ],
+    )
+
+    results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/curl@7.76.1-19.el9?arch=src"),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"curl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["created"] == 1
+    assert stats["marked_notaffected"] == 0
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
+
+
+def test_sync_creates_affected_when_no_range(
+    monkeypatch, ace_enabled, mock_querier, result
+):
+    """
+    upstream_purls entry matches the component but has empty ranges.
+    Falls back to AFFECTED (no range to compare against).
+    """
+    flaw = FlawFactory(components=["openssl"])
+    UpstreamDataFactory(
+        flaw=flaw,
+        upstream_purls=[
+            {
+                "purl": "pkg:rpm/redhat/openssl",
+                "name": "openssl",
+                "ecosystem": "Linux",
+                "ranges": [],
+                "versions": [],
+            }
+        ],
+    )
+
+    results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/openssl@3.5.1-7.el9_7?arch=src"),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["created"] == 1
+    assert stats["marked_notaffected"] == 0
+
+
+def test_sync_assist_meta_includes_osv_fields(
+    monkeypatch, ace_enabled, mock_querier, result, upstream_purls_openssl_rpm
+):
+    """
+    Every created affect (AFFECTED or NOTAFFECTED) must have osv_* keys in assist_meta.
+    """
+    flaw = FlawFactory(components=["openssl"])
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/openssl@3.5.1-7.el9_7?arch=src"),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    affect = flaw.affects.get()
+    meta = affect.assist_meta
+    assert meta["osv_range_used"] == "< 3.0.9"
+    assert meta["osv_version_checked"] == "3.5.1-7.el9_7"
+    assert meta["osv_status"] == "not_affected"
+
+
+def test_sync_returns_marked_notaffected_count(
+    monkeypatch, ace_enabled, mock_querier, result, upstream_purls_openssl_rpm
+):
+    """sync_flaw_affects_from_newcli return dict includes marked_notaffected."""
+    flaw = FlawFactory(components=["openssl"])
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/openssl@3.5.1-7.el9_7?arch=src"),
+        result("rhel-8.8.0.z", "pkg:rpm/redhat/openssl@3.5.1-7.el8?arch=src"),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats == {
+        "created": 2,
+        "skipped": 0,
+        "skipped_existing": 0,
+        "marked_notaffected": 2,
+    }
+
+
+# ── Ecosystem scoping tests ────────────────────────────────────────────────────
 
 
 def test_sync_passes_ecosystem_to_newtopia(monkeypatch, ace_enabled):

--- a/apps/ace/tests/test_version.py
+++ b/apps/ace/tests/test_version.py
@@ -1,0 +1,123 @@
+"""Smoke tests for apps.ace.version (copied from vulncli).
+
+The comprehensive test suite lives in ~/Projects/vulncli/tests/. These smoke
+tests verify that the copy is functional and covers the ecosystems used in ACE.
+"""
+
+import pytest
+
+from apps.ace.version import (
+    OsvStatus,
+    _rpm_compare,
+    determine_status,
+    extract_upstream_version,
+    parse_version_range_or,
+)
+
+pytestmark = pytest.mark.unit
+
+
+# ── extract_upstream_version ──────────────────────────────────────────────────
+
+
+def test_rpm_strips_release():
+    assert extract_upstream_version("3.0.7-18.el9_2", "rpm") == "3.0.7"
+
+
+def test_rpm_strips_epoch_and_release():
+    assert extract_upstream_version("1:1.1.1k-6.el8_5", "rpm") == "1.1.1k"
+
+
+def test_golang_strips_v_prefix():
+    assert extract_upstream_version("v0.40.0", "golang") == "0.40.0"
+
+
+def test_semver_unchanged():
+    assert extract_upstream_version("14.10.3", "nuget") == "14.10.3"
+
+
+def test_empty_version():
+    assert extract_upstream_version("", "rpm") is None
+
+
+# ── determine_status ──────────────────────────────────────────────────────────
+
+
+def test_determine_affected_semver():
+    constraints = parse_version_range_or("< 14.10.3", "nuget")
+    assert determine_status("10.0.0", constraints) == OsvStatus.AFFECTED
+
+
+def test_determine_not_affected_semver():
+    constraints = parse_version_range_or("< 14.10.3", "nuget")
+    assert determine_status("14.10.3", constraints) == OsvStatus.NOT_AFFECTED
+
+
+def test_determine_not_affected_fixed_version():
+    constraints = parse_version_range_or("< 3.0.9", "nuget")
+    assert determine_status("3.5.6", constraints) == OsvStatus.NOT_AFFECTED
+
+
+def test_determine_affected_with_lower_bound():
+    constraints = parse_version_range_or(">= 2.0, < 2.15.0", "maven")
+    assert determine_status("2.13.0", constraints) == OsvStatus.AFFECTED
+
+
+def test_determine_not_affected_below_lower_bound():
+    constraints = parse_version_range_or(">= 2.0, < 2.15.0", "maven")
+    assert determine_status("1.9.9", constraints) == OsvStatus.NOT_AFFECTED
+
+
+def test_determine_affected_rpm():
+    constraints = parse_version_range_or("< 3.0.9", "rpm")
+    assert determine_status("3.0.7", constraints) == OsvStatus.AFFECTED
+
+
+def test_determine_not_affected_rpm():
+    constraints = parse_version_range_or("< 3.0.9", "rpm")
+    assert determine_status("3.0.9", constraints) == OsvStatus.NOT_AFFECTED
+
+
+# ── _rpm_compare edge cases ──────────────────────────────────────────────────
+
+
+def test_rpm_empty_release_sorts_before_nonempty():
+    assert _rpm_compare("1.0", "1.0-1") == -1
+
+
+def test_rpm_nonempty_release_sorts_after_empty():
+    assert _rpm_compare("1.0-1", "1.0") == 1
+
+
+def test_rpm_both_releases_empty_equal():
+    assert _rpm_compare("1.0", "1.0") == 0
+
+
+def test_rpm_numeric_segment_beats_alpha():
+    assert _rpm_compare("1.1", "1a") == 1
+    assert _rpm_compare("1a", "1.1") == -1
+
+
+# ── caret all-zeros ─────────────────────────────────────────────────────────
+
+
+def test_caret_all_zeros():
+    constraints = parse_version_range_or("^ 0.0.0", "npm")
+    assert determine_status("0.0.0", constraints) == OsvStatus.AFFECTED
+
+
+def test_caret_all_zeros_upper_bound():
+    constraints = parse_version_range_or("^ 0.0.0", "npm")
+    assert determine_status("0.0.1", constraints) == OsvStatus.NOT_AFFECTED
+
+
+# ── determine_status ────────────────────────────────────────────────────────
+
+
+def test_determine_unknown_no_constraints():
+    assert determine_status("1.0.0", []) == OsvStatus.UNKNOWN
+
+
+def test_determine_unknown_no_version():
+    constraints = parse_version_range_or("< 3.0.9", "nuget")
+    assert determine_status("", constraints) == OsvStatus.UNKNOWN

--- a/apps/ace/version.py
+++ b/apps/ace/version.py
@@ -1,0 +1,802 @@
+"""
+version.py — Version range parsing and comparison engine.
+
+Supports all major package ecosystems used in Red Hat products:
+
+  RPM (Fedora/RHEL):
+    Format  : E:V-R  e.g. "1:3.0.7-18.el9_2"
+    Engine  : rpmvercmp (pure Python; uses rpm.labelCompare if installed)
+    Special : ~ (pre-release), ^ (snapshot), numeric integer comparison
+
+  PyPI (Python):
+    Format  : PEP 440  e.g. "1.2.0", "1.2.0rc1", "1.2.0.post1", "1.2.0a1"
+    Engine  : packaging.version.Version (handles epoch, pre/post/dev)
+    Special : ~= compatible-release operator  e.g. "~= 1.4" → ">= 1.4, < 2.0"
+
+  npm (Node.js):  https://docs.npmjs.com/about-semantic-versioning
+    Format  : SemVer 2.0  e.g. "4.1.0", "1.0.0-beta.1"
+    Engine  : packaging.version.Version (semver-compatible)
+    Special : ~ tilde  "~ 1.2.3" → ">= 1.2.3, < 1.3.0"
+              ^ caret  "^ 1.2.3" → ">= 1.2.3, < 2.0.0"
+                       "^ 0.2.3" → ">= 0.2.3, < 0.3.0"  (0.x rule)
+                       "^ 0.0.3" → ">= 0.0.3, < 0.0.4"  (0.0.x rule)
+
+  Maven (Java):   https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
+    Format  : "1.0", "1.0-SNAPSHOT", "1.0-alpha-1", "1.0.Final"
+    Engine  : _maven_compare() — qualifier ordering per Maven spec
+    Ranges  : [1.0,2.0)  (,1.0]  [1.0,)  [1.0]  (Maven interval notation)
+    Special : SNAPSHOT < release; qualifier rank: alpha<beta<milestone<rc<""<sp
+
+  Golang:         https://go.dev/doc/modules/version-numbers
+    Format  : "v1.21.0", "go1.21.0", pseudo "v0.0.0-20170915032832-14c0d48ead0c"
+    Engine  : packaging.version.Version; fallback segment comparator
+    Special : "v" and "go" prefixes stripped; pseudo-versions compared by base
+
+  RubyGems:       https://guides.rubygems.org/specification-reference/
+    Format  : "1.0.0", "1.0.0.pre", "1.0.0.rc1"
+    Engine  : packaging.version.Version (semver-compatible)
+    Special : ~> pessimistic constraint  "~> 1.2.3" → ">= 1.2.3, < 1.3.0"
+                                         "~> 1.2"   → ">= 1.2,   < 2.0"
+
+  cargo (Rust), gem, nuget, composer, generic:
+    Engine  : packaging.version.Version (semver-compatible fallback)
+
+Version range expression syntax accepted by vulncli:
+  Standard  : "< 3.0.9"             single operator constraint
+  Compound  : ">= 2.0, < 2.17.1"    AND logic (comma-separated)
+  Exact     : "== 3.0.7"            exact match
+  MITRE     : "[2.0, 3.0)"          interval notation (incl/excl)
+  Dash      : "2.0-3.0"             → ">= 2.0, < 3.0"
+  npm ~     : "~ 1.2.3"             → ">= 1.2.3, < 1.3.0"
+  npm ^     : "^ 1.2.3"             → ">= 1.2.3, < 2.0.0"
+  Python ~= : "~= 1.4"              → ">= 1.4, < 2.0"
+  Ruby  ~>  : "~> 1.2.3"            → ">= 1.2.3, < 1.3.0"
+  Maven open: "(,1.0]"              → "<= 1.0"
+              "[1.0,)"              → ">= 1.0"
+              "[1.0]"               → "== 1.0"
+
+Operators: <  <=  >  >=  ==  =  !=
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+RPM_ECOSYSTEM = "rpm"
+GOLANG_ECOSYSTEM = "golang"
+MAVEN_ECOSYSTEM = "maven"
+SEMVER_ECOSYSTEMS = frozenset(
+    {"npm", "cargo", "gem", "pypi", "nuget", "maven", "composer", "generic", "github"}
+)
+
+
+class OsvStatus(enum.Enum):
+    AFFECTED = "affected"
+    NOT_AFFECTED = "not_affected"
+    UNKNOWN = "unknown"
+    NO_MATCH = "no_match"  # no upstream_purls entry matched the component
+    NO_RANGE = "no_range"  # matched entry has no meaningful range expression
+    NO_VERSION = "no_version"  # result purl carries no version to compare
+
+
+# ── Version extraction ─────────────────────────────────────────────────────────
+
+
+def extract_upstream_version(
+    version_str: str | None, ecosystem: str = ""
+) -> str | None:
+    """
+    Return just the upstream version component, stripping packaging-specific suffixes.
+
+    Returns ``None`` when ``version_str`` is ``None`` or empty.
+
+    RPM EVR examples:
+      "3.0.7-18.el9_2"    → "3.0.7"    (release stripped)
+      "1:1.1.1k-6.el8_5"  → "1.1.1k"   (epoch + release stripped)
+
+    Golang:
+      "v0.40.0"           → "0.40.0"   (leading 'v' stripped)
+      "go1.21.0"          → "1.21.0"   (leading 'go' stripped)
+      "v0.0.0-20170915032832-14c0d48ead0c" → "0.0.0-20170915032832-14c0d48ead0c"
+
+    Others (cargo, npm, pypi, maven, gem…):
+      "0.10.63"           → "0.10.63"  (unchanged)
+      None / ""           → None
+    """
+    if not version_str:
+        return None
+
+    v = version_str.strip()
+
+    is_rpm = ecosystem == RPM_ECOSYSTEM or (
+        not ecosystem and re.search(r"-\d+\.\w+\d+", v)
+    )
+
+    if is_rpm:
+        # Strip epoch
+        if ":" in v:
+            v = v.split(":", 1)[1]
+        # Strip release (everything after last "-")
+        if "-" in v:
+            v = v.rsplit("-", 1)[0]
+        return v
+
+    if ecosystem == GOLANG_ECOSYSTEM or (
+        not ecosystem and (v.startswith("v") or v.startswith("go"))
+    ):
+        # Strip 'v' or 'go' prefix (e.g. v1.21.0 → 1.21.0, go1.21.0 → 1.21.0)
+        if v.startswith("go"):
+            v = v[2:]
+        else:
+            v = v.lstrip("v")
+        return v
+
+    return v
+
+
+# ── RPM version comparison ─────────────────────────────────────────────────────
+
+
+def _split_evr(evr: str) -> tuple[str, str, str]:
+    """Split "epoch:version-release" into (epoch, version, release)."""
+    epoch, release = "0", ""
+    v = evr.strip()
+    if ":" in v:
+        epoch, v = v.split(":", 1)
+    if "-" in v:
+        v, release = v.rsplit("-", 1)
+    return epoch, v, release
+
+
+def _rpmvercmp(a: str, b: str) -> int:
+    """
+    Pure-Python implementation of the RPM C library rpmvercmp() algorithm.
+    Returns -1, 0, or 1.
+
+    Handles all Fedora Packaging Guideline cases:
+      ~  tilde  — sorts BEFORE everything (pre-releases): 1.0~rc1 < 1.0
+      ^  caret  — sorts AFTER base but BEFORE .next (snapshots): 1.0 < 1.0^snap < 1.1
+      numeric   — compared as integers: 9 < 10
+      alpha     — compared lexicographically
+    """
+    if a == b:
+        return 0
+
+    ia, ib = 0, 0
+    la, lb = len(a), len(b)
+
+    while ia < la or ib < lb:
+        # ── Skip non-alphanumeric, non-tilde, non-caret characters ──────────
+        while ia < la and not (a[ia].isalnum() or a[ia] in ("~", "^")):
+            ia += 1
+        while ib < lb and not (b[ib].isalnum() or b[ib] in ("~", "^")):
+            ib += 1
+
+        # ── Tilde: sorts before EVERYTHING, even empty string ───────────────
+        # "1.0~rc1" < "1.0"  (pre-release comes before release)
+        a_tilde = ia < la and a[ia] == "~"
+        b_tilde = ib < lb and b[ib] == "~"
+        if a_tilde or b_tilde:
+            if not a_tilde:
+                return 1  # b has tilde → b is pre-release → a > b
+            if not b_tilde:
+                return -1  # a has tilde → a is pre-release → a < b
+            ia += 1
+            ib += 1
+            continue
+
+        # ── End of string handling ───────────────────────────────────────────
+        if ia >= la and ib >= lb:
+            return 0
+        if ia >= la:
+            # a ended; if b continues with caret → b is snapshot → b > a
+            # otherwise b has more version → b > a
+            return -1
+        if ib >= lb:
+            return 1
+
+        # ── Caret: sorts AFTER base but BEFORE next release ─────────────────
+        # "1.0" < "1.0^20210101g" < "1.0.1"
+        a_caret = a[ia] == "^"
+        b_caret = b[ib] == "^"
+        if a_caret or b_caret:
+            if not a_caret:
+                return 1  # b is snapshot, a is release → a > b
+            if not b_caret:
+                return -1  # a is snapshot, b is release → a < b
+            ia += 1
+            ib += 1
+            continue
+
+        # ── Collect next segment: digits or alpha (never mixed) ─────────────
+        a_is_num = a[ia].isdigit()
+        b_is_num = ib < lb and b[ib].isdigit()
+
+        if a_is_num != b_is_num:
+            return 1 if a_is_num else -1
+
+        if a_is_num:
+            ja = ia
+            while ja < la and a[ja].isdigit():
+                ja += 1
+            jb = ib
+            while jb < lb and b[jb].isdigit():
+                jb += 1
+            seg_a = a[ia:ja].lstrip("0") or "0"
+            seg_b = b[ib:jb].lstrip("0") or "0"
+            ia, ib = ja, jb
+            # Longer numeric string wins (both stripped of leading zeros)
+            if len(seg_a) != len(seg_b):
+                return 1 if len(seg_a) > len(seg_b) else -1
+        else:
+            # Alpha segment
+            ja = ia
+            while ja < la and a[ja].isalpha():
+                ja += 1
+            jb = ib
+            while jb < lb and b[jb].isalpha():
+                jb += 1
+            seg_a, seg_b = a[ia:ja], b[ib:jb]
+            ia, ib = ja, jb
+            if not seg_b:
+                return 1
+            if not seg_a:
+                return -1
+
+        # ── Lexicographic comparison of the segment ──────────────────────────
+        if seg_a < seg_b:
+            return -1
+        if seg_a > seg_b:
+            return 1
+
+    return 0
+
+
+def _rpm_compare(v1: str, v2: str) -> int:
+    """
+    Full RPM EVR comparison (epoch:version-release).
+    Prefers the rpm C extension; falls back to pure Python.
+    Returns -1, 0, or 1.
+    """
+    try:
+        import rpm as _rpm_mod
+
+        return _rpm_mod.labelCompare(_split_evr(v1), _split_evr(v2))
+    except ImportError:
+        pass
+
+    e1, ver1, rel1 = _split_evr(v1)
+    e2, ver2, rel2 = _split_evr(v2)
+
+    r = (int(e1) > int(e2)) - (int(e1) < int(e2))
+    if r:
+        return r
+    r = _rpmvercmp(ver1, ver2)
+    if r:
+        return r
+    # Empty release should sort before non-empty release (e.g. 1.0 < 1.0-1)
+    if not rel1 and not rel2:
+        return 0
+    if not rel1:
+        return -1
+    if not rel2:
+        return 1
+    return _rpmvercmp(rel1, rel2)
+
+
+# ── Semver comparison ──────────────────────────────────────────────────────────
+
+
+def _semver_compare(v1: str, v2: str) -> int:
+    """
+    Compare two semver-ish version strings.
+    Returns -1, 0, or 1.
+    Uses the `packaging` library if available.
+    """
+    try:
+        from packaging.version import InvalidVersion, Version
+
+        try:
+            pv1, pv2 = Version(v1), Version(v2)
+            return (pv1 > pv2) - (pv1 < pv2)
+        except InvalidVersion:
+            pass
+    except ImportError:
+        pass
+
+    # Numeric-segment fallback
+    def _segs(s: str) -> list:
+        parts = []
+        for p in re.split(r"[.\-_]", s):
+            try:
+                parts.append((0, int(p)))
+            except ValueError:
+                parts.append((1, p.lower()))
+        return parts
+
+    a_segs, b_segs = _segs(v1), _segs(v2)
+    for a, b in zip(a_segs, b_segs):
+        if a < b:
+            return -1
+        if a > b:
+            return 1
+    return (len(a_segs) > len(b_segs)) - (len(a_segs) < len(b_segs))
+
+
+# ── Maven version comparison ───────────────────────────────────────────────────
+# Spec: https://maven.apache.org/enforcer/enforcer-rules/versionRanges.html
+#
+# Maven qualifier ordering (lowest → highest):
+#   alpha/a  <  beta/b  <  milestone/m  <  rc/cr  <  snapshot  <  (none/ga/final)  <  sp
+#
+# Examples:
+#   1.0-alpha-1  <  1.0-beta-1  <  1.0-rc-1  <  1.0-SNAPSHOT  <  1.0  <  1.0-sp1
+
+_MAVEN_QUALIFIER_RANK: dict[str, int] = {
+    "alpha": 0,
+    "a": 0,
+    "beta": 1,
+    "b": 1,
+    "milestone": 2,
+    "m": 2,
+    "rc": 3,
+    "cr": 3,
+    "snapshot": 4,
+    "": 5,
+    "ga": 5,
+    "final": 5,
+    "release": 5,
+    "sp": 6,
+}
+
+
+def _parse_maven_version(version: str) -> tuple[list[int], int, int]:
+    """
+    Parse a Maven version string into (numeric_parts, qualifier_rank, qualifier_number).
+
+    Examples:
+      "1.2.3"            → ([1,2,3], 5, 0)
+      "1.0-SNAPSHOT"     → ([1,0],   4, 0)
+      "1.0-alpha-2"      → ([1,0],   0, 2)
+      "1.0-sp1"          → ([1,0],   6, 1)
+      "2.0.Final"        → ([2,0],   5, 0)
+    """
+    v = version.strip()
+
+    # Separate numeric prefix from qualifier
+    # Handles: 1.2.3-alpha-1, 1.2.3.Final, 1.2.3-SNAPSHOT
+    qualifier_num = 0
+
+    m = re.match(r"^([\d.]+)[.\-](.+)$", v)
+    if m:
+        num_part = m.group(1)
+        qualifier_raw = m.group(2).lower()
+
+        # Check if the rest is purely numeric (e.g. 1.0.1 → qualifier is just another segment)
+        if qualifier_raw.isdigit():
+            num_part = v  # no qualifier, all numeric
+            qualifier_raw = ""
+        else:
+            # Extract trailing number from qualifier: "alpha-2" → ("alpha", 2)
+            qm = re.match(r"^([a-z]+)[.\-]?(\d+)?$", qualifier_raw)
+            if qm:
+                qualifier_raw = qm.group(1)
+                qualifier_num = int(qm.group(2)) if qm.group(2) else 0
+    else:
+        num_part = v
+        qualifier_raw = ""
+
+    numeric_parts = [int(x) for x in num_part.split(".") if x.isdigit()]
+    rank = _MAVEN_QUALIFIER_RANK.get(
+        qualifier_raw.lower(), 5
+    )  # unknown → treat as release
+
+    return numeric_parts, rank, qualifier_num
+
+
+def _maven_compare(v1: str, v2: str) -> int:
+    """
+    Compare two Maven version strings per the Maven version ordering spec.
+    Returns -1, 0, or 1.
+
+    Falls back to _semver_compare if parsing fails.
+    """
+    try:
+        nums1, rank1, qnum1 = _parse_maven_version(v1)
+        nums2, rank2, qnum2 = _parse_maven_version(v2)
+
+        # Pad numeric parts to same length
+        length = max(len(nums1), len(nums2))
+        nums1 += [0] * (length - len(nums1))
+        nums2 += [0] * (length - len(nums2))
+
+        for a, b in zip(nums1, nums2):
+            if a < b:
+                return -1
+            if a > b:
+                return 1
+
+        # Numeric parts equal — compare qualifier rank
+        if rank1 < rank2:
+            return -1
+        if rank1 > rank2:
+            return 1
+
+        # Same qualifier — compare qualifier number
+        if qnum1 < qnum2:
+            return -1
+        if qnum1 > qnum2:
+            return 1
+
+        return 0
+    except Exception:
+        return _semver_compare(v1, v2)
+
+
+# ── VersionConstraint ──────────────────────────────────────────────────────────
+
+_OP_CHECK: dict = {
+    "<": lambda c: c < 0,
+    "<=": lambda c: c <= 0,
+    ">": lambda c: c > 0,
+    ">=": lambda c: c >= 0,
+    "=": lambda c: c == 0,
+    "==": lambda c: c == 0,
+    "!=": lambda c: c != 0,
+}
+_RANGE_RE = re.compile(r"^\s*(<=|>=|!=|==|<|>|=)\s*(\S+)\s*$")
+
+
+@dataclass
+class VersionConstraint:
+    """A single version constraint: operator + bound + comparison mode."""
+
+    operator: str
+    bound: str
+    ecosystem: str = "semver"  # "rpm" or "semver"
+
+    def check(self, version: str) -> Optional[bool]:
+        """
+        Returns True  if the constraint is satisfied,
+                False if it is violated,
+                None  if the comparison cannot be determined.
+        """
+        if not version or not self.bound:
+            return None
+        try:
+            if self.ecosystem == RPM_ECOSYSTEM:
+                cmp_result = _rpm_compare(version, self.bound)
+            elif self.ecosystem == MAVEN_ECOSYSTEM:
+                cmp_result = _maven_compare(version, self.bound)
+            else:
+                cmp_result = _semver_compare(version, self.bound)
+            return _OP_CHECK[self.operator](cmp_result)
+        except Exception as exc:
+            log.debug(
+                "Version comparison failed (%r %s %r): %s",
+                version,
+                self.operator,
+                self.bound,
+                exc,
+            )
+            return None
+
+
+_DASH_RANGE_RE = re.compile(
+    r"^([0-9][^\s-]*)-([0-9].*)$"  # "4.1-8.1", "1.1.1k-1.1.1m"
+)
+
+
+def _compatible_release_bounds(version: str, op: str) -> str:
+    """
+    Expand a compatible-release expression to a '>= lo, < hi' pair.
+
+    Used for:
+      ~=  (Python PEP 440 compatible release)
+      ~>  (Ruby pessimistic constraint)
+      ~   (npm tilde)
+      ^   (npm caret)
+
+    Args:
+        version : the version string after the operator (e.g. "1.2.3")
+        op      : one of "~=", "~>", "~", "^"
+
+    Returns a normalized range string like ">= 1.2.3, < 1.3.0".
+    """
+    parts = [p for p in re.split(r"[.\-]", version) if p.isdigit()]
+    if not parts:
+        return f">= {version}"
+
+    nums = [int(p) for p in parts]
+
+    if op in ("~=", "~>"):
+        # Drop last segment, increment second-to-last → upper bound
+        # ~= 1.2.3 → >= 1.2.3, < 1.3.0
+        # ~= 1.2   → >= 1.2,   < 2.0
+        # ~> 1.2.3 → >= 1.2.3, < 1.3.0  (Ruby same as Python for 3-part)
+        # ~> 1.2   → >= 1.2,   < 2.0    (Ruby: increment first part)
+        if len(nums) >= 2:
+            upper = list(nums[:-1])
+            upper[-1] += 1
+        else:
+            upper = [nums[0] + 1]
+        # Pad upper to same number of dotted parts as the original version
+        while len(upper) < len(nums):
+            upper.append(0)
+        upper_str = ".".join(str(x) for x in upper)
+        lower_str = ".".join(str(x) for x in nums)
+        return f">= {lower_str}, < {upper_str}"
+
+    elif op == "~":
+        # npm tilde: allows patch-level changes
+        # ~ 1.2.3 → >= 1.2.3, < 1.3.0  (patch range)
+        # ~ 1.2   → >= 1.2.0, < 1.3.0  (patch range within minor)
+        # ~ 1     → >= 1.0.0, < 2.0.0  (minor range within major)
+        if len(nums) >= 2:
+            upper = list(nums[:2])
+            upper[1] += 1
+            upper_str = ".".join(str(x) for x in upper) + ".0"
+        else:
+            upper_str = f"{nums[0] + 1}.0.0"
+        lower_str = ".".join(str(x) for x in nums)
+        return f">= {lower_str}, < {upper_str}"
+
+    elif op == "^":
+        # npm caret: allows changes that don't modify left-most non-zero digit
+        # ^ 1.2.3 → >= 1.2.3, < 2.0.0
+        # ^ 0.2.3 → >= 0.2.3, < 0.3.0
+        # ^ 0.0.3 → >= 0.0.3, < 0.0.4
+        lower_str = ".".join(str(x) for x in nums)
+        # Find left-most non-zero position
+        pivot = next((i for i, n in enumerate(nums) if n != 0), len(nums) - 1)
+        upper = list(nums)
+        upper[pivot] += 1
+        for j in range(pivot + 1, len(upper)):
+            upper[j] = 0
+        upper_str = ".".join(str(x) for x in upper)
+        # Pad to 3 parts
+        missing = max(0, 3 - len(upper))
+        if missing:
+            upper_str += ".0" * missing
+        return f">= {lower_str}, < {upper_str}"
+
+    return f">= {version}"
+
+
+def _normalize_range_expr(expr: str) -> str:
+    """
+    Normalize alternative range formats to the standard operator syntax.
+
+    Supported input formats:
+      Standard  : "< 3.0.9"              → unchanged
+      Compound  : ">= 2.0, < 2.17.1"    → unchanged
+      MITRE     : "[4.1, 8.1)"           → ">= 4.1, < 8.1"
+                  "(4.1, 8.1]"           → "> 4.1, <= 8.1"
+      Dash      : "4.1-8.1"             → ">= 4.1, < 8.1"
+      Maven     : "(,1.0]"              → "<= 1.0"     (open-ended upper)
+                  "[1.0,)"              → ">= 1.0"     (open-ended lower)
+                  "[1.0]"               → "== 1.0"     (exact)
+      npm ~     : "~ 1.2.3"             → ">= 1.2.3, < 1.3.0"
+      npm ^     : "^ 1.2.3"             → ">= 1.2.3, < 2.0.0"
+      Python ~= : "~= 1.4"              → ">= 1.4, < 2.0"
+      Ruby  ~>  : "~> 1.2.3"            → ">= 1.2.3, < 1.3.0"
+    """
+    expr = expr.strip()
+    if not expr:
+        return expr
+
+    # Already starts with a standard operator — return as-is
+    if _RANGE_RE.match(expr.split(",")[0].strip()):
+        return expr
+
+    # ── Compatible-release / pessimistic operators ────────────────────────────
+    # ~= (Python), ~> (Ruby), ~ (npm tilde), ^ (npm caret)
+    for op_str in ("~=", "~>", "~", "^"):
+        if expr.startswith(op_str):
+            ver = expr[len(op_str) :].strip()
+            if ver:
+                result = _compatible_release_bounds(ver, op_str)
+                log.debug("Expanded %r %r → %r", op_str, ver, result)
+                return result
+
+    # ── Maven open-ended interval notation ────────────────────────────────────
+    # "(,1.0]" → "<= 1.0"    "[1.0,)" → ">= 1.0"    "[1.0]" → "== 1.0"
+    maven_open_re = re.compile(
+        r"^([\[\(])\s*([^,\]\)]*)\s*,?\s*([^,\]\)]*)\s*([\]\)])$"
+    )
+    m = maven_open_re.match(expr)
+    if m:
+        lo_bracket = m.group(1)
+        lo_val = m.group(2).strip()
+        hi_val = m.group(3).strip()
+        hi_bracket = m.group(4)
+
+        # [1.0] — exact match (no comma, both lo and hi are same)
+        if not hi_val and lo_val and lo_bracket == "[" and hi_bracket == "]":
+            return f"== {lo_val}"
+
+        # (,1.0] or (,1.0) — upper bound only
+        if not lo_val and hi_val:
+            hi_op = "<=" if hi_bracket == "]" else "<"
+            return f"{hi_op} {hi_val}"
+
+        # [1.0,) or (1.0,) — lower bound only
+        if lo_val and not hi_val:
+            lo_op = ">=" if lo_bracket == "[" else ">"
+            return f"{lo_op} {lo_val}"
+
+        # [1.0, 2.0) — full interval (both bounds present)
+        if lo_val and hi_val:
+            lo_op = ">=" if lo_bracket == "[" else ">"
+            hi_op = "<=" if hi_bracket == "]" else "<"
+            return f"{lo_op} {lo_val}, {hi_op} {hi_val}"
+
+    # ── Dash range: "4.1-8.1" → ">= 4.1, < 8.1" ─────────────────────────────
+    m = _DASH_RANGE_RE.match(expr)
+    if m:
+        lo, hi = m.group(1), m.group(2)
+        normalized = f">= {lo}, < {hi}"
+        log.debug("Normalized dash range %r → %r", expr, normalized)
+        return normalized
+
+    return expr
+
+
+def _parse_single_range(
+    expr: str, ecosystem: str = "semver"
+) -> list[VersionConstraint]:
+    """Parse a single AND-group of constraints (no ``||``)."""
+    constraints: list[VersionConstraint] = []
+    if not expr:
+        return constraints
+    expr = _normalize_range_expr(expr)
+    for part in expr.split(","):
+        m = _RANGE_RE.match(part.strip())
+        if m:
+            constraints.append(
+                VersionConstraint(m.group(1), m.group(2).strip(), ecosystem)
+            )
+        else:
+            log.warning("Could not parse version range part: %r", part.strip())
+    return constraints
+
+
+def parse_version_range(
+    expr: str, ecosystem: str = "semver"
+) -> list[VersionConstraint]:
+    """
+    Parse a version range expression into a list of VersionConstraints.
+
+    Supports OR groups separated by ``||``.  Within each group, constraints
+    are comma-separated (AND logic).  A version matches if it satisfies
+    ALL constraints in ANY group.
+
+    Supported formats:
+      Operator  : "< 3.0.9"                          →  < 3.0.9
+      Compound  : ">= 2.0, < 2.17.1"                 →  >= 2.0 AND < 2.17.1
+      OR groups : "< 4.2.1 || >= 4.1.0, < 4.1.6"     →  (< 4.2.1) OR (>= 4.1.0 AND < 4.1.6)
+      Exact     : "== 3.0.7"                          →  exactly 3.0.7
+      Dash      : "4.1-8.1"                           →  >= 4.1 AND < 8.1
+      Interval  : "[4.1, 8.1)"                        →  >= 4.1 AND < 8.1 (MITRE notation)
+
+    Operators:  <  <=  >  >=  ==  =  !=
+
+    When ``||`` is present the returned list is a *flat merge* of all
+    groups — the OR boundary info is kept internally for
+    ``version_in_range`` / ``determine_status`` which accept the
+    ``or_groups`` form via ``parse_version_range_or``.
+
+    For backward compatibility this still returns ``list[VersionConstraint]``
+    (the first group when ``||`` is absent, or a flat merge).  Use
+    ``parse_version_range_or`` when OR semantics are needed.
+    """
+    if "||" not in (expr or ""):
+        return _parse_single_range(expr, ecosystem)
+    # Flat merge for callers that don't understand OR groups
+    all_constraints: list[VersionConstraint] = []
+    for group_expr in expr.split("||"):
+        all_constraints.extend(_parse_single_range(group_expr.strip(), ecosystem))
+    return all_constraints
+
+
+def parse_version_range_or(
+    expr: str, ecosystem: str = "semver"
+) -> list[list[VersionConstraint]]:
+    """
+    Parse a version range expression into OR groups.
+
+    Each group is a ``list[VersionConstraint]`` where all constraints
+    must be satisfied (AND).  A version is affected if it matches
+    **any** group (OR).
+
+    Examples::
+
+        "< 4.2.1"                        → [[< 4.2.1]]
+        ">= 2.0, < 2.17.1"              → [[>= 2.0, < 2.17.1]]
+        "< 4.2.1 || >= 4.1.0, < 4.1.6"  → [[< 4.2.1], [>= 4.1.0, < 4.1.6]]
+    """
+    if not expr:
+        return []
+    groups: list[list[VersionConstraint]] = []
+    for group_expr in expr.split("||"):
+        parsed = _parse_single_range(group_expr.strip(), ecosystem)
+        if parsed:
+            groups.append(parsed)
+    return groups
+
+
+def version_in_range(
+    version: str,
+    constraints: list[VersionConstraint] | list[list[VersionConstraint]],
+) -> Optional[bool]:
+    """
+    Check whether *version* falls within the given constraints.
+
+    Accepts two forms:
+
+    - ``list[VersionConstraint]`` — single AND group (legacy).
+      Returns True if ALL constraints are satisfied.
+    - ``list[list[VersionConstraint]]`` — OR groups (from
+      ``parse_version_range_or``).  Returns True if ALL constraints
+      in ANY group are satisfied.
+
+    Returns None if any comparison could not be determined.
+    """
+    if not constraints:
+        return None
+
+    # Detect OR-groups form: list of lists
+    if constraints and isinstance(constraints[0], list):
+        or_groups: list[list[VersionConstraint]] = constraints  # type: ignore[assignment]
+        any_true = False
+        for group in or_groups:
+            results = [c.check(version) for c in group]
+            if any(r is None for r in results):
+                continue
+            if all(results):
+                any_true = True
+                break
+        if any_true:
+            return True
+        # If no group matched, check if any had unknown results
+        all_known = True
+        for group in or_groups:
+            results = [c.check(version) for c in group]
+            if any(r is None for r in results):
+                all_known = False
+        return None if not all_known else False
+
+    # Single AND group (legacy path)
+    results = [c.check(version) for c in constraints]
+    if any(r is None for r in results):
+        return None
+    return all(results)
+
+
+def determine_status(
+    version: str,
+    constraints: list[VersionConstraint] | list[list[VersionConstraint]],
+) -> OsvStatus:
+    """
+    Determine affectedness status for a single version string.
+
+    Accepts both single AND group and OR groups (list of lists).
+
+    Returns:
+        OsvStatus.AFFECTED     — version falls within the vulnerable range
+        OsvStatus.NOT_AFFECTED — version is outside the vulnerable range
+        OsvStatus.UNKNOWN      — version is missing or comparison failed
+    """
+    # version_in_range is tri-state: True (in range), False (out of range), None (unknown).
+    result = version_in_range(version, constraints)
+    if result is None:
+        return OsvStatus.UNKNOWN
+    return OsvStatus.AFFECTED if result else OsvStatus.NOT_AFFECTED

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Scope lib-newtopia queries by ecosystem derived from upstream PURLs (OSIDB-4966)
+- Base auto-affect determination on upstream affected versions (OSIDB-5031)
 
 ### Changed
 - Make HashiCorp Vault integration credential-based opt-in (OSIDB-5108)

--- a/osidb/models/flaw/upstream.py
+++ b/osidb/models/flaw/upstream.py
@@ -4,6 +4,7 @@ from django.contrib.postgres.indexes import GinIndex
 from django.db import models
 from packageurl import PackageURL
 
+from apps.ace.constants import OSV_ECOSYSTEM_MAP
 from osidb.mixins import (
     ACLMixin,
     ACLMixinManager,
@@ -14,24 +15,6 @@ from osidb.mixins import (
 from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .flaw import Flaw
-
-# OSV ecosystem string to normalized ecosystem identifier.
-_OSV_ECOSYSTEM_MAP: dict[str, str] = {
-    "maven": "maven",
-    "pypi": "pypi",
-    "npm": "npm",
-    "crates.io": "cargo",
-    "go": "golang",
-    "rubygems": "gem",
-    "nuget": "nuget",
-    "packagist": "generic",
-    "hex": "generic",
-    "pub": "generic",
-    "hackage": "generic",
-    "bioconductor": "generic",
-    "cran": "generic",
-    "github actions": "generic",
-}
 
 
 class UpstreamDataManager(ACLMixinManager, TrackingMixinManager):
@@ -107,7 +90,7 @@ class UpstreamData(AlertMixin, ACLMixin, TrackingMixin):
             return result
 
         for entry in self.upstream_purls:
-            name = entry.get("name", "")
+            name = (entry.get("name") or "").strip().lower()
             if not name:
                 continue
 
@@ -121,7 +104,7 @@ class UpstreamData(AlertMixin, ACLMixin, TrackingMixin):
 
             if not ecosystem:
                 raw_eco = (entry.get("ecosystem") or "").lower()
-                ecosystem = _OSV_ECOSYSTEM_MAP.get(raw_eco, "")
+                ecosystem = OSV_ECOSYSTEM_MAP.get(raw_eco, "")
 
             if ecosystem and ecosystem not in result.get(name, []):
                 result.setdefault(name, []).append(ecosystem)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Integrated upstream vulnerability version ranges to automatically determine affect status; affects are now marked NOTAFFECTED when component versions fall outside vulnerable ranges
  * Added version comparison support across multiple package ecosystems (RPM, NuGet, Maven, SemVer, Golang)

* **Tests**
  * Added comprehensive test coverage for version range matching and upstream vulnerability integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->