### PR TITLE
OSIDB-5244: Add context to signals that saves the instance flaw

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduce workflow labels
 - ACE: Add Chromium special CVE workflow (OSIDB-5033)
 - ACE: Add Go stdlib special CVE workflow (OSIDB-5033)
+- Context for signals (OSIDB-5244)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/osidb/signals.py
+++ b/osidb/signals.py
@@ -1,5 +1,8 @@
 import logging
+from contextlib import contextmanager
+from typing import Any, Iterator
 
+import pghistory
 from bugzilla import Bugzilla
 from django.contrib.auth.models import User
 from django.db.models.signals import post_delete, post_save, pre_save
@@ -34,6 +37,30 @@ from osidb.models.flaw.reference import FlawReference
 from osidb.tasks import async_send_email
 
 logger = logging.getLogger(__name__)
+
+
+@contextmanager
+def signal_pghistory_context(
+    signal_name: str, sender: Any = None, instance: Any = None
+) -> Iterator[None]:
+    """
+    Attribute Flaw re-saves triggered by post_save/post_delete signals.
+
+    Uses `signal` / `signal_sender` keys so nested celery `action` metadata is
+    preserved. When no parent context exists, also sets action/user so the UI
+    does not show a bare "system"/None context.
+    """
+    metadata = {
+        "source": "signal",
+        "signal": signal_name,
+        "signal_sender": getattr(sender, "__name__", str(sender)),
+        "instance": getattr(instance, "uuid", instance),
+    }
+    if getattr(pghistory.runtime._tracker, "value", None) is None:
+        metadata["action"] = signal_name
+        metadata["user"] = "system"
+    with pghistory.context(**metadata):
+        yield
 
 
 def get_bz_user_id(email: str) -> str:
@@ -136,7 +163,10 @@ def update_flaw_fields(sender, instance, **kwargs):
 )  # cascade deletion of multi-table inheritance fires from the parent
 @receiver(post_save, sender=FlawCVSS)
 def flaw_dependant_update_local_updated_dt(sender, instance, **kwargs):
-    instance.flaw.save(auto_timestamps=False, raise_validation_error=False)
+    with signal_pghistory_context(
+        "flaw_dependant_update_local_updated_dt", sender=sender, instance=instance
+    ):
+        instance.flaw.save(auto_timestamps=False, raise_validation_error=False)
 
 
 @receiver(post_save, sender=Tracker)
@@ -151,17 +181,23 @@ def update_local_updated_dt_tracker(sender, instance, **kwargs):
             flaws.add(affect.flaw)
     for flaw in list(flaws):
         flaw.refresh_from_db()
-        flaw.save(
-            auto_timestamps=False,
-            no_alerts=True,  # recreating alerts from nested entities can cause deadlocks
-            raise_validation_error=False,
-        )
+        with signal_pghistory_context(
+            "update_local_updated_dt_tracker", sender=sender, instance=instance
+        ):
+            flaw.save(
+                auto_timestamps=False,
+                no_alerts=True,  # recreating alerts from nested entities can cause deadlocks
+                raise_validation_error=False,
+            )
 
 
 @receiver(post_save, sender=AffectCVSS)
 def updated_local_updated_dt_affectcvss(sender, instance, **kwargs):
     instance.affect.flaw.refresh_from_db()
-    instance.affect.flaw.save(auto_timestamps=False, raise_validation_error=False)
+    with signal_pghistory_context(
+        "updated_local_updated_dt_affectcvss", sender=sender, instance=instance
+    ):
+        instance.affect.flaw.save(auto_timestamps=False, raise_validation_error=False)
 
 
 @receiver(post_save, sender=Affect)

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -729,8 +729,12 @@ class BZSyncManager(SyncManager):
         set_user_acls(settings.ALL_GROUPS)
 
         try:
-            flaw = Flaw.objects.get(uuid=flaw_id)
-            flaw._perform_bzsync()
+            with pghistory_context(
+                action="bzsync",
+                celery_task_id=getattr(getattr(task, "request", None), "id", None),
+            ):
+                flaw = Flaw.objects.get(uuid=flaw_id)
+                flaw._perform_bzsync()
         except Exception as e:
             BZSyncManager.failed(flaw_id, e)
         else:

--- a/osidb/tests/test_history_context.py
+++ b/osidb/tests/test_history_context.py
@@ -1,0 +1,84 @@
+"""
+Tests that Flaw re-saves from signals carry pghistory context so UI audit
+no longer shows an opaque "system"/None writer.
+
+Note: FlawAudit excludes local_updated_dt, so a signal that only bumps that
+field creates no Flaw history row. Tests therefore use a stale in-memory Flaw
+writeback (tracked field change) to observe context on the resulting event.
+"""
+
+import pghistory
+import pytest
+
+from osidb.models import Flaw, FlawReference
+from osidb.tests.factories import FlawFactory, FlawReferenceFactory
+
+pytestmark = [pytest.mark.unit, pytest.mark.enable_signals]
+
+MITIGATION_TEXT = "disable the vulnerable RPC via --block-rpcs"
+
+
+@pytest.mark.django_db(transaction=True)
+class TestSignalHistoryContext:
+    def test_flaw_reference_stale_resave_sets_signal_history_context(self):
+        flaw = FlawFactory(mitigation="", embargoed=False)
+        ref = FlawReferenceFactory(flaw=flaw)
+        loaded_ref = FlawReference.objects.select_related("flaw").get(pk=ref.pk)
+        assert loaded_ref.flaw.mitigation == ""
+
+        Flaw.objects.filter(pk=flaw.pk).update(mitigation=MITIGATION_TEXT)
+        assert Flaw.objects.get(pk=flaw.pk).mitigation == MITIGATION_TEXT
+
+        loaded_ref.save()
+
+        assert Flaw.objects.get(pk=flaw.pk).mitigation == ""
+
+        events = (
+            pghistory.models.Events.objects.tracks(flaw)
+            .filter(pgh_context__source="signal")
+            .order_by("-pgh_created_at")
+        )
+        assert events.count() >= 1
+        event = events.first()
+        assert event.pgh_context["signal"] == "flaw_dependant_update_local_updated_dt"
+        assert event.pgh_context["signal_sender"] == FlawReference.__name__
+        assert event.pgh_context["user"] == "system"
+        assert event.pgh_context["action"] == "flaw_dependant_update_local_updated_dt"
+        assert event.pgh_context["instance"] == str(ref.uuid)
+
+    def test_nested_api_context_keeps_user_and_adds_signal(self):
+        flaw = FlawFactory(mitigation="", embargoed=False)
+        ref = FlawReferenceFactory(flaw=flaw)
+        loaded_ref = FlawReference.objects.select_related("flaw").get(pk=ref.pk)
+
+        Flaw.objects.filter(pk=flaw.pk).update(mitigation=MITIGATION_TEXT)
+
+        with pghistory.context(user="analyst@redhat.com", path="/osidb/api/v2/flaws"):
+            loaded_ref.save()
+
+        event = (
+            pghistory.models.Events.objects.tracks(flaw)
+            .filter(pgh_context__source="signal")
+            .order_by("-pgh_created_at")
+            .first()
+        )
+
+        assert event is not None
+        assert event.pgh_context["user"] == "analyst@redhat.com"
+        assert event.pgh_context["path"] == "/osidb/api/v2/flaws"
+        assert event.pgh_context["signal"] == "flaw_dependant_update_local_updated_dt"
+        assert "action" not in event.pgh_context
+
+    def test_direct_pghistory_context_attaches_to_flaw_update(self):
+        """Sanity check that pghistory.context works for Flaw updates in this suite."""
+        flaw = FlawFactory(mitigation="", embargoed=False)
+        with pghistory.context(source="testcase", action="manual"):
+            flaw.mitigation = MITIGATION_TEXT
+            flaw.save()
+
+        assert (
+            pghistory.models.Events.objects.tracks(flaw)
+            .filter(pgh_context__source="testcase", pgh_context__action="manual")
+            .count()
+            >= 1
+        )


### PR DESCRIPTION
# context 

Sadly the revert issue is back again.

This CVE  [CVE-2026-12080](https://osim.prodsec.redhat.com/flaws/CVE-2026-12080) is the case where can be seen a reversion happened.

as can be seen in the history that this reverts where done by the System 


## revert example: 
**2026-07-20 13:07:52 UTC - System**
Update Mitigation: If the `guest-ssh-add-authorized-keys` command is not required, it can be disabled by adding it to the qemu-guest-agent block list (qemu-ga --block-rpcs). This prevents the vulnerable code path from being reached while preserving all other guest-agent functionality. 
**2026-07-20 13:07:50 UTC - mcascell@redhat.com**
Update Mitigation:  If the `guest-ssh-add-authorized-keys` command is not required, it can be disabled by adding it to the qemu-guest-agent block list (qemu-ga --block-rpcs). This prevents the vulnerable code path from being reached while preserving all other guest-agent functionality. 


it keeps looking like a signal did the reversion but the only parts I know have no context are the signals  and a part that's missing the context in one of the  sync_manager. 


# changes 

Adds context to the missing sync_manager task and to the signals that changes the Flaw. 



