### PR TITLE
OSIDB-5068: trigger srp milestone creation on reportability change

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -328,6 +328,9 @@ CRA_NOTIFICATIONS_ENABLED = get_env(
     "CRA_NOTIFICATIONS_ENABLED", default="False", is_bool=True
 )
 
+# opt-in-flag for CRA upstream reporting
+CRA_REPORTING_ENABLED = get_env("CRA_REPORTING_ENABLED", default="False", is_bool=True)
+
 # sets the Access-Control-Allow-Origin response header - accepts regex
 # example value: [ r"^https://([^.]*\.)?\.example\.com$" ]
 CORS_ALLOWED_ORIGIN_REGEXES = get_env(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new Models SRPReport and SRPReportMilestone (OSIDB-5066)
 - Add `upstream maintainer` notification models (OSIDB-5076)
 - Add create SRP report when Flaw is EXPLOITS_KEV_APPROVED or MAJOR_INCIDENT (OSIDB-5067)
+- Add SRP report milestone creation (OSIDB-5068)
 - Automatic creation of upstream maintainer notification when criteria is met for flaw (OSIDB-5077)
 - Add serializers for upstream maintainer notification (OSIDB-5081)
 - Add signal to trigger upstream maintainer notification creation on FlawUpstreamMapping save (OSIDB-5078)

--- a/regulatory_reporting/apps.py
+++ b/regulatory_reporting/apps.py
@@ -12,10 +12,14 @@ class RegulatoryReportingConfig(AppConfig):
 
             from osidb.models import Flaw
 
+            from .models.upstream import FlawUpstreamMapping
+            from .signals import link_mapping_to_notification
+
         if settings.CRA_NOTIFICATIONS_ENABLED:
             from .signals import check_upstream_notifiable
 
             post_save.connect(check_upstream_notifiable, sender=Flaw)
+            post_save.connect(link_mapping_to_notification, sender=FlawUpstreamMapping)
 
         if settings.CRA_REPORTING_ENABLED:
             from .signals import create_srp_report

--- a/regulatory_reporting/apps.py
+++ b/regulatory_reporting/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 
 
 class RegulatoryReportingConfig(AppConfig):
@@ -6,4 +7,17 @@ class RegulatoryReportingConfig(AppConfig):
     name = "regulatory_reporting"
 
     def ready(self):
-        from . import signals  # noqa: F401
+        if settings.CRA_NOTIFICATIONS_ENABLED or settings.CRA_REPORTING_ENABLED:
+            from django.db.models.signals import post_save
+
+            from osidb.models import Flaw
+
+        if settings.CRA_NOTIFICATIONS_ENABLED:
+            from .signals import check_upstream_notifiable
+
+            post_save.connect(check_upstream_notifiable, sender=Flaw)
+
+        if settings.CRA_REPORTING_ENABLED:
+            from .signals import create_srp_report
+
+            post_save.connect(create_srp_report, sender=Flaw)

--- a/regulatory_reporting/models/srp_report_milestone.py
+++ b/regulatory_reporting/models/srp_report_milestone.py
@@ -59,7 +59,7 @@ class SRPReportMilestone(SRPReportBase):
     MILESTONE_DURATION_BY_TYPE = {
         MilestoneType.LEVEL_24H: timedelta(hours=24),
         MilestoneType.LEVEL_72H: timedelta(hours=72),
-        MilestoneType.LEVEL_FINAL: timedelta(days=14),
+        MilestoneType.LEVEL_FINAL: None,  # Duration is calculated based on the reportable event type
         MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE: timedelta(days=30),
     }
 
@@ -129,19 +129,62 @@ class SRPReportMilestone(SRPReportBase):
 
     @property
     def due_at(self):
+        """
+        Calculate milestone due date.
+
+        For LEVEL_FINAL: duration depends on event type:
+        - KEV (actively_exploited_vulnerability): 14 days
+        - Severe Incident (severe_incident): 30 days
+        - Additional Information Request (additional_information_request): 30 days from the request received
+        """
+        if (
+            self.milestone_type
+            == self.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE
+        ):
+            if not self.request_received_at:
+                return None
+            return self.request_received_at + timedelta(days=30)
+
         if not self.srp_report.timer_started_at:
             return None
 
-        return (
-            self.srp_report.timer_started_at
-            + self.MILESTONE_DURATION_BY_TYPE[self.milestone_type]
-        )
+        if self.milestone_type == self.MilestoneType.LEVEL_FINAL:
+            # Check parent report's event type
+            if (
+                self.srp_report.reportable_event_type
+                == SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY
+            ):
+                duration = timedelta(days=14)
+            elif (
+                self.srp_report.reportable_event_type
+                == SRPReport.ReportableEventType.SEVERE_INCIDENT
+            ):
+                duration = timedelta(days=30)
+            else:
+                raise ValidationError("Invalid reportable event type")
+        else:
+            # Use static duration for 24h, 72h, etc.
+            duration = self.MILESTONE_DURATION_BY_TYPE[self.milestone_type]
+
+        return self.srp_report.timer_started_at + duration
 
     def __str__(self):
         return f"{self.milestone_type} - {self.srp_report.flaw.cve_id or self.srp_report.flaw.uuid}"
 
     @validator
     def _validate_due_at_required(self, **kwargs):
-        """Due date must be set for all milestones"""
+        """
+        Due date must be set for all milestones.
+
+        Exception: LEVEL_ADDITIONAL_INFORMATION_RESPONSE milestones can have
+        None due_at if request_received_at is not yet set.
+        """
         if not self.due_at:
+            # Allow None for additional info milestones without request time
+            if (
+                self.milestone_type
+                == self.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE
+                and not self.request_received_at
+            ):
+                return  # Valid state - waiting for request
             raise ValidationError("due_at must be set for all milestones")

--- a/regulatory_reporting/models/srp_report_milestone.py
+++ b/regulatory_reporting/models/srp_report_milestone.py
@@ -161,7 +161,7 @@ class SRPReportMilestone(SRPReportBase):
             ):
                 duration = timedelta(days=30)
             else:
-                raise ValidationError("Invalid reportable event type")
+                return None
         else:
             # Use static duration for 24h, 72h, etc.
             duration = self.MILESTONE_DURATION_BY_TYPE[self.milestone_type]
@@ -179,6 +179,16 @@ class SRPReportMilestone(SRPReportBase):
         Exception: LEVEL_ADDITIONAL_INFORMATION_RESPONSE milestones can have
         None due_at if request_received_at is not yet set.
         """
+        if (
+            self.milestone_type == self.MilestoneType.LEVEL_FINAL
+            and self.srp_report.reportable_event_type
+            not in {
+                SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY,
+                SRPReport.ReportableEventType.SEVERE_INCIDENT,
+            }
+        ):
+            raise ValidationError("Invalid reportable event type")
+
         if not self.due_at:
             # Allow None for additional info milestones without request time
             if (

--- a/regulatory_reporting/signals.py
+++ b/regulatory_reporting/signals.py
@@ -71,7 +71,6 @@ def update_srp_report_milestones(srp_report: SRPReport):
         )
 
 
-@receiver(post_save, sender=Flaw)
 def create_srp_report(sender, instance: Flaw, created: bool, **kwargs):
     """
     Auto-create SRP Report and milestones when Flaw is marked as KEV or Major Incident approved.
