### PR TITLE
fix: Add BU labels in flaw label sync command

### DIFF
--- a/osidb/management/commands/sync_flaw_labels.py
+++ b/osidb/management/commands/sync_flaw_labels.py
@@ -11,9 +11,13 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         now = timezone.now()
-        context_based, product_based = fetch_flaw_labels(FLAW_LABELS_URL)
+        context_based, product_based, bu_labels = fetch_flaw_labels(FLAW_LABELS_URL)
 
-        sync_flaw_labels(context_based, product_based)
+        sync_flaw_labels(
+            context_based=context_based,
+            product_family=product_based,
+            bu_labels=bu_labels,
+        )
         cm = CollectorMetadata.objects.get(
             name="collectors.flaw_labels.tasks.flaw_labels_collector"
         )


### PR DESCRIPTION
## Summary
- Updated `sync_flaw_labels` command to handle BU labels from the flaw labels API
- Modified the function call to use keyword arguments for clarity

🤖 Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>