### PR TITLE
Add ecosystem property for UpstreamData

### DIFF
--- a/apps/ace/tasks.py
+++ b/apps/ace/tasks.py
@@ -8,6 +8,7 @@ from config.celery import app
 from osidb.helpers import bypass_rls
 from osidb.models import Flaw
 from osidb.models.affect import Affect, AffectSettings
+from osidb.models.flaw.upstream import UpstreamData
 
 logger = get_task_logger(__name__)
 
@@ -27,9 +28,15 @@ def _flaw_components(flaw: Flaw) -> list[str]:
     return components
 
 
-def _query_newtopia(flaw_component: str, ps_modules: list[str]) -> list:
+def _query_newtopia(
+    flaw_component: str, ps_modules: list[str], ecosystem: str = ""
+) -> list:
     nq = NewtopiaQuerier()  # type: ignore[misc]
-    return nq.search([flaw_component], strict=True).filter(products=ps_modules).all()
+    return (
+        nq.search([flaw_component], strict=True, ecosystem=ecosystem)
+        .filter(products=ps_modules)
+        .all()
+    )
 
 
 def _ace_tool_name() -> str:
@@ -49,6 +56,7 @@ def _sync_affects_from_results(
     results: list,
     flaw_component: str = "",
     ps_modules: list[str] | None = None,
+    ecosystem: str = "",
 ) -> dict[str, int]:
     """Create affects on ``flaw`` for each entry in ``results``.
 
@@ -100,7 +108,7 @@ def _sync_affects_from_results(
                 assist_meta={
                     "tool_name": tool_name,
                     "tool_input": (
-                        f"NewtopiaQuerier().search([{flaw_component!r}], strict=True)"
+                        f"NewtopiaQuerier().search([{flaw_component!r}], ecosystem={ecosystem!r}, strict=True)"
                         f".filter(products={ps_modules!r}).all()"
                     ),
                     "tool_output": repr(result),
@@ -155,11 +163,18 @@ def sync_flaw_affects_from_newcli(flaw_id: str) -> dict[str, Any]:
     ps_modules = AffectSettings().auto_create_ps_modules
     totals: dict[str, int] = {"created": 0, "skipped": 0, "skipped_existing": 0}
 
+    osv_data = flaw.upstream_data.filter(source=UpstreamData.Source.OSV).first()
+    component_ecosystems = osv_data.component_ecosystems if osv_data else {}
+
     for flaw_component in components:
-        results = _query_newtopia(flaw_component, ps_modules)
-        stats = _sync_affects_from_results(flaw, results, flaw_component, ps_modules)
-        for key in totals:
-            totals[key] += stats[key]
+        ecosystems = component_ecosystems.get(flaw_component, [""])
+        for ecosystem in ecosystems:
+            results = _query_newtopia(flaw_component, ps_modules, ecosystem=ecosystem)
+            stats = _sync_affects_from_results(
+                flaw, results, flaw_component, ps_modules, ecosystem=ecosystem
+            )
+            for key in totals:
+                totals[key] += stats[key]
 
     logger.info(
         "sync_flaw_affects_from_newcli flaw=%s components=%s %s",

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -7,13 +7,14 @@ the real network-calling library is never invoked.
 """
 
 from collections import defaultdict
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
 from packageurl import PackageURL
 
 from apps.ace.tasks import sync_flaw_affects_from_newcli
-from osidb.tests.factories import FlawFactory
+from osidb.tests.factories import FlawFactory, UpstreamDataFactory
 
 pytestmark = pytest.mark.unit
 
