### PR TITLE
ignore repeated related entries on snippets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed double error raise problem in sync_manager.
 - Fix incorrect OpenAPI schema types for audit endpoint fields (pgh_data, pgh_context, pgh_diff) (OSIDB-3637)
 - Return descriptive 400 error instead of 500 on malformed bulk affects requests (OSIDB-3134)
+- Fix collectors being blocked by duplicated related model entries (OSIDB-5221)
 
 ### Removed
 - deprecate workflow manipulation endpoints

--- a/osidb/models/snippet.py
+++ b/osidb/models/snippet.py
@@ -8,7 +8,9 @@ from django.db import models
 from collectors.bzimport.constants import BZ_API_KEY
 from osidb.mixins import ACLMixin, AlertMixin, TrackingMixin, validator
 
+from .flaw.cvss import FlawCVSS
 from .flaw.flaw import Flaw
+from .flaw.reference import FlawReference
 
 
 class Snippet(ACLMixin, AlertMixin, TrackingMixin):
@@ -126,6 +128,14 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
         # creates related models (e.g. FlawCVSS)
         for model, list_of_data in related_models.items():
             for data in list_of_data:
+                lookup = self._related_model_lookup(model, flaw, data)
+                if lookup is not None:
+                    defaults = {
+                        k: v for k, v in (data | shared_acl).items() if k not in lookup
+                    }
+                    model.objects.get_or_create(**lookup, defaults=defaults)
+                    continue
+
                 related_model = model(flaw=flaw, **data, **shared_acl)
                 related_model.save()
 
@@ -142,6 +152,20 @@ class Snippet(ACLMixin, AlertMixin, TrackingMixin):
         )
 
         return Flaw.objects.get(uuid=flaw.uuid)
+
+    @staticmethod
+    def _related_model_lookup(model, flaw: Flaw, data: dict) -> dict | None:
+        if model is FlawCVSS and data.get("issuer") and data.get("version"):
+            return {
+                "flaw": flaw,
+                "issuer": data["issuer"],
+                "version": data["version"],
+            }
+
+        if model is FlawReference and data.get("url"):
+            return {"flaw": flaw, "url": data["url"]}
+
+        return None
 
     @validator
     def _validate_acl_identical_to_parent_flaw(self, **kwargs) -> None:

--- a/osidb/tests/test_snippet.py
+++ b/osidb/tests/test_snippet.py
@@ -163,3 +163,41 @@ class TestSnippet:
         flaw_from_snippet = snippet.flaw
         assert flaw_from_snippet.cve_id != undesired_cve_id
         assert flaw_from_snippet.cve_id == desired_cve_id
+
+    def test_create_flaw_from_snippet_ignores_duplicate_cvss_scores(self):
+        snippet = SnippetFactory(source=Snippet.Source.NVD)
+        content = snippet.content
+        first_cvss = content["cvss_scores"][0]
+        content["cvss_scores"].append(
+            first_cvss
+            | {
+                "score": 9.8,
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            }
+        )
+        snippet.content = content
+        snippet.save()
+
+        flaw = snippet._create_flaw()
+
+        assert flaw.cvss_scores.count() == 1
+        assert flaw.cvss_scores.get().vector == first_cvss["vector"]
+
+    def test_create_flaw_from_snippet_ignores_duplicate_references(self):
+        snippet = SnippetFactory(source=Snippet.Source.NVD)
+        content = snippet.content
+        first_reference = content["references"][0]
+        content["references"].append(
+            first_reference
+            | {
+                "description": "duplicate URL with different payload",
+                "type": FlawReference.FlawReferenceType.EXTERNAL,
+            }
+        )
+        snippet.content = content
+        snippet.save()
+
+        flaw = snippet._create_flaw()
+
+        assert flaw.references.count() == 1
+        assert flaw.references.get().type == first_reference["type"]


### PR DESCRIPTION
This PR makes Snippets ignore some possible repeated related model entries.

Example of the issue: cveorg collector data will have multiple CVSS score that will defaults to `FlawCVSS.CVSSIssuer.CVEORG`  and will block the entire collector queue due uniqueness constraint, problematic data:
```
curl -s https://raw.githubusercontent.com/CVEProject/cvelistV5/main/cves/2026/42xxx/CVE-2026-42043.json   | jq -r '
    ([.containers.cna] + (.containers.adp // []))[]
    | .providerMetadata as $p
    | (.metrics // [])[]
    | select(.cvssV3_1)
    | "\($p.shortName) \($p.orgId) \(.cvssV3_1.vectorString)"
  '
GitHub_M a0819718-46f1-4df5-94e2-005712e83aaa CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
redhat-SADP 0b0ca135-0b70-47e7-9f44-1890c2a1c46c CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:L/I:L/A:N
```

Closes OSIDB-5221.