### PR TITLE
OSIDB-5081 Add serializers to Upstream Maintainer Notification

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `upstream maintainer` notification models (OSIDB-5076)
 - Add create SRP report when Flaw is EXPLOITS_KEV_APPROVED or MAJOR_INCIDENT (OSIDB-5067)
 - Automatic creation of upsteam maintainer notification when criteria is met for flaw (OSIDB-5077)
+- Add serializers for upstream maintainer notification (OSIDB-5081)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/regulatory_reporting/serializers/__init__.py
+++ b/regulatory_reporting/serializers/__init__.py
@@ -1,0 +1,11 @@
+from .upstream import (
+    FlawUpstreamMappingSerializer,
+    UpstreamNotificationSerializer,
+    UpstreamProjectSerializer,
+)
+
+__all__ = [
+    "FlawUpstreamMappingSerializer",
+    "UpstreamProjectSerializer",
+    "UpstreamNotificationSerializer",
+]

--- a/regulatory_reporting/serializers/upstream.py
+++ b/regulatory_reporting/serializers/upstream.py
@@ -1,0 +1,70 @@
+from rest_framework import serializers
+
+from osidb.serializer import ACLMixinSerializer, TrackingMixinSerializer
+from regulatory_reporting.models.upstream import (
+    FlawUpstreamMapping,
+    UpstreamNotification,
+    UpstreamProject,
+)
+
+
+class UpstreamProjectSerializer(TrackingMixinSerializer):
+    uuid = serializers.UUIDField(read_only=True)
+
+    class Meta:
+        model = UpstreamProject
+        fields = TrackingMixinSerializer.Meta.fields + [
+            "uuid",
+            "component_name",
+            "repository_url",
+            "security_contact",
+            "contact_method",
+            "contact_url",
+            "source",
+            "confidence",
+            "verified_at",
+            "verified_by",
+            "unsupported",
+            "stewarded_awareness",
+            "stewarded_awareness_reason",
+            "stewarded_awareness_marked_by",
+            "stewarded_awareness_marked_at",
+            "notes",
+        ]
+
+
+class FlawUpstreamMappingSerializer(TrackingMixinSerializer):
+    uuid = serializers.UUIDField(read_only=True)
+    flaw_uuid = serializers.UUIDField(read_only=True, source="flaw.uuid")
+
+    class Meta:
+        model = FlawUpstreamMapping
+        fields = TrackingMixinSerializer.Meta.fields + [
+            "uuid",
+            "flaw_uuid",
+            "upstream_project",
+            "notes",
+        ]
+
+
+class UpstreamNotificationSerializer(ACLMixinSerializer, TrackingMixinSerializer):
+    uuid = serializers.UUIDField(read_only=True)
+    flaw_uuid = serializers.UUIDField(read_only=True, source="flaw.uuid")
+    last_error = serializers.CharField(read_only=True)
+
+    class Meta(ACLMixinSerializer.Meta, TrackingMixinSerializer.Meta):
+        model = UpstreamNotification
+        fields = (
+            ACLMixinSerializer.Meta.fields
+            + TrackingMixinSerializer.Meta.fields
+            + [
+                "uuid",
+                "flaw_uuid",
+                "upstream_project",
+                "status",
+                "reportability_reason",
+                "method",
+                "timer_started_at",
+                "last_error",
+            ]
+        )

--- a/regulatory_reporting/tests/factories.py
+++ b/regulatory_reporting/tests/factories.py
@@ -2,7 +2,13 @@ import factory
 from django.utils import timezone
 
 from osidb.tests.factories import FlawFactory
-from regulatory_reporting.models import SRPReport, SRPReportMilestone
+from regulatory_reporting.models import (
+    FlawUpstreamMapping,
+    SRPReport,
+    SRPReportMilestone,
+    UpstreamNotification,
+    UpstreamProject,
+)
 
 
 class SRPReportFactory(factory.django.DjangoModelFactory):
