### PR TITLE
OSIDB-5086 Add Upstream maintainer email template

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add signal to trigger upstream maintainer notification creation on FlawUpstreamMapping save (OSIDB-5078)
 - Add SRP report serializer (OSIDB-5072)
 - Add Upstream Maintainer Notification Subresource Endpoints (OSIDB-5083)
+- Add Upstream Maintainer Email Template (OSIDB-5086)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/osidb/templates/email/upstream_maintainer_notification.html
+++ b/osidb/templates/email/upstream_maintainer_notification.html
@@ -11,15 +11,11 @@
     <p><strong>Identifier:</strong> {{ flaw_id }}</p>
     <p><strong>Summary:</strong> {{ vulnerability_summary }}</p>
     <p><strong>Affected component:</strong> {{ upstream_component }}</p>
-    <p><strong>Severity:</strong> {{ severity }}</p>
-    {% if exploitation_state %}
-    <p><strong>Known exploitation state:</strong> {{ exploitation_state }}</p>
-    {% endif %}
-    {% if embargo_notice %}
-    <p>{{ embargo_notice }}</p>
-    {% endif %}
-    {% if corrective_measure %}
+    <p><strong>Impact:</strong> {{ impact }}</p>
     <p><strong>Corrective or mitigating measure:</strong> {{ corrective_measure }}</p>
+    <p><strong>Contact information:</strong> {{ contact_info }}</p>
+    {% if confidentiality_notice %}
+    <p>{{ confidentiality_notice }}</p>
     {% endif %}
 
     <p>Sent by Red Hat Product Security under applicable regulatory requirements.</p>

--- a/osidb/templates/email/upstream_maintainer_notification.txt
+++ b/osidb/templates/email/upstream_maintainer_notification.txt
@@ -6,15 +6,13 @@ Summary: {{ vulnerability_summary }}
 
 Affected component: {{ upstream_component }}
 
-Severity: {{ severity }}
-{% if exploitation_state %}
-Known exploitation state: {{ exploitation_state }}
-{% endif %}
-{% if embargo_notice %}
-{{ embargo_notice }}
-{% endif %}
-{% if corrective_measure %}
+Impact: {{ impact }}
+
 Corrective or mitigating measure: {{ corrective_measure }}
+
+Contact information: {{ contact_info }}
+{% if confidentiality_notice %}
+{{ confidentiality_notice }}
 {% endif %}
 
 Sent by Red Hat Product Security under applicable regulatory requirements.

--- a/regulatory_reporting/tests/test_templates.py
+++ b/regulatory_reporting/tests/test_templates.py
@@ -1,0 +1,76 @@
+from django.template.loader import render_to_string
+
+
+class TestUpstreamMaintainerNotificationTemplate:
+    """Tests for the upstream maintainer email template"""
+
+    REQUIRED_CONTEXT = {
+        "flaw_id": "CVE-2026-12345",
+        "vulnerability_summary": "Test summary",
+        "upstream_component": "test-component",
+        "impact": "Moderate",
+        "corrective_measure": "Upgrade to 1.2.3",
+        "contact_info": "test@example.com",
+    }
+
+    def test_txt_renders_required_fields(self):
+        rendered = render_to_string(
+            "email/upstream_maintainer_notification.txt", self.REQUIRED_CONTEXT
+        )
+        assert "CVE-2026-12345" in rendered
+        assert "Test summary" in rendered
+        assert "test-component" in rendered
+        assert "Moderate" in rendered
+        assert "Upgrade to 1.2.3" in rendered
+        assert "test@example.com" in rendered
+
+    def test_txt_omits_confidentiality_notice_when_not_passed(self):
+        rendered = render_to_string(
+            "email/upstream_maintainer_notification.txt", self.REQUIRED_CONTEXT
+        )
+        assert "confidential" not in rendered.lower()
+
+    def test_txt_includes_confidentiality_notice_when_passed(self):
+        context = {
+            **self.REQUIRED_CONTEXT,
+            "confidentiality_notice": "This information is confidential until public disclosure.",
+        }
+        rendered = render_to_string(
+            "email/upstream_maintainer_notification.txt", context
+        )
+        assert "confidential until public disclosure" in rendered
+
+    def test_html_renders_required_fields(self):
+        rendered = render_to_string(
+            "email/upstream_maintainer_notification.html", self.REQUIRED_CONTEXT
+        )
+        assert "CVE-2026-12345" in rendered
+        assert "Test summary" in rendered
+        assert "test-component" in rendered
+        assert "Moderate" in rendered
+        assert "Upgrade to 1.2.3" in rendered
+        assert "test@example.com" in rendered
+
+    def test_html_omits_confidentiality_notice_when_not_passed(self):
+        rendered = render_to_string(
+            "email/upstream_maintainer_notification.html", self.REQUIRED_CONTEXT
+        )
+        assert "confidential" not in rendered.lower()
+
+    def test_html_includes_confidentiality_notice_when_passed(self):
+        context = {
+            **self.REQUIRED_CONTEXT,
+            "confidentiality_notice": "This information is confidential until public disclosure.",
+        }
+        rendered = render_to_string(
+            "email/upstream_maintainer_notification.html", context
+        )
+        assert "confidential until public disclosure" in rendered
+
+    def test_renders_for_common_flaw_states(self):
+        for state in ["NEW", "TRIAGE", "DONE", "REJECTED"]:
+            context = {**self.REQUIRED_CONTEXT, "flaw_id": f"CVE-2026-{state}"}
+            rendered = render_to_string(
+                "email/upstream_maintainer_notification.txt", context
+            )
+            assert f"CVE-2026-{state}" in rendered