@@ -119,13 +118,10 @@ def create_srp_report(sender, instance: Flaw, created: bool, **kwargs):
         )
 
 
-@receiver(post_save, sender=Flaw)
 def check_upstream_notifiable(sender, instance, **kwargs):
     """
     On Flaw save, check criteria for upstream maintainer notification.
     """
-    if not settings.CRA_NOTIFICATIONS_ENABLED:
-        return
     if not is_flaw_upstream_notifiable(instance):
         return
 

--- a/regulatory_reporting/signals.py
+++ b/regulatory_reporting/signals.py
@@ -24,6 +24,15 @@ REPORTABLE_EVENT_TYPE_MAP = {
 
 
 def create_srp_report_milestones(srp_report: SRPReport):
+    """
+    Create the required SRP milestones (24h, 72h, final) for a new SRP Report.
+
+    Does NOT create additional_information_response milestones - those are
+    created on-demand when requests are received.
+
+    Args:
+        srp_report: The SRP Report to create milestones for
+    """
     milestone_types = [
         SRPReportMilestone.MilestoneType.LEVEL_24H,
         SRPReportMilestone.MilestoneType.LEVEL_72H,
@@ -31,25 +40,62 @@ def create_srp_report_milestones(srp_report: SRPReport):
     ]
 
     for milestone_type in milestone_types:
-        SRPReportMilestone.objects.create(
+        milestone = SRPReportMilestone.objects.create(
             srp_report=srp_report,
             milestone_type=milestone_type,
             status=SRPReport.SRPReportStatus.REQUIRED,
             acl_read=srp_report.acl_read,
             acl_write=srp_report.acl_write,
         )
+        logger.info(
+            f"Created {milestone_type} milestone for SRP Report {srp_report.uuid} "
+            f"for Flaw {srp_report.flaw.uuid}, created at {milestone.created_dt}, due at {milestone.due_at}"
+        )
+
+
+def update_srp_report_milestones(srp_report: SRPReport):
+    """
+    Update the milestones for an existing SRP Report.
+
+    Args:
+        srp_report: The SRP Report to update milestones for
+    """
+    all_milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+    for milestone in all_milestones:
+        milestone.acl_read = srp_report.acl_read
+        milestone.acl_write = srp_report.acl_write
+        milestone.save()
+        logger.info(
+            f"Updated {milestone.milestone_type} milestone for SRP Report {srp_report.uuid} "
+            f"for Flaw {srp_report.flaw.uuid}, created at {milestone.created_dt}, due at {milestone.due_at}"
+        )
 
 
 @receiver(post_save, sender=Flaw)
 def create_srp_report(sender, instance: Flaw, created: bool, **kwargs):
+    """
+    Auto-create SRP Report and milestones when Flaw is marked as KEV or Major Incident approved.
+
+    Triggers on:
+    - EXPLOITS_KEV_APPROVED → Creates ACTIVELY_EXPLOITED_VULNERABILITY report
+    - MAJOR_INCIDENT_APPROVED → Creates SEVERE_INCIDENT report
+
+    Uses Flaw.major_incident_start_dt as the SLA timer start.
+    """
+    # Skip during fixture loading or migrations
+    if kwargs.get("raw"):
+        return
+
     if instance.major_incident_state not in INCIDENT_STATES_THAT_REQUIRE_SRP_REPORT:
         return
 
-    srp_report, created = SRPReport.objects.get_or_create(
+    event_type = REPORTABLE_EVENT_TYPE_MAP[instance.major_incident_state]
+
+    srp_report, report_created = SRPReport.objects.get_or_create(
         flaw=instance,
-        reportable_event_type=REPORTABLE_EVENT_TYPE_MAP[instance.major_incident_state],
+        reportable_event_type=event_type,
         defaults={
-            "title": instance.title,
+            "title": instance.title or f"SRP Report for {instance.uuid}",
             "status": SRPReport.SRPReportStatus.REQUIRED,
             "responsibility_scope": SRPReport.ResponsibilityScope.MANUFACTURER,
             "timer_started_at": instance.major_incident_start_dt,
@@ -58,16 +104,19 @@ def create_srp_report(sender, instance: Flaw, created: bool, **kwargs):
         },
     )
 
-    if not created:
-        srp_report.title = instance.title
+    if not report_created:
+        srp_report.title = instance.title or f"SRP Report for {instance.uuid}"
         srp_report.acl_read = instance.acl_read
         srp_report.acl_write = instance.acl_write
         srp_report.timer_started_at = instance.major_incident_start_dt
         srp_report.save()
-        logger.info(f"Updated SRP Report {srp_report.uuid} for {instance.uuid}")
+        update_srp_report_milestones(srp_report)
+        logger.info(f"Updated SRP Report {srp_report.uuid} for Flaw {instance.uuid} ")
     else:
         create_srp_report_milestones(srp_report)
-        logger.info(f"Created SRP Report {srp_report.uuid} for {instance.uuid}")
+        logger.info(
+            f"Created SRP Report {srp_report.uuid} for Flaw {instance.uuid}, event type {event_type}"
+        )
 
 
 @receiver(post_save, sender=Flaw)

--- a/regulatory_reporting/signals.py
+++ b/regulatory_reporting/signals.py
@@ -1,9 +1,5 @@
 import logging
 
-from django.conf import settings
-from django.db.models.signals import post_save
-from django.dispatch import receiver
-
 from osidb.models import Flaw
 from regulatory_reporting.models import SRPReport, SRPReportMilestone
 
@@ -73,6 +69,7 @@ def update_srp_report_milestones(srp_report: SRPReport):
 
 def create_srp_report(sender, instance: Flaw, created: bool, **kwargs):
     """
+    SIGNAL attached to Flaw model in apps.py when Flaw is saved.
     Auto-create SRP Report and milestones when Flaw is marked as KEV or Major Incident approved.
 
     Triggers on:

--- a/regulatory_reporting/signals.py
+++ b/regulatory_reporting/signals.py
@@ -3,7 +3,7 @@ import logging
 from osidb.models import Flaw
 from regulatory_reporting.models import SRPReport, SRPReportMilestone
 
-from .models.upstream import FlawUpstreamMapping, UpstreamNotification
+from .models.upstream import UpstreamNotification
 from .services import is_flaw_upstream_notifiable
 
 logger = logging.getLogger(__name__)
@@ -136,13 +136,10 @@ def check_upstream_notifiable(sender, instance, **kwargs):
         )
 
 
-@receiver(post_save, sender=FlawUpstreamMapping)
 def link_mapping_to_notification(sender, instance, created, **kwargs):
     """
     On FlawUpstreamMapping creation, backfill the existing project
     """
-    if not settings.CRA_NOTIFICATIONS_ENABLED:
-        return
     if not created:
         return
 

--- a/regulatory_reporting/tests/conftest.py
+++ b/regulatory_reporting/tests/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def enable_db_access_for_all_tests(db):
+    pass

--- a/regulatory_reporting/tests/conftest.py
+++ b/regulatory_reporting/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 def enable_db_access_for_all_tests(db):
     pass
 
+
 def pytest_configure(config):
     config.addinivalue_line(
         "markers", "cra_reporting: connect CRA reporting signal for this test."
@@ -51,8 +52,14 @@ def cra_notification_signals(request, settings):
     from django.db.models.signals import post_save
 
     from osidb.models import Flaw
-    from regulatory_reporting.signals import check_upstream_notifiable
+    from regulatory_reporting.models.upstream import FlawUpstreamMapping
+    from regulatory_reporting.signals import (
+        check_upstream_notifiable,
+        link_mapping_to_notification,
+    )
 
     post_save.connect(check_upstream_notifiable, sender=Flaw)
+    post_save.connect(link_mapping_to_notification, sender=FlawUpstreamMapping)
     yield
     post_save.disconnect(check_upstream_notifiable, sender=Flaw)
+    post_save.disconnect(link_mapping_to_notification, sender=FlawUpstreamMapping)

--- a/regulatory_reporting/tests/conftest.py
+++ b/regulatory_reporting/tests/conftest.py
@@ -4,3 +4,55 @@ import pytest
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):
     pass
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "cra_reporting: connect CRA reporting signal for this test."
+    )
+    config.addinivalue_line(
+        "markers",
+        "no_cra_reporting: do not connect CRA reporting signal for this test.",
+    )
+    config.addinivalue_line(
+        "markers", "cra_notifications: connect CRA notification signal for this test."
+    )
+    config.addinivalue_line(
+        "markers",
+        "no_cra_notifications: do not connect CRA notification signal for this test.",
+    )
+
+
+@pytest.fixture(autouse=True)
+def cra_reporting_signals(request, settings):
+    if request.node.get_closest_marker("no_cra_reporting"):
+        settings.CRA_REPORTING_ENABLED = False
+        yield
+        return
+
+    settings.CRA_REPORTING_ENABLED = True
+    from django.db.models.signals import post_save
+
+    from osidb.models import Flaw
+    from regulatory_reporting.signals import create_srp_report
+
+    post_save.connect(create_srp_report, sender=Flaw)
+    yield
+    post_save.disconnect(create_srp_report, sender=Flaw)
+
+
+@pytest.fixture(autouse=True)
+def cra_notification_signals(request, settings):
+    if request.node.get_closest_marker("no_cra_notifications"):
+        settings.CRA_NOTIFICATIONS_ENABLED = False
+        yield
+        return
+
+    settings.CRA_NOTIFICATIONS_ENABLED = True
+    from django.db.models.signals import post_save
+
+    from osidb.models import Flaw
+    from regulatory_reporting.signals import check_upstream_notifiable
+
+    post_save.connect(check_upstream_notifiable, sender=Flaw)
+    yield
+    post_save.disconnect(check_upstream_notifiable, sender=Flaw)

--- a/regulatory_reporting/tests/test_milestone_creation.py
+++ b/regulatory_reporting/tests/test_milestone_creation.py
@@ -225,28 +225,48 @@ class TestSRPMilestoneAutoCreation:
             )
 
     @pytest.mark.enable_signals
-    def test_milestones_not_duplicated_on_flaw_resave(self):
+    def test_milestones_refreshed_in_place_on_flaw_resave(
+        self,
+        internal_read_groups,
+        internal_write_groups,
+        public_read_groups,
+        public_write_groups,
+    ):
         """
-        If a flaw is saved again without state changes, milestones should not be duplicated.
+        Re-saving a flaw with the same major-incident state should refresh existing
+        milestones in place rather than creating duplicates.
         """
 
         start_time = timezone.now()
         flaw = FlawFactory(
             major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
             major_incident_start_dt=start_time,
+            embargoed=False,
+            acl_read=internal_read_groups,
+            acl_write=internal_write_groups,
         )
 
-        # Verify initial milestones created
         srp_report = SRPReport.objects.get(flaw=flaw)
-        initial_count = SRPReportMilestone.objects.filter(srp_report=srp_report).count()
-        assert initial_count == 3
+        initial_uuids = set(
+            SRPReportMilestone.objects.filter(srp_report=srp_report).values_list(
+                "uuid", flat=True
+            )
+        )
+        assert len(initial_uuids) == 3
 
-        # Act - save flaw again without changes
+        flaw.acl_read = public_read_groups
+        flaw.acl_write = public_write_groups
         flaw.save()
 
-        # Assert no duplicates
-        final_count = SRPReportMilestone.objects.filter(srp_report=srp_report).count()
-        assert final_count == 3, "Should not create duplicate milestones on flaw resave"
+        refreshed = SRPReportMilestone.objects.filter(srp_report=srp_report)
+        assert refreshed.count() == 3
+        assert set(refreshed.values_list("uuid", flat=True)) == initial_uuids, (
+            "Should update existing milestones in place, not create duplicates"
+        )
+
+        for milestone in refreshed:
+            assert milestone.acl_read == public_read_groups
+            assert milestone.acl_write == public_write_groups
 
     @pytest.mark.enable_signals
     def test_additional_information_response_not_auto_created(self):

--- a/regulatory_reporting/tests/test_milestone_creation.py
+++ b/regulatory_reporting/tests/test_milestone_creation.py
@@ -1,0 +1,575 @@
+"""
+Tests for automatic SRP Milestone creation when SRP Report is created.
+
+These tests verify that when an SRP Report is created (via OSIDB-5067),
+the appropriate milestones (24h, 72h, final) are automatically created
+with correct due dates based on the event type.
+
+OSIDB-5068: Trigger SRP Milestone Creation on Reportability Change
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils import timezone
+
+from osidb.models import Flaw
+from osidb.tests.factories import FlawFactory
+from regulatory_reporting.models import SRPReport, SRPReportMilestone
+from regulatory_reporting.models.abstracts import SRPReportBase
+
+pytestmark = pytest.mark.unit
+
+
+class TestSRPMilestoneAutoCreation:
+    """Test automatic SRP Milestone creation when SRP Report is created"""
+
+    @pytest.mark.enable_signals
+    def test_milestones_created_for_kev_report(self):
+        """
+        When SRP Report is created for KEV, create 24h, 72h, and final milestones
+        with correct due dates (14 days for final).
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            cve_id="CVE-2024-1234",
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        assert (
+            srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY
+        )
+
+        # Exactly 3 milestones created
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+        assert milestones.count() == 3, (
+            "Should create exactly 3 milestones (24h, 72h, final)"
+        )
+
+        # All expected milestone types present
+        milestone_types = {m.milestone_type for m in milestones}
+        assert SRPReportMilestone.MilestoneType.LEVEL_24H in milestone_types
+        assert SRPReportMilestone.MilestoneType.LEVEL_72H in milestone_types
+        assert SRPReportMilestone.MilestoneType.LEVEL_FINAL in milestone_types
+
+        # Additional information response NOT created
+        assert (
+            SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE
+            not in milestone_types
+        )
+
+    @pytest.mark.enable_signals
+    def test_milestones_created_for_severe_incident_report(self):
+        """
+        When SRP Report is created for Severe Incident, create 24h, 72h, and final milestones.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            cve_id="CVE-2024-5678",
+            major_incident_state=Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Assert - SRP Report was created
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        assert (
+            srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.SEVERE_INCIDENT
+        )
+
+        # Assert - Exactly 3 milestones created
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+        assert milestones.count() == 3, "Should create exactly 3 milestones"
+
+        # Assert - Correct milestone types
+        milestone_types = {m.milestone_type for m in milestones}
+        assert SRPReportMilestone.MilestoneType.LEVEL_24H in milestone_types
+        assert SRPReportMilestone.MilestoneType.LEVEL_72H in milestone_types
+        assert SRPReportMilestone.MilestoneType.LEVEL_FINAL in milestone_types
+
+    @pytest.mark.enable_signals
+    def test_milestone_due_dates_for_kev(self):
+        """
+        Verify correct due dates for KEV milestones:
+        - 24h milestone: start_time + 24 hours
+        - 72h milestone: start_time + 72 hours
+        - Final milestone: start_time + 14 days
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Assert
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+
+        # Check 24h milestone
+        milestone_24h = milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_24H
+        )
+        expected_24h = start_time + timedelta(hours=24)
+        assert milestone_24h.due_at == expected_24h, (
+            "24h milestone should be due 24 hours after start"
+        )
+
+        # Check 72h milestone
+        milestone_72h = milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_72H
+        )
+        expected_72h = start_time + timedelta(hours=72)
+        assert milestone_72h.due_at == expected_72h, (
+            "72h milestone should be due 72 hours after start"
+        )
+
+        # Check final milestone - 14 days for KEV
+        milestone_final = milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_FINAL
+        )
+        expected_final = start_time + timedelta(days=14)
+        assert milestone_final.due_at == expected_final, (
+            "Final milestone for KEV should be due 14 days after start"
+        )
+
+    @pytest.mark.enable_signals
+    def test_milestone_due_dates_for_severe_incident(self):
+        """
+        Verify correct due dates for Severe Incident milestones:
+        - 24h milestone: start_time + 24 hours
+        - 72h milestone: start_time + 72 hours
+        - Final milestone: start_time + 30 days (1 month)
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Assert
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+
+        # Check 24h milestone
+        milestone_24h = milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_24H
+        )
+        expected_24h = start_time + timedelta(hours=24)
+        assert milestone_24h.due_at == expected_24h
+
+        # Check 72h milestone
+        milestone_72h = milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_72H
+        )
+        expected_72h = start_time + timedelta(hours=72)
+        assert milestone_72h.due_at == expected_72h
+
+        # Check final milestone - 30 days for Severe Incident
+        milestone_final = milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_FINAL
+        )
+        expected_final = start_time + timedelta(days=30)
+        assert milestone_final.due_at == expected_final, (
+            "Final milestone for Severe Incident should be due 30 days after start"
+        )
+
+    @pytest.mark.enable_signals
+    def test_milestones_inherit_acl_from_srp_report(self):
+        """
+        All milestones should inherit ACL permissions from their parent SRP Report.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Assert
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+
+        for milestone in milestones:
+            assert milestone.acl_read == srp_report.acl_read, (
+                f"{milestone.milestone_type} should inherit acl_read"
+            )
+            assert milestone.acl_write == srp_report.acl_write, (
+                f"{milestone.milestone_type} should inherit acl_write"
+            )
+
+    @pytest.mark.enable_signals
+    def test_milestone_status_defaults_to_required(self):
+        """
+        All auto-created milestones should have status = REQUIRED by default.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+
+        for milestone in milestones:
+            assert milestone.status == SRPReportBase.SRPReportStatus.REQUIRED, (
+                f"{milestone.milestone_type} should have REQUIRED status"
+            )
+
+    @pytest.mark.enable_signals
+    def test_milestones_not_duplicated_on_flaw_resave(self):
+        """
+        If a flaw is saved again without state changes, milestones should not be duplicated.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Verify initial milestones created
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        initial_count = SRPReportMilestone.objects.filter(srp_report=srp_report).count()
+        assert initial_count == 3
+
+        # Act - save flaw again without changes
+        flaw.save()
+
+        # Assert no duplicates
+        final_count = SRPReportMilestone.objects.filter(srp_report=srp_report).count()
+        assert final_count == 3, "Should not create duplicate milestones on flaw resave"
+
+    @pytest.mark.enable_signals
+    def test_additional_information_response_not_auto_created(self):
+        """
+        LEVEL_ADDITIONAL_INFORMATION_RESPONSE should NOT be created automatically.
+        It's only created on-demand when authorities send follow-up requests.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        srp_report = SRPReport.objects.get(flaw=flaw)
+
+        # Should have no additional_information_response milestones
+        additional_info_milestones = SRPReportMilestone.objects.filter(
+            srp_report=srp_report,
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE,
+        )
+        assert additional_info_milestones.count() == 0, (
+            "Additional information response milestones should NOT be auto-created"
+        )
+
+    @pytest.mark.enable_signals
+    def test_milestones_created_for_both_event_types_on_state_transition(self):
+        """
+        If a flaw transitions from MAJOR_INCIDENT_APPROVED to EXPLOITS_KEV_APPROVED,
+        both SRP Reports should get their own sets of milestones.
+        """
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Verify first report and milestones created
+        severe_report = SRPReport.objects.get(
+            flaw=flaw,
+            reportable_event_type=SRPReport.ReportableEventType.SEVERE_INCIDENT,
+        )
+        severe_milestones = SRPReportMilestone.objects.filter(srp_report=severe_report)
+        assert severe_milestones.count() == 3
+
+        # Act - transition to KEV approved
+        flaw.major_incident_state = Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED
+        flaw.save()
+
+        # KEV report created with its own milestones
+        kev_report = SRPReport.objects.get(
+            flaw=flaw,
+            reportable_event_type=SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY,
+        )
+        kev_milestones = SRPReportMilestone.objects.filter(srp_report=kev_report)
+        assert kev_milestones.count() == 3, (
+            "KEV report should have its own 3 milestones"
+        )
+
+        # both sets of milestones exist
+        total_milestones = SRPReportMilestone.objects.filter(srp_report__flaw=flaw)
+        assert total_milestones.count() == 6, (
+            "Should have 6 total milestones (3 per report)"
+        )
+
+    @pytest.mark.enable_signals
+    def test_milestone_creation_on_flaw_creation_with_approved_state(self):
+        """
+        If a flaw is created with major_incident_state already set to an approved state,
+        milestones should be created immediately.
+        """
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        # Assert - milestones created
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+        assert milestones.count() == 3, (
+            "Milestones should be created even on initial flaw creation"
+        )
+
+    @pytest.mark.enable_signals
+    @pytest.mark.parametrize(
+        "milestone_type",
+        [
+            SRPReportMilestone.MilestoneType.LEVEL_24H,
+            SRPReportMilestone.MilestoneType.LEVEL_72H,
+            SRPReportMilestone.MilestoneType.LEVEL_FINAL,
+        ],
+    )
+    def test_milestone_uniqueness_constraint(self, milestone_type):
+        """
+        Each SRP Report should only have ONE milestone of each type (24h, 72h, final).
+        The uniqueness constraint should prevent duplicates.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        srp_report = SRPReport.objects.get(flaw=flaw)
+
+        assert (
+            SRPReportMilestone.objects.filter(
+                srp_report=srp_report,
+                milestone_type=milestone_type,
+            ).count()
+            == 1
+        )
+        with pytest.raises(
+            ValidationError, match="unique_srp_report_milestone_type_level"
+        ):
+            SRPReportMilestone.objects.create(
+                srp_report=srp_report,
+                milestone_type=milestone_type,
+                status=SRPReportBase.SRPReportStatus.REQUIRED,
+                acl_read=srp_report.acl_read,
+                acl_write=srp_report.acl_write,
+            )
+
+    @pytest.mark.enable_signals
+    def test_milestone_relationships_to_srp_report(self):
+        """
+        Verify the relationship between milestones and their parent SRP Report works correctly.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        srp_report = SRPReport.objects.get(flaw=flaw)
+
+        # Test forward relationship (milestones -> report)
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+        for milestone in milestones:
+            assert milestone.srp_report == srp_report
+
+        # Test reverse relationship (report -> milestones)
+        assert srp_report.milestones.count() == 3
+        milestone_types_via_reverse = {
+            m.milestone_type for m in srp_report.milestones.all()
+        }
+        assert SRPReportMilestone.MilestoneType.LEVEL_24H in milestone_types_via_reverse
+        assert SRPReportMilestone.MilestoneType.LEVEL_72H in milestone_types_via_reverse
+        assert (
+            SRPReportMilestone.MilestoneType.LEVEL_FINAL in milestone_types_via_reverse
+        )
+
+    @pytest.mark.enable_signals
+    def test_milestones_not_created_for_non_approved_states(self):
+        """
+        Milestones should only be created when major_incident_state is APPROVED.
+        Not for REQUESTED or REJECTED states.
+        """
+        flaw = FlawFactory(
+            major_incident_state="EXPLOITS_KEV_REQUESTED",  # Not approved yet
+            major_incident_start_dt=timezone.now(),
+        )
+        assert SRPReport.objects.filter(flaw=flaw).count() == 0
+        assert SRPReportMilestone.objects.filter(srp_report__flaw=flaw).count() == 0
+
+
+class TestMilestoneDueDateProperty:
+    """Test the due_at property calculation for different milestone types"""
+
+    @pytest.mark.enable_signals
+    def test_due_at_calculation_uses_timer_started_at(self):
+        """
+        The due_at property should calculate from srp_report.timer_started_at,
+        which comes from flaw.major_incident_start_dt.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        assert srp_report.timer_started_at == start_time
+
+        milestones = SRPReportMilestone.objects.filter(srp_report=srp_report)
+        for milestone in milestones:
+            # All due dates should be calculated from the same start time
+            assert milestone.due_at > start_time, (
+                f"{milestone.milestone_type} due_at should be after start time"
+            )
+
+    @pytest.mark.enable_signals
+    def test_milestone_string_representation(self):
+        """
+        Test the __str__ method of milestones includes milestone type and CVE ID.
+        """
+
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            cve_id="CVE-2024-9999",
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        milestone_24h = SRPReportMilestone.objects.get(
+            srp_report=srp_report,
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_24H,
+        )
+
+        milestone_str = str(milestone_24h)
+        assert "24h" in milestone_str
+        assert "CVE-2024-9999" in milestone_str
+
+    @pytest.mark.enable_signals
+    def test_additional_information_response_due_at_uses_request_received_at(self):
+        """
+        LEVEL_ADDITIONAL_INFORMATION_RESPONSE milestones should calculate due_at
+        from request_received_at (not timer_started_at) and use 30 days duration.
+        """
+        # Arrange - create SRP Report
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+        srp_report = SRPReport.objects.get(flaw=flaw)
+
+        # Act - manually create additional information response milestone
+        request_time = timezone.now() + timedelta(
+            days=5
+        )  # Request comes 5 days after report
+        additional_info_milestone = SRPReportMilestone.objects.create(
+            srp_report=srp_report,
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE,
+            status=SRPReport.SRPReportStatus.REQUIRED,
+            request_received_at=request_time,
+            request_source="ENISA",
+            request_text="Please provide additional technical details",
+            acl_read=srp_report.acl_read,
+            acl_write=srp_report.acl_write,
+        )
+
+        # Assert - due_at should be 30 days from request_received_at
+        expected_due_at = request_time + timedelta(days=30)
+        assert additional_info_milestone.due_at == expected_due_at, (
+            "Additional info milestone should be due 30 days from request_received_at"
+        )
+
+        # Verify it's NOT calculated from timer_started_at
+        wrong_due_at = start_time + timedelta(days=30)
+        assert additional_info_milestone.due_at != wrong_due_at, (
+            "Should NOT use timer_started_at for additional info milestones"
+        )
+
+    @pytest.mark.enable_signals
+    def test_additional_information_response_due_at_returns_none_without_request_time(
+        self,
+    ):
+        """
+        LEVEL_ADDITIONAL_INFORMATION_RESPONSE milestone with no request_received_at
+        should return None for due_at (can't calculate deadline without request time).
+        """
+        # Arrange - create SRP Report
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+        srp_report = SRPReport.objects.get(flaw=flaw)
+
+        # Act - create additional info milestone WITHOUT request_received_at
+        additional_info_milestone = SRPReportMilestone.objects.create(
+            srp_report=srp_report,
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE,
+            status=SRPReport.SRPReportStatus.REQUIRED,
+            request_received_at=None,  # No request time set yet
+            acl_read=srp_report.acl_read,
+            acl_write=srp_report.acl_write,
+        )
+
+        # Assert - due_at should be None
+        assert additional_info_milestone.due_at is None, (
+            "due_at should be None when request_received_at is not set"
+        )
+
+    @pytest.mark.enable_signals
+    def test_additional_information_response_milestone_for_severe_incident(self):
+        """
+        LEVEL_ADDITIONAL_INFORMATION_RESPONSE should work the same for
+        Severe Incident reports (30 days from request, not affected by
+        parent report's event type).
+        """
+        # Arrange - create Severe Incident report
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+            major_incident_start_dt=start_time,
+        )
+        srp_report = SRPReport.objects.get(flaw=flaw)
+        assert (
+            srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.SEVERE_INCIDENT
+        )
+
+        # Act - create additional info milestone
+        request_time = timezone.now() + timedelta(days=10)
+        additional_info_milestone = SRPReportMilestone.objects.create(
+            srp_report=srp_report,
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE,
+            status=SRPReport.SRPReportStatus.REQUIRED,
+            request_received_at=request_time,
+            acl_read=srp_report.acl_read,
+            acl_write=srp_report.acl_write,
+        )
+
+        # Assert - still 30 days from request (not affected by parent's 30-day final deadline)
+        expected_due_at = request_time + timedelta(days=30)
+        assert additional_info_milestone.due_at == expected_due_at, (
+            "Additional info response should always be 30 days from request, "
+            "regardless of parent report type"
+        )

--- a/regulatory_reporting/tests/test_milestone_creation.py
+++ b/regulatory_reporting/tests/test_milestone_creation.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 
 import pytest
 from django.core.exceptions import ValidationError
+from django.test import override_settings
 from django.utils import timezone
 
 from osidb.models import Flaw
@@ -19,13 +20,12 @@ from osidb.tests.factories import FlawFactory
 from regulatory_reporting.models import SRPReport, SRPReportMilestone
 from regulatory_reporting.models.abstracts import SRPReportBase
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.enable_signals, pytest.mark.cra_reporting]
 
 
 class TestSRPMilestoneAutoCreation:
     """Test automatic SRP Milestone creation when SRP Report is created"""
 
-    @pytest.mark.enable_signals
     def test_milestones_created_for_kev_report(self):
         """
         When SRP Report is created for KEV, create 24h, 72h, and final milestones
@@ -62,7 +62,6 @@ class TestSRPMilestoneAutoCreation:
             not in milestone_types
         )
 
-    @pytest.mark.enable_signals
     def test_milestones_created_for_severe_incident_report(self):
         """
         When SRP Report is created for Severe Incident, create 24h, 72h, and final milestones.
@@ -92,7 +91,6 @@ class TestSRPMilestoneAutoCreation:
         assert SRPReportMilestone.MilestoneType.LEVEL_72H in milestone_types
         assert SRPReportMilestone.MilestoneType.LEVEL_FINAL in milestone_types
 
-    @pytest.mark.enable_signals
     def test_milestone_due_dates_for_kev(self):
         """
         Verify correct due dates for KEV milestones:
@@ -138,7 +136,6 @@ class TestSRPMilestoneAutoCreation:
             "Final milestone for KEV should be due 14 days after start"
         )
 
