### PR TITLE
OSIDB-5108: Change HashiCorp Vault integration to opt-in

### DIFF
--- a/apps/workflows/tests/conftest.py
+++ b/apps/workflows/tests/conftest.py
@@ -131,11 +131,20 @@ def patch_hvac_client(monkeypatch, mock_hvac_client_instance):
     """Patches hvac.Client in vault_integration module to return our mock instance."""
     MockHvacClientClass = MagicMock(return_value=mock_hvac_client_instance)
     monkeypatch.setattr("osidb.integrations.hvac.Client", MockHvacClientClass)
+    # Note: Credentials are set per-test via set_hvac_test_env_vars fixture or fake_integration_settings
     return MockHvacClientClass
 
 
 @pytest.fixture
 def set_hvac_test_env_vars():
+    """Set Vault credentials as environment variables for tests."""
     os.environ["OSIDB_VAULT_ADDR"] = "https://fake-vault:8200/"
     os.environ["OSIDB_ROLE_ID"] = "fake-role"
     os.environ["OSIDB_SECRET_ID"] = "fake-secret"
+
+    yield
+
+    # Clean up to prevent leaking to other tests
+    os.environ.pop("OSIDB_VAULT_ADDR", None)
+    os.environ.pop("OSIDB_ROLE_ID", None)
+    os.environ.pop("OSIDB_SECRET_ID", None)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Make HashiCorp Vault integration credential-based opt-in (OSIDB-5108)
+
 ### Fixed
 - Fix FieldDoesNotExist being raised for non-DB declared filters (OSIDB-4734)
 

--- a/openapi.yml
+++ b/openapi.yml
@@ -13699,6 +13699,25 @@ paths:
                     version:
                       type: string
           description: ''
+        '503':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+                description: Vault integration is disabled
+          description: ''
     patch:
       operationId: osidb_integrations_partial_update
       description: Set third-party integration tokens for the current user.
@@ -13733,6 +13752,25 @@ paths:
                     type: string
                   version:
                     type: string
