### PR TITLE
Add worktree make commands for runtime isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ pyrightconfig.json
 \#*\#
 .\#*
 
+# Worktree-specific environment
+.env.worktree
+
 # Codegraph knowledge graph directory
 .codegraph/

--- a/docker-compose.test.worktree.yml
+++ b/docker-compose.test.worktree.yml
@@ -1,0 +1,14 @@
+version: '3'
+
+# Worktree isolation override for test services
+# Usage: docker-compose -f docker-compose.test.yml -f docker-compose.test.worktree.yml up
+
+services:
+  testldap:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-testldap
+
+  testrunner:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-testrunner
+
+  locust:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-locust

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,8 +7,8 @@ services:
       image: mirror.gcr.io/osixia/openldap:1.5.0
       command: --copy-service -l debug
       ports:
-        - '1389:1389'
-        - '1636:1636'
+        - '${LDAP_PORT:-1389}:1389'
+        - '${LDAPS_PORT:-1636}:1636'
       environment:
         - LDAP_DOMAIN=redhat.com
         - LDAP_BASE_DN=dc=redhat,dc=com
@@ -50,7 +50,7 @@ services:
       container_name: locust
       image: mirror.gcr.io/locustio/locust:2.20.1
       ports:
-        - '9000:8089'
+        - '${LOCUST_PORT:-9000}:8089'
       volumes:
         - ${PWD}/perf/main.py:/mnt/locust/main.py:z
       command: -f /mnt/locust/main.py -H http://osidb-service:8000 --web-host 0.0.0.0 --modern-ui SFM2User SDEngineUser GriffonUser OSIMUser

--- a/docker-compose.worktree.yml
+++ b/docker-compose.worktree.yml
@@ -1,0 +1,31 @@
+version: '3'
+
+# Worktree isolation override
+# Usage: docker-compose -f docker-compose.yml -f docker-compose.worktree.yml up
+# Set COMPOSE_PROJECT_NAME to namespace containers/volumes per worktree
+
+services:
+  osidb-service:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-service
+
+  osidb-data:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-data
+
+  redis:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-redis
+
+  flower:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-flower
+
+  celery_beat:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-celery-beat
+
+  celery-fifo-1:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-celery-fifo-1
+
+  celery-fifo-2:
+    container_name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-celery-fifo-2
+
+volumes:
+  pg-data:
+    name: ${COMPOSE_PROJECT_NAME:?COMPOSE_PROJECT_NAME is required - run make worktree-generate-env first}-pg-data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
       stdin_open: true
       tty: true
       ports:
-        - "8000:8000"
+        - "${OSIDB_PORT:-8000}:8000"
       environment:
         BBSYNC_SYNC_TO_BZ: ${BBSYNC_SYNC_TO_BZ}
         BBSYNC_SYNC_FLAWS_TO_BZ: ${BBSYNC_SYNC_FLAWS_TO_BZ}
@@ -144,7 +144,7 @@ services:
         - ${PWD}/etc/pg/local-server.crt:/var/lib/postgresql/local-server.crt:z
         - ${PWD}/etc/pg/local-server.key:/var/lib/postgresql/local-server.key:z
       ports:
-        - "5432"
+        - "${POSTGRES_PORT:+${POSTGRES_PORT}:}5432"
       command: >
           -c ssl=on
           -c ssl_cert_file=/var/lib/postgresql/local-server.crt
@@ -269,7 +269,7 @@ services:
       pull_policy: never
       command: ./scripts/run-flower.sh
       ports:
-        - "5555:5555"
+        - "${FLOWER_PORT:-5555}:5555"
       volumes:
         - ${PWD}:/opt/app-root/src:z
       environment:
@@ -287,7 +287,7 @@ services:
       hostname: redis
       image: mirror.gcr.io/library/redis:6
       ports:
-        - "6379"
+        - "${REDIS_PORT:+${REDIS_PORT}:}6379"
 
 volumes:
   pg-data:

