### PR TITLE
Add relative datetime queries for API

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Base auto-affect determination on upstream affected versions (OSIDB-5031)
+- Add support for relative datetime queries in API filters (OSIDB-5168)
 
 ## [5.12.0] - 2026-06-25
 ### Added

--- a/osidb/datetime_utils.py
+++ b/osidb/datetime_utils.py
@@ -1,0 +1,77 @@
+"""
+Utility functions for parsing and handling date/time values
+"""
+
+import re
+
+from dateutil.relativedelta import relativedelta
+
+# Constants for relative date/datetime parsing
+RELATIVE_TIME_UNIT_MAP = {
+    "s": "seconds",
+    "m": "minutes",
+    "h": "hours",
+    "d": "days",
+    "w": "weeks",
+    "M": "months",
+    "y": "years",
+}
+
+RELATIVE_DATETIME_REGEX = re.compile(r"^\s*([+-]?)\s*(\d+)\s*([smhdwMy])\s*$")
+
+
+def parse_relative_datetime(value, base_value):
+    """
+    Parse relative date/datetime strings and return absolute value.
+
+    Accepts relative time strings in the format: [+/-]<number><unit>
+    where unit is one of: s (seconds), m (minutes), h (hours), d (days),
+    w (weeks), M (months), y (years)
+
+    Examples:
+        -1d     -> 1 day ago from base_value
+        +2h     -> 2 hours from base_value
+        -30m    -> 30 minutes ago from base_value
+        -6M     -> 6 months ago from base_value
+         1y     -> 1 year from base_value
+        -1w     -> 1 week ago from base_value
+         1s     -> 1 second from base_value
+
+    Args:
+        value: String to parse as relative datetime
+        base_value: Base date or datetime to calculate relative to
+
+    Returns:
+        Absolute date or datetime object if the value is a valid relative string,
+        None otherwise (allowing fallback to absolute parsing)
+
+    Notes:
+        - Sign defaults to '+' if omitted (e.g., "1d" means "+1d")
+        - Fractional values are not supported (e.g., "1.5d" will return None)
+        - Whitespace is allowed but excessive whitespace may cause parsing to fail
+        - Unit 'M' (uppercase) = months; 'm' (lowercase) = minutes
+        - Month/year arithmetic uses calendar dates, not fixed durations
+        - If target day doesn't exist (e.g., Jan 31 + 1M), uses last day
+          of target month (Feb 28/29)
+        - Uses relativedelta for all units for simplicity and consistency
+    """
+    if not value:
+        return None
+
+    match = RELATIVE_DATETIME_REGEX.match(str(value))
+    if not match:
+        return None
+
+    sign, amount, unit = match.groups()
+    amount = int(amount) if sign != "-" else -int(amount)
+
+    # Case-sensitive lookup to distinguish 'm' (minutes) from 'M' (months)
+    delta_unit = RELATIVE_TIME_UNIT_MAP.get(unit)
+    if not delta_unit:
+        return None
+
+    delta_kwargs = {delta_unit: amount}
+    try:
+        return base_value + relativedelta(**delta_kwargs)
+    except OverflowError:
+        return None

--- a/osidb/djangoql.py
+++ b/osidb/djangoql.py
@@ -3,7 +3,13 @@ import uuid
 from django.conf import settings
 from django.db import models
 from django.db.models import Q
-from djangoql.schema import BoolField, DjangoQLSchema, StrField
+from django.utils import timezone
+from djangoql.schema import (
+    BoolField,
+    DateTimeField,
+    DjangoQLSchema,
+    StrField,
+)
 
 from osidb.models import (
     Affect,
@@ -17,6 +23,54 @@ from osidb.models import (
 )
 
 from .core import generate_acls
+from .datetime_utils import parse_relative_datetime
+
+
+class RelativeDateTimeQLField(DateTimeField):
+    """
+    DjangoQL DateTimeField that supports relative datetime strings.
+
+    Extends the standard DjangoQL DateTimeField to accept relative datetime
+    strings like "-1d", "+2h", "-30m", "-6M", "1y", etc., in addition to
+    absolute timestamps in "YYYY-MM-DD HH:MM" format.
+
+    Examples:
+        Absolute formats:
+            "2024-06-15"
+            "2024-06-15 14:30"
+            "2024-06-15 14:30:00"
+
+        Relative formats:
+            "-1d"   -> 1 day ago
+            "+2h"   -> 2 hours from now
+            "1h"    -> 1 hour from now (+ is optional)
+            "-30m"  -> 30 minutes ago
+            "-6M"   -> 6 months ago
+            "1y"   -> 1 year from now
+    """
+
+    value_types_description = (
+        'timestamps in "YYYY-MM-DD HH:MM" format or relative like -1d, +2h'
+    )
+
+    def get_lookup_value(self, value):
+        """
+        Parse datetime value, trying relative format first, then absolute.
+
+        First attempts to parse as a relative datetime string (e.g., "-1d", "2h").
+        If that fails (returns None), falls back to the parent class absolute
+        datetime parsing.
+        """
+        if not value:
+            return None
+
+        # Try relative datetime parsing first
+        parsed = parse_relative_datetime(value, timezone.now())
+        if parsed is not None:
+            return parsed
+
+        # Fall back to parent class absolute datetime parsing
+        return super().get_lookup_value(value)
 
 
 class FlawQLSchema(DjangoQLSchema):
@@ -56,6 +110,12 @@ class FlawQLSchema(DjangoQLSchema):
         FlawReference: ["type"],
         Tracker: ["resolution", "status", "type"],
     }
