### PR TITLE
add basic auth to jira forwarder

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -468,6 +468,16 @@
         "is_secret": false
       }
     ],
+    "osidb/tests/endpoints/test_jira_stage_forwarder.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "osidb/tests/endpoints/test_jira_stage_forwarder.py",
+        "hashed_secret": "43ab036388b700546d6707c984052bedc9ddb216",
+        "is_verified": false,
+        "line_number": 50,
+        "is_secret": false
+      }
+    ],
     "osidb/tests/endpoints/test_trackers.py": [
       {
         "type": "Secret Keyword",

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - migrate alias-typed manual-triage labels to workflow type (OSIDB-5335)
 - bulk add approved workflow label to the flaws resolved before Argus (OSIDB-5334)
 - make V2 labels be just labels (OSIDB-5320)
+- Add basic auth to Jira forwarder (OSIDB-5253)
 
 ### Fixed
 - Gate ACE behind workflow eligibility to prevent spurious affects on manually-triaged,

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from importlib.metadata import distributions
 from types import SimpleNamespace
 from typing import Any, Type, cast
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 from uuid import uuid4
 
 import pghistory
@@ -2230,13 +2230,31 @@ class LabelView(
         raise Http404
 
 
+JIRA_RELATIVE_PATH_ERROR = "A Jira-relative path is required."
+
+
+def _validate_jira_relative_path(path_value):
+    parsed_path = urlparse(path_value or "")
+
+    if (
+        not path_value
+        or not parsed_path.path.startswith("/")
+        or parsed_path.scheme
+        or parsed_path.netloc
+    ):
+        raise ValidationError({"path": JIRA_RELATIVE_PATH_ERROR})
+
+    return path_value
+
+
 class IsAuthenticatedOrJiraBasicOrReadOnly(IsAuthenticatedOrReadOnly):
     def has_permission(self, request, view):
-        if super().has_permission(request, view):
+        authorization = request.headers.get("Authorization", "")
+        if authorization.lower().startswith("basic "):
+            _validate_jira_relative_path(request.query_params.get("path"))
             return True
 
-        authorization = request.headers.get("Authorization", "")
-        return authorization.lower().startswith("basic ")
+        return super().has_permission(request, view)
 
 
 # TODO: this view is temporary/undocumented and only applies to accessing JIRA stage and someday should be removed
@@ -2246,6 +2264,21 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
 
     proxies = {"https": HTTPS_PROXY}
     permission_classes = [IsAuthenticatedOrJiraBasicOrReadOnly]
+
+    def _get_target_url(self, request):
+        path_value = _validate_jira_relative_path(request.GET.get("path"))
+        target_url = f"{JIRA_SERVER.rstrip('/')}{path_value}"
+        jira_url = urlparse(JIRA_SERVER)
+        parsed_target = urlparse(target_url)
+
+        if (
+            parsed_target.scheme != jira_url.scheme
+            or parsed_target.hostname != jira_url.hostname
+            or parsed_target.port != jira_url.port
+        ):
+            raise ValidationError({"path": JIRA_RELATIVE_PATH_ERROR})
+
+        return target_url
 
     def _set_authorization_header(self, request, headers):
         authorization = request.headers.get("Authorization")
@@ -2263,8 +2296,7 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
     def get(self, request, *args, **kwargs):
         """perform JIRA stage HTTP GET"""
 
-        path_value = request.GET.get("path")
-        target_url = f"{JIRA_SERVER}{path_value}"
+        target_url = self._get_target_url(request)
         headers = {
             "Accept": "application/json",
             "Accept-Encoding": "gzip, deflate, br, zstd",
@@ -2285,8 +2317,7 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
     def post(self, request, *args, **kwargs):
         """perform JIRA stage HTTP POST"""
 
-        path_value = request.GET.get("path")
-        target_url = f"{JIRA_SERVER}{path_value}"
+        target_url = self._get_target_url(request)
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",
@@ -2309,8 +2340,7 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
     def put(self, request, *args, **kwargs):
         """perform JIRA stage HTTP PUT"""
 
-        path_value = request.GET.get("path")
-        target_url = f"{JIRA_SERVER}{path_value}"
+        target_url = self._get_target_url(request)
         headers = {
             "Accept": "application/json",
             "Content-Type": "application/json",

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -2230,13 +2230,35 @@ class LabelView(
         raise Http404
 
 
+class IsAuthenticatedOrJiraBasicOrReadOnly(IsAuthenticatedOrReadOnly):
+    def has_permission(self, request, view):
+        if super().has_permission(request, view):
+            return True
+
+        authorization = request.headers.get("Authorization", "")
+        return authorization.lower().startswith("basic ")
+
+
 # TODO: this view is temporary/undocumented and only applies to accessing JIRA stage and someday should be removed
 @extend_schema(exclude=True)
 class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
     """authenticated view which performs http forwarding specifically for Jira stage"""
 
     proxies = {"https": HTTPS_PROXY}
-    permission_classes = [IsAuthenticatedOrReadOnly]
+    permission_classes = [IsAuthenticatedOrJiraBasicOrReadOnly]
+
+    def _set_authorization_header(self, request, headers):
+        authorization = request.headers.get("Authorization")
+        if authorization and authorization.lower().startswith("basic "):
+            headers["Authorization"] = authorization
+            return
+
+        jira_api_key = request.headers.get("Jira-Api-Key")
+        if jira_api_key:
+            headers["Authorization"] = f"Bearer {jira_api_key}"
+            return
+
+        raise ValidationError({"Jira-Api-Key": "This HTTP header is required."})
 
     def get(self, request, *args, **kwargs):
         """perform JIRA stage HTTP GET"""
@@ -2249,11 +2271,7 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
             "User-Agent": "OSIM",
         }
         params = request.GET.copy()
-        jira_api_key = request.headers.get("Jira-Api-Key")
-        if jira_api_key:
-            headers["Authorization"] = f"Bearer {jira_api_key}"
-        else:
-            raise ValidationError({"Jira-Api-Key": "This HTTP header is required."})
+        self._set_authorization_header(request, headers)
 
         response = requests.get(
             target_url,
@@ -2276,11 +2294,7 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
             "User-Agent": "OSIM",
         }
         params = request.GET.copy()
-        jira_api_key = request.headers.get("Jira-Api-Key")
-        if jira_api_key:
-            headers["Authorization"] = f"Bearer {jira_api_key}"
-        else:
-            raise ValidationError({"Jira-Api-Key": "This HTTP header is required."})
+        self._set_authorization_header(request, headers)
 
         response = requests.post(
             target_url,
@@ -2303,11 +2317,7 @@ class JiraStageForwarderView(RudimentaryUserPathLoggingMixin, APIView):
             "Accept-Encoding": "gzip, deflate, br, zstd",
             "User-Agent": "OSIM",
         }
-        jira_api_key = request.headers.get("Jira-Api-Key")
-        if jira_api_key:
-            headers["Authorization"] = f"Bearer {jira_api_key}"
-        else:
-            raise ValidationError({"Jira-Api-Key": "This HTTP header is required."})
+        self._set_authorization_header(request, headers)
 
         response = requests.put(
             target_url,

--- a/osidb/tests/endpoints/test_jira_stage_forwarder.py
+++ b/osidb/tests/endpoints/test_jira_stage_forwarder.py
@@ -33,7 +33,7 @@ class TestJiraStageForwarder:
         assert response.status_code == 200
         assert response.json() == {"ok": True}
         request_mock.assert_called_once()
-        assert request_mock.call_args.args[0] == f"{JIRA_SERVER}{path}"
+        assert request_mock.call_args.args[0] == f"{JIRA_SERVER.rstrip('/')}{path}"
         assert (
             request_mock.call_args.kwargs["headers"]["Authorization"] == authorization
         )
@@ -56,6 +56,47 @@ class TestJiraStageForwarder:
         assert request_mock.call_args.kwargs["headers"]["Authorization"] == (
             "Bearer jira-token"
         )
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "https://evil.example/rest/api/3/myself",
+            f"{JIRA_SERVER}/rest/api/3/myself",
+            "//evil.example/rest/api/3/myself",
+            "@evil.example/rest/api/3/myself",
+        ],
+    )
+    def test_post_rejects_unsafe_basic_authorization_path(
+        self, client, test_api_uri, monkeypatch, path
+    ):
+        request_mock = Mock()
+        monkeypatch.setattr("osidb.api_views.requests.post", request_mock)
+
+        response = client.post(
+            f"{test_api_uri}/jira_stage_forwarder?path={path}",
+            data=b'{"body": "test"}',
+            content_type="application/json",
+            HTTP_AUTHORIZATION="Basic fake==",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"path": ["A Jira-relative path is required."]}
+        request_mock.assert_not_called()
+
+    def test_get_rejects_unsafe_jira_api_key_path(
+        self, client, test_api_uri, monkeypatch
+    ):
+        request_mock = Mock()
+        monkeypatch.setattr("osidb.api_views.requests.get", request_mock)
+
+        response = client.get(
+            f"{test_api_uri}/jira_stage_forwarder?path=@evil.example/rest/api/3/myself",
+            HTTP_JIRA_API_KEY="jira-token",
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"path": ["A Jira-relative path is required."]}
+        request_mock.assert_not_called()
 
     def test_get_requires_jira_authorization(self, client, test_api_uri, monkeypatch):
         request_mock = Mock()

--- a/osidb/tests/endpoints/test_jira_stage_forwarder.py
+++ b/osidb/tests/endpoints/test_jira_stage_forwarder.py
@@ -1,0 +1,70 @@
+from unittest.mock import Mock
+
+import pytest
+
+from collectors.jiraffe.constants import JIRA_SERVER
+
+pytestmark = pytest.mark.unit
+
+
+class TestJiraStageForwarder:
+    @pytest.mark.parametrize("method", ["get", "post", "put"])
+    def test_forwards_basic_authorization(
+        self, client, test_api_uri, monkeypatch, method
+    ):
+        authorization = "Basic fake=="
+        path = "/rest/api/3/issue/OSIDB-1"
+        response_mock = Mock(status_code=200, text='{"ok": true}')
+        response_mock.json.return_value = {"ok": True}
+        request_mock = Mock(return_value=response_mock)
+        monkeypatch.setattr(f"osidb.api_views.requests.{method}", request_mock)
+
+        url = f"{test_api_uri}/jira_stage_forwarder?path={path}"
+        if method == "get":
+            response = client.get(url, HTTP_AUTHORIZATION=authorization)
+        else:
+            response = getattr(client, method)(
+                url,
+                data=b'{"body": "test"}',
+                content_type="application/json",
+                HTTP_AUTHORIZATION=authorization,
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        request_mock.assert_called_once()
+        assert request_mock.call_args.args[0] == f"{JIRA_SERVER}{path}"
+        assert (
+            request_mock.call_args.kwargs["headers"]["Authorization"] == authorization
+        )
+
+    def test_get_falls_back_to_jira_api_key(self, client, test_api_uri, monkeypatch):
+        path = "/rest/api/3/myself"
+        response_mock = Mock(status_code=200)
+        response_mock.json.return_value = {"ok": True}
+        request_mock = Mock(return_value=response_mock)
+        monkeypatch.setattr("osidb.api_views.requests.get", request_mock)
+
+        response = client.get(
+            f"{test_api_uri}/jira_stage_forwarder?path={path}",
+            HTTP_JIRA_API_KEY="jira-token",
+        )
+
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+        request_mock.assert_called_once()
+        assert request_mock.call_args.kwargs["headers"]["Authorization"] == (
+            "Bearer jira-token"
+        )
+
+    def test_get_requires_jira_authorization(self, client, test_api_uri, monkeypatch):
+        request_mock = Mock()
+        monkeypatch.setattr("osidb.api_views.requests.get", request_mock)
+
+        response = client.get(
+            f"{test_api_uri}/jira_stage_forwarder?path=/rest/api/3/myself"
+        )
+
+        assert response.status_code == 400
+        assert response.json() == {"Jira-Api-Key": ["This HTTP header is required."]}
+        request_mock.assert_not_called()


### PR DESCRIPTION
This PR adds basic authentication header needed for Jira forwarder in stage.

Closes OSIDB-5253.