@@ -28,3 +34,30 @@ class SRPReportMilestoneFactory(factory.django.DjangoModelFactory):
     milestone_type = SRPReportMilestone.MilestoneType.LEVEL_24H
     acl_read = factory.LazyAttribute(lambda o: o.srp_report.acl_read)
     acl_write = factory.LazyAttribute(lambda o: o.srp_report.acl_write)
+
+
+class UpstreamProjectFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = UpstreamProject
+
+    component_name = factory.Faker("word")
+    repository_url = factory.Faker("url")
+
+
+class UpstreamNotificationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = UpstreamNotification
+
+    flaw = factory.SubFactory(FlawFactory)
+    upstream_project = factory.SubFactory(UpstreamProjectFactory)
+    status = UpstreamNotification.NotificationStatus.REQUIRED
+    acl_read = factory.LazyAttribute(lambda o: o.flaw.acl_read)
+    acl_write = factory.LazyAttribute(lambda o: o.flaw.acl_write)
+
+
+class FlawUpstreamMappingFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = FlawUpstreamMapping
+
+    flaw = factory.SubFactory(FlawFactory)
+    upstream_project = factory.SubFactory(UpstreamProjectFactory)

--- a/regulatory_reporting/tests/test_serializers.py
+++ b/regulatory_reporting/tests/test_serializers.py
@@ -1,0 +1,61 @@
+import pytest
+
+from regulatory_reporting.serializers import (
+    FlawUpstreamMappingSerializer,
+    UpstreamNotificationSerializer,
+    UpstreamProjectSerializer,
+)
+from regulatory_reporting.tests.factories import (
+    FlawUpstreamMappingFactory,
+    UpstreamNotificationFactory,
+    UpstreamProjectFactory,
+)
+
+
+class TestUpstreamProjectSerializer:
+    def test_fields(self):
+        fields = UpstreamProjectSerializer().fields.keys()
+        assert "uuid" in fields
+        assert "component_name" in fields
+        assert "repository_url" in fields
+        assert "created_dt" in fields
+        assert "updated_dt" in fields
+
+    @pytest.mark.django_db
+    def test_serializes_instance(self):
+        project = UpstreamProjectFactory()
+        data = UpstreamProjectSerializer(project).data
+        assert data["component_name"] == project.component_name
+        assert data["repository_url"] == project.repository_url
+        assert str(project.uuid) == data["uuid"]
+
+
+class TestUpstreamNotificationSerializer:
+    def test_fields(self):
+        fields = UpstreamNotificationSerializer().fields.keys()
+        assert "status" in fields
+        assert "flaw_uuid" in fields
+        assert "embargoed" in fields
+        assert "visibility" in fields
+        assert "created_dt" in fields
+
+    @pytest.mark.django_db
+    def test_serializes_instance(self):
+        notification = UpstreamNotificationFactory()
+        data = UpstreamNotificationSerializer(notification).data
+        assert data["status"] == notification.status
+        assert data["upstream_project"] == notification.upstream_project.uuid
+
+
+class TestFlawUpstreamMappingSerializer:
+    def test_fields(self):
+        fields = FlawUpstreamMappingSerializer().fields.keys()
+        assert "flaw_uuid" in fields
+        assert "upstream_project" in fields
+
+    @pytest.mark.django_db
+    def test_serializes_instance(self):
+        mapping = FlawUpstreamMappingFactory()
+        data = FlawUpstreamMappingSerializer(mapping).data
+        assert data["upstream_project"] == mapping.upstream_project.uuid
+        assert data["notes"] == mapping.notes


### PR DESCRIPTION
 Add serializers to Upstream Maintainer Notification
- Added `serializers` for `UpStreamProject,` `UpstreamNotification` and `FlawUpstreamMapping` in `upstream.py.`
- Added `factories.py` and tests in `test_serializers.py`.
- Added entry in `CHANGELOG.md`
Closes: OSIDB-5081
