### PR TITLE
fix: implement cpe-based filtering for windows-only Flaws (OSIDB-5235)

### DIFF
--- a/collectors/cveorg/collectors.py
+++ b/collectors/cveorg/collectors.py
@@ -32,6 +32,96 @@ from osidb.validators import CVE_RE_STR
 
 logger = get_task_logger(__name__)
 
+# CPE URI field indices (cpe:2.3:<type>:<vendor>:<product>:...)
+_CPE_TYPE_IDX = 2
+_CPE_VENDOR_IDX = 3
+_CPE_PRODUCT_IDX = 4
+
+# CPE type component for operating systems
+_CPE_TYPE_OS = "o"
+
+# Vendor name as it appears in CPE URIs for Microsoft
+_CPE_VENDOR_MICROSOFT = "microsoft"
+
+# CPE product name prefixes that unambiguously identify Windows OS families.
+# Matched against the product field (index 4) of a CPE URI after splitting on ':'.
+_WINDOWS_OS_CPE_PRODUCT_PREFIXES = (
+    "windows_10",
+    "windows_11",
+    "windows_server",
+    "windows_rt",
+    "windows_vista",
+    "windows_xp",
+    "windows_7",
+    "windows_8",
+)
+
+
+def _is_windows_only_cve(file_content: dict) -> bool:
+    """
+    Return True if every CPE in the CNA's cpeApplicability is a Windows OS
+    component (cpe:2.3:o:microsoft:windows_*) and none is an application-layer
+    or non-Microsoft CPE.
+
+    Uses the structured cpeApplicability field from the CVE 5.x schema rather
+    than keyword matching on free text. Only fires when cpeApplicability is
+    present and non-empty; returns False (do not filter) when the field is
+    absent so that CVEs without CPE data are still processed normally.
+
+    Application-layer CPEs from Microsoft (cpe:2.3:a:microsoft:*) are NOT
+    treated as Windows-only because Microsoft ships cross-platform applications
+    (e.g. .NET, VS Code, Azure CLI, PowerShell) under the microsoft vendor.
+    A CVE mixing Windows OS CPEs with any application CPE will return False
+    and pass through to the keyword filter.
+    """
+    nodes = []
+    for applicability in (
+        file_content.get("containers", {}).get("cna", {}).get("cpeApplicability", [])
+    ):
+        if applicability.get("negate"):
+            return False
+        for node in applicability.get("nodes", []):
+            nodes.append(node)
+
+    if not nodes:
+        return False
+
+    cpe_matches = []
+    for node in nodes:
+        # A negated node inverts its CPE set (meaning "all platforms except these"),
+        # which we cannot evaluate without full boolean CPE logic. Bail out
+        # conservatively so the CVE passes through to the keyword filter.
+        if node.get("negate"):
+            return False
+        cpe_matches.extend(node.get("cpeMatch", []))
+
+    if not cpe_matches:
+        return False
+
+    for match in cpe_matches:
+        criteria = match.get("criteria", "")
+        parts = criteria.split(":")
+        # CPE 2.3 URI: cpe:2.3:<type>:<vendor>:<product>:...
+        if len(parts) < 5:
+            return False
+        cpe_type = parts[_CPE_TYPE_IDX]
+        vendor = parts[_CPE_VENDOR_IDX]
+        product = parts[_CPE_PRODUCT_IDX]
+
+        if vendor != _CPE_VENDOR_MICROSOFT:
+            return False
+
+        if cpe_type != _CPE_TYPE_OS:
+            # Application, hardware, or other non-OS CPE — do not filter
+            return False
+
+        if not any(
+            product.startswith(prefix) for prefix in _WINDOWS_OS_CPE_PRODUCT_PREFIXES
+        ):
+            return False
+
+    return True
+
 
 class CVEorgCollectorException(Exception):
     pass