+
+    def get_field_cls(self, field):
+        """Override to use RelativeDateTimeQLField for DateTimeField instances."""
+        if isinstance(field, models.DateTimeField):
+            return RelativeDateTimeQLField
+        return super().get_field_cls(field)
 
     def get_fields(self, model):
         fields = super(FlawQLSchema, self).get_fields(model)

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -2,9 +2,11 @@
 Implement filters for OSIDB REST API results
 """
 
+from copy import deepcopy
 from datetime import timedelta
 from typing import Union
 
+from django import forms
 from django.contrib.postgres.search import (
     SearchQuery,
     SearchRank,
@@ -15,6 +17,7 @@ from django.core.exceptions import ValidationError
 from django.core.validators import EMPTY_VALUES
 from django.db import models
 from django.db.models import Max, Min, Q
+from django.utils import timezone
 from django_filters.rest_framework import (
     BaseInFilter,
     BooleanFilter,
@@ -48,6 +51,7 @@ from osidb.models import (
 )
 from osidb.sync_manager import SyncManager
 
+from .datetime_utils import parse_relative_datetime
 from .djangoql import FlawQLSchema
 from .mixins import ACLMixinVisibility, Alert
 
@@ -79,6 +83,71 @@ class UUIDInFilter(BaseInFilter, UUIDFilter):
     """
 
     pass
+
+
+class RelativeDateTimeField(forms.DateTimeField):
+    """
+    DateTimeField that accepts both absolute datetime values (default behavior)
+    and relative datetime strings like "-1d", "+2h", "-30m", "-6M", "+1y", etc.
+
+    Relative format: [+/-]<number><unit>
+    where unit is one of: s (seconds), m (minutes), h (hours), d (days),
+    w (weeks), M (months), y (years)
+
+    Examples:
+        -1d     -> 1 day ago
+        +2h     -> 2 hours from now
+        -30m    -> 30 minutes ago
+        -6M     -> 6 months ago (calendar arithmetic)
+         1y     -> 1 year from now
+
+    If the value doesn't match the relative format, it falls back to standard
+    absolute datetime parsing.
+
+    Notes:
+        - Month/year arithmetic uses calendar dates, not fixed durations
+        - If target day doesn't exist (e.g., Jan 31 + 1M), uses last day
+          of target month (Feb 28/29)
+        - Unit 'M' (uppercase) = months; 'm' (lowercase) = minutes
+    """
+
+    def strptime(self, value, format):
+        """
+        Parse a datetime string using the given format.
+
+        First tries standard strptime parsing with the given format.
+        If that fails, attempts to parse as a relative datetime.
+
+        This override is necessary because Django's DateTimeField.to_python()
+        internally calls strptime() in a loop for each input_format. Without this,
+        relative datetime strings would fail validation since they don't match
+        standard datetime formats.
+        """
+        try:
+            return super().strptime(value, format)
+        except (ValueError, TypeError):
+            parsed = parse_relative_datetime(value, timezone.now())
+            if parsed is not None:
+                return parsed
+            raise
+
+
+class RelativeDateTimeFilter(DateTimeFilter):
+    field_class = RelativeDateTimeField
+
+
+FILTER_FOR_DBFIELD_DEFAULTS = deepcopy(FilterSet.FILTER_DEFAULTS)
+FILTER_FOR_DBFIELD_DEFAULTS.update(
+    {
+        models.DateTimeField: {
+            "filter_class": RelativeDateTimeFilter,
+        },
+    }
+)
+
+
+class OSIDBFilterSet(FilterSet):
+    FILTER_DEFAULTS = FILTER_FOR_DBFIELD_DEFAULTS
 
 
 class PURLFilter(CharFilter):
@@ -208,7 +277,7 @@ class NullForeignKeyFilter(BooleanFilter):
         return method(query)
 
 