-    @pytest.mark.enable_signals
     def test_milestone_due_dates_for_severe_incident(self):
         """
         Verify correct due dates for Severe Incident milestones:
@@ -180,7 +177,6 @@ class TestSRPMilestoneAutoCreation:
             "Final milestone for Severe Incident should be due 30 days after start"
         )
 
-    @pytest.mark.enable_signals
     def test_milestones_inherit_acl_from_srp_report(self):
         """
         All milestones should inherit ACL permissions from their parent SRP Report.
@@ -204,7 +200,6 @@ class TestSRPMilestoneAutoCreation:
                 f"{milestone.milestone_type} should inherit acl_write"
             )
 
-    @pytest.mark.enable_signals
     def test_milestone_status_defaults_to_required(self):
         """
         All auto-created milestones should have status = REQUIRED by default.
@@ -224,7 +219,6 @@ class TestSRPMilestoneAutoCreation:
                 f"{milestone.milestone_type} should have REQUIRED status"
             )
 
-    @pytest.mark.enable_signals
     def test_milestones_refreshed_in_place_on_flaw_resave(
         self,
         internal_read_groups,
@@ -268,7 +262,6 @@ class TestSRPMilestoneAutoCreation:
             assert milestone.acl_read == public_read_groups
             assert milestone.acl_write == public_write_groups
 
-    @pytest.mark.enable_signals
     def test_additional_information_response_not_auto_created(self):
         """
         LEVEL_ADDITIONAL_INFORMATION_RESPONSE should NOT be created automatically.