@@ -203,6 +293,12 @@ class CVEorgCollector(Collector):
             raise CVEorgCollectorValidationError(
                 f"Cannot create '{cve}' because it was rejected by CVE Program."
             )
+
+        if _is_windows_only_cve(file_content):
+            raise CVEorgCollectorValidationError(
+                f"Skipping '{cve}' because all CPE applicability entries target Windows OS components."
+            )
+
         try:
             content = self.extract_content(file_content)
         except Exception as exc:

--- a/collectors/cveorg/tests/conftest.py
+++ b/collectors/cveorg/tests/conftest.py
@@ -95,3 +95,17 @@ def cisa_cvss_content(repo_path):
 def no_descriptions_content(repo_path):
     with open(f"{repo_path}/CVE-2025-37902.json", "r") as f:
         return json.load(f)
+
+
+@pytest.fixture
+def windows_os_only_cve_content(repo_path):
+    """CVE-2026-50462: all CPEs are cpe:2.3:o:microsoft:windows_* — no application CPEs."""
+    with open(f"{repo_path}/CVE-2026-50462.json", "r") as f:
+        return json.load(f)
+
+
+@pytest.fixture
+def windows_with_dotnet_cve_content(repo_path):
+    """CVE-2026-50355: mixes windows OS CPEs with cpe:2.3:a:microsoft:.net — cross-platform app."""
+    with open(f"{repo_path}/CVE-2026-50355.json", "r") as f:
+        return json.load(f)

