### PR TITLE
OSIDB-3134: Fix 500 error on empty bulk affects requests

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrapped bulk ACL updates in a transaction to prevent them from auto-committing outside the request transaction (OSIDB-4992)
 - Fixed double error raise problem in sync_manager.
 - Fix incorrect OpenAPI schema types for audit endpoint fields (pgh_data, pgh_context, pgh_diff) (OSIDB-3637)
+- Return descriptive 400 error instead of 500 on malformed bulk affects requests (OSIDB-3134)
 
 ### Removed
 - deprecate workflow manipulation endpoints

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -1590,7 +1590,17 @@ class AffectView(
         flaws = set()
         uuids = set()
         validated_serializers = []
+
+        if not request.data:
+            raise ValidationError({"affect": "At least one affect is required."})
+
+        if not isinstance(request.data, list):
+            raise ValidationError({"affect": "Expected a list of affects."})
+
         for datum in request.data:
+            if not isinstance(datum, dict):
+                raise ValidationError({"affect": "Expected a dict."})
+
             try:
                 uuid = datum["uuid"]
             except KeyError:
@@ -1673,19 +1683,26 @@ class AffectView(
 
         # --- Pre-scan: collect flaw UUIDs and enforce constraints ---
         flaw_uuids = set()
+
+        if not request.data:
+            raise ValidationError({"affect": "At least one affect is required."})
+
+        if not isinstance(request.data, list):
+            raise ValidationError({"affect": "Expected a list of affects."})
+
         for datum in request.data:
+            if not isinstance(datum, dict):
+                raise ValidationError({"affect": "Expected a dict."})
+
             try:
                 flaw_uuids.add(datum["flaw"])
-            except (KeyError, TypeError):
+            except KeyError:
                 raise ValidationError({"flaw": "This field is required."})
 
         if len(flaw_uuids) > 1:
             raise ValidationError(
                 {"flaw": "Provided affects belong to multiple flaws."}
             )
-
-        if not flaw_uuids:
-            raise ValidationError({"flaw": "This field is required."})
 
         flaw_uuid = next(iter(flaw_uuids))
         flaw = get_object_or_404(Flaw, uuid=flaw_uuid)
@@ -1792,7 +1809,17 @@ class AffectView(
 
         flaws = set()
         uuids = set()
+
+        if not request.data:
+            raise ValidationError({"affect": "At least one affect is required."})
+
+        if not isinstance(request.data, list):
+            raise ValidationError({"affect": "Expected a list of affects."})
+
         for uuid in request.data:
+            if not isinstance(uuid, str):
+                raise ValidationError({"uuid": "Expected a UUID string."})
+
             if uuid in uuids:
                 raise ValidationError(
                     {"uuid": "Multiple objects with the same uuid provided."}
@@ -1802,16 +1829,14 @@ class AffectView(
 
             try:
                 affect_obj = Affect.objects.get(uuid=uuid)
-            except Affect.DoesNotExist:
+            except (ValueError, ValidationError, Affect.DoesNotExist):
                 raise ValidationError({"uuid": "Affect matching query does not exist."})
 
             flaw_obj = affect_obj.flaw
             flaws.add(flaw_obj.uuid)
             if len(flaws) > 1:
                 raise ValidationError(
-                    {
-                        "uuid": "Affect object UUIDs belonging to multiple Flaws provided."
-                    }
+                    {"flaw": "Provided affects belong to multiple flaws."}
                 )
 
             # Relying on the whole transaction being aborted if a validation fails along the way.

--- a/osidb/tests/endpoints/test_affects.py
+++ b/osidb/tests/endpoints/test_affects.py
@@ -650,6 +650,152 @@ class TestEndpointsAffectsBulk:
         assert response.status_code == 200
         assert Affect.objects.count() == 0
 
+    def test_affect_update_bulk_empty_list(
+        self, auth_client, test_api_v2_uri, bugzilla_token, jira_token
+    ):
+        bulk_request = []
+        response = auth_client().put(
+            f"{test_api_v2_uri}/affects/bulk",
+            bulk_request,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["At least one affect is required."]
+
+    def test_affect_create_bulk_empty_list(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        bulk_request = []
+        response = auth_client().post(
+            f"{test_api_v2_uri}/affects/bulk",
+            bulk_request,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["At least one affect is required."]
+
+    def test_affect_delete_bulk_empty_list(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        bulk_request = []
+        response = auth_client().delete(
+            f"{test_api_v2_uri}/affects/bulk",
+            bulk_request,
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["At least one affect is required."]
+
+    def test_affect_update_bulk_non_list_payload(
+        self, auth_client, test_api_v2_uri, bugzilla_token, jira_token
+    ):
+        response = auth_client().put(
+            f"{test_api_v2_uri}/affects/bulk",
+            {"uuid": "something"},
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["Expected a list of affects."]
+
+    def test_affect_create_bulk_non_list_payload(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        response = auth_client().post(
+            f"{test_api_v2_uri}/affects/bulk",
+            {"flaw": "something"},
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["Expected a list of affects."]
+
+    def test_affect_delete_bulk_non_list_payload(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        response = auth_client().delete(
+            f"{test_api_v2_uri}/affects/bulk",
+            {"uuid": "something"},
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["Expected a list of affects."]
+
+    def test_affect_update_bulk_malformed_entries(
+        self, auth_client, test_api_v2_uri, bugzilla_token, jira_token
+    ):
+        response = auth_client().put(
+            f"{test_api_v2_uri}/affects/bulk",
+            ["not-a-dict"],
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+            HTTP_JIRA_API_KEY=jira_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["Expected a dict."]
+
+    def test_affect_create_bulk_malformed_entries(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        response = auth_client().post(
+            f"{test_api_v2_uri}/affects/bulk",
+            ["not-a-dict"],
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["affect"] == ["Expected a dict."]
+
+    def test_affect_delete_bulk_malformed_entries(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        response = auth_client().delete(
+            f"{test_api_v2_uri}/affects/bulk",
+            [{}],
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["uuid"] == ["Expected a UUID string."]
+
+    def test_affect_delete_bulk_invalid_uuid_format(
+        self, auth_client, test_api_v2_uri, bugzilla_token
+    ):
+        response = auth_client().delete(
+            f"{test_api_v2_uri}/affects/bulk",
+            ["not-a-uuid"],
+            format="json",
+            HTTP_BUGZILLA_API_KEY=bugzilla_token,
+        )
+
+        assert response.status_code == 400
+        body = response.json()
+        assert body["uuid"] == ["Affect matching query does not exist."]
+
     @pytest.mark.enable_signals
     def test_affect_create_bulk_public_acls(self, auth_client, test_api_v2_uri):
         """


### PR DESCRIPTION
-   PUT/POST/DELETE /affects/bulk returned 500 StopIteration on empty request body
-   Added early validation to return 400 with descriptive error
-   Added tests for all three endpoints

**EDIT:** Also validate request payload shape (must be a list), catch TypeError on non-dict items in PUT, catch ValueError on invalid UUIDs in DELETE, reject non-string entries in DELETE, add explicit type guards for per-item validation in PUT/POST, and normalize the multi-flaw error message in DELETE to match PUT/POST.

Closes: OSIDB-3134