+          description: ''
+        '503':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  detail:
+                    type: string
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+                description: Vault integration is disabled
           description: ''
   /osidb/whoami:
     get:

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -40,6 +40,7 @@ from rest_framework.status import (
     HTTP_204_NO_CONTENT,
     HTTP_400_BAD_REQUEST,
     HTTP_404_NOT_FOUND,
+    HTTP_503_SERVICE_UNAVAILABLE,
 )
 from rest_framework.views import APIView
 from rest_framework.viewsets import (
@@ -1132,12 +1133,30 @@ def whoami(request: Request) -> Response:
 
 @extend_schema(
     methods=["GET"],
-    responses={200: OpenApiResponse(response=IntegrationTokenGetSerializer)},
+    responses={
+        200: OpenApiResponse(response=IntegrationTokenGetSerializer),
+        503: {
+            "type": "object",
+            "properties": {
+                "detail": {"type": "string"},
+            },
+            "description": "Vault integration is disabled",
+        },
+    },
 )
 @extend_schema(
     methods=["PATCH"],
     request=OpenApiRequest(request=IntegrationTokenPatchSerializer),
-    responses={204: {}},
+    responses={
+        204: {},
+        503: {
+            "type": "object",
+            "properties": {
+                "detail": {"type": "string"},
+            },
+            "description": "Vault integration is disabled",
+        },
+    },
 )
 @api_view(["GET", "PATCH"])
 def integration_tokens(request: Request) -> Response:
@@ -1147,6 +1166,14 @@ def integration_tokens(request: Request) -> Response:
     integration_settings = IntegrationSettings()
     integration_repo = IntegrationRepository(integration_settings)
     current_user = cast(User, request.user)
+
+    if integration_repo.client is None:
+        return Response(
+            {
+                "detail": "Vault integration is disabled because required credentials are not provided"
+            },
+            status=HTTP_503_SERVICE_UNAVAILABLE,
+        )
 
     if request.method == "GET":
         data = {

--- a/osidb/integrations.py
+++ b/osidb/integrations.py
@@ -14,9 +14,18 @@ _logger = logging.getLogger(__name__)
 class IntegrationSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="OSIDB_")
 
-    vault_addr: str = Field(default=...)
-    role_id: str = Field(default=...)
-    secret_id: str = Field(default=...)
+    vault_addr: str = Field(default="")
+    role_id: str = Field(default="")
+    secret_id: str = Field(default="")
+
+    def is_vault_enabled(self) -> bool:
+        """
+        Determine if Vault should be enabled based on credentials.
+
+        Vault is enabled only when ALL THREE credentials are provided:
+        OSIDB_VAULT_ADDR, OSIDB_ROLE_ID, OSIDB_SECRET_ID
+        """
+        return bool(self.vault_addr and self.role_id and self.secret_id)
 
 
 class IntegrationRepository:
@@ -24,6 +33,16 @@ class IntegrationRepository:
     BASE_MOUNTPOINT = "apps"
 
     def __init__(self, settings: IntegrationSettings):
+        self.settings = settings
+
+        if not settings.is_vault_enabled():
+            _logger.info(
+                "Vault integration is disabled because required credentials are not provided"
+            )
+            self.client = None
+            return
+
+        # Credentials are guaranteed to be present by is_vault_enabled()
         self.client = hvac.Client(url=settings.vault_addr)
         try:
             self.client.auth.approle.login(
@@ -33,6 +52,10 @@ class IntegrationRepository:
             _logger.error("Vault AppRole authentication failed.", exc_info=e)
 
     def upsert_secret(self, subpath: Path, key: str, value: str) -> None:
+        if self.client is None:
+            _logger.debug(f"Vault is disabled, cannot write secret at {subpath}/{key}")
+            return
+
         self.client.secrets.kv.v2.patch(
             path=str(self.BASE_PATH / subpath),
             secret={key: value},
@@ -40,6 +63,10 @@ class IntegrationRepository:
         )
 
     def read_secret(self, subpath: Path, key: str) -> Optional[str]:
+        if self.client is None:
+            _logger.debug(f"Vault is disabled, cannot read secret at {subpath}/{key}")
+            return None
+
         r = self.client.secrets.kv.v2.read_secret_version(
             path=str(self.BASE_PATH / subpath),
             mount_point=self.BASE_MOUNTPOINT,

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -145,11 +145,20 @@ def patch_hvac_client(monkeypatch, mock_hvac_client_instance):
     """Patches hvac.Client in vault_integration module to return our mock instance."""
     MockHvacClientClass = MagicMock(return_value=mock_hvac_client_instance)
     monkeypatch.setattr("osidb.integrations.hvac.Client", MockHvacClientClass)
+    # Note: Credentials are set per-test via set_hvac_test_env_vars fixture or fake_integration_settings
     return MockHvacClientClass
 
 
 @pytest.fixture
 def set_hvac_test_env_vars():
+    """Set Vault credentials as environment variables for tests."""
     os.environ["OSIDB_VAULT_ADDR"] = "https://fake-vault:8200/"
     os.environ["OSIDB_ROLE_ID"] = "fake-role"
     os.environ["OSIDB_SECRET_ID"] = "fake-secret"
+
+    yield
+
+    # Clean up to prevent leaking to other tests
+    os.environ.pop("OSIDB_VAULT_ADDR", None)
+    os.environ.pop("OSIDB_ROLE_ID", None)
+    os.environ.pop("OSIDB_SECRET_ID", None)

--- a/osidb/tests/test_hcv_integration.py
+++ b/osidb/tests/test_hcv_integration.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from osidb.helpers import get_execution_env
+from osidb.integrations import IntegrationRepository, IntegrationSettings
 
 pytestmark = pytest.mark.unit
 
@@ -92,3 +93,89 @@ def test_integration_repo_read_bz_token(
         path=f"/osidb-integrations/{get_execution_env()}/bugzilla",
         mount_point="apps",
     )
+
+
+def test_vault_disabled_when_vault_addr_missing():
+    """Test that Vault is disabled when OSIDB_VAULT_ADDR is missing"""
+    settings = IntegrationSettings(vault_addr="", role_id="test", secret_id="test")
+    assert not settings.is_vault_enabled()
+
+
+def test_vault_disabled_when_role_id_missing():
+    """Test that Vault is disabled when OSIDB_ROLE_ID is missing"""
+    settings = IntegrationSettings(
+        vault_addr="http://vault:8200", role_id="", secret_id="test"
+    )
+    assert not settings.is_vault_enabled()
+
+
+def test_vault_disabled_when_secret_id_missing():
+    """Test that Vault is disabled when OSIDB_SECRET_ID is missing"""
+    settings = IntegrationSettings(
+        vault_addr="http://vault:8200", role_id="test", secret_id=""
+    )
+    assert not settings.is_vault_enabled()
+
+
+def test_vault_disabled_when_all_credentials_missing(monkeypatch):
+    """Test that Vault is disabled when all credentials are missing"""
+    monkeypatch.delenv("OSIDB_VAULT_ADDR", raising=False)
+    monkeypatch.delenv("OSIDB_ROLE_ID", raising=False)
+    monkeypatch.delenv("OSIDB_SECRET_ID", raising=False)
+
+    settings = IntegrationSettings()  # All credentials default to empty string
+    assert not settings.is_vault_enabled()
+
+
+def test_vault_enabled_when_all_credentials_provided(set_hvac_test_env_vars):
+    """Test that Vault is enabled when all THREE credentials are provided"""
+    settings = IntegrationSettings()
+    assert settings.is_vault_enabled()
+
+
+def test_vault_disabled_read_returns_none(monkeypatch):
+    """Test that read operations return None when Vault is disabled"""
+    monkeypatch.delenv("OSIDB_VAULT_ADDR", raising=False)
+    monkeypatch.delenv("OSIDB_ROLE_ID", raising=False)
+    monkeypatch.delenv("OSIDB_SECRET_ID", raising=False)
+
+    settings = IntegrationSettings()  # All credentials empty
+    repo = IntegrationRepository(settings)
+
+    assert repo.read_secret(Path("test"), "key") is None
+    assert repo.read_jira_token("testuser") is None
+    assert repo.read_jira_email("testuser") is None
+    assert repo.read_bz_token("testuser") is None
+
+
+def test_vault_disabled_write_is_noop(monkeypatch):
+    """Test that write operations are no-ops when Vault is disabled"""
+    monkeypatch.delenv("OSIDB_VAULT_ADDR", raising=False)
+    monkeypatch.delenv("OSIDB_ROLE_ID", raising=False)
+    monkeypatch.delenv("OSIDB_SECRET_ID", raising=False)
+
+    settings = IntegrationSettings()  # All credentials empty
+    repo = IntegrationRepository(settings)
+
+    # These should not raise exceptions, just no-op
+    repo.upsert_secret(Path("test"), "key", "value")
+    repo.upsert_jira_token("testuser", "token")
+    repo.upsert_jira_email("testuser", "email@example.com")
+    repo.upsert_bz_token("testuser", "token")
+
+    assert repo.client is None
+
+
+def test_vault_repository_init_with_missing_credentials(monkeypatch):
+    """Test that IntegrationRepository gracefully handles missing credentials"""
+    monkeypatch.delenv("OSIDB_VAULT_ADDR", raising=False)
+    monkeypatch.delenv("OSIDB_ROLE_ID", raising=False)
+    monkeypatch.delenv("OSIDB_SECRET_ID", raising=False)
+
+    settings = IntegrationSettings(
+        vault_addr="http://vault:8200"
+    )  # Partial credentials
+    repo = IntegrationRepository(settings)
+
+    # Should have None client without raising
+    assert repo.client is None

--- a/tox.ini
+++ b/tox.ini
@@ -83,3 +83,4 @@ commands = uvx {[ruff]ruff_version} check --fix --diff --select I .
 [testenv:ruff-format]
 commands_pre = 
 commands = uvx {[ruff]ruff_version} format --check .
+


### PR DESCRIPTION
## Summary

Makes HashiCorp Vault integration **credential-based opt-in**: Vault is enabled ONLY when all three credentials (OSIDB_VAULT_ADDR, OSIDB_ROLE_ID, OSIDB_SECRET_ID) are provided. If any credential is missing, Vault integration is gracefully disabled.

**Change in Direction**: Initial implementation used environment-based detection (disabled for local, enabled otherwise). This was changed to credential-based opt-in to make Vault truly optional without coupling to specific environments.

## Changes

### Core Implementation
- **`osidb/integrations.py`**:
  - Made Vault credentials optional (empty string defaults)
  - `is_vault_enabled()` now checks if all three credentials are provided (not environment)
  - Removed `validate_credentials()` method (no longer needed)
  - Modified `IntegrationRepository.__init__()` to skip Vault client initialization when credentials missing
  - Guards in `read_secret()` and `upsert_secret()` return None/no-op when client is None

- **`osidb/api_views.py`**:
  - `integration_tokens()` endpoint returns 503 when Vault is disabled
  - Updated error message to reflect credential-based disable

### Test Updates
- **`osidb/tests/test_hcv_integration.py`**:
  - Replaced environment-based tests with credential-based tests
  - 8 new tests covering all credential combinations
  - Tests verify disabled behavior when credentials missing
  - Tests verify enabled behavior when all credentials provided

- **`osidb/tests/conftest.py`** & **`apps/workflows/tests/conftest.py`**:
  - `set_hvac_test_env_vars` fixture sets test credentials with cleanup
  - Tests opt-in to credentials via fixture parameter
  - Removed environment mocking from `patch_hvac_client`

### Documentation
- **`.env`**: Updated comments to clarify credential-based opt-in
- **`config/settings_local.py`**: Added note about credential-based behavior

## Behavior

- **Vault enabled** (all credentials provided):
  - Works in any environment (local, prod, stage, ci)
  - Requires `OSIDB_VAULT_ADDR`, `OSIDB_ROLE_ID`, `OSIDB_SECRET_ID`

- **Vault disabled** (any credential missing):
  - Works in any environment (local, prod, stage, ci)
  - Integration tokens fall back to HTTP headers (`Bugzilla-Api-Key`, `JIRA-Taskman-Api-Key`)
  - No Vault connection attempted

## Test Plan

- ✅ All existing Vault integration tests pass
- ✅ New credential-based tests verify disabled state behavior
- ✅ Endpoint tests work with credential fixture
- ✅ Manual verification: Local dev works without credentials, Vault activates when credentials set

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
* HashiCorp Vault integration is now credential-based opt-in—provide `OSIDB_VAULT_ADDR`, `OSIDB_ROLE_ID`, and `OSIDB_SECRET_ID` environment variables to enable.
* API endpoints return `503 Service Unavailable` with clear messaging when Vault integration is disabled.

## Documentation
* Updated API documentation to reflect optional Vault integration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->