### PR TITLE
OSIDB:5038 - Wrap bulk PUT external errors with affect context

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -448,7 +448,7 @@
         "filename": "osidb/tests/endpoints/test_affects.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 208,
+        "line_number": 209,
         "is_secret": false
       }
     ],

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix FieldDoesNotExist being raised for non-DB declared filters (OSIDB-4734)
+- Wrap external errors with affect context for bulk PUT endpoint (OSIDB-5038)
 
 ## [5.11.1] - 2026-06-10
 ### Fixed

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -1447,16 +1447,38 @@ class AffectView(
         # Second, save the updated affects to the database, but not sync with BZ.
         actor = self._actor(request.user)
         ret = []
+        errors = []
         for serializer in validated_serializers:
             # Make the serializer skip the sync for each affect
-            serializer.save(skip_bz_sync=True, updated_by=actor)
-            ret.append(serializer.data)
+            try:
+                serializer.save(skip_bz_sync=True, updated_by=actor)
+                ret.append(serializer.data)
+            except ValidationError as e:
+                instance = serializer.instance
+                error_detail = (
+                    e.message_dict
+                    if hasattr(e, "message_dict")
+                    else {"non_field_errors": e.messages}
+                )
+                errors.append(
+                    {
+                        "input": {
+                            "uuid": str(instance.uuid),
+                            "ps_update_stream": instance.ps_update_stream,
+                            "ps_component": instance.ps_component,
+                            "purl": instance.purl,
+                            "ps_module": instance.ps_module,
+                        },
+                        "errors": error_detail,
+                    }
+                )
 
         # Third, proxy the update to Bugzilla
         flaw = Flaw.objects.get(uuid=next(iter(flaws)))
-        flaw.save(bz_api_key=bz_api_key)
+        if ret:
+            flaw.save(bz_api_key=bz_api_key)
 
-        return Response({"results": ret})
+        return Response({"results": ret, "failed": errors})
 
     @extend_schema(
         request=AffectPostSerializer(many=True),

--- a/osidb/tests/endpoints/test_affects.py
+++ b/osidb/tests/endpoints/test_affects.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from django.core.exceptions import ValidationError
 from rest_framework import status
 
 from osidb.models import Affect, AffectCVSS, Tracker
@@ -1212,8 +1213,10 @@ class TestEndpointsAffectsBulk:
             HTTP_BUGZILLA_API_KEY="SECRET",
             HTTP_JIRA_API_KEY="SECRET",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "must have either purl or ps_component" in str(response.content)
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["failed"]
+        assert "must have either purl or ps_component" in str(response.data["failed"])
 
     def test_create_neither_purl_nor_ps_component(self, auth_client, test_api_v2_uri):
         """
@@ -1270,6 +1273,49 @@ class TestEndpointsAffectsBulk:
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "must have either purl or ps_component" in str(response.content)
+
+    def test_bulk_put_external_error_includes_context(
+        self, auth_client, test_api_v2_uri
+    ):
+        """bulk PUT external errors should include affect context fields"""
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_component="test-component",
+            purl="",
+            **_community_ps_for_affect(),
+        )
+
+        update_data = {
+            "uuid": str(affect.uuid),
+            "flaw": str(flaw.uuid),
+            "affectedness": affect.affectedness,
+            "resolution": affect.resolution,
+            "ps_update_stream": affect.ps_update_stream,
+            "embargoed": affect.is_embargoed,
+            "updated_dt": affect.updated_dt,
+            "ps_component": affect.ps_component,
+        }
+
+        with patch(
+            "osidb.api_views.AffectSerializer.save",
+            side_effect=ValidationError("Jira connection failed"),
+        ):
+            response = auth_client().put(
+                f"{test_api_v2_uri}/affects/bulk",
+                [update_data],
+                format="json",
+                HTTP_BUGZILLA_API_KEY="SECRET",
+                HTTP_JIRA_API_KEY="SECRET",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["failed"]
+        failed = response.data["failed"][0]
+        assert "ps_update_stream" in failed["input"]
+        assert "ps_component" in failed["input"]
+        assert "purl" in failed["input"]
+        assert "ps_module" in failed["input"]
 
 
 class TestEndpointsAffectsUpdateTrackers:


### PR DESCRIPTION
Wraps external errors in the bulk affect PUT endpoint with meaningful context.
- Updated `bulk_put` to collect per-item errors when affect failed in `api_views.py` 
- Updated existing test and added new test case
Closes: OSIDB-5038