### PR TITLE
Update ACE task to use new workflow framework

### DIFF
--- a/apps/ace/tasks.py
+++ b/apps/ace/tasks.py
@@ -35,7 +35,7 @@ from config.celery import app
 from osidb.helpers import bypass_rls
 from osidb.models import Flaw
 from osidb.models.affect import Affect, AffectSettings, NotAffectedJustification
-from osidb.models.flaw.label import FlawCollaborator, FlawLabel
+from osidb.models.flaw.label_v2 import WorkflowLabel
 from osidb.models.flaw.upstream import UpstreamData
 
 logger = get_task_logger(__name__)
@@ -119,14 +119,7 @@ def _is_verified_mapping(component: str, resolved: list[str]) -> bool:
 def _apply_label(flaw: Flaw, label: str) -> None:
     if not label:
         return
-    FlawCollaborator.objects.get_or_create(
-        flaw=flaw,
-        label=label,
-        defaults={
-            "type": FlawLabel.FlawLabelType.CONTEXT_BASED,
-            "state": FlawCollaborator.FlawCollaboratorState.NEW,
-        },
-    )
+    WorkflowLabel.objects.get_or_create(flaw=flaw, name=label)
 
 
 def _pre_filter_component(

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -658,7 +658,7 @@ def test_sync_skips_blocked_component(monkeypatch, ace_enabled, mock_querier):
     stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
 
     assert stats["created"] == 0
-    assert flaw.labels.filter(label=LABEL_AUTO_REJECTED).exists()
+    assert flaw.labels_v2.filter(name=LABEL_AUTO_REJECTED).exists()
 
 
 @pytest.mark.django_db
@@ -688,8 +688,8 @@ def test_sync_blocked_component_skips_entire_flaw(
     assert stats["created"] == 0
     assert stats["pre_filtered"] == 1
     assert search_calls == []
-    assert flaw.labels.filter(label=LABEL_AUTO_REJECTED).exists()
-    assert not flaw.labels.filter(label=LABEL_AUTO_AFFECTS).exists()
+    assert flaw.labels_v2.filter(name=LABEL_AUTO_REJECTED).exists()
+    assert not flaw.labels_v2.filter(name=LABEL_AUTO_AFFECTS).exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
The new workflow framework uses `WorkflowLabels` instead of the old labels. ACE will rely on this framework so that flaws can be auto-rejected under certain conditions, using the new labels, so the ACE code has been updated accordingly.