@@ -292,7 +285,6 @@ class TestSRPMilestoneAutoCreation:
             "Additional information response milestones should NOT be auto-created"
         )
 
-    @pytest.mark.enable_signals
     def test_milestones_created_for_both_event_types_on_state_transition(self):
         """
         If a flaw transitions from MAJOR_INCIDENT_APPROVED to EXPLOITS_KEV_APPROVED,
@@ -332,7 +324,6 @@ class TestSRPMilestoneAutoCreation:
             "Should have 6 total milestones (3 per report)"
         )
 
-    @pytest.mark.enable_signals
     def test_milestone_creation_on_flaw_creation_with_approved_state(self):
         """
         If a flaw is created with major_incident_state already set to an approved state,
@@ -351,7 +342,6 @@ class TestSRPMilestoneAutoCreation:
             "Milestones should be created even on initial flaw creation"
         )
 
-    @pytest.mark.enable_signals
     @pytest.mark.parametrize(
         "milestone_type",
         [
@@ -392,7 +382,6 @@ class TestSRPMilestoneAutoCreation:
                 acl_write=srp_report.acl_write,
             )
 
-    @pytest.mark.enable_signals
     def test_milestone_relationships_to_srp_report(self):
         """
         Verify the relationship between milestones and their parent SRP Report works correctly.
@@ -422,7 +411,6 @@ class TestSRPMilestoneAutoCreation:
             SRPReportMilestone.MilestoneType.LEVEL_FINAL in milestone_types_via_reverse
         )
 
-    @pytest.mark.enable_signals
     def test_milestones_not_created_for_non_approved_states(self):
         """
         Milestones should only be created when major_incident_state is APPROVED.
@@ -435,11 +423,27 @@ class TestSRPMilestoneAutoCreation:
         assert SRPReport.objects.filter(flaw=flaw).count() == 0
         assert SRPReportMilestone.objects.filter(srp_report__flaw=flaw).count() == 0
 
+    @pytest.mark.no_cra_reporting
+    def test_milestones_not_created_when_cra_reporting_is_disabled(self):
+        """
+        Milestones should not be created when CRA reporting is disabled.
+        """
+        start_time = timezone.now()
+        flaw = FlawFactory(
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_REQUESTED,
+            major_incident_start_dt=start_time,
+        )
+        assert SRPReport.objects.filter(flaw=flaw).count() == 0, (
+            "No SRP Report should be created"
+        )
+        assert SRPReportMilestone.objects.filter(srp_report__flaw=flaw).count() == 0, (
+            "No milestones should be created"
+        )
+
 
 class TestMilestoneDueDateProperty:
     """Test the due_at property calculation for different milestone types"""
 
-    @pytest.mark.enable_signals
     def test_due_at_calculation_uses_timer_started_at(self):
         """
         The due_at property should calculate from srp_report.timer_started_at,
@@ -462,7 +466,6 @@ class TestMilestoneDueDateProperty:
                 f"{milestone.milestone_type} due_at should be after start time"
             )
 
-    @pytest.mark.enable_signals
     def test_milestone_string_representation(self):
         """
         Test the __str__ method of milestones includes milestone type and CVE ID.
@@ -485,7 +488,6 @@ class TestMilestoneDueDateProperty:
         assert "24h" in milestone_str
         assert "CVE-2024-9999" in milestone_str
 
-    @pytest.mark.enable_signals
     def test_additional_information_response_due_at_uses_request_received_at(self):
         """
         LEVEL_ADDITIONAL_INFORMATION_RESPONSE milestones should calculate due_at
@@ -526,7 +528,6 @@ class TestMilestoneDueDateProperty:
             "Should NOT use timer_started_at for additional info milestones"
         )
 
-    @pytest.mark.enable_signals
     def test_additional_information_response_due_at_returns_none_without_request_time(
         self,
     ):
@@ -557,7 +558,6 @@ class TestMilestoneDueDateProperty:
             "due_at should be None when request_received_at is not set"
         )
 
-    @pytest.mark.enable_signals
     def test_additional_information_response_milestone_for_severe_incident(self):
         """
         LEVEL_ADDITIONAL_INFORMATION_RESPONSE should work the same for

--- a/regulatory_reporting/tests/test_milestone_creation.py
+++ b/regulatory_reporting/tests/test_milestone_creation.py
@@ -430,7 +430,7 @@ class TestSRPMilestoneAutoCreation:
         """
         start_time = timezone.now()
         flaw = FlawFactory(
-            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_REQUESTED,
+            major_incident_state=Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
             major_incident_start_dt=start_time,
         )
         assert SRPReport.objects.filter(flaw=flaw).count() == 0, (

--- a/regulatory_reporting/tests/test_models.py
+++ b/regulatory_reporting/tests/test_models.py
@@ -17,7 +17,11 @@ from regulatory_reporting.tests.factories import (
     SRPReportMilestoneFactory,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.no_cra_reporting,
+    pytest.mark.no_cra_notifications,
+]
 
 
 def _report_kwargs(**overrides):

--- a/regulatory_reporting/tests/test_serializers.py
+++ b/regulatory_reporting/tests/test_serializers.py
@@ -23,7 +23,7 @@ from regulatory_reporting.tests.factories import (
     UpstreamProjectFactory,
 )
 
-pytestmark = pytest.mark.unit
+pytestmark = [pytest.mark.unit, pytest.mark.enable_signals]
 
 
 class TestUpstreamProjectSerializer:
@@ -172,7 +172,7 @@ class TestSRPReportSerializer:
             milestone_type=SRPReportMilestone.MilestoneType.LEVEL_FINAL
         )
         assert final_milestone_obj.due_at == srp_report.timer_started_at + timedelta(
-            days=14
+            days=30
         )
 
         final_milestone = next(
@@ -193,5 +193,5 @@ class TestSRPReportSerializer:
         assert data["milestones"][1]["hours_remaining"] == 71
         assert data["milestones"][1]["days_remaining"] == 2
         assert data["milestones"][2]["milestone_type"] == "final"
-        assert data["milestones"][2]["hours_remaining"] == 14 * 24 - 1
-        assert data["milestones"][2]["days_remaining"] == 13
+        assert data["milestones"][2]["hours_remaining"] == 30 * 24 - 1
+        assert data["milestones"][2]["days_remaining"] == 29

--- a/regulatory_reporting/tests/test_services.py
+++ b/regulatory_reporting/tests/test_services.py
@@ -10,6 +10,12 @@ from regulatory_reporting.models.upstream import (
 )
 from regulatory_reporting.services import is_flaw_upstream_notifiable
 
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.enable_signals,
+    pytest.mark.cra_notifications,
+]
+
 
 @pytest.mark.django_db
 class TestIsFlawUpstreamNotifiable:
@@ -29,7 +35,6 @@ class TestIsFlawUpstreamNotifiable:
         assert is_flaw_upstream_notifiable(flaw) is False
 
 
-@pytest.mark.enable_signals
 @pytest.mark.django_db
 class TestUpstreamNotificationSignal:
     @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
@@ -48,6 +53,7 @@ class TestUpstreamNotificationSignal:
         flaw = FlawFactory(source=FlawSource.NVD)
         assert not UpstreamNotification.objects.filter(flaw=flaw).exists()
 
+    @pytest.mark.no_cra_notifications
     def test_flag_disabled_does_not_create_notification(self):
         flaw = FlawFactory(
             embargoed=False,

--- a/regulatory_reporting/tests/test_services.py
+++ b/regulatory_reporting/tests/test_services.py
@@ -37,7 +37,6 @@ class TestIsFlawUpstreamNotifiable:
 
 @pytest.mark.django_db
 class TestUpstreamNotificationSignal:
-    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
     def test_redhat_flaw_creates_notification(self):
         flaw = FlawFactory(
             embargoed=False,
@@ -48,7 +47,6 @@ class TestUpstreamNotificationSignal:
         assert notification.status == UpstreamNotification.NotificationStatus.REQUIRED
         assert notification.upstream_project is None
 
-    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
     def test_nvd_flaw_does_not_create_notification(self):
         flaw = FlawFactory(source=FlawSource.NVD)
         assert not UpstreamNotification.objects.filter(flaw=flaw).exists()

--- a/regulatory_reporting/tests/test_services.py
+++ b/regulatory_reporting/tests/test_services.py
@@ -63,7 +63,6 @@ class TestUpstreamNotificationSignal:
 @pytest.mark.enable_signals
 @pytest.mark.django_db
 class TestMappingNotificationSignal:
-    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
     def test_backfills_existing_blank_notification(self):
         flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
         notification = UpstreamNotification.objects.get(flaw=flaw)
@@ -74,7 +73,6 @@ class TestMappingNotificationSignal:
         assert notification.upstream_project == project
         assert UpstreamNotification.objects.filter(flaw=flaw).count() == 1
 
-    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
     def test_second_mapping_creates_separate_notification(self):
         flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
         project1 = UpstreamProject.objects.create(component_name="comp-1")
@@ -83,7 +81,6 @@ class TestMappingNotificationSignal:
         FlawUpstreamMapping.objects.create(flaw=flaw, upstream_project=project2)
         assert UpstreamNotification.objects.filter(flaw=flaw).count() == 2
 
-    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
     def test_backfills_even_if_status_already_blocked(self):
         flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
         notification = UpstreamNotification.objects.get(flaw=flaw)
@@ -95,7 +92,7 @@ class TestMappingNotificationSignal:
         assert notification.upstream_project == project
         assert notification.status == UpstreamNotification.NotificationStatus.BLOCKED
 
-    @override_settings(CRA_NOTIFICATIONS_ENABLED=False)
+    @pytest.mark.no_cra_notifications
     def test_flag_disabled_does_not_backfill(self):
         flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
         project = UpstreamProject.objects.create(component_name="test-component")

--- a/regulatory_reporting/tests/test_signals.py
+++ b/regulatory_reporting/tests/test_signals.py
@@ -16,13 +16,16 @@ from osidb.models import Flaw
 from osidb.tests.factories import FlawFactory
 from regulatory_reporting.models import SRPReport
 
-pytestmark = pytest.mark.unit
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.enable_signals,
+    pytest.mark.cra_reporting,
+]
 
 
 class TestSRPReportAutoCreation:
     """Test automatic SRP Report creation via signals"""
 
-    @pytest.mark.enable_signals
     def test_srp_report_created_when_kev_approved(self):
         """
         When a flaw's major_incident_state is set to EXPLOITS_KEV_APPROVED,
@@ -62,7 +65,6 @@ class TestSRPReportAutoCreation:
         assert report.title  # Title should be populated from flaw
         assert flaw.cve_id in report.title or flaw.title in report.title
 
-    @pytest.mark.enable_signals
     def test_srp_report_created_when_major_incident_approved(self):
         """
         When a flaw's major_incident_state is set to MAJOR_INCIDENT_APPROVED,
@@ -98,7 +100,6 @@ class TestSRPReportAutoCreation:
         assert report.status == SRPReport.SRPReportStatus.REQUIRED
         assert report.responsibility_scope == SRPReport.ResponsibilityScope.MANUFACTURER
 
-    @pytest.mark.enable_signals
     def test_srp_report_created_on_flaw_creation_with_kev_approved(self):
         """
         When a flaw is created with major_incident_state already set to
@@ -122,7 +123,6 @@ class TestSRPReportAutoCreation:
         )
         assert report.timer_started_at == start_time
 