--- a/mk/worktree.mk
+++ b/mk/worktree.mk
@@ -1,0 +1,169 @@
+############################################################################
+## Worktree-isolated development
+############################################################################
+
+# Load worktree-specific environment if it exists
+-include .env.worktree
+
+
+#***********************************
+### Generate worktree environment file with unique ports
+#***********************************
+.PHONY: worktree-generate-env
+worktree-generate-env:
+	@./scripts/generate-worktree-ports.sh
+
+
+#***********************************
+### Ensure .env.worktree exists (generate if absent)
+#***********************************
+.PHONY : worktree-ensure-env
+worktree-ensure-env:
+	@[ -f .env.worktree ] || $(MAKE) worktree-generate-env
+
+
+#***********************************
+### Build worktree-isolated docker images
+#***********************************
+.PHONY: worktree-build
+worktree-build: worktree-ensure-env
+	@echo ">building docker images for worktree: $(COMPOSE_PROJECT_NAME)"
+	$(podman) compose --env-file=.env.worktree -f docker-compose.yml -f docker-compose.worktree.yml -f docker-compose.test.yml -f docker-compose.test.worktree.yml down
+	$(podman) compose --env-file=.env.worktree -f docker-compose.yml -f docker-compose.worktree.yml build
+	$(podman) compose --env-file=.env.worktree -f docker-compose.yml -f docker-compose.worktree.yml pull
+	$(podman) compose --env-file=.env.worktree -f docker-compose.test.yml -f docker-compose.test.worktree.yml build
+	$(podman) compose --env-file=.env.worktree -f docker-compose.test.yml -f docker-compose.test.worktree.yml pull
+
+
+#***********************************
+### Build worktree dev env: images, venv, do checks
+#***********************************
+.PHONY: worktree-dev-env
+worktree-dev-env:
+	@echo -n "This will check installed RPMs, create certificate files, build podman images, and create a python venv for this worktree. Continue? [y/N]" && read ans && [ $${ans:-N} = y ]
+	$(MAKE) worktree-generate-env
+	$(MAKE) dev-rpm-install
+	$(MAKE) check-reg
+	$(MAKE) generate_local_pg_tls_cert
+	$(MAKE) worktree-build
+	$(MAKE) venv
+	$(MAKE) check-venv
+
+
+#***********************************
+### Start containers for worktree-isolated development
+#***********************************
+# Automatically derives COMPOSE_PROJECT_NAME from directory name to avoid collisions
+.PHONY : worktree-start
+worktree-start: check-venv generate_local_pg_tls_cert
+	$(MAKE) worktree-generate-env
+	$(MAKE) worktree-compose-up
+	$(MAKE) worktree-restart-django-foreground
+
+.PHONY : worktree-start-bg
+worktree-start-bg: check-venv generate_local_pg_tls_cert
+	$(MAKE) worktree-generate-env
+	$(MAKE) worktree-compose-up
+	$(MAKE) worktree-start-bg-info
+
+.PHONY : worktree-start-bg-info
+worktree-start-bg-info:
+	@echo ">Django is running in the background in $(COMPOSE_PROJECT_NAME)-service"
+	@echo ">Use 'make worktree-restart-django-foreground' to attach to it"
+	@echo ">Use 'make worktree-stop' to stop containers"
+
+
+#***********************************
+### Stop worktree containers without deleting
+#***********************************
+.PHONY : worktree-stop
+worktree-stop: worktree-ensure-env
+	@echo ">stopping worktree env without deleting containers"
+	$(podman) compose --env-file=.env.worktree \
+		-f docker-compose.yml -f docker-compose.worktree.yml \
+		-f docker-compose.test.yml -f docker-compose.test.worktree.yml \
+		stop \
+	|| $(podman) compose --env-file=.env.worktree \
+		-f docker-compose.yml -f docker-compose.worktree.yml \
+		-f docker-compose.test.yml -f docker-compose.test.worktree.yml \
+		stop testrunner testldap flower redis celery_beat celery \
+		celery-fifo-1 celery-fifo-2 locust osidb-service osidb-data
+
+
+#***********************************
+### Stop and delete worktree containers and volumes, but not images
+#***********************************
+.PHONY : worktree-compose-down
+worktree-compose-down: worktree-ensure-env
+	@echo ">$(podman) compose down - stopping and deleting worktree containers and volumes, but not deleting images"
+	@echo -n "Are you really sure? [y/N] " && read ans && [ $${ans:-N} = y ]
+	$(podman) compose --env-file=.env.worktree -f docker-compose.yml -f docker-compose.worktree.yml -f docker-compose.test.yml -f docker-compose.test.worktree.yml down -v
+
+
+#***********************************
+### podman-compose up for worktree isolation
+#***********************************
+.PHONY : worktree-compose-up
+worktree-compose-up: worktree-ensure-env
+	$(MAKE) worktree-compose-up-exec
+
+.PHONY : worktree-compose-up-exec
+worktree-compose-up-exec:
+	@echo ">compose up for worktree: $(COMPOSE_PROJECT_NAME)"
+	@echo ">Ports: OSIDB=$(OSIDB_PORT) POSTGRES=$(POSTGRES_PORT) REDIS=$(REDIS_PORT) FLOWER=$(FLOWER_PORT) LDAP=$(LDAP_PORT) LDAPS=$(LDAPS_PORT) LOCUST=$(LOCUST_PORT)"
+	@$(podman) compose --env-file=.env.worktree -f docker-compose.yml -f docker-compose.worktree.yml -f docker-compose.test.yml -f docker-compose.test.worktree.yml up -d
+	@attempts=0; max=60; \
+	while ! $(podman) exec -it $(COMPOSE_PROJECT_NAME)-service bash -c '( { curl -f http://127.0.0.1:8000/osidb/healthy >/dev/null 2>&1 || exit 1 ; } )' ; do \
+	  attempts=$$((attempts + 1)) ; \
+	  if [ $$attempts -ge $$max ] ; then echo ">$(COMPOSE_PROJECT_NAME)-service failed to become healthy after $$((max * 2)) seconds" ; exit 1 ; fi ; \
+	  echo ">waiting for $(COMPOSE_PROJECT_NAME)-service ($$attempts/$$max)" ; \
+	  sleep 2 ; \
+	done
+	@sleep 2
+	@echo ">setting up static files directory and collecting static files"
+	@$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service bash -c "mkdir -p /var/www/osidb/static && python3 manage.py collectstatic --noinput --settings=config.settings_local"
+	@echo ">compose is up"
+
+
+#***********************************
+### Restart django and run it in foreground (worktree)
+#***********************************
+.PHONY : worktree-restart-django-foreground
+worktree-restart-django-foreground: worktree-ensure-env
+	@echo ">Note that after CTRL+C, django server will restart in the background, as long as $(COMPOSE_PROJECT_NAME)-service is running."
+	@sleep 0.5
+	$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service pkill -f "python3 manage.py runserver"
+	$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service python3 manage.py runserver 0.0.0.0:8000
+
+
+#***********************************
+### Start development shell in worktree osidb-service container
+#***********************************
+.PHONY : worktree-shell-service
+worktree-shell-service: worktree-ensure-env
+	$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service python3 manage.py shell --settings=config.settings_local
+
+
+#***********************************
+### Start bash shell in worktree osidb-service container
+#***********************************
+.PHONY : worktree-bash-service
+worktree-bash-service: worktree-ensure-env
+	$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service bash
+
+
+#***********************************
+### Create and apply migrations in worktree
+#***********************************
+.PHONY : worktree-migrate
+worktree-migrate:
+	$(MAKE) worktree-generate-env
+	$(MAKE) worktree-migrate-exec
+
+.PHONY : worktree-migrate-exec
+worktree-migrate-exec:
+	@if ! $(podman) exec -it $(COMPOSE_PROJECT_NAME)-service bash -c '( { curl -f http://127.0.0.1:8000/osidb/healthy >/dev/null 2>&1 || exit 1 ; } )' ; then $(MAKE) worktree-compose-up ; fi
+	@echo ">creating migrations in $(COMPOSE_PROJECT_NAME)-service"
+	$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service python3 manage.py makemigrations --settings config.settings_local
+	@echo ">applying migrations in $(COMPOSE_PROJECT_NAME)-service"
+	$(podman) exec -it $(COMPOSE_PROJECT_NAME)-service python3 manage.py migrate --settings config.settings_local