@@ -234,3 +235,113 @@ def test_sync_respects_ps_modules_setting(monkeypatch, ace_enabled, urllib3_resu
     sync_flaw_affects_from_newcli(str(flaw.uuid))
 
     assert seen_filter_products == [["hummingbird-1", "rhel-9"]]
+
+
+def test_sync_passes_ecosystem_to_newtopia(monkeypatch, ace_enabled):
+    """When UpstreamData exists for a flaw, the ecosystem derived from its PURLs
+    is forwarded to NewtopiaQuerier.search()."""
+    flaw = FlawFactory(components=["redis"])
+    UpstreamDataFactory(
+        flaw=flaw,
+        upstream_purls=[
+            {
+                "purl": "pkg:npm/redis",
+                "name": "redis",
+                "ecosystem": "npm",
+                "ranges": [],
+                "versions": [],
+            }
+        ],
+    )
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = []
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == "npm"
+
+
+def test_sync_no_ecosystem_when_no_upstream_data(monkeypatch, ace_enabled):
+    """Without UpstreamData the ecosystem falls back to an empty string."""
+    flaw = FlawFactory(components=["curl"])
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = []
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == ""
+
+
+def test_sync_queries_each_ecosystem_for_component(monkeypatch, ace_enabled):
+    """When a component maps to multiple ecosystems, lib-newtopia is queried
+    once per ecosystem and all results are accumulated."""
+    flaw = FlawFactory(components=["redis"])
+    UpstreamDataFactory(
+        flaw=flaw,
+        upstream_purls=[
+            {
+                "purl": "pkg:npm/redis",
+                "name": "redis",
+                "ecosystem": "npm",
+                "ranges": [],
+                "versions": [],
+            },
+            {
+                "purl": "pkg:pypi/redis",
+                "name": "redis",
+                "ecosystem": "PyPI",
+                "ranges": [],
+                "versions": [],
+            },
+        ],
+    )
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        eco = kwargs.get("ecosystem", "")
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = [
+            SimpleNamespace(
+                ps_update_stream="hummingbird-1",
+                purls=[
+                    f"pkg:oci/redis-{eco}?repository_url=registry.redhat.io/redis-{eco}"
+                ],
+                build_nvr=None,
+            )
+        ]
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 2
+    assert search_kwargs[0]["ecosystem"] == "npm"
+    assert search_kwargs[1]["ecosystem"] == "pypi"
+    assert stats["created"] == 2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
+### Added
+- Scope lib-newtopia queries by ecosystem derived from upstream PURLs (OSIDB-4966)
+
 ### Changed
 - Make HashiCorp Vault integration credential-based opt-in (OSIDB-5108)
 - Performance improvements for pghistory-related queries (OSIDB-4906)

--- a/osidb/models/flaw/upstream.py
+++ b/osidb/models/flaw/upstream.py
@@ -2,6 +2,7 @@ import uuid
 
 from django.contrib.postgres.indexes import GinIndex
 from django.db import models
+from packageurl import PackageURL
 
 from osidb.mixins import (
     ACLMixin,
@@ -13,6 +14,24 @@ from osidb.mixins import (
 from osidb.query_sets import CustomQuerySetUpdatedDt
 
 from .flaw import Flaw
+
+# OSV ecosystem string to normalized ecosystem identifier.
+_OSV_ECOSYSTEM_MAP: dict[str, str] = {
+    "maven": "maven",
+    "pypi": "pypi",
+    "npm": "npm",
+    "crates.io": "cargo",
+    "go": "golang",
+    "rubygems": "gem",
+    "nuget": "nuget",
+    "packagist": "generic",
+    "hex": "generic",
+    "pub": "generic",
+    "hackage": "generic",
+    "bioconductor": "generic",
+    "cran": "generic",
+    "github actions": "generic",
+}
 
 
 class UpstreamDataManager(ACLMixinManager, TrackingMixinManager):
@@ -74,6 +93,40 @@ class UpstreamData(AlertMixin, ACLMixin, TrackingMixin):
     source = models.CharField(choices=Source.choices, max_length=10, blank=True)
 
     objects = UpstreamDataManager.from_queryset(CustomQuerySetUpdatedDt)()
+
+    @property
+    def component_ecosystems(self) -> dict[str, list[str]]:
+        """
+        Create a mapping of component names to ecosystems derived from upstream PURLs.
+
+        PURL type strings are used directly when available, falling back to OSV ecosystem
+        string when PURL parsing fails. A component may appear in multiple ecosystems.
+        """
+        result: dict[str, list[str]] = {}
+        if not self.upstream_purls:
+            return result
+
+        for entry in self.upstream_purls:
+            name = entry.get("name", "")
+            if not name:
+                continue
+
+            ecosystem = ""
+            purl_str = entry.get("purl", "")
+            if purl_str:
+                try:
+                    ecosystem = PackageURL.from_string(purl_str).type
+                except ValueError:
+                    pass
+
+            if not ecosystem:
+                raw_eco = (entry.get("ecosystem") or "").lower()
+                ecosystem = _OSV_ECOSYSTEM_MAP.get(raw_eco, "")
+
+            if ecosystem and ecosystem not in result.get(name, []):
+                result.setdefault(name, []).append(ecosystem)
+
+        return result
 
     class Meta:
         constraints = [

--- a/osidb/models/tests/test_upstream.py
+++ b/osidb/models/tests/test_upstream.py
@@ -1,0 +1,110 @@
+import pytest
+
+from osidb.models.flaw.upstream import UpstreamData
+from osidb.tests.factories import FlawFactory
+
+pytestmark = pytest.mark.unit
+
+
+class TestComponentEcosystems:
+    def test_component_ecosystems_from_purl_type(self):
+        """PURL type strings are used as ecosystem identifiers."""
+        flaw = FlawFactory()
+        upstream = UpstreamData(
+            flaw=flaw,
+            source=UpstreamData.Source.OSV,
+            upstream_purls=[
+                {"purl": "pkg:npm/express", "name": "express", "ecosystem": "npm"},
+                {"purl": "pkg:pypi/requests", "name": "requests", "ecosystem": "PyPI"},
+                {
+                    "purl": "pkg:maven/org.apache/log4j",
+                    "name": "log4j",
+                    "ecosystem": "Maven",
+                },
+            ],
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+
+        result = upstream.component_ecosystems
+
+        assert result == {
+            "express": ["npm"],
+            "requests": ["pypi"],
+            "log4j": ["maven"],
+        }
+
+    def test_component_ecosystems_no_entries(self):
+        """Empty upstream_purls returns an empty dict."""
+        flaw = FlawFactory()
+        upstream = UpstreamData(
+            flaw=flaw,
+            source=UpstreamData.Source.OSV,
+            upstream_purls=[],
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+
+        result = upstream.component_ecosystems
+
+        assert result == {}
+
+    def test_component_ecosystems_malformed_purl_fallback(self):
+        """Malformed PURL falls back to _OSV_ECOSYSTEM_MAP lookup."""
+        flaw = FlawFactory()
+        upstream = UpstreamData(
+            flaw=flaw,
+            source=UpstreamData.Source.OSV,
+            upstream_purls=[
+                {
+                    "purl": "not-a-valid-purl",
+                    "name": "mygolib",
+                    "ecosystem": "Go",
+                },
+            ],
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+
+        result = upstream.component_ecosystems
+
+        assert result == {"mygolib": ["golang"]}
+
+    def test_component_ecosystems_unknown_ecosystem_skipped(self):
+        """Entry with unrecognized ecosystem and no valid PURL is skipped."""
+        flaw = FlawFactory()
+        upstream = UpstreamData(
+            flaw=flaw,
+            source=UpstreamData.Source.OSV,
+            upstream_purls=[
+                {
+                    "purl": "not-a-valid-purl",
+                    "name": "some-package",
+                    "ecosystem": "UnknownEcosystem",
+                },
+            ],
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+
+        result = upstream.component_ecosystems
+
+        assert result == {}
+
+    def test_component_ecosystems_multiple_ecosystems(self):
+        """When two entries share a component name, both ecosystems are collected."""
+        flaw = FlawFactory()
+        upstream = UpstreamData(
+            flaw=flaw,
+            source=UpstreamData.Source.OSV,
+            upstream_purls=[
+                {"purl": "pkg:npm/redis", "name": "redis", "ecosystem": "npm"},
+                {"purl": "pkg:pypi/redis", "name": "redis", "ecosystem": "PyPI"},
+            ],
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+
+        result = upstream.component_ecosystems
+
+        assert result == {"redis": ["npm", "pypi"]}


### PR DESCRIPTION
Add a property that computes the ecosystem from upstream PURLs. This property is used in the query to lib-newtopia to filter out results by ecosystem. For example, if redis is affected, it could be redis-py, npm, go, etc but not necessarily all of them.

Closes OSIDB-4966.