### PR TITLE
OSIDB-3637: Fix audit endpoint schema

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrap external errors with affect context for bulk PUT endpoint (OSIDB-5038)
 - Wrapped bulk ACL updates in a transaction to prevent them from auto-committing outside the request transaction (OSIDB-4992)
 - Fixed double error raise problem in sync_manager.
+- Fix incorrect OpenAPI schema types for audit endpoint fields (pgh_data, pgh_context, pgh_diff) (OSIDB-3637)
 
 ### Removed
 - deprecate workflow manipulation endpoints

--- a/openapi.yml
+++ b/openapi.yml
@@ -15056,16 +15056,21 @@ components:
           type: string
           description: The event label.
         pgh_context:
-          oneOf:
-          - {}
-          - type: 'null'
+          type:
+          - object
+          - 'null'
+          additionalProperties: {}
           description: The context associated with the event.
         pgh_diff:
+          type: object
+          additionalProperties: {}
           description: The diff between the previous event of the same label.
         pgh_data:
-          type: string
+          type: object
+          additionalProperties: {}
           readOnly: true
       required:
+      - pgh_context
       - pgh_created_at
       - pgh_data
       - pgh_diff

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -626,7 +626,20 @@ class AlertMixinSerializer(serializers.ModelSerializer):
 
 class AuditSerializer(serializers.ModelSerializer):
     pgh_data = serializers.SerializerMethodField()
+    pgh_context = serializers.DictField(
+        allow_null=True,
+        help_text="The context associated with the event.",
+    )
+    pgh_diff = serializers.DictField(
+        help_text="The diff between the previous event of the same label.",
+    )
 
+    @extend_schema_field(
+        {
+            "type": "object",
+            "additionalProperties": {},
+        }
+    )
     def get_pgh_data(self, obj):
         # remove acls from entity snapshot
         data = obj.pgh_data


### PR DESCRIPTION
- Fixes OSIDB API schema for the GET **/osidb/api/v1/audit** endpoint.
- **pgh_data, pgh_context, pgh_diff** now appear as objects instead of defaulting to string.

Closes: OSIDB-3637