-    @pytest.mark.enable_signals
     def test_srp_report_not_created_for_other_states(self):
         """
         When a flaw's major_incident_state is set to values other than
@@ -137,7 +137,6 @@ class TestSRPReportAutoCreation:
         # Assert
         assert SRPReport.objects.filter(flaw=flaw).count() == 0
 
-    @pytest.mark.enable_signals
     def test_srp_report_not_duplicated_if_already_exists(self):
         """
         If an SRP Report already exists for a flaw with the same
@@ -160,7 +159,6 @@ class TestSRPReportAutoCreation:
         # Assert - no duplicate created
         assert SRPReport.objects.filter(flaw=flaw).count() == 1
 
-    @pytest.mark.enable_signals
     def test_srp_report_uses_major_incident_start_dt(self):
         """
         The timer_started_at field should use the flaw's major_incident_start_dt
@@ -183,7 +181,6 @@ class TestSRPReportAutoCreation:
         assert report.timer_started_at == start_time
         assert report.timer_started_at == flaw.major_incident_start_dt
 
-    @pytest.mark.enable_signals
     def test_srp_report_inherits_acl_from_flaw(self):
         """
         The automatically created SRP Report should inherit ACL permissions
@@ -201,7 +198,6 @@ class TestSRPReportAutoCreation:
         assert report.acl_read == flaw.acl_read
         assert report.acl_write == flaw.acl_write
 