--- a/collectors/cveorg/tests/cvelistV5/CVE-2026-50355.json
+++ b/collectors/cveorg/tests/cvelistV5/CVE-2026-50355.json
@@ -1,0 +1,564 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.2",
+    "cveMetadata": {
+        "cveId": "CVE-2026-50355",
+        "assignerOrgId": "f38d906d-7342-40ea-92c1-6c4a2c6478c8",
+        "state": "PUBLISHED",
+        "assignerShortName": "microsoft",
+        "dateReserved": "2026-06-04T18:48:26.815Z",
+        "datePublished": "2026-07-14T17:06:53.291Z",
+        "dateUpdated": "2026-07-21T22:33:29.396Z"
+    },
+    "containers": {
+        "cna": {
+            "title": "Windows Active Directory Federation Services Denial of Service Vulnerability",
+            "datePublic": "2026-07-14T14:00:00.000Z",
+            "cpeApplicability": [
+                {
+                    "nodes": [
+                        {
+                            "operator": "OR",
+                            "negate": false,
+                            "cpeMatch": [
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_10_1809:*:*:*:*:*:*:x86:*",
+                                    "versionStartIncluding": "10.0.17763.0",
+                                    "versionEndExcluding": "10.0.17763.9020"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2019:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.17763.0",
+                                    "versionEndExcluding": "10.0.17763.9020"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2019:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.17763.0",
+                                    "versionEndExcluding": "10.0.17763.9020"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2022:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.20348.0",
+                                    "versionEndExcluding": "10.0.20348.5386"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2025:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.26100.0",
+                                    "versionEndExcluding": "10.0.26100.33158"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2025:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.26100.0",
+                                    "versionEndExcluding": "10.0.26100.33158"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_10_1607:*:*:*:*:*:*:x86:*",
+                                    "versionStartIncluding": "10.0.14393.0",
+                                    "versionEndExcluding": "10.0.14393.9339"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2016:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.14393.0",
+                                    "versionEndExcluding": "10.0.14393.9339"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2016:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.14393.0",
+                                    "versionEndExcluding": "10.0.14393.9339"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.2.9200.0",
+                                    "versionEndExcluding": "6.2.9200.26226"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.2.9200.0",
+                                    "versionEndExcluding": "6.2.9200.26226"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012_R2:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.3.9600.0",
+                                    "versionEndExcluding": "6.3.9600.23291"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012_R2:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.3.9600.0",
+                                    "versionEndExcluding": "6.3.9600.23291"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:a:microsoft:.net:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "4.8.0",
+                                    "versionEndExcluding": "4.8.4803.0"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:a:microsoft:.net:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "4.8.0",
+                                    "versionEndExcluding": "2.0.50727.9069 & 3.0.30729.9067 & 4.8.4803.0"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:a:microsoft:.net:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "4.7.0",
+                                    "versionEndExcluding": "2.0.50727.9069 & 3.0.30729.9067 & 4.7.4143.0"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:a:microsoft:.net:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "4.7.0",
+                                    "versionEndExcluding": "4.7.4143.0"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:a:microsoft:.net:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "4.8.1",
+                                    "versionEndExcluding": "2.0.50727.9182 & 3.0.30729.9168 & 4.8.9339.0"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:a:microsoft:.net:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "3.5.0",
+                                    "versionEndExcluding": "2.0.50727.8983 & 3.0.30729.8978"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "Microsoft",
+                    "product": "Microsoft .NET Framework 3.5",
+                    "platforms": [
+                        "Windows Server 2012",
+                        "Windows Server 2012 (Server Core installation)",
+                        "Windows Server 2012 R2",
+                        "Windows Server 2012 R2 (Server Core installation)"
+                    ],
+                    "versions": [
+                        {
+                            "version": "3.5.0",
+                            "lessThan": "2.0.50727.8983 & 3.0.30729.8978",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Microsoft .NET Framework 3.5 AND 4.7.2",
+                    "platforms": [
+                        "Windows 10 Version 1607 for 32-bit Systems",
+                        "Windows 10 Version 1607 for x64-based Systems",
+                        "Windows 10 Version 1809 for 32-bit Systems",
+                        "Windows 10 Version 1809 for x64-based Systems",
+                        "Windows Server 2016",
+                        "Windows Server 2016 (Server Core installation)",
+                        "Windows Server 2019",
+                        "Windows Server 2019 (Server Core installation)"
+                    ],
+                    "versions": [
+                        {
+                            "version": "4.7.0",
+                            "lessThan": "2.0.50727.9069 & 3.0.30729.9067 & 4.7.4143.0",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Microsoft .NET Framework 3.5 AND 4.8",
+                    "platforms": [
+                        "Windows 10 Version 1809 for 32-bit Systems",
+                        "Windows 10 Version 1809 for x64-based Systems",
+                        "Windows 10 Version 21H2 for 32-bit Systems",
+                        "Windows 10 Version 21H2 for ARM64-based Systems",
+                        "Windows 10 Version 21H2 for x64-based Systems",
+                        "Windows 10 Version 22H2 for 32-bit Systems",
+                        "Windows 10 Version 22H2 for ARM64-based Systems",
+                        "Windows 10 Version 22H2 for x64-based Systems",
+                        "Windows Server 2019",
+                        "Windows Server 2019 (Server Core installation)",
+                        "Windows Server 2022",
+                        "Windows Server 2022 (Server Core installation)"
+                    ],
+                    "versions": [
+                        {
+                            "version": "4.8.0",
+                            "lessThan": "2.0.50727.9069 & 3.0.30729.9067 & 4.8.4803.0",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Microsoft .NET Framework 3.5 AND 4.8.1",
+                    "platforms": [
+                        "Windows 10 Version 21H2 for 32-bit Systems",
+                        "Windows 10 Version 21H2 for ARM64-based Systems",
+                        "Windows 10 Version 21H2 for x64-based Systems",
+                        "Windows 10 Version 22H2 for 32-bit Systems",
+                        "Windows 10 Version 22H2 for ARM64-based Systems",
+                        "Windows 10 Version 22H2 for x64-based Systems",
+                        "Windows 11 Version 23H2 for ARM64-based Systems",
+                        "Windows 11 Version 23H2 for x64-based Systems",
+                        "Windows 11 Version 24H2 for ARM64-based Systems",
+                        "Windows 11 Version 24H2 for x64-based Systems",
+                        "Windows 11 Version 25H2 for ARM64-based Systems",
+                        "Windows 11 Version 25H2 for x64-based Systems",
+                        "Windows 11 Version 26H1 for ARM64-based Systems",
+                        "Windows 11 version 26H1 for x64-based Systems",
+                        "Windows Server 2022",
+                        "Windows Server 2022 (Server Core installation)"
+                    ],
+                    "versions": [
+                        {
+                            "version": "4.8.1",
+                            "lessThan": "2.0.50727.9182 & 3.0.30729.9168 & 4.8.9339.0",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Microsoft .NET Framework 4.6.2/4.7/4.7.1/4.7.2",
+                    "platforms": [
+                        "Windows Server 2012",
+                        "Windows Server 2012 (Server Core installation)",
+                        "Windows Server 2012 R2",
+                        "Windows Server 2012 R2 (Server Core installation)"
+                    ],
+                    "versions": [
+                        {
+                            "version": "4.7.0",
+                            "lessThan": "4.7.4143.0",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Microsoft .NET Framework 4.8",
+                    "platforms": [
+                        "Windows 10 Version 1607 for 32-bit Systems",
+                        "Windows 10 Version 1607 for x64-based Systems",
+                        "Windows Server 2012",
+                        "Windows Server 2012 (Server Core installation)",
+                        "Windows Server 2012 R2",
+                        "Windows Server 2012 R2 (Server Core installation)",
+                        "Windows Server 2016",
+                        "Windows Server 2016 (Server Core installation)"
+                    ],
+                    "versions": [
+                        {
+                            "version": "4.8.0",
+                            "lessThan": "4.8.4803.0",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 10 Version 1607",
+                    "platforms": [
+                        "32-bit Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.14393.0",
+                            "lessThan": "10.0.14393.9339",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 10 Version 1809",
+                    "platforms": [
+                        "32-bit Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.17763.0",
+                            "lessThan": "10.0.17763.9020",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.2.9200.0",
+                            "lessThan": "6.2.9200.26226",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.2.9200.0",
+                            "lessThan": "6.2.9200.26226",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012 R2",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.3.9600.0",
+                            "lessThan": "6.3.9600.23291",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012 R2 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.3.9600.0",
+                            "lessThan": "6.3.9600.23291",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2016",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.14393.0",
+                            "lessThan": "10.0.14393.9339",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2016 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.14393.0",
+                            "lessThan": "10.0.14393.9339",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2019",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.17763.0",
+                            "lessThan": "10.0.17763.9020",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2019 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.17763.0",
+                            "lessThan": "10.0.17763.9020",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2022",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.20348.0",
+                            "lessThan": "10.0.20348.5386",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2025",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.26100.0",
+                            "lessThan": "10.0.26100.33158",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2025 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.26100.0",
+                            "lessThan": "10.0.26100.33158",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "value": "Stack-based buffer overflow in Active Directory Federation Services allows an unauthorized attacker to deny service over a network.",
+                    "lang": "en-US"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "description": "CWE-121: Stack-based Buffer Overflow",
+                            "lang": "en-US",
+                            "type": "CWE",
+                            "cweId": "CWE-121"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "f38d906d-7342-40ea-92c1-6c4a2c6478c8",
+                "shortName": "microsoft",
+                "dateUpdated": "2026-07-21T22:33:29.396Z"
+            },
+            "references": [
+                {
+                    "name": "Windows Active Directory Federation Services Denial of Service Vulnerability",
+                    "tags": [
+                        "vendor-advisory",
+                        "patch"
+                    ],
+                    "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-50355"
+                }
+            ],
+            "metrics": [
+                {
+                    "format": "CVSS",
+                    "scenarios": [
+                        {
+                            "lang": "en-US",
+                            "value": "GENERAL"
+                        }
+                    ],
+                    "cvssV3_1": {
+                        "version": "3.1",
+                        "baseSeverity": "HIGH",
+                        "baseScore": 7.5,
+                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H/E:U/RL:O/RC:C"
+                    }
+                }
+            ]
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "id": "CVE-2026-50355",
+                                "role": "CISA Coordinator",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "yes"
+                                    },
+                                    {
+                                        "Technical Impact": "partial"
+                                    }
+                                ],
+                                "version": "2.0.3",
+                                "timestamp": "2026-07-14T20:35:49.993254Z"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2026-07-14T20:48:11.122Z"
+                }
+            }
+        ]
+    }
+}

--- a/collectors/cveorg/tests/cvelistV5/CVE-2026-50462.json
+++ b/collectors/cveorg/tests/cvelistV5/CVE-2026-50462.json
@@ -1,0 +1,504 @@
+{
+    "dataType": "CVE_RECORD",
+    "dataVersion": "5.2",
+    "cveMetadata": {
+        "cveId": "CVE-2026-50462",
+        "assignerOrgId": "f38d906d-7342-40ea-92c1-6c4a2c6478c8",
+        "state": "PUBLISHED",
+        "assignerShortName": "microsoft",
+        "dateReserved": "2026-06-04T18:59:17.977Z",
+        "datePublished": "2026-07-14T17:07:25.474Z",
+        "dateUpdated": "2026-07-21T22:37:00.690Z"
+    },
+    "containers": {
+        "cna": {
+            "title": "Windows Ancillary Function Driver for WinSock Elevation of Privilege Vulnerability",
+            "datePublic": "2026-07-14T14:00:00.000Z",
+            "cpeApplicability": [
+                {
+                    "nodes": [
+                        {
+                            "operator": "OR",
+                            "negate": false,
+                            "cpeMatch": [
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_10_1809:*:*:*:*:*:*:x86:*",
+                                    "versionStartIncluding": "10.0.17763.0",
+                                    "versionEndExcluding": "10.0.17763.9020"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2019:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.17763.0",
+                                    "versionEndExcluding": "10.0.17763.9020"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2019:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.17763.0",
+                                    "versionEndExcluding": "10.0.17763.9020"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2022:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.20348.0",
+                                    "versionEndExcluding": "10.0.20348.5386"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_10_21H2:*:*:*:*:*:*:x86:*",
+                                    "versionStartIncluding": "10.0.19044.0",
+                                    "versionEndExcluding": "10.0.19044.7548"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_10_22H2:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "10.0.19045.0",
+                                    "versionEndExcluding": "10.0.19045.7548"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2025:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.26100.0",
+                                    "versionEndExcluding": "10.0.26100.33158"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_11_25H2:*:*:*:*:*:*:arm64:*",
+                                    "versionStartIncluding": "10.0.26200.0",
+                                    "versionEndExcluding": "10.0.26200.8875"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_11_24H2:*:*:*:*:*:*:arm64:*",
+                                    "versionStartIncluding": "10.0.26100.0",
+                                    "versionEndExcluding": "10.0.26100.8875"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2025:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.26100.0",
+                                    "versionEndExcluding": "10.0.26100.33158"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_11_26H1:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "10.0.28000.0",
+                                    "versionEndExcluding": "10.0.28000.2269"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_10_1607:*:*:*:*:*:*:x86:*",
+                                    "versionStartIncluding": "10.0.14393.0",
+                                    "versionEndExcluding": "10.0.14393.9339"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2016:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.14393.0",
+                                    "versionEndExcluding": "10.0.14393.9339"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2016:*:*:*:*:*:*:*:*",
+                                    "versionStartIncluding": "10.0.14393.0",
+                                    "versionEndExcluding": "10.0.14393.9339"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.2.9200.0",
+                                    "versionEndExcluding": "6.2.9200.26226"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.2.9200.0",
+                                    "versionEndExcluding": "6.2.9200.26226"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012_R2:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.3.9600.0",
+                                    "versionEndExcluding": "6.3.9600.23291"
+                                },
+                                {
+                                    "vulnerable": true,
+                                    "criteria": "cpe:2.3:o:microsoft:windows_server_2012_R2:*:*:*:*:*:*:x64:*",
+                                    "versionStartIncluding": "6.3.9600.0",
+                                    "versionEndExcluding": "6.3.9600.23291"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "affected": [
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 10 Version 1607",
+                    "platforms": [
+                        "32-bit Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.14393.0",
+                            "lessThan": "10.0.14393.9339",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 10 Version 1809",
+                    "platforms": [
+                        "32-bit Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.17763.0",
+                            "lessThan": "10.0.17763.9020",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 10 Version 21H2",
+                    "platforms": [
+                        "32-bit Systems",
+                        "ARM64-based Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.19044.0",
+                            "lessThan": "10.0.19044.7548",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 10 Version 22H2",
+                    "platforms": [
+                        "32-bit Systems",
+                        "ARM64-based Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.19045.0",
+                            "lessThan": "10.0.19045.7548",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 11 Version 24H2",
+                    "platforms": [
+                        "ARM64-based Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.26100.0",
+                            "lessThan": "10.0.26100.8875",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 11 Version 25H2",
+                    "platforms": [
+                        "ARM64-based Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.26200.0",
+                            "lessThan": "10.0.26200.8875",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows 11 version 26H1",
+                    "platforms": [
+                        "ARM64-based Systems",
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.28000.0",
+                            "lessThan": "10.0.28000.2269",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.2.9200.0",
+                            "lessThan": "6.2.9200.26226",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.2.9200.0",
+                            "lessThan": "6.2.9200.26226",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012 R2",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.3.9600.0",
+                            "lessThan": "6.3.9600.23291",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2012 R2 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "6.3.9600.0",
+                            "lessThan": "6.3.9600.23291",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2016",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.14393.0",
+                            "lessThan": "10.0.14393.9339",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2016 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.14393.0",
+                            "lessThan": "10.0.14393.9339",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2019",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.17763.0",
+                            "lessThan": "10.0.17763.9020",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2019 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.17763.0",
+                            "lessThan": "10.0.17763.9020",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2022",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.20348.0",
+                            "lessThan": "10.0.20348.5386",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2025",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.26100.0",
+                            "lessThan": "10.0.26100.33158",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                },
+                {
+                    "vendor": "Microsoft",
+                    "product": "Windows Server 2025 (Server Core installation)",
+                    "platforms": [
+                        "x64-based Systems"
+                    ],
+                    "versions": [
+                        {
+                            "version": "10.0.26100.0",
+                            "lessThan": "10.0.26100.33158",
+                            "versionType": "custom",
+                            "status": "affected"
+                        }
+                    ]
+                }
+            ],
+            "descriptions": [
+                {
+                    "value": "External control of file name or path in Windows Ancillary Function Driver for WinSock allows an authorized attacker to elevate privileges locally.",
+                    "lang": "en-US"
+                }
+            ],
+            "problemTypes": [
+                {
+                    "descriptions": [
+                        {
+                            "description": "CWE-73: External Control of File Name or Path",
+                            "lang": "en-US",
+                            "type": "CWE",
+                            "cweId": "CWE-73"
+                        }
+                    ]
+                }
+            ],
+            "providerMetadata": {
+                "orgId": "f38d906d-7342-40ea-92c1-6c4a2c6478c8",
+                "shortName": "microsoft",
+                "dateUpdated": "2026-07-21T22:37:00.690Z"
+            },
+            "references": [
+                {
+                    "name": "Windows Ancillary Function Driver for WinSock Elevation of Privilege Vulnerability",
+                    "tags": [
+                        "vendor-advisory",
+                        "patch"
+                    ],
+                    "url": "https://msrc.microsoft.com/update-guide/vulnerability/CVE-2026-50462"
+                }
+            ],
+            "metrics": [
+                {
+                    "format": "CVSS",
+                    "scenarios": [
+                        {
+                            "lang": "en-US",
+                            "value": "GENERAL"
+                        }
+                    ],
+                    "cvssV3_1": {
+                        "version": "3.1",
+                        "baseSeverity": "HIGH",
+                        "baseScore": 7.8,
+                        "vectorString": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H/E:U/RL:O/RC:C"
+                    }
+                }
+            ]
+        },
+        "adp": [
+            {
+                "metrics": [
+                    {
+                        "other": {
+                            "type": "ssvc",
+                            "content": {
+                                "timestamp": "2026-07-15T03:56:45.570702Z",
+                                "id": "CVE-2026-50462",
+                                "options": [
+                                    {
+                                        "Exploitation": "none"
+                                    },
+                                    {
+                                        "Automatable": "no"
+                                    },
+                                    {
+                                        "Technical Impact": "total"
+                                    }
+                                ],
+                                "role": "CISA Coordinator",
+                                "version": "2.0.3"
+                            }
+                        }
+                    }
+                ],
+                "title": "CISA ADP Vulnrichment",
+                "providerMetadata": {
+                    "orgId": "134c704f-9b21-4f2e-91b3-4a467353bcc0",
+                    "shortName": "CISA-ADP",
+                    "dateUpdated": "2026-07-15T11:07:30.727Z"
+                }
+            }
+        ]
+    }
+}

--- a/collectors/cveorg/tests/test_processing.py
+++ b/collectors/cveorg/tests/test_processing.py
@@ -1,8 +1,13 @@
+import copy
 from typing import Optional
 
 import pytest
 
-from collectors.cveorg.collectors import CVEorgCollector
+from collectors.cveorg.collectors import (
+    CVEorgCollector,
+    CVEorgCollectorValidationError,
+    _is_windows_only_cve,
+)
 from osidb.models.flaw.cvss import FlawCVSS
 from osidb.models.flaw.flaw import Flaw
 
@@ -138,3 +143,96 @@ class TestCVEorgProcessing:
         updated_flaw = Flaw.objects.get(uuid=flaw.uuid)
         assert updated_flaw.mitre_cve_description == original_description
         assert updated_flaw.mitre_cve_description == content["mitre_cve_description"]
+
+
+class TestWindowsOnlyCPEFilter:
+    """
+    Unit tests for _is_windows_only_cve and its integration into the collector.
+    """
+
+    def test_windows_os_only_cve_is_blocked(self, windows_os_only_cve_content):
+        """CVE-2026-50462 — all CPEs are cpe:2.3:o:microsoft:windows_*."""
+        assert _is_windows_only_cve(windows_os_only_cve_content) is True
+
+    def test_windows_with_application_cpe_passes(self, windows_with_dotnet_cve_content):
+        """CVE-2026-50355 — mixes Windows OS CPEs with cpe:2.3:a:microsoft:.net.
+        Must not be filtered: .NET is a cross-platform Microsoft application."""
+        assert _is_windows_only_cve(windows_with_dotnet_cve_content) is False
+
+    def test_no_cpe_applicability_passes(self, windows_os_only_cve_content):
+        """CVEs without cpeApplicability should not be filtered out."""
+        content = copy.deepcopy(windows_os_only_cve_content)
+        del content["containers"]["cna"]["cpeApplicability"]
+        assert _is_windows_only_cve(content) is False
+
+    def test_empty_cpe_applicability_passes(self, windows_os_only_cve_content):
+        """An empty cpeApplicability list is treated as no CPE data — do not filter."""
+        content = copy.deepcopy(windows_os_only_cve_content)
+        content["containers"]["cna"]["cpeApplicability"] = []
+        assert _is_windows_only_cve(content) is False
+
+    def test_non_microsoft_vendor_passes(self, windows_os_only_cve_content):
+        """A single non-Microsoft CPE is enough to let the CVE through."""
+        content = copy.deepcopy(windows_os_only_cve_content)
+        content["containers"]["cna"]["cpeApplicability"][0]["nodes"][0][
+            "cpeMatch"
+        ].append(
+            {
+                "vulnerable": True,
+                "criteria": "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*",
+            }
+        )
+        assert _is_windows_only_cve(content) is False
+
+    def test_negated_node_passes(self, windows_os_only_cve_content):
+        """A negated node means 'all platforms except these' — semantics we cannot
+        evaluate without full boolean CPE logic, so bail out conservatively."""
+        content = copy.deepcopy(windows_os_only_cve_content)
+        content["containers"]["cna"]["cpeApplicability"][0]["nodes"][0]["negate"] = True
+        assert _is_windows_only_cve(content) is False
+
+    def test_negated_applicability_passes(self, windows_os_only_cve_content):
+        """negate at the cpeApplicability (configuration) level inverts the entire
+        node set — bail out conservatively for the same reason as node-level negate."""
+        content = copy.deepcopy(windows_os_only_cve_content)
+        content["containers"]["cna"]["cpeApplicability"][0]["negate"] = True
+        assert _is_windows_only_cve(content) is False
+
+    def test_microsoft_non_windows_os_cpe_passes(self, windows_os_only_cve_content):
+        """A Microsoft OS CPE that is not a Windows family is not filtered."""
+        content = copy.deepcopy(windows_os_only_cve_content)
+        content["containers"]["cna"]["cpeApplicability"] = [
+            {
+                "nodes": [
+                    {
+                        "operator": "OR",
+                        "negate": False,
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:o:microsoft:azure_sphere:*:*:*:*:*:*:*:*",
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+        assert _is_windows_only_cve(content) is False
+
+    def test_upsert_raises_for_windows_only_cve(
+        self, windows_os_only_cve_content, tmp_path
+    ):
+        """_upsert_from_file_content must raise CVEorgCollectorValidationError for Windows-only CVEs."""
+        import json
+
+        fixture = tmp_path / "CVE-2026-50462.json"
+        fixture.write_text(json.dumps(windows_os_only_cve_content))
+
+        collector = CVEorgCollector()
+        collector.snippet_creation_enabled = True
+        collector.snippet_creation_start_date = None
+
+        with pytest.raises(CVEorgCollectorValidationError, match="Windows OS"):
+            collector._upsert_from_file_content(str(fixture))
+
+        assert Flaw.objects.count() == 0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix incorrect OpenAPI schema types for audit endpoint fields (pgh_data, pgh_context, pgh_diff) (OSIDB-3637)
 - Return descriptive 400 error instead of 500 on malformed bulk affects requests (OSIDB-3134)
 - Fix collectors being blocked by duplicated related model entries (OSIDB-5221)
+- Filter windows-only Flaws by leveraging CPEs in addition to keywords / blocklist (OSIDB-5235)
 
 ### Removed
 - deprecate workflow manipulation endpoints


### PR DESCRIPTION
This commit changes the way that Windows-only flaws collected are auto-rejected from purely keyword-driven to a cpe-based pre-filter.

This is because on July 14th Microsoft made public ~400 Windows-only CVEs that did not Red Hat products and which bypassed the existing keyword filters.

By leveraging CPEs we can easily filter windows-only Flaws.

**Stats**

From a list of 530 CVEs that were REJECTED on July 14th (including the Microsoft ones that had to be manually rejected):


Result | Count | %
-- | -- | --
Blocked by CPE filter | 351 | 66.2%
Passed — no CPE data | 146 | 27.5%
Passed — CPE present but not Windows OS-only | 33 | 6.2%
Total | 530 | 100%

TL;DR: 351 out of 378 windows-only flaws released on July 14th would have been auto-rejected by this CPE filter.