### PR TITLE
make exploit collectors opt-in

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -286,7 +286,7 @@
         "filename": "docs/developer/DEVELOP.md",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 118,
+        "line_number": 122,
         "is_secret": false
       }
     ],
@@ -501,5 +501,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-19T16:14:17Z"
+  "generated_at": "2026-06-23T13:47:30Z"
 }

--- a/collectors/exploits_cisa/constants.py
+++ b/collectors/exploits_cisa/constants.py
@@ -1,0 +1,6 @@
+from osidb.helpers import get_env
+
+# Switch to turn the collector on/off
+EXPLOITS_CISA_COLLECTOR_ENABLED = get_env(
+    "EXPLOITS_CISA_COLLECTOR_ENABLED", default="False", is_bool=True
+)

--- a/collectors/exploits_cisa/tasks.py
+++ b/collectors/exploits_cisa/tasks.py
@@ -16,6 +16,8 @@ from apps.exploits.helpers import (
 from apps.exploits.models import Exploit
 from collectors.framework.models import collector
 
+from .constants import EXPLOITS_CISA_COLLECTOR_ENABLED
+
 logger = get_task_logger(__name__)
 
 CISA_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
@@ -59,7 +61,8 @@ def cisa_collector_main():
 
 @collector(
     # Execute once an hour in production or stage, otherwise daily
-    crontab=settings.CISA_COLLECTOR_CRONTAB
+    crontab=settings.CISA_COLLECTOR_CRONTAB,
+    enabled=EXPLOITS_CISA_COLLECTOR_ENABLED,
 )
 def exploit_cisa_collector(collector_obj):
     logger.info(f"Collector {collector_obj.name} is running")

--- a/collectors/exploits_exploitdb/constants.py
+++ b/collectors/exploits_exploitdb/constants.py
@@ -1,0 +1,6 @@
+from osidb.helpers import get_env
+
+# Switch to turn the collector on/off
+EXPLOITS_EXPLOITDB_COLLECTOR_ENABLED = get_env(
+    "EXPLOITS_EXPLOITDB_COLLECTOR_ENABLED", default="False", is_bool=True
+)

--- a/collectors/exploits_exploitdb/tasks.py
+++ b/collectors/exploits_exploitdb/tasks.py
@@ -22,6 +22,8 @@ from apps.exploits.models import Exploit
 from collectors.framework.models import collector
 from osidb.validators import CVE_RE_STR
 
+from .constants import EXPLOITS_EXPLOITDB_COLLECTOR_ENABLED
+
 logger = get_task_logger(__name__)
 
 EXPLOITDB_URL = (
@@ -113,6 +115,7 @@ def exploitdb_collector_main():
 @collector(
     # Execute once a day
     crontab=crontab(minute=10, hour=1),
+    enabled=EXPLOITS_EXPLOITDB_COLLECTOR_ENABLED,
 )
 def exploit_exploitdb_collector(collector_obj):
     logger.info(f"Collector {collector_obj.name} is running")

--- a/collectors/exploits_metasploit/constants.py
+++ b/collectors/exploits_metasploit/constants.py
@@ -1,0 +1,6 @@
+from osidb.helpers import get_env
+
+# Switch to turn the collector on/off
+EXPLOITS_METASPLOIT_COLLECTOR_ENABLED = get_env(
+    "EXPLOITS_METASPLOIT_COLLECTOR_ENABLED", default="False", is_bool=True
+)

--- a/collectors/exploits_metasploit/tasks.py
+++ b/collectors/exploits_metasploit/tasks.py
@@ -16,6 +16,8 @@ from apps.exploits.helpers import (
 from apps.exploits.models import Exploit
 from collectors.framework.models import collector
 
+from .constants import EXPLOITS_METASPLOIT_COLLECTOR_ENABLED
+
 logger = get_task_logger(__name__)
 
 METASPLOIT_URL = "https://raw.githubusercontent.com/rapid7/metasploit-framework/master/db/modules_metadata_base.json"
@@ -69,6 +71,7 @@ def metasploit_collector_main():
 @collector(
     # Execute once a day
     crontab=crontab(minute=5, hour=1),
+    enabled=EXPLOITS_METASPLOIT_COLLECTOR_ENABLED,
 )
 def exploit_metasploit_collector(collector_obj):
     logger.info(f"Collector {collector_obj.name} is running")

--- a/docs/developer/DEVELOP.md
+++ b/docs/developer/DEVELOP.md
@@ -108,6 +108,10 @@ JIRA_METADATA_COLLECTOR_ENABLED=1
 CVEORG_COLLECTOR_ENABLED=1
 NVD_COLLECTOR_ENABLED=1
 OSV_COLLECTOR_ENABLED=1
+# Exploit collector switches: set to 0 to turn each collector off (default), or 1 to turn it on
+EXPLOITS_CISA_COLLECTOR_ENABLED=0
+EXPLOITS_EXPLOITDB_COLLECTOR_ENABLED=0
+EXPLOITS_METASPLOIT_COLLECTOR_ENABLED=0
 
 # If set, it will append the tracker accuracy feedback form at the end of the description when creating Jira trackers
 TRACKER_FEEDBACK_FORM_URL="https://foo.bar"


### PR DESCRIPTION
This makes the exploit collectors configurable and turned off by default. Here is an ops counterpart
https://gitlab.cee.redhat.com/product-security/dev/osidb-ops/-/merge_requests/178
(please review that also).

Closes OSIDB-5151