-    @pytest.mark.enable_signals
     def test_srp_report_created_when_transitioning_states(self):
         """
         Test that SRP Reports are created when transitioning from one
@@ -227,7 +223,6 @@ class TestSRPReportAutoCreation:
             == SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY
         )
 
-    @pytest.mark.enable_signals
     def test_flaw_can_have_both_event_type_reports(self):
         """
         A flaw could theoretically transition from MAJOR_INCIDENT_APPROVED
@@ -303,7 +298,6 @@ class TestSRPReportNoAutoCreation:
             "EXPLOITS_KEV_REJECTED",
         ],
     )
-    @pytest.mark.enable_signals
     def test_srp_report_not_created_for_non_approved_states(self, state):
         """
         SRP Reports should only be created for APPROVED states, not for
@@ -320,7 +314,6 @@ class TestSRPReportNoAutoCreation:
         # Assert
         assert SRPReport.objects.filter(flaw=flaw).count() == 0
 
-    @pytest.mark.enable_signals
     def test_srp_report_not_created_when_only_start_dt_changes(self):
         """
         If only major_incident_start_dt changes but major_incident_state
@@ -339,7 +332,6 @@ class TestSRPReportNoAutoCreation:
         # Assert
         assert SRPReport.objects.filter(flaw=flaw).count() == 0
 