--- a/scripts/generate-worktree-ports.sh
+++ b/scripts/generate-worktree-ports.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# Auto-generate unique ports for worktree based on directory name
+IFS=$' \t\n'
+set -euo pipefail
+
+WORKTREE_NAME=$(basename "$PWD" | tr '[:upper:]' '[:lower:]' | sed 's/^[^a-z0-9]*//' | sed 's/[^a-z0-9_-]/-/g')
+[ -n "$WORKTREE_NAME" ] || WORKTREE_NAME="worktree-$(echo "$PWD" | cksum | cut -d' ' -f1)"
+
+PORT_OFFSET=$(echo "$PWD" | cksum | cut -d' ' -f1)
+[[ "$PORT_OFFSET" =~ ^[0-9]+$ ]] || { echo "ERROR: cksum produced non-numeric output: $PORT_OFFSET" >&2; exit 1; }
+PORT_OFFSET=$(( (PORT_OFFSET % 999) + 1 ))
+
+# Probe for port conflicts with other git worktrees; increment offset until clear
+_has_port_conflict() {
+    local offset="$1"
+    local my_ports="$((8000 + offset)) $((5432 + offset)) $((6379 + offset)) $((5555 + offset)) $((1389 + offset)) $((1636 + offset)) $((9000 + offset))"
+    local wt_path env_file line port p
+    while IFS= read -r wt_path; do
+        [ "$wt_path" = "$PWD" ] && continue
+        env_file="${wt_path}/.env.worktree"
+        [ -f "$env_file" ] || continue
+        while IFS= read -r line; do
+            case "$line" in
+                OSIDB_PORT=*|POSTGRES_PORT=*|REDIS_PORT=*|FLOWER_PORT=*|LDAP_PORT=*|LDAPS_PORT=*|LOCUST_PORT=*)
+                    port="${line#*=}"
+                    for p in $my_ports; do [ "$p" = "$port" ] && return 0; done
+                    ;;
+            esac
+        done < "$env_file"
+    done < <(git worktree list --porcelain 2>/dev/null | sed -n 's/^worktree //p')
+    return 1
+}
+
+if git rev-parse --git-dir >/dev/null 2>&1; then
+    tries=0
+    while _has_port_conflict "$PORT_OFFSET"; do
+        PORT_OFFSET=$(( (PORT_OFFSET % 999) + 1 ))
+        tries=$((tries + 1))
+        [ "$tries" -lt 999 ] || { echo "ERROR: Cannot find a non-conflicting port allocation" >&2; exit 1; }
+    done
+fi
+
+# Copy base .env to .env.worktree
+cp .env .env.worktree
+
+# Append worktree-specific overrides
+cat >> .env.worktree <<EOF
+
+# === Worktree-specific overrides below ===
+# Auto-generated - DO NOT EDIT - regenerate with: make worktree-generate-env
+
+# Worktree-specific project name
+COMPOSE_PROJECT_NAME=${WORKTREE_NAME}
+
+# Worktree-specific service ports (base + offset to avoid collisions)
+OSIDB_PORT=$((8000 + PORT_OFFSET))
+POSTGRES_PORT=$((5432 + PORT_OFFSET))
+REDIS_PORT=$((6379 + PORT_OFFSET))
+FLOWER_PORT=$((5555 + PORT_OFFSET))
+LDAP_PORT=$((1389 + PORT_OFFSET))
+LDAPS_PORT=$((1636 + PORT_OFFSET))
+LOCUST_PORT=$((9000 + PORT_OFFSET))
+EOF
+
+echo "Generated .env.worktree for worktree: $WORKTREE_NAME"
+echo "Ports: OSIDB=$((8000 + PORT_OFFSET)) POSTGRES=$((5432 + PORT_OFFSET)) REDIS=$((6379 + PORT_OFFSET)) FLOWER=$((5555 + PORT_OFFSET))"


### PR DESCRIPTION
## Summary
- Added make commands for running OSIDB in git worktrees with runtime isolation
- Auto-generates unique ports per worktree to avoid conflicts with main development environment
- Adds worktree-specific docker-compose overrides

## Changes
- New `mk/worktree.mk` with commands: `worktree-start`, `worktree-dev-env`, `worktree-migrate`, etc.
- New `scripts/generate-worktree-ports.sh` for automatic port allocation based on worktree name
- New `docker-compose.worktree.yml` and `docker-compose.test.worktree.yml` override files
- Updated main docker-compose files to support configurable ports via environment variables

🤖 Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>