### PR TITLE
Update oasdiff to version 1.21.0

### DIFF
--- a/.github/workflows/meta.yml
+++ b/.github/workflows/meta.yml
@@ -15,9 +15,9 @@ jobs:
           path: base
       - uses: actions/setup-go@v5
       - name: Install oasdiff go package
-        run: go install github.com/tufin/oasdiff@v1.5.0
+        run: go install github.com/oasdiff/oasdiff@v1.21.0
       - name: Compare existing schema to new schema
-        run: oasdiff -fail-on-diff -fail-on-warns -check-breaking -base base/openapi.yml -revision head/openapi.yml
+        run: oasdiff breaking base/openapi.yml head/openapi.yml --fail-on WARN --auto-upgrade
   changelog:
     runs-on: ubuntu-latest
     if: ${{ github.actor != 'dependabot[bot]' }}


### PR DESCRIPTION
## Summary
Since we are using OpenAPI 3.1 now, we need to update our pipelines oasdiff package from the pinned 1.5.0 to 1.21.0