-    @pytest.mark.enable_signals
     def test_srp_report_status_is_not_changed_when_flaw_is_saved(self):
         """
         The status of the SRP Report should not be changed when the flaw is saved.
@@ -362,7 +354,6 @@ class TestSRPReportNoAutoCreation:
         srp_report.refresh_from_db()
         assert srp_report.status == SRPReport.SRPReportStatus.PREPARED
 
-    @pytest.mark.enable_signals
     def test_srp_report_title_is_updated_when_flaw_is_saved(self):
         """
         The title of the SRP Report should be updated when the flaw is saved.
@@ -381,7 +372,6 @@ class TestSRPReportNoAutoCreation:
         assert SRPReport.objects.filter(flaw=flaw).count() == 1
         assert SRPReport.objects.get(flaw=flaw).title == "New title"
 
-    @pytest.mark.enable_signals
     def test_srp_report_acl_is_updated_when_flaw_is_saved(
         self,
         internal_read_groups,


### PR DESCRIPTION
Implements automatic creation of SRP reports milestones when flaws are marked as actively exploited (KEV) or severe incidents, enabling EU Cyber Resilience Act compliance.

This PR follows the logic that if Flaw is saved it will create the 3 main milestones. 
If the SRP is created then updates attached milestones ACL's 


OSIDB-5068