### PR TITLE
Make LDAP group names configurable via environment variables

### DIFF
--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -1,6 +1,7 @@
 import ssl
 
 import ldap
+from django.core.exceptions import ImproperlyConfigured
 from django_auth_ldap.config import GroupOfUniqueNamesType, LDAPSearch, LDAPSearchUnion
 
 from .settings import *
@@ -18,6 +19,8 @@ PUBLIC_READ_GROUPS = get_env(
     default='["osidb-prod-public-read", "red-hat-product-security"]',
     is_json=True,
 )
+if not PUBLIC_READ_GROUPS:
+    raise ImproperlyConfigured("OSIDB_PUBLIC_READ_GROUPS must be a non-empty list")
 PUBLIC_WRITE_GROUP = get_env("OSIDB_PUBLIC_WRITE_GROUP", default="osidb-prod-public-write")
 EMBARGO_READ_GROUP = get_env("OSIDB_EMBARGO_READ_GROUP", default="osidb-prod-embargo-read")
 EMBARGO_WRITE_GROUP = get_env("OSIDB_EMBARGO_WRITE_GROUP", default="osidb-prod-embargo-write")

--- a/config/settings_prod.py
+++ b/config/settings_prod.py
@@ -13,22 +13,16 @@ SECRET_KEY = get_env("DJANGO_SECRET_KEY")
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# Minimal group for read access of public flaws in OSIDB
-# TODO: In the future we might simply use a proxy group in which
-# membership is based off of one or more LDAP groups
-# e.g. (|(memberOf=group-a)(memberOf=group-b))
-PUBLIC_READ_GROUPS = ["osidb-prod-public-read", "red-hat-product-security"]
-# Minimal group for write access of public flaws in OSIDB
-PUBLIC_WRITE_GROUP = "osidb-prod-public-write"
-# Minimal group for read access of embargoed flaws in OSIDB
-EMBARGO_READ_GROUP = "osidb-prod-embargo-read"
-# Minimal group for write access of embargoed flaws in OSIDB
-EMBARGO_WRITE_GROUP = "osidb-prod-embargo-write"
-# Minimal group for read access of internal flaws in OSIDB
-INTERNAL_READ_GROUP = "osidb-prod-internal-read"
-# Minimal group for write access of internal flaws in OSIDB
-INTERNAL_WRITE_GROUP = "osidb-prod-internal-write"
-# Contains all non-admin groups
+PUBLIC_READ_GROUPS = get_env(
+    "OSIDB_PUBLIC_READ_GROUPS",
+    default='["osidb-prod-public-read", "red-hat-product-security"]',
+    is_json=True,
+)
+PUBLIC_WRITE_GROUP = get_env("OSIDB_PUBLIC_WRITE_GROUP", default="osidb-prod-public-write")
+EMBARGO_READ_GROUP = get_env("OSIDB_EMBARGO_READ_GROUP", default="osidb-prod-embargo-read")
+EMBARGO_WRITE_GROUP = get_env("OSIDB_EMBARGO_WRITE_GROUP", default="osidb-prod-embargo-write")
+INTERNAL_READ_GROUP = get_env("OSIDB_INTERNAL_READ_GROUP", default="osidb-prod-internal-read")
+INTERNAL_WRITE_GROUP = get_env("OSIDB_INTERNAL_WRITE_GROUP", default="osidb-prod-internal-write")
 ALL_GROUPS = [
     *PUBLIC_READ_GROUPS,
     PUBLIC_WRITE_GROUP,
@@ -37,8 +31,7 @@ ALL_GROUPS = [
     INTERNAL_READ_GROUP,
     INTERNAL_WRITE_GROUP,
 ]
-# Minimal group for managing the OSIDB service
-SERVICE_MANAGE_GROUP = "osidb-prod-manage"
+SERVICE_MANAGE_GROUP = get_env("OSIDB_SERVICE_MANAGE_GROUP", default="osidb-prod-manage")
 
 ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
 

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -13,22 +13,16 @@ SECRET_KEY = get_env("DJANGO_SECRET_KEY")
 USE_X_FORWARDED_HOST = True
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
-# Minimal group for read access of public flaws in OSIDB
-# TODO: In the future we might simply use a proxy group in which
-# membership is based off of one or more LDAP groups
-# e.g. (|(memberOf=group-a)(memberOf=group-b))
-PUBLIC_READ_GROUPS = ["osidb-stage-public-read", "red-hat-product-security"]
-# Minimal group for write access of public flaws in OSIDB
-PUBLIC_WRITE_GROUP = "osidb-stage-public-write"
-# Minimal group for read access of embargoed flaws in OSIDB
-EMBARGO_READ_GROUP = "osidb-stage-embargo-read"
-# Minimal group for write access of embargoed flaws in OSIDB
-EMBARGO_WRITE_GROUP = "osidb-stage-embargo-write"
-# Minimal group for read access of internal flaws in OSIDB
-INTERNAL_READ_GROUP = "osidb-stage-internal-read"
-# Minimal group for write access of internal flaws in OSIDB
-INTERNAL_WRITE_GROUP = "osidb-stage-internal-write"
-# Contains all non-admin groups
+PUBLIC_READ_GROUPS = get_env(
+    "OSIDB_PUBLIC_READ_GROUPS",
+    default='["osidb-stage-public-read", "red-hat-product-security"]',
+    is_json=True,
+)
+PUBLIC_WRITE_GROUP = get_env("OSIDB_PUBLIC_WRITE_GROUP", default="osidb-stage-public-write")
+EMBARGO_READ_GROUP = get_env("OSIDB_EMBARGO_READ_GROUP", default="osidb-stage-embargo-read")
+EMBARGO_WRITE_GROUP = get_env("OSIDB_EMBARGO_WRITE_GROUP", default="osidb-stage-embargo-write")
+INTERNAL_READ_GROUP = get_env("OSIDB_INTERNAL_READ_GROUP", default="osidb-stage-internal-read")
+INTERNAL_WRITE_GROUP = get_env("OSIDB_INTERNAL_WRITE_GROUP", default="osidb-stage-internal-write")
 ALL_GROUPS = [
     *PUBLIC_READ_GROUPS,
     PUBLIC_WRITE_GROUP,
@@ -37,8 +31,7 @@ ALL_GROUPS = [
     INTERNAL_READ_GROUP,
     INTERNAL_WRITE_GROUP,
 ]
-# Minimal group for managing the OSIDB service
-SERVICE_MANAGE_GROUP = "osidb-stage-manage"
+SERVICE_MANAGE_GROUP = get_env("OSIDB_SERVICE_MANAGE_GROUP", default="osidb-stage-manage")
 
 ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_DEMAND)
 

--- a/config/settings_stage.py
+++ b/config/settings_stage.py
@@ -1,6 +1,7 @@
 import ssl
 
 import ldap
+from django.core.exceptions import ImproperlyConfigured
 from django_auth_ldap.config import GroupOfUniqueNamesType, LDAPSearch, LDAPSearchUnion
 
 from .settings import *
@@ -18,6 +19,8 @@ PUBLIC_READ_GROUPS = get_env(
     default='["osidb-stage-public-read", "red-hat-product-security"]',
     is_json=True,
 )
+if not PUBLIC_READ_GROUPS:
+    raise ImproperlyConfigured("OSIDB_PUBLIC_READ_GROUPS must be a non-empty list")
 PUBLIC_WRITE_GROUP = get_env("OSIDB_PUBLIC_WRITE_GROUP", default="osidb-stage-public-write")
 EMBARGO_READ_GROUP = get_env("OSIDB_EMBARGO_READ_GROUP", default="osidb-stage-embargo-read")
 EMBARGO_WRITE_GROUP = get_env("OSIDB_EMBARGO_WRITE_GROUP", default="osidb-stage-embargo-write")


### PR DESCRIPTION
## Summary
- Replace hardcoded LDAP group names in `settings_stage.py` and `settings_prod.py` with `get_env()` calls
- Allows deployments to customize group names via environment variables without code changes
- Defaults preserve the existing behavior — no change for current deployments

## New environment variables
| Variable | Default (stage) | Default (prod) |
|---|---|---|
| `OSIDB_PUBLIC_READ_GROUPS` | `["osidb-stage-public-read", "red-hat-product-security"]` | `["osidb-prod-public-read", "red-hat-product-security"]` |
| `OSIDB_PUBLIC_WRITE_GROUP` | `osidb-stage-public-write` | `osidb-prod-public-write` |
| `OSIDB_EMBARGO_READ_GROUP` | `osidb-stage-embargo-read` | `osidb-prod-embargo-read` |
| `OSIDB_EMBARGO_WRITE_GROUP` | `osidb-stage-embargo-write` | `osidb-prod-embargo-write` |
| `OSIDB_INTERNAL_READ_GROUP` | `osidb-stage-internal-read` | `osidb-prod-internal-read` |
| `OSIDB_INTERNAL_WRITE_GROUP` | `osidb-stage-internal-write` | `osidb-prod-internal-write` |
| `OSIDB_SERVICE_MANAGE_GROUP` | `osidb-stage-manage` | `osidb-prod-manage` |

## Motivation
Downstream deployments that use different Rover/LDAP group naming conventions (e.g. prefixed with their project name) currently cannot override the group names without forking the settings files.

## Test plan
- [ ] Verify default behavior is unchanged (no env vars set → uses existing group names)
- [ ] Verify setting env vars overrides the group names
- [ ] Existing tests pass — test suite uses `settings_ci.py` which is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)