### PR TITLE
OSIDB-5078:Trigger Upstream Maintainer Notification Creation on Mapping Change

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `upstream maintainer` notification models (OSIDB-5076)
 - Add create SRP report when Flaw is EXPLOITS_KEV_APPROVED or MAJOR_INCIDENT (OSIDB-5067)
 - Automatic creation of upsteam maintainer notification when criteria is met for flaw (OSIDB-5077)
+- Add signal to trigger upstream maintainer notification creation on FlawUpstreamMapping save (OSIDB-5078)
+
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/regulatory_reporting/signals.py
+++ b/regulatory_reporting/signals.py
@@ -7,7 +7,7 @@ from django.dispatch import receiver
 from osidb.models import Flaw
 from regulatory_reporting.models import SRPReport, SRPReportMilestone
 
-from .models.upstream import UpstreamNotification
+from .models.upstream import FlawUpstreamMapping, UpstreamNotification
 from .services import is_flaw_upstream_notifiable
 
 logger = logging.getLogger(__name__)
@@ -82,6 +82,7 @@ def check_upstream_notifiable(sender, instance, **kwargs):
 
     notification, created = UpstreamNotification.objects.get_or_create(
         flaw=instance,
+        upstream_project=None,
         defaults={
             "status": UpstreamNotification.NotificationStatus.REQUIRED,
             "reportability_reason": UpstreamNotification.ReportabilityReason.RED_HAT_IDENTIFIED,
@@ -90,4 +91,41 @@ def check_upstream_notifiable(sender, instance, **kwargs):
     if created:
         logger.info(
             f"Created upstream notification {notification.uuid} for flaw {instance.uuid}"
+        )
+
+
+@receiver(post_save, sender=FlawUpstreamMapping)
+def link_mapping_to_notification(sender, instance, created, **kwargs):
+    """
+    On FlawUpstreamMapping creation, backfill the existing project
+    """
+    if not settings.CRA_NOTIFICATIONS_ENABLED:
+        return
+    if not created:
+        return
+
+    notification = (
+        UpstreamNotification.objects.filter(
+            flaw=instance.flaw, upstream_project__isnull=True
+        )
+        .order_by("created_dt")
+        .first()
+    )
+
+    if notification:
+        notification.upstream_project = instance.upstream_project
+        notification.save(update_fields=["upstream_project", "updated_dt"])
+        logger.info(
+            f"Backfilled upstream_project on notification {notification.uuid} "
+            f"for {instance.flaw.uuid}"
+        )
+    else:
+        notification = UpstreamNotification.objects.create(
+            flaw=instance.flaw,
+            upstream_project=instance.upstream_project,
+            status=UpstreamNotification.NotificationStatus.REQUIRED,
+            reportability_reason=UpstreamNotification.ReportabilityReason.RED_HAT_IDENTIFIED,
+        )
+        logger.info(
+            f"Created new notification {notification.uuid} for {instance.flaw.uuid}"
         )

--- a/regulatory_reporting/tests/test_services.py
+++ b/regulatory_reporting/tests/test_services.py
@@ -3,7 +3,11 @@ from django.test import override_settings
 
 from osidb.models import FlawSource
 from osidb.tests.factories import FlawFactory
-from regulatory_reporting.models.upstream import UpstreamNotification
+from regulatory_reporting.models.upstream import (
+    FlawUpstreamMapping,
+    UpstreamNotification,
+    UpstreamProject,
+)
 from regulatory_reporting.services import is_flaw_upstream_notifiable
 
 
@@ -49,4 +53,47 @@ class TestUpstreamNotificationSignal:
             embargoed=False,
             source=FlawSource.REDHAT,
         )
+        assert not UpstreamNotification.objects.filter(flaw=flaw).exists()
+
+
+@pytest.mark.enable_signals
+@pytest.mark.django_db
+class TestMappingNotificationSignal:
+    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
+    def test_backfills_existing_blank_notification(self):
+        flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
+        notification = UpstreamNotification.objects.get(flaw=flaw)
+        assert notification.upstream_project is None
+        project = UpstreamProject.objects.create(component_name="test-component")
+        FlawUpstreamMapping.objects.create(flaw=flaw, upstream_project=project)
+        notification.refresh_from_db()
+        assert notification.upstream_project == project
+        assert UpstreamNotification.objects.filter(flaw=flaw).count() == 1
+
+    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
+    def test_second_mapping_creates_separate_notification(self):
+        flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
+        project1 = UpstreamProject.objects.create(component_name="comp-1")
+        project2 = UpstreamProject.objects.create(component_name="comp-2")
+        FlawUpstreamMapping.objects.create(flaw=flaw, upstream_project=project1)
+        FlawUpstreamMapping.objects.create(flaw=flaw, upstream_project=project2)
+        assert UpstreamNotification.objects.filter(flaw=flaw).count() == 2
+
+    @override_settings(CRA_NOTIFICATIONS_ENABLED=True)
+    def test_backfills_even_if_status_already_blocked(self):
+        flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
+        notification = UpstreamNotification.objects.get(flaw=flaw)
+        notification.status = UpstreamNotification.NotificationStatus.BLOCKED
+        notification.save()
+        project = UpstreamProject.objects.create(component_name="test-component")
+        FlawUpstreamMapping.objects.create(flaw=flaw, upstream_project=project)
+        notification.refresh_from_db()
+        assert notification.upstream_project == project
+        assert notification.status == UpstreamNotification.NotificationStatus.BLOCKED
+
+    @override_settings(CRA_NOTIFICATIONS_ENABLED=False)
+    def test_flag_disabled_does_not_backfill(self):
+        flaw = FlawFactory(embargoed=False, source=FlawSource.REDHAT)
+        project = UpstreamProject.objects.create(component_name="test-component")
+        FlawUpstreamMapping.objects.create(flaw=flaw, upstream_project=project)
         assert not UpstreamNotification.objects.filter(flaw=flaw).exists()


### PR DESCRIPTION
When a `FlawUpstreamMapping` is created backfill the `upstream_project`
- Add post-save signal on `FlawUpstreamMapping` in `signals.py`
- Add tests
Closes:OSIDB-5078