-class InFilterSet(FilterSet):
+class InFilterSet(OSIDBFilterSet):
     """
     Adds 'in' support for ChoiceFilter, CharFilter, and UUIDFilter fields for Meta fields.
     Does not add 'in' for date and numeric comparisons.
@@ -247,7 +316,7 @@ class InFilterSet(FilterSet):
         return filters
 
 
-class DistinctFilterSet(FilterSet):
+class DistinctFilterSet(OSIDBFilterSet):
     """
     Custom FilterSet which enforces the distinct for field names that starts
     with specified prefixes so filtering on related models would not cause
@@ -324,7 +393,7 @@ class DistinctOrderingFilter(OrderingFilter):
         return queryset
 
 
-class SparseFieldsFilterSet(FilterSet):
+class SparseFieldsFilterSet(OSIDBFilterSet):
     def _preprocess_fields(self, value):
         """
         Converts a comma-separated list of fields into an ORM-friendly format.
@@ -517,10 +586,10 @@ class FlawFilter(
     cve_id = CharInFilter(field_name="cve_id")
     components = CharInFilter(field_name="components", lookup_expr="contains")
 
-    changed_after = DateTimeFilter(
+    changed_after = RelativeDateTimeFilter(
         field_name="updated_dt", method="changed_after_filter"
     )
-    changed_before = DateTimeFilter(
+    changed_before = RelativeDateTimeFilter(
         field_name="updated_dt", method="changed_before_filter"
     )
 

--- a/osidb/tests/conftest.py
+++ b/osidb/tests/conftest.py
@@ -3,10 +3,19 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+from django.utils import timezone as django_timezone
+from freezegun import freeze_time
 
 from osidb.helpers import get_env
 from osidb.integrations import IntegrationRepository, IntegrationSettings
-from osidb.models import FlawSource
+from osidb.models import Affect, FlawSource, Tracker
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+    TrackerFactory,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -129,3 +138,89 @@ def set_hvac_test_env_vars():
     os.environ.pop("OSIDB_VAULT_ADDR", None)
     os.environ.pop("OSIDB_ROLE_ID", None)
     os.environ.pop("OSIDB_SECRET_ID", None)
+
+
+# Fixtures for relative datetime filtering tests
+
+
+@pytest.fixture
+@freeze_time("2024-06-15 12:00:00")
+def affects_at_different_times():
+    """Create affects at different times for testing relative datetime filters"""
+    flaw = FlawFactory(embargoed=False)
+
+    return {
+        "flaw": flaw,
+        "affect_5_hours_ago": AffectFactory(
+            flaw=flaw,
+            created_dt=django_timezone.now() - django_timezone.timedelta(hours=5),
+        ),
+        "affect_2_hours_ago": AffectFactory(
+            flaw=flaw,
+            created_dt=django_timezone.now() - django_timezone.timedelta(hours=2),
+        ),
+        "affect_30_min_ago": AffectFactory(
+            flaw=flaw,
+            created_dt=django_timezone.now() - django_timezone.timedelta(minutes=30),
+        ),
+    }
+
+
+@pytest.fixture
+@freeze_time("2024-06-15 12:00:00")
+def trackers_at_different_times():
+    """Create trackers at different times for testing relative datetime filters"""
+    ps_module = PsModuleFactory(bts_name="bugzilla")
+    ps_stream = PsUpdateStreamFactory(ps_module=ps_module)
+    flaw = FlawFactory(embargoed=False)
+    affect = AffectFactory(
+        flaw=flaw,
+        ps_module=ps_module.name,
+        ps_update_stream=ps_stream.name,
+        affectedness=Affect.AffectAffectedness.AFFECTED,
+        resolution=Affect.AffectResolution.DELEGATED,
+    )
+
+    return {
+        "tracker_3_days_ago": TrackerFactory(
+            type=Tracker.TrackerType.BUGZILLA,
+            affects=[affect],
+            ps_update_stream=ps_stream.name,
+            created_dt=django_timezone.now() - django_timezone.timedelta(days=3),
+        ),
+        "tracker_1_day_ago": TrackerFactory(
+            type=Tracker.TrackerType.BUGZILLA,
+            affects=[affect],
+            ps_update_stream=ps_stream.name,
+            created_dt=django_timezone.now() - django_timezone.timedelta(days=1),
+        ),
+        "tracker_2_hours_ago": TrackerFactory(
+            type=Tracker.TrackerType.BUGZILLA,
+            affects=[affect],
+            ps_update_stream=ps_stream.name,
+            created_dt=django_timezone.now() - django_timezone.timedelta(hours=2),
+        ),
+    }
+
+
+@pytest.fixture
+@freeze_time("2024-06-15 12:00:00")
+def flaws_at_different_update_times():
+    """Create flaws with different updated_dt for testing changed_after and changed_before"""
+    return {
+        "flaw_3_days_ago": FlawFactory(
+            embargoed=False,
+            local_updated_dt=django_timezone.now() - django_timezone.timedelta(days=3),
+            updated_dt=django_timezone.now() - django_timezone.timedelta(days=3),
+        ),
+        "flaw_1_day_ago": FlawFactory(
+            embargoed=False,
+            local_updated_dt=django_timezone.now() - django_timezone.timedelta(days=1),
+            updated_dt=django_timezone.now() - django_timezone.timedelta(days=1),
+        ),
+        "flaw_2_hours_ago": FlawFactory(
+            embargoed=False,
+            local_updated_dt=django_timezone.now() - django_timezone.timedelta(hours=2),
+            updated_dt=django_timezone.now() - django_timezone.timedelta(hours=2),
+        ),
+    }

--- a/osidb/tests/endpoints/flaws/test_query_relative_datetime.py
+++ b/osidb/tests/endpoints/flaws/test_query_relative_datetime.py
@@ -1,0 +1,138 @@
+"""
+Integration tests for DjangoQL relative datetime queries
+"""
+
+import datetime
+
+import pytest
+from freezegun import freeze_time
+
+from osidb.tests.factories import FlawFactory
+
+pytestmark = pytest.mark.integration
+
+
+class TestRelativeDateTimeQueries:
+    """Test DjangoQL queries with relative datetime formats"""
+
+    @freeze_time("2024-06-15 12:00:00")
+    @pytest.mark.parametrize(
+        "test_api_uri", ["test_api_uri", "test_api_v2_uri"], indirect=True
+    )
+    def test_query_updated_dt_relative_days(
+        self, auth_client, test_api_uri, flaws_at_different_update_times
+    ):
+        """Test query with relative days format"""
+        query = 'updated_dt > "-2d"'
+        response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+
+        assert response.status_code == 200
+        body = response.json()
+
+        returned_uuids = {flaw["uuid"] for flaw in body["results"]}
+        expected_uuids = {
+            str(flaws_at_different_update_times["flaw_1_day_ago"].uuid),
+            str(flaws_at_different_update_times["flaw_2_hours_ago"].uuid),
+        }
+
+        assert returned_uuids == expected_uuids
+
+    @freeze_time("2024-06-15 12:00:00")
+    @pytest.mark.parametrize(
+        "test_api_uri", ["test_api_uri", "test_api_v2_uri"], indirect=True
+    )
+    def test_query_updated_dt_relative_hours(
+        self, auth_client, test_api_uri, flaws_at_different_update_times
+    ):
+        """Test query with relative hours format"""
+        query = 'updated_dt >= "-3h"'
+        response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+
+        assert response.status_code == 200
+        body = response.json()
+
+        returned_uuids = {flaw["uuid"] for flaw in body["results"]}
+        expected_uuids = {
+            str(flaws_at_different_update_times["flaw_2_hours_ago"].uuid),
+        }
+
+        assert returned_uuids == expected_uuids
+
+    @freeze_time("2024-06-15 12:00:00")
+    @pytest.mark.parametrize(
+        "test_api_uri", ["test_api_uri", "test_api_v2_uri"], indirect=True
+    )
+    def test_query_updated_dt_relative_weeks(
+        self, auth_client, test_api_uri, flaws_at_different_update_times
+    ):
+        """Test query with relative weeks format"""
+        query = 'updated_dt > "-1w"'
+        response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+
+        assert response.status_code == 200
+        body = response.json()
+
+        # All test flaws are within the past week
+        assert body["count"] == 3
+
+    @freeze_time("2024-06-15 12:00:00")
+    @pytest.mark.parametrize(
+        "test_api_uri", ["test_api_uri", "test_api_v2_uri"], indirect=True
+    )
+    def test_query_created_dt_absolute_format(self, auth_client, test_api_uri):
+        """Test that absolute datetime formats still work"""
+        flaw1 = FlawFactory(
+            created_dt=datetime.datetime(2024, 6, 10, tzinfo=datetime.timezone.utc)
+        )
+        FlawFactory(
+            created_dt=datetime.datetime(2024, 6, 1, tzinfo=datetime.timezone.utc)
+        )
+
+        query = 'created_dt > "2024-06-05"'
+        response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+
+        assert response.status_code == 200
+        body = response.json()
+
+        assert body["count"] == 1
+        assert body["results"][0]["uuid"] == str(flaw1.uuid)
+
+    @freeze_time("2024-06-15 12:00:00")
+    @pytest.mark.parametrize(
+        "test_api_uri", ["test_api_uri", "test_api_v2_uri"], indirect=True
+    )
+    def test_query_updated_dt_mixed_relative_and_absolute(
+        self, auth_client, test_api_uri, flaws_at_different_update_times
+    ):
+        """Test query combining relative and absolute datetime formats"""
+        query = 'updated_dt > "-4d" and updated_dt < "-12h"'
+        response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+
+        assert response.status_code == 200
+        body = response.json()
+
+        returned_uuids = {flaw["uuid"] for flaw in body["results"]}
+        expected_uuids = {
+            str(flaws_at_different_update_times["flaw_1_day_ago"].uuid),
+            str(flaws_at_different_update_times["flaw_3_days_ago"].uuid),
+        }
+
+        assert returned_uuids == expected_uuids
+
+    @freeze_time("2024-06-15 12:00:00")
+    @pytest.mark.parametrize(
+        "test_api_uri", ["test_api_uri", "test_api_v2_uri"], indirect=True
+    )
+    def test_query_updated_dt_no_sign_defaults_positive(
+        self, auth_client, test_api_uri, flaws_at_different_update_times
+    ):
+        """Test that omitting sign defaults to positive (future)"""
+        # All test flaws are in the past, so querying for future should return all
+        query = 'updated_dt < "1d"'
+        response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+
+        assert response.status_code == 200
+        body = response.json()
+
+        # Should return all test flaws (they're all before tomorrow)
+        assert body["count"] == 3

--- a/osidb/tests/test_datetime_utils.py
+++ b/osidb/tests/test_datetime_utils.py
@@ -1,0 +1,140 @@
+"""
+Unit tests for datetime_utils module
+"""
+
+from datetime import timedelta
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone as django_timezone
+from freezegun import freeze_time
+
+from osidb.datetime_utils import parse_relative_datetime
+
+pytestmark = pytest.mark.unit
+
+
+class TestParseRelativeDatetime:
+    """
+    Unit tests for parse_relative_datetime function
+    """
+
+    @pytest.mark.parametrize(
+        "value,delta",
+        [
+            pytest.param("+1d", timedelta(days=1), id="plus_one_day"),
+            pytest.param("-30s", -timedelta(seconds=30), id="minus_thirty_seconds"),
+            pytest.param("-1w", -timedelta(weeks=1), id="minus_one_week"),
+            pytest.param("-30m", -timedelta(minutes=30), id="minus_thirty_minutes"),
+            pytest.param("-2h", -timedelta(hours=2), id="minus_two_hours"),
+            pytest.param("-1d", -timedelta(days=1), id="minus_one_day"),
+            pytest.param("-0d", timedelta(days=0), id="zero_days"),
+            pytest.param("1h", timedelta(hours=1), id="no_sign_defaults_positive"),
+            pytest.param("-1M", relativedelta(months=-1), id="minus_one_month"),
+            pytest.param("+1y", relativedelta(years=1), id="plus_one_year"),
+        ],
+    )
+    def test_parse_relative_time_offset(self, value, delta):
+        """Test that relative time offsets are parsed correctly"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime(value, base_time)
+
+        expected_time = base_time + delta
+
+        # Allow 1 second tolerance for test execution time
+        assert abs(result - expected_time) < timedelta(seconds=1)
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            pytest.param(" -1d ", id="leading_and_trailing_whitespace"),
+            pytest.param("- 1d", id="whitespace_after_sign"),
+            pytest.param("-1 d", id="whitespace_before_unit"),
+        ],
+    )
+    def test_whitespace_handling(self, value):
+        """Test that whitespace is handled correctly in relative datetimes"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime(value, base_time)
+        expected_time = base_time - timedelta(days=1)
+
+        assert abs(result - expected_time) < timedelta(seconds=1)
+
+    @freeze_time("2024-01-31 12:00:00")
+    def test_month_overflow_datetime_jan_to_feb(self):
+        """Jan 31 12:00 + 1M should be Feb 29 12:00 (leap year)"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime("+1M", base_time)
+        expected = django_timezone.make_aware(
+            django_timezone.datetime(2024, 2, 29, 12, 0, 0)
+        )
+        assert abs(result - expected) < timedelta(seconds=1)
+
+    @freeze_time("2024-02-29 12:00:00")
+    def test_leap_day_datetime_plus_year(self):
+        """Feb 29, 2024 12:00 + 1y should be Feb 28, 2025 12:00"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime("+1y", base_time)
+        expected = django_timezone.make_aware(
+            django_timezone.datetime(2025, 2, 28, 12, 0, 0)
+        )
+        assert abs(result - expected) < timedelta(seconds=1)
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_uppercase_m_is_months_not_minutes_datetime(self):
+        """-1M should be 1 month ago, not 1 minute"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime("-1M", base_time)
+        expected_month = django_timezone.make_aware(
+            django_timezone.datetime(2024, 5, 15, 12, 0, 0)
+        )
+        expected_minute = django_timezone.make_aware(
+            django_timezone.datetime(2024, 6, 15, 11, 59, 0)
+        )
+        # Should match month calculation, not minute
+        assert abs(result - expected_month) < timedelta(seconds=1)
+        assert abs(result - expected_minute) > timedelta(minutes=1)
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_lowercase_m_is_minutes_not_months_datetime(self):
+        """-1m should be 1 minute ago, not 1 month"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime("-1m", base_time)
+        expected_minute = django_timezone.make_aware(
+            django_timezone.datetime(2024, 6, 15, 11, 59, 0)
+        )
+        expected_month = django_timezone.make_aware(
+            django_timezone.datetime(2024, 5, 15, 12, 0, 0)
+        )
+        # Should match minute calculation, not month
+        assert abs(result - expected_minute) < timedelta(seconds=1)
+        assert abs(result - expected_month) > timedelta(days=1)
+
+    @pytest.mark.parametrize(
+        "invalid_value",
+        [
+            pytest.param("999999999999999999999d", id="overflow_days"),
+            pytest.param("-999999999999999999999y", id="overflow_years"),
+            pytest.param("1.5d", id="fractional_days"),
+            pytest.param("-1.5d", id="fractional_days_negative"),
+            pytest.param("1x", id="invalid_unit_x"),
+            pytest.param("-1x", id="invalid_unit_x_negative"),
+            pytest.param("abc", id="not_a_number"),
+            pytest.param("d", id="missing_number"),
+            pytest.param("d1", id="reversed_format"),
+            pytest.param("--1d", id="double_negative"),
+            pytest.param("1D", id="uppercase_day_unit"),
+            pytest.param("-1d2h", id="multiple_units"),
+        ],
+    )
+    def test_invalid_relative_formats_return_none(self, invalid_value):
+        """Test that invalid relative formats return None"""
+        base_time = django_timezone.now()
+        result = parse_relative_datetime(invalid_value, base_time)
+        assert result is None
+
+    def test_empty_value_returns_none(self):
+        """Test that empty values return None"""
+        base_time = django_timezone.now()
+        assert parse_relative_datetime(None, base_time) is None
+        assert parse_relative_datetime("", base_time) is None

--- a/osidb/tests/test_djangoql_relative_datetime.py
+++ b/osidb/tests/test_djangoql_relative_datetime.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for RelativeDateTimeQLField in osidb.djangoql
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.utils import timezone as django_timezone
+
+from osidb.djangoql import RelativeDateTimeQLField
+
+pytestmark = pytest.mark.unit
+
+
+class TestRelativeDateTimeQLField:
+    """
+    Unit tests for RelativeDateTimeQLField class
+    """
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            pytest.param(
+                "2024-06-15",
+                datetime(2024, 6, 15, 0, 0, 0),
+                id="date_only",
+            ),
+            pytest.param(
+                "2024-06-15 14:30",
+                datetime(2024, 6, 15, 14, 30, 0),
+                id="datetime_no_seconds",
+            ),
+            pytest.param(
+                "2024-06-15 14:30:45",
+                datetime(2024, 6, 15, 14, 30, 45),
+                id="datetime_with_seconds",
+            ),
+        ],
+    )
+    def test_get_lookup_value_with_absolute_formats(self, value, expected):
+        """Test that absolute date/datetime strings are parsed correctly"""
+        field = RelativeDateTimeQLField(model=None, name="test_field")
+        result = field.get_lookup_value(value)
+        expected_aware = django_timezone.make_aware(expected)
+
+        assert result == expected_aware
+
+    @pytest.mark.parametrize(
+        "value,delta",
+        [
+            pytest.param("-1d", -timedelta(days=1), id="minus_one_day"),
+            pytest.param("+2h", timedelta(hours=2), id="plus_two_hours"),
+            pytest.param("1h", timedelta(hours=1), id="one_hour_no_sign"),
+            pytest.param("-30m", -timedelta(minutes=30), id="minus_thirty_minutes"),
+            pytest.param("-6M", relativedelta(months=-6), id="minus_six_months"),
+            pytest.param("+1y", relativedelta(years=1), id="plus_one_year"),
+        ],
+    )
+    def test_get_lookup_value_with_relative_formats(self, value, delta):
+        """Test that relative datetime strings are parsed correctly"""
+        field = RelativeDateTimeQLField(model=None, name="test_field")
+        base_time = django_timezone.now()
+        result = field.get_lookup_value(value)
+        expected_time = base_time + delta
+
+        # Allow 1 second tolerance for test execution time
+        assert abs(result - expected_time) < timedelta(seconds=1)
+
+    def test_get_lookup_value_with_empty_value(self):
+        """Test that empty values return None"""
+        field = RelativeDateTimeQLField(model=None, name="test_field")
+        assert field.get_lookup_value(None) is None
+        assert field.get_lookup_value("") is None
+
+    def test_get_lookup_value_with_invalid_format_raises_value_error(self):
+        """Test that invalid formats raise ValueError"""
+        field = RelativeDateTimeQLField(model=None, name="test_field")
+        with pytest.raises(ValueError):
+            field.get_lookup_value("invalid_format")

--- a/osidb/tests/test_relative_datetime_field.py
+++ b/osidb/tests/test_relative_datetime_field.py
@@ -1,0 +1,78 @@
+"""
+Unit tests for RelativeDateTimeField in osidb.filters
+"""
+
+from datetime import timedelta
+
+import pytest
+from django.core.exceptions import ValidationError
+from django.utils import timezone as django_timezone
+
+from osidb.filters import RelativeDateTimeField
+
+pytestmark = pytest.mark.unit
+
+
+class TestRelativeDateTimeField:
+    """
+    Unit tests for RelativeDateTimeField class - Django integration only
+    """
+
+    def test_required_field_with_empty_value(self):
+        """Test that required field raises ValidationError for empty values"""
+        field = RelativeDateTimeField(required=True)
+
+        with pytest.raises(ValidationError):
+            field.clean(None)
+
+        with pytest.raises(ValidationError):
+            field.clean("")
+
+    def test_optional_field_with_empty_value(self):
+        """Test that optional field accepts empty values"""
+        field = RelativeDateTimeField(required=False)
+
+        # Should not raise exception
+        result = field.clean(None)
+        assert result is None
+
+        result = field.clean("")
+        assert result is None
+
+    def test_clean_method_with_absolute_datetime(self):
+        """Test that clean() method properly processes absolute datetimes"""
+        field = RelativeDateTimeField()
+
+        result = field.clean("2024-06-15T14:30:00Z")
+
+        assert result is not None
+        assert result.year == 2024
+        assert result.month == 6
+        assert result.day == 15
+
+    def test_strptime_called_internally_during_clean(self):
+        """Test that strptime is called during field.clean() and handles relative datetimes"""
+        field = RelativeDateTimeField(input_formats=["%Y-%m-%d"])
+
+        # This should trigger strptime internally with the input format
+        # When the format doesn't match, it should fall back to relative parsing
+        result = field.clean("-1d")
+
+        expected_time = django_timezone.now() - timedelta(days=1)
+        assert abs(result - expected_time) < timedelta(seconds=1)
+
+    def test_relative_datetime_parsing_integration(self):
+        """Test basic relative datetime parsing through the field"""
+        field = RelativeDateTimeField()
+
+        result = field.clean("-1d")
+        expected_time = django_timezone.now() - timedelta(days=1)
+
+        assert abs(result - expected_time) < timedelta(seconds=1)
+
+    def test_invalid_relative_format_raises_validation_error(self):
+        """Test that invalid relative formats raise ValidationError"""
+        field = RelativeDateTimeField()
+
+        with pytest.raises(ValidationError):
+            field.clean("invalid_format")

--- a/osidb/tests/test_relative_datetime_filtering.py
+++ b/osidb/tests/test_relative_datetime_filtering.py
@@ -1,0 +1,181 @@
+"""
+Tests for relative datetime filtering via query parameters
+
+This test suite validates that the RelativeDateTimeFilter and RelativeDateFilter
+work correctly when filtering API endpoints using relative time strings like
+"-1d", "+2h", "-30m", etc.
+"""
+
+import datetime
+
+import pytest
+from freezegun import freeze_time
+from rest_framework import status
+
+from osidb.models import Affect
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+)
+
+pytestmark = pytest.mark.integration
+
+
+class TestRelativeDateTimeFilteringAffects:
+    """
+    Test relative datetime filtering on Affect endpoints
+    """
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_affect_created_dt_gt_filter(
+        self, auth_client, test_api_v2_uri, affects_at_different_times
+    ):
+        """Test created_dt__gt=-3h (created within last 3 hours)"""
+        affects = affects_at_different_times
+
+        response = auth_client().get(f"{test_api_v2_uri}/affects?created_dt__gt=-3h")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+
+        assert str(affects["affect_2_hours_ago"].uuid) in uuids
+        assert str(affects["affect_30_min_ago"].uuid) in uuids
+        assert str(affects["affect_5_hours_ago"].uuid) not in uuids
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_affect_created_dt_lte_filter(
+        self, auth_client, test_api_v2_uri, affects_at_different_times
+    ):
+        """Test created_dt__lte=-1h (created 1 hour ago or earlier)"""
+        affects = affects_at_different_times
+
+        response = auth_client().get(f"{test_api_v2_uri}/affects?created_dt__lte=-1h")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+
+        assert str(affects["affect_5_hours_ago"].uuid) in uuids
+        assert str(affects["affect_2_hours_ago"].uuid) in uuids
+        assert str(affects["affect_30_min_ago"].uuid) not in uuids
+
+
+class TestRelativeDateTimeFilteringTrackers:
+    """
+    Test relative datetime filtering on Tracker endpoints
+    """
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_tracker_created_dt_gt_filter(
+        self, auth_client, test_api_v2_uri, trackers_at_different_times
+    ):
+        """Test created_dt__gt=-2d (created within last 2 days)"""
+        trackers = trackers_at_different_times
+
+        response = auth_client().get(f"{test_api_v2_uri}/trackers?created_dt__gt=-2d")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+
+        assert str(trackers["tracker_1_day_ago"].uuid) in uuids
+        assert str(trackers["tracker_2_hours_ago"].uuid) in uuids
+        assert str(trackers["tracker_3_days_ago"].uuid) not in uuids
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_tracker_created_dt_lte_filter(
+        self, auth_client, test_api_v2_uri, trackers_at_different_times
+    ):
+        """Test created_dt__lte=-12h (created 12 hours ago or earlier)"""
+        trackers = trackers_at_different_times
+
+        response = auth_client().get(f"{test_api_v2_uri}/trackers?created_dt__lte=-12h")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+
+        assert str(trackers["tracker_3_days_ago"].uuid) in uuids
+        assert str(trackers["tracker_1_day_ago"].uuid) in uuids
+        assert str(trackers["tracker_2_hours_ago"].uuid) not in uuids
+
+
+class TestFlawChangedFilters:
+    """
+    Test relative datetime filtering using changed_after and changed_before on Flaw endpoints
+    """
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_flaw_changed_after_filter(
+        self, auth_client, test_api_v2_uri, flaws_at_different_update_times
+    ):
+        """Test changed_after=-2d (updated within last 2 days)"""
+        flaws = flaws_at_different_update_times
+
+        response = auth_client().get(f"{test_api_v2_uri}/flaws?changed_after=-2d")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+
+        assert str(flaws["flaw_1_day_ago"].uuid) in uuids
+        assert str(flaws["flaw_2_hours_ago"].uuid) in uuids
+        assert str(flaws["flaw_3_days_ago"].uuid) not in uuids
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_flaw_changed_before_filter(
+        self, auth_client, test_api_v2_uri, flaws_at_different_update_times
+    ):
+        """Test changed_before=-12h (updated 12 hours ago or earlier)"""
+        flaws = flaws_at_different_update_times
+
+        response = auth_client().get(f"{test_api_v2_uri}/flaws?changed_before=-12h")
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+
+        assert str(flaws["flaw_3_days_ago"].uuid) in uuids
+        assert str(flaws["flaw_1_day_ago"].uuid) in uuids
+        assert str(flaws["flaw_2_hours_ago"].uuid) not in uuids
+
+
+class TestRelativeDateTimeCompatibility:
+    """
+    Test that absolute datetime filtering still works alongside relative datetime filtering
+    """
+
+    @freeze_time("2024-06-15 12:00:00")
+    def test_absolute_datetime_still_works(self, auth_client, test_api_v2_uri):
+        """Test that absolute datetime strings still work alongside relative ones"""
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_stream = PsUpdateStreamFactory(ps_module=ps_module)
+        flaw = FlawFactory(embargoed=False)
+
+        affect_recent = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_update_stream=ps_stream.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            created_dt=datetime.datetime(
+                2024, 6, 14, 10, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+        affect_old = AffectFactory(
+            flaw=flaw,
+            ps_module=ps_module.name,
+            ps_update_stream=ps_stream.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            created_dt=datetime.datetime(
+                2024, 6, 1, 10, 0, 0, tzinfo=datetime.timezone.utc
+            ),
+        )
+
+        # Test with absolute datetime string
+        response = auth_client().get(
+            f"{test_api_v2_uri}/affects?created_dt__gt=2024-06-10T00:00:00Z"
+        )
+        assert response.status_code == status.HTTP_200_OK
+        results = response.json()["results"]
+        uuids = {r["uuid"] for r in results}
+        assert str(affect_recent.uuid) in uuids
+        assert str(affect_old.uuid) not in uuids


### PR DESCRIPTION
## Summary
- Added `RelativeDateTimeField` that accept relative time expressions (e.g., `-1d`, `+2h`, `-30m`) and absolute time expressions (e.g. `2026-07-02 00:00:00`)
- Update filters to use this relative field for datetime values (excluding deprecated V1 filters)

🤖 Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>