--- a/regulatory_reporting/tests/test_views.py
+++ b/regulatory_reporting/tests/test_views.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
+from osidb.models.abstract import Impact
 from osidb.models.flaw import FlawSource
 from osidb.tests.factories import FlawFactory
 from regulatory_reporting.models.upstream import UpstreamNotification
@@ -156,3 +157,59 @@ class TestSendEmailAction:
         )
 
         assert response.status_code == 400
+
+    @patch("regulatory_reporting.views.async_send_email")
+    def test_send_email_uses_new_template_fields(
+        self, mock_task, auth_client, test_api_v2_uri
+    ):
+        """Test that send-email renders the new template fields."""
+        upstream_project = UpstreamProjectFactory(
+            security_contact="maintainer@example.com"
+        )
+        flaw = FlawFactory(
+            embargoed=False,
+            source=FlawSource.REDHAT,
+            impact=Impact.MODERATE,
+            mitigation="Upgrade to version 1.2.3",
+        )
+        notification = UpstreamNotificationFactory(
+            flaw=flaw,
+            upstream_project=upstream_project,
+            method=UpstreamNotification.NotificationMethod.EMAIL,
+            status=UpstreamNotification.NotificationStatus.REVIEWED,
+        )
+
+        response = auth_client().post(
+            f"{test_api_v2_uri}/notifications/upstream/{notification.uuid}/send-email"
+        )
+
+        assert response.status_code == 200
+        notification.refresh_from_db()
+        assert Impact.MODERATE in notification.payload_text
+        assert flaw.mitigation in notification.payload_text
+        assert upstream_project.security_contact in notification.payload_text
+        assert "severity" not in notification.payload_text.lower()
+
+    @patch("regulatory_reporting.views.async_send_email")
+    def test_send_email_includes_confidentiality_notice_when_embargoed(
+        self, mock_task, auth_client, test_api_v2_uri
+    ):
+        """Test that send-email includes the confidentiality notice for embargoed flaws."""
+        upstream_project = UpstreamProjectFactory(
+            security_contact="maintainer@example.com"
+        )
+        flaw = FlawFactory(embargoed=True, source=FlawSource.REDHAT)
+        notification = UpstreamNotificationFactory(
+            flaw=flaw,
+            upstream_project=upstream_project,
+            method=UpstreamNotification.NotificationMethod.EMAIL,
+            status=UpstreamNotification.NotificationStatus.REVIEWED,
+        )
+
+        response = auth_client().post(
+            f"{test_api_v2_uri}/notifications/upstream/{notification.uuid}/send-email"
+        )
+
+        assert response.status_code == 200
+        notification.refresh_from_db()
+        assert "This flaw is currently embargoed." in notification.payload_text

--- a/regulatory_reporting/views.py
+++ b/regulatory_reporting/views.py
@@ -68,17 +68,19 @@ class UpstreamNotificationView(
             "flaw_id": flaw_id,
             "vulnerability_summary": flaw.title,
             "upstream_component": upstream_project.component_name,
-            "severity": flaw.impact,
-            "exploitation_state": "",
-            "embargo_notice": "This flaw is currently embargoed."
-            if flaw.is_embargoed
-            else "",
-            "corrective_measure": "",
+            "impact": flaw.impact,
+            "confidentiality_notice": (
+                "This flaw is currently embargoed." if flaw.is_embargoed else ""
+            ),
+            "corrective_measure": flaw.mitigation,
+            "contact_info": upstream_project.security_contact,
         }
 
-        text_body = render_to_string("email/upstream_notification.txt", context=context)
+        text_body = render_to_string(
+            "email/upstream_maintainer_notification.txt", context=context
+        )
         html_body = render_to_string(
-            "email/upstream_notification.html", context=context
+            "email/upstream_maintainer_notification.html", context=context
         )
 
         payload = {


### PR DESCRIPTION
Adds the text and HTML email templates used to notify upstream maintainers of a security vulnerability
- Added files `upstream_maintainer_notification.txt` and `upstream_maintainer_notification.html`
- Added test cases in `test_templates.py`
- Added entry in `CHANGELOG.md`
Closes:OSIDB-5086