### PR TITLE
OSIDB-4734-skip non-DB  fields without raising FieldDoesNotExist

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fix FieldDoesNotExist being raised for non-DB declared filters (OSIDB-4734)
 
 ## [5.11.1] - 2026-06-10
 ### Fixed

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -11,7 +11,7 @@ from django.contrib.postgres.search import (
     SearchVector,
     TrigramSimilarity,
 )
-from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.exceptions import ValidationError
 from django.core.validators import EMPTY_VALUES
 from django.db import models
 from django.db.models import Max, Min, Q
@@ -352,6 +352,7 @@ class SparseFieldsFilterSet(FilterSet):
         """
         prefetch_set = set()
         field_set = set()
+        valid_field_names = {f.name for f in self._meta.model._meta.get_fields()}
         for fname in list(fields):
             relation = fname
             if "__" in fname:
@@ -374,11 +375,10 @@ class SparseFieldsFilterSet(FilterSet):
                 # affects__trackers to include_fields, we'll consider this
                 # a limitation of these filters.
                 relation = relation.rsplit("__", 1)[0]
-            try:
-                # check that the field actually exists
-                field = self._meta.model._meta.get_field(fname)
-            except FieldDoesNotExist:
+
+            if fname not in valid_field_names:
                 continue
+            field = self._meta.model._meta.get_field(fname)
             if not field.concrete:
                 # a field is concrete if it has a column in the database, we don't
                 # want non-concrete fields as we cannot filter them via SQL

--- a/osidb/tests/test_filters.py
+++ b/osidb/tests/test_filters.py
@@ -531,6 +531,19 @@ class TestInFilterSet:
         assert response.status_code == status.HTTP_200_OK
         assert response.json()["count"] == 4
 
+    def test_flaw_list_with_non_db_fields(self, auth_client, test_api_v2_uri):
+        """
+        Test passing non-DB fields without raising error
+        """
+        FlawFactory(embargoed=False)
+
+        response = auth_client().get(
+            f"{test_api_v2_uri}/flaws?include_fields=cve_id,uuid,classification,embargoed"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        assert len(results) > 0
+
 
 class TestPURLFilter:
     """


### PR DESCRIPTION
Non-DB fields cause `FieldDoesNotExist` to be raised on every request.
-Fix in `filters.py` check field names against `get_fields()` before calling `get_fields()`.
-Added test case.
Closes: OSIDB-4734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the `/flaws` API endpoint incorrectly raised errors when using non-database declared fields in filter parameters. The endpoint now properly accepts and processes these fields without raising exceptions. This improves the flexibility of the filtering system for API consumers who need to work with extended field sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->