### PR TITLE
Add CRA_regulatory_reporting for atomated reviews in this proyect

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -40,6 +40,8 @@ reviews:
       - "main"
       - "master"
       - "release-\\d+\\.\\d+\\.\\d+(-prep)?$"
+      # Special branch for CRA regulatory reporting project (remove after merge)
+      - "CRA_regulatory_reporting"
 
   path_instructions:
 

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,7 +118,7 @@
         "filename": ".coderabbit.yaml",
         "hashed_secret": "ca52d31b2cba483277e66742e4d2ede314423d5d",
         "is_verified": false,
-        "line_number": 81,
+        "line_number": 83,
         "is_secret": false
       },
       {
@@ -126,7 +126,7 @@
         "filename": ".coderabbit.yaml",
         "hashed_secret": "e780f4f97756171032bb50c038e230569962b982",
         "is_verified": false,
-        "line_number": 238,
+        "line_number": 240,
         "is_secret": false
       },
       {
@@ -134,7 +134,7 @@
         "filename": ".coderabbit.yaml",
         "hashed_secret": "e2833497abf87e11d44c286c1792011fa8e3cec5",
         "is_verified": false,
-        "line_number": 399,
+        "line_number": 401,
         "is_secret": false
       }
     ],
@@ -501,5 +501,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-11T08:22:05Z"
+  "generated_at": "2026-06-17T12:25:44Z"
 }


### PR DESCRIPTION
# Context

For the CRA regulatory reporting project we create a specific branch that will be our base for de moment. The coderabbit only triggers a review for project its master or release. 

# change
This will make code rabbit to also run automatically for PR's CRA_regulatory_reporting as a base 