### PR TITLE
fix: do not perform mod7 check on hummingbird affects

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - move automatic visibility change handling specification into the workflow definitions
 - align workflow definition YAMLs with the Argus requirements (OSIDB-5050)
 - introduce true labels and deprecate collaborator-centric pseudo-labels (OSIDB-5191)
+- mod7 check no longer influences hummingbird affects
 
 ### Fixed
 - Fix FieldDoesNotExist being raised for non-DB declared filters (OSIDB-4734)

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -907,7 +907,8 @@ class Affect(
             return
 
         # AFFECTED/DEFER — low severity or moderate without high CVSS (non-community)
-        if not is_community:
+        # Hummingbird (HUM) modules skip this check and always get AFFECTED/DELEGATED
+        if not is_community and not self.is_hummingbird():
             if impact == Impact.LOW:
                 self.resolution = self.AffectResolution.DEFER
                 return

--- a/osidb/models/tests/conftest.py
+++ b/osidb/models/tests/conftest.py
@@ -124,6 +124,22 @@ def community_ps_stream_with_tracker():
 
 
 @pytest.fixture
+def hummingbird_ps_stream_with_moderate_tracker():
+    """
+    Hummingbird (bts_key="HUM") stream that passes OOSS and WONTFIX checks.
+    Used to verify that the mod7 DEFER check is skipped for HUM modules.
+    """
+    ps_product = PsProductFactory(business_unit="RHEL")
+    ps_module = PsModuleFactory(ps_product=ps_product, bts_key="HUM")
+    return PsUpdateStreamFactory(
+        ps_module=ps_module,
+        active_to_ps_module=ps_module,
+        moderate_to_ps_module=ps_module,
+        unacked_to_ps_module=None,
+    )
+
+
+@pytest.fixture
 def flaw_with_cvss():
     """
     Factory fixture: call with (impact, cvss_vector) to get a saved Flaw with

--- a/osidb/models/tests/test_affect.py
+++ b/osidb/models/tests/test_affect.py
@@ -533,3 +533,37 @@ class TestAutoResolve:
         affect.auto_resolve()
         assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
         assert affect.resolution == Affect.AffectResolution.DELEGATED
+
+    # ── Hummingbird (HUM) skips mod7 DEFER check ────────────────────────────
+
+    def test_hummingbird_low_impact_skips_defer(
+        self, hummingbird_ps_stream_with_moderate_tracker
+    ):
+        stream = hummingbird_ps_stream_with_moderate_tracker
+        affect = AffectFactory.build(
+            flaw=FlawFactory(impact=Impact.LOW),
+            ps_module=stream.ps_module.name,
+            ps_update_stream=stream.name,
+            impact=Impact.LOW,
+        )
+        affect.auto_resolve()
+        assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
+        assert affect.resolution == Affect.AffectResolution.DELEGATED
+
+    def test_hummingbird_moderate_low_cvss_skips_defer(
+        self, hummingbird_ps_stream_with_moderate_tracker, flaw_with_cvss
+    ):
+        stream = hummingbird_ps_stream_with_moderate_tracker
+        flaw = flaw_with_cvss(
+            Impact.MODERATE,
+            "CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:L/I:N/A:N",  # score 3.5
+        )
+        affect = AffectFactory.build(
+            flaw=flaw,
+            ps_module=stream.ps_module.name,
+            ps_update_stream=stream.name,
+            impact=Impact.MODERATE,
+        )
+        affect.auto_resolve()
+        assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
+        assert affect.resolution == Affect.AffectResolution.DELEGATED


### PR DESCRIPTION
hummingbird affects should be affected/delegated regardless of low impact / low cvss.