### PR TITLE
feat: add django-silk profiling and sample data tooling (OSIDB-5268)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ pyrightconfig.json
 \#*\#
 .\#*
 
+# Silk profiling output
+*.prof
+
 # Codegraph knowledge graph directory
 .codegraph/

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -238,7 +238,7 @@
         "filename": "config/settings_local.py",
         "hashed_secret": "efacc4001e857f7eba4ae781c2932dedf843865e",
         "is_verified": false,
-        "line_number": 43,
+        "line_number": 47,
         "is_secret": false
       },
       {
@@ -246,7 +246,7 @@
         "filename": "config/settings_local.py",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 77,
+        "line_number": 81,
         "is_secret": false
       }
     ],
@@ -256,7 +256,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 132,
+        "line_number": 133,
         "is_secret": false
       }
     ],

--- a/config/settings_local.py
+++ b/config/settings_local.py
@@ -1,3 +1,7 @@
+import os
+import sys
+from importlib.util import find_spec
+
 import ldap
 from django_auth_ldap.config import GroupOfNamesType, LDAPSearch
 
@@ -102,3 +106,29 @@ INSTALLED_APPS += ["osidb.tests"]
 # Email configuration
 
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
+
+# django-silk profiling (opt-in)
+#
+# Setup:
+#   1. Add OSIDB_ENABLE_SILK=1 to your .env
+#   2. make sync-deps              (update local venv)
+#   3. make apply-uv-dev-sync      (install dev deps in osidb-service container)
+#   4. podman restart osidb-service (runs migrate + starts runserver)
+#   5. Browse http://localhost:8000/silk/
+#
+# For load testing + profiling, see perf/silk_profiling.py
+#
+# To disable: remove OSIDB_ENABLE_SILK from .env and restart.
+# Silk tables are harmless when left behind; to drop them:
+#   podman exec osidb-service python manage.py migrate silk zero
+if (
+    os.environ.get("OSIDB_ENABLE_SILK", "").strip() not in ("", "0")
+    and "pytest" not in sys.modules
+    and find_spec("silk")
+):
+    INSTALLED_APPS += ["silk"]
+    # Must be after GZipMiddleware per silk docs
+    _gzip = MIDDLEWARE.index("django.middleware.gzip.GZipMiddleware")
+    MIDDLEWARE.insert(_gzip + 1, "silk.middleware.SilkyMiddleware")
+    SILKY_PYTHON_PROFILER = True
+    SILKY_INTERCEPT_PERCENT = 100

--- a/config/urls.py
+++ b/config/urls.py
@@ -37,3 +37,6 @@ urlpatterns = [
     path("auth/token/refresh", refresh_token, name="token_refresh"),
     path("auth/token/verify", TokenVerifyView.as_view(), name="token_verify"),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+if "silk" in settings.INSTALLED_APPS:
+    urlpatterns += [path("silk/", include("silk.urls", namespace="silk"))]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,6 +107,7 @@ services:
         OSIDB_VAULT_ADDR: ${OSIDB_VAULT_ADDR}
         OSIDB_ROLE_ID: ${OSIDB_ROLE_ID}
         OSIDB_SECRET_ID: ${OSIDB_SECRET_ID}
+        OSIDB_ENABLE_SILK: ${OSIDB_ENABLE_SILK}
       command: ./scripts/setup-osidb-service.sh
       volumes:
         - ${PWD}:/opt/app-root/src:z

--- a/mk/setup.mk
+++ b/mk/setup.mk
@@ -114,6 +114,15 @@ apply-uv-sync: check-reg check-venv sync-deps
 
 
 #***********************************
+### Sync dev dependencies into osidb-service (e.g. for django-silk profiling)
+#***********************************
+.PHONY : apply-uv-dev-sync
+apply-uv-dev-sync: check-reg check-venv sync-deps
+	@echo ">syncing dev dependencies into osidb-service"
+	$(podman) exec -it osidb-service uv sync --frozen
+
+
+#***********************************
 ### Install necessary development packages
 #***********************************
 DEVRPMS = make podman podman-compose libpq-devel python3.12-devel gcc openldap-devel krb5-devel openldap-clients python3.12 black openssl libffi-devel libxslt-devel

--- a/osidb/management/commands/generate_sample_data.py
+++ b/osidb/management/commands/generate_sample_data.py
@@ -1,0 +1,834 @@
+import random
+import uuid
+from datetime import datetime, timezone
+
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+
+from osidb.acls import ACL
+from osidb.core import generate_acls, set_user_acls
+from osidb.helpers import bypass_rls
+from osidb.mixins import Alert
+from osidb.models import (
+    CVSS,
+    Affect,
+    AffectCVSS,
+    Flaw,
+    FlawAcknowledgment,
+    FlawComment,
+    FlawCVSS,
+    FlawLabelV2,
+    FlawReference,
+    FlawSource,
+    Impact,
+    Package,
+    PackageVer,
+    PsModule,
+    PsProduct,
+    PsUpdateStream,
+    Tracker,
+)
+from osidb.models.affect import NotAffectedJustification
+
+# ---------------------------------------------------------------------------
+# Constants used for sample-data identification (cleanup queries)
+# ---------------------------------------------------------------------------
+SAMPLE_MODULE_NAMES = [
+    "rhel-9",
+    "rhel-8",
+    "openshift-4",
+    "satellite-6",
+    "ansible-automation-platform-2",
+]
+SAMPLE_CVE_PREFIX = "CVE-2024-5"
+SAMPLE_NO_CVE_TITLE = "[sample] flaw without CVE"
+SAMPLE_PRODUCT_NAMES = [
+    "sample_rhel_9",
+    "sample_rhel_8",
+    "sample_openshift",
+    "sample_satellite",
+    "sample_aap",
+]
+SAMPLE_TRACKER_PREFIX = "SAMPLE-"
+SAMPLE_BZ_TRACKER_START = 2200000
+
+# ---------------------------------------------------------------------------
+# Pools of values cycled / randomly picked when scaling up
+# ---------------------------------------------------------------------------
+IMPACT_POOL = [
+    Impact.CRITICAL,
+    Impact.IMPORTANT,
+    Impact.MODERATE,
+    Impact.LOW,
+    Impact.NOVALUE,
+]
+SOURCE_POOL = [
+    FlawSource.INTERNET,
+    FlawSource.CUSTOMER,
+    FlawSource.REDHAT,
+    FlawSource.GIT,
+    FlawSource.RESEARCHER,
+    FlawSource.UPSTREAM,
+    FlawSource.GOOGLE,
+]
+MI_POOL = [
+    Flaw.FlawMajorIncident.NOVALUE,
+    Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+    Flaw.FlawMajorIncident.MAJOR_INCIDENT_REQUESTED,
+    Flaw.FlawMajorIncident.MAJOR_INCIDENT_REJECTED,
+    Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+    Flaw.FlawMajorIncident.EXPLOITS_KEV_REQUESTED,
+    Flaw.FlawMajorIncident.EXPLOITS_KEV_REJECTED,
+    Flaw.FlawMajorIncident.MINOR_INCIDENT_APPROVED,
+    Flaw.FlawMajorIncident.MINOR_INCIDENT_REQUESTED,
+    Flaw.FlawMajorIncident.MINOR_INCIDENT_REJECTED,
+]
+WF_STATE_POOL = [
+    "NEW",
+    "TRIAGE",
+    "PRE_SECONDARY_ASSESSMENT",
+    "SECONDARY_ASSESSMENT",
+    "ANALYSIS",
+    "DONE",
+]
+COMPONENT_POOL = [
+    "kernel",
+    "openssl",
+    "httpd",
+    "podman",
+    "firefox",
+    "curl",
+    "systemd",
+    "glibc",
+    "bash",
+    "sudo",
+    "nginx",
+    "python",
+]
+# (affectedness, resolution) pairs that are mutually valid
+AFFECTEDNESS_RESOLUTION_POOL = [
+    (Affect.AffectAffectedness.AFFECTED, Affect.AffectResolution.DELEGATED),
+    (Affect.AffectAffectedness.AFFECTED, Affect.AffectResolution.WONTFIX),
+    (Affect.AffectAffectedness.AFFECTED, Affect.AffectResolution.OOSS),
+    (Affect.AffectAffectedness.AFFECTED, Affect.AffectResolution.DEFER),
+    (Affect.AffectAffectedness.NEW, Affect.AffectResolution.NOVALUE),
+    (Affect.AffectAffectedness.NOTAFFECTED, Affect.AffectResolution.NOVALUE),
+]
+TRACKER_STATUS_POOL = [
+    ("In Progress", ""),
+    ("New", ""),
+    ("Review", ""),
+    ("Closed", "Done"),
+    ("Closed", "Won't Do"),
+]
+
+# Fixed CVSS vectors used for sample data
+CVSS3_VECTOR = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+CVSS2_VECTOR = "AV:N/AC:L/Au:N/C:C/I:C/A:C"
+
+# Default counts (preserve original hardcoded behaviour when no args given)
+DEFAULT_FLAWS = 15
+DEFAULT_AFFECTS_PER_FLAW = (1, 3)
+DEFAULT_TRACKERS = 10
+
+
+def _parse_range(value):
+    """Parse a 'min,max' or single int string into a (min, max) tuple."""
+    parts = value.split(",")
+    if len(parts) == 1:
+        n = int(parts[0])
+        return (n, n)
+    elif len(parts) == 2:
+        lo, hi = int(parts[0]), int(parts[1])
+        if lo > hi:
+            raise ValueError
+        return (lo, hi)
+    else:
+        raise ValueError
+
+
+def _acls(embargoed):
+    """Return (acl_read, acl_write) UUID lists matching the factory logic."""
+    read_groups = (
+        settings.EMBARGO_READ_GROUPS if embargoed else settings.PUBLIC_READ_GROUPS
+    )
+    write_groups = (
+        settings.EMBARGO_WRITE_GROUPS if embargoed else settings.PUBLIC_WRITE_GROUPS
+    )
+    return (
+        [uuid.UUID(a) for a in generate_acls(read_groups)],
+        [uuid.UUID(a) for a in generate_acls(write_groups)],
+    )
+
+
+def _now():
+    return datetime.now(tz=timezone.utc)
+
+
+class Command(BaseCommand):
+    help = "Populate the dev database with sample flaws, affects, trackers, and related objects"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--flaws",
+            type=int,
+            default=DEFAULT_FLAWS,
+            help=f"Number of flaws to generate (default: {DEFAULT_FLAWS})",
+        )
+        parser.add_argument(
+            "--affects-per-flaw",
+            type=str,
+            default=f"{DEFAULT_AFFECTS_PER_FLAW[0]},{DEFAULT_AFFECTS_PER_FLAW[1]}",
+            help=(
+                "Range of affects per flaw as 'min,max' or a single number "
+                f"(default: {DEFAULT_AFFECTS_PER_FLAW[0]},{DEFAULT_AFFECTS_PER_FLAW[1]})"
+            ),
+        )
+        parser.add_argument(
+            "--trackers",
+            type=int,
+            default=DEFAULT_TRACKERS,
+            help=(
+                f"Total number of trackers to generate (default: {DEFAULT_TRACKERS}). "
+                "Each tracker is linked to one or more affects."
+            ),
+        )
+
+    def handle(self, *args, **options):
+        num_flaws = options["flaws"]
+        try:
+            affects_range = _parse_range(options["affects_per_flaw"])
+        except (ValueError, TypeError):
+            raise CommandError(
+                "Invalid --affects-per-flaw value. Use a single int or 'min,max'."
+            )
+        num_trackers = options["trackers"]
+
+        if num_flaws < 1:
+            raise CommandError("--flaws must be at least 1.")
+        if affects_range[0] < 0:
+            raise CommandError("--affects-per-flaw minimum must be >= 0.")
+        if num_trackers < 0:
+            raise CommandError("--trackers must be >= 0.")
+
+        set_user_acls(settings.ALL_GROUPS)
+
+        sample_qs = self._sample_querysets()
+        counts = {label: qs.count() for label, qs in sample_qs}
+        if any(counts.values()):
+            summary = ", ".join(f"{v} {k}" for k, v in counts.items() if v)
+            self.stdout.write(f"Found: {summary}")
+            confirm = input("Delete all sample data before regenerating? [y/N] ")
+            if confirm.lower() != "y":
+                self.stdout.write("Aborted.")
+                return
+            self._delete_sample_data(sample_qs)
+
+        self.stdout.write(
+            f"Generating sample data: {num_flaws} flaws, "
+            f"{affects_range[0]}-{affects_range[1]} affects/flaw, "
+            f"{num_trackers} trackers..."
+        )
+        with transaction.atomic():
+            ps_modules, streams = self._create_product_structure()
+            flaws = self._create_flaws(num_flaws)
+            affects = self._create_affects(flaws, ps_modules, streams, affects_range)
+            tracker_count = self._create_trackers(affects, num_trackers)
+            self._create_cvss(flaws, affects)
+            self._create_related_objects(flaws)
+            self._create_alerts(flaws, affects)
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Created: {len(flaws)} flaws, {len(affects)} affects, "
+                f"{tracker_count} trackers, {len(SAMPLE_MODULE_NAMES)} modules"
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Cleanup helpers
+    # ------------------------------------------------------------------
+    @bypass_rls
+    def _delete_sample_data(self, sample_qs):
+        """Delete all sample querysets.
+
+        FlawLabelV2 is a PolymorphicModel whose FK to Flaw is not traversed
+        by Django's cascade deletion collector, causing a FK violation at
+        commit time.  Deleting it explicitly first (under bypass_rls so the
+        ACL-filtered manager actually finds the rows) avoids the issue.
+        """
+        # Use non_polymorphic() to bypass the PolymorphicManager type
+        # resolution that silently drops rows the cascade collector misses.
+        FlawLabelV2.objects.non_polymorphic().filter(
+            flaw__cve_id__startswith=SAMPLE_CVE_PREFIX
+        ).delete()
+        FlawLabelV2.objects.non_polymorphic().filter(
+            flaw__title=SAMPLE_NO_CVE_TITLE
+        ).delete()
+        for _, qs in sample_qs:
+            qs.delete()
+
+    def _sample_querysets(self):
+        return [
+            (
+                "trackers",
+                Tracker.objects.filter(
+                    external_system_id__startswith=SAMPLE_TRACKER_PREFIX
+                )
+                | Tracker.objects.filter(
+                    external_system_id__gte=str(SAMPLE_BZ_TRACKER_START),
+                    external_system_id__lt=str(SAMPLE_BZ_TRACKER_START + 1_000_000),
+                ),
+            ),
+            (
+                "flaws",
+                Flaw.objects.filter(cve_id__startswith=SAMPLE_CVE_PREFIX),
+            ),
+            (
+                "flaws (no CVE)",
+                Flaw.objects.filter(title=SAMPLE_NO_CVE_TITLE),
+            ),
+            (
+                "streams",
+                PsUpdateStream.objects.filter(ps_module__name__in=SAMPLE_MODULE_NAMES),
+            ),
+            (
+                "modules",
+                PsModule.objects.filter(name__in=SAMPLE_MODULE_NAMES),
+            ),
+            (
+                "products",
+                PsProduct.objects.filter(short_name__in=SAMPLE_PRODUCT_NAMES),
+            ),
+        ]
+
+    # ------------------------------------------------------------------
+    # Product structure (modules + streams, shared across all affects)
+    # ------------------------------------------------------------------
+    def _create_product_structure(self):
+        module_defs = [
+            ("rhel-9", "jboss", "RHEL", "sample_rhel_9"),
+            ("rhel-8", "bugzilla", "Red Hat Enterprise Linux 8", "sample_rhel_8"),
+            ("openshift-4", "jboss", "OCPBUGS", "sample_openshift"),
+            ("satellite-6", "jboss", "SAT", "sample_satellite"),
+            ("ansible-automation-platform-2", "jboss", "AAP", "sample_aap"),
+        ]
+        ps_modules = []
+        for name, bts_name, bts_key, product_short_name in module_defs:
+            product, _ = PsProduct.objects.get_or_create(
+                short_name=product_short_name,
+                defaults={
+                    "name": f"{product_short_name} long name",
+                    "business_unit": "Engineering",
+                },
+            )
+            module, _ = PsModule.objects.get_or_create(
+                name=name,
+                defaults={
+                    "bts_name": bts_name,
+                    "bts_key": bts_key,
+                    "bts_groups": {"public": [bts_key]},
+                    "public_description": f"Sample module {name}",
+                    "ps_product": product,
+                    "private_trackers_allowed": False,
+                    "autofile_trackers": False,
+                },
+            )
+            ps_modules.append(module)
+
+        stream_defs = [
+            ("rhel-9.4.0.z", 0),
+            ("rhel-9.3.0.z", 0),
+            ("rhel-8.9.0.z", 1),
+            ("openshift-4.15.z", 2),
+            ("satellite-6.14.z", 3),
+            ("ansible-automation-platform-2.4", 4),
+        ]
+        streams = []
+        for stream_name, module_idx in stream_defs:
+            stream, _ = PsUpdateStream.objects.get_or_create(
+                name=stream_name,
+                defaults={
+                    "ps_module": ps_modules[module_idx],
+                    "active_to_ps_module": ps_modules[module_idx],
+                    "version": stream_name,
+                    "target_release": "",
+                },
+            )
+            streams.append(stream)
+
+        return ps_modules, streams
+
+    # ------------------------------------------------------------------
+    # Flaws
+    # ------------------------------------------------------------------
+    def _create_flaws(self, num_flaws):
+        flaws = []
+        now = _now()
+        for i in range(num_flaws):
+            impact = IMPACT_POOL[i % len(IMPACT_POOL)]
+            source = SOURCE_POOL[i % len(SOURCE_POOL)]
+            mi_state = MI_POOL[i % len(MI_POOL)]
+            wf_state = WF_STATE_POOL[i % len(WF_STATE_POOL)]
+            embargoed = source in (FlawSource.CUSTOMER, FlawSource.RESEARCHER)
+            # One in every 5 non-embargoed flaws is internal-only, so internal
+            # visibility is actually exercised by the sample data.
+            internal = not embargoed and i % 5 == 4
+            wf_name = "EMBARGOED" if embargoed else "DEFAULT"
+
+            # One in every 15 flaws has no CVE
+            if i > 0 and i % 15 == 13:
+                cve_id = None
+                title = SAMPLE_NO_CVE_TITLE
+            else:
+                cve_id = f"CVE-2024-5{i:04d}"
+                prefix = "EMBARGOED " if embargoed else ""
+                title = f"{prefix}{cve_id} kernel: sample vulnerability"
+
+            is_mi = mi_state in (
+                Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+                Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+                Flaw.FlawMajorIncident.MINOR_INCIDENT_APPROVED,
+            )
+            if internal:
+                acl_read, acl_write = ACL.INTERNAL.uuid_read, ACL.INTERNAL.uuid_write
+            else:
+                acl_read, acl_write = _acls(embargoed)
+
+            flaw = Flaw(
+                cve_id=cve_id,
+                title=title,
+                comment_zero=f"Comment zero for {cve_id or 'sample'}",
+                impact=impact,
+                source=source,
+                major_incident_state=mi_state,
+                nist_cvss_validation=Flaw.FlawNistCvssValidation.NOVALUE,
+                workflow_name=wf_name,
+                workflow_state=wf_state,
+                statement="Sample statement" if is_mi else "",
+                cve_description="I am a spooky CVE" if is_mi else "",
+                mitigation="CVE mitigation" if is_mi else "",
+                acl_read=acl_read,
+                acl_write=acl_write,
+                unembargo_dt=None if embargoed else now,
+                meta_attr={
+                    "bz_id": str(10000 + i),
+                    "last_change_time": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "test": "1",
+                },
+                created_dt=now,
+                updated_dt=now,
+                local_updated_dt=now,
+            )
+            flaw.save(auto_timestamps=False)
+            flaws.append(flaw)
+        return flaws
+
+    # ------------------------------------------------------------------
+    # Affects
+    # ------------------------------------------------------------------
+    def _create_affects(self, flaws, ps_modules, streams, affects_range):
+        # Build (module_idx, stream_idx) pairs that belong together
+        module_stream_pairs = []
+        for mi, mod in enumerate(ps_modules):
+            for si, stream in enumerate(streams):
+                if stream.ps_module_id == mod.pk:
+                    module_stream_pairs.append((mi, si))
+
+        affects = []
+        now = _now()
+        for flaw in flaws:
+            count = random.randint(affects_range[0], affects_range[1])  # noqa: S311
+            # (ps_update_stream, ps_component) must be unique per flaw, so pick
+            # from all pair/component combos rather than risking random collisions.
+            combos = [
+                (pair, comp) for pair in module_stream_pairs for comp in COMPONENT_POOL
+            ]
+            random.shuffle(combos)  # noqa: S311
+            count = min(count, len(combos))
+            for (pm_idx, stream_idx), component in combos[:count]:
+                affectedness, resolution = random.choice(AFFECTEDNESS_RESOLUTION_POOL)  # noqa: S311
+                stream = streams[stream_idx]
+                module = ps_modules[pm_idx]
+
+                impact = Impact.NOVALUE
+                if random.random() < 0.1:  # noqa: S311
+                    impact = random.choice(  # noqa: S311
+                        [
+                            Impact.CRITICAL,
+                            Impact.IMPORTANT,
+                            Impact.MODERATE,
+                            Impact.LOW,
+                        ]
+                    )
+
+                acl_read, acl_write = _acls(flaw.is_embargoed)
+                not_affected_justification = (
+                    NotAffectedJustification.COMPONENT_NOT_PRESENT
+                    if affectedness == Affect.AffectAffectedness.NOTAFFECTED
+                    else ""
+                )
+                affect = Affect(
+                    flaw=flaw,
+                    cve_id=flaw.cve_id,
+                    affectedness=affectedness,
+                    resolution=resolution,
+                    not_affected_justification=not_affected_justification,
+                    ps_module=module.name,
+                    ps_component=component,
+                    ps_update_stream=stream.name,
+                    impact=impact,
+                    purl=f"pkg:rpm/redhat/{component}@1?arch=src",
+                    acl_read=acl_read,
+                    acl_write=acl_write,
+                    meta_attr={"test": "1"},
+                    created_dt=now,
+                    updated_dt=now,
+                )
+                affect.save(auto_timestamps=False)
+                affects.append(affect)
+        return affects
+
+    # ------------------------------------------------------------------
+    # Trackers — each tracker links to 1+ affects
+    # ------------------------------------------------------------------
+    def _create_trackers(self, affects, num_trackers):
+        if num_trackers == 0 or not affects:
+            return 0
+
+        # Only DELEGATED affects typically get trackers
+        eligible = [
+            a for a in affects if a.resolution == Affect.AffectResolution.DELEGATED
+        ]
+        if not eligible:
+            eligible = list(affects)
+
+        random.shuffle(eligible)  # noqa: S311
+        actual_trackers = min(num_trackers, len(eligible))
+        buckets = [[] for _ in range(actual_trackers)]
+        for idx, affect in enumerate(eligible):
+            buckets[idx % actual_trackers].append(affect)
+
+        now = _now()
+        created = 0
+        for i, linked_affects in enumerate(buckets):
+            if not linked_affects:
+                continue
+
+            if i % 5 == 0:
+                ttype = Tracker.TrackerType.BUGZILLA
+                ext_id = str(SAMPLE_BZ_TRACKER_START + i)
+            else:
+                ttype = Tracker.TrackerType.JIRA
+                ext_id = f"{SAMPLE_TRACKER_PREFIX}{i:05d}"
+
+            status, resolution = random.choice(TRACKER_STATUS_POOL)  # noqa: S311
+            embargoed = linked_affects[0].flaw.is_embargoed
+            acl_read, acl_write = _acls(embargoed)
+
+            tracker = Tracker(
+                type=ttype,
+                external_system_id=ext_id,
+                status=status,
+                resolution=resolution,
+                ps_update_stream=linked_affects[0].ps_update_stream,
+                cve_id=linked_affects[0].cve_id,
+                acl_read=acl_read,
+                acl_write=acl_write,
+                meta_attr={"test": "1"},
+                created_dt=now,
+                updated_dt=now,
+            )
+            tracker.save(auto_timestamps=False)
+            tracker.affects.set(linked_affects)
+            created += 1
+        return created
+
+    # ------------------------------------------------------------------
+    # CVSS scores
+    # ------------------------------------------------------------------
+    def _create_cvss(self, flaws, affects):
+        now = _now()
+        for i, flaw in enumerate(flaws):
+            acl_read, acl_write = _acls(flaw.is_embargoed)
+            if flaw.impact != Impact.NOVALUE:
+                FlawCVSS.objects.create(
+                    flaw=flaw,
+                    version=CVSS.CVSSVersion.VERSION3,
+                    issuer=CVSS.CVSSIssuer.REDHAT,
+                    vector=CVSS3_VECTOR,
+                    comment="CVSS RH comment",
+                    acl_read=acl_read,
+                    acl_write=acl_write,
+                    created_dt=now,
+                    updated_dt=now,
+                )
+            # First third + last flaw get NIST v3
+            if i < len(flaws) // 3 or i == len(flaws) - 1:
+                FlawCVSS.objects.create(
+                    flaw=flaw,
+                    version=CVSS.CVSSVersion.VERSION3,
+                    issuer=CVSS.CVSSIssuer.NIST,
+                    vector=CVSS3_VECTOR,
+                    comment="",
+                    acl_read=acl_read,
+                    acl_write=acl_write,
+                    created_dt=now,
+                    updated_dt=now,
+                )
+            # First two flaws also get NIST v2
+            if i < 2:
+                FlawCVSS.objects.create(
+                    flaw=flaw,
+                    version=CVSS.CVSSVersion.VERSION2,
+                    issuer=CVSS.CVSSIssuer.NIST,
+                    vector=CVSS2_VECTOR,
+                    comment="",
+                    acl_read=acl_read,
+                    acl_write=acl_write,
+                    created_dt=now,
+                    updated_dt=now,
+                )
+
+        # Affect CVSS for first few affects
+        for affect in affects[: min(5, len(affects))]:
+            acl_read, acl_write = _acls(affect.flaw.is_embargoed)
+            AffectCVSS.objects.create(
+                affect=affect,
+                version=CVSS.CVSSVersion.VERSION3,
+                issuer=CVSS.CVSSIssuer.REDHAT,
+                vector=CVSS3_VECTOR,
+                comment="CVSS RH comment",
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+
+        # Last flaw gets nist_cvss_validation=REQUESTED, but only if it actually
+        # has both an RH and a NIST v3 score (RH v3 requires impact != NOVALUE).
+        if flaws[-1].impact != Impact.NOVALUE:
+            flaws[-1].nist_cvss_validation = Flaw.FlawNistCvssValidation.REQUESTED
+            flaws[-1].save(auto_timestamps=False)
+
+    # ------------------------------------------------------------------
+    # Related objects (comments, acknowledgments, references, packages)
+    # ------------------------------------------------------------------
+    def _create_related_objects(self, flaws):
+        now = _now()
+        for flaw in flaws[: min(8, len(flaws))]:
+            acl_read, acl_write = _acls(flaw.is_embargoed)
+            FlawComment.objects.create(
+                flaw=flaw,
+                text=f"Initial triage comment for {flaw.cve_id or flaw.uuid}",
+                external_system_id=f"sample-{flaw.uuid}",
+                synced_to_bz=False,
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+            if flaw.impact in (Impact.CRITICAL, Impact.IMPORTANT):
+                FlawComment.objects.create(
+                    flaw=flaw,
+                    text="Priority escalation noted.",
+                    external_system_id=f"sample-priv-{flaw.uuid}",
+                    synced_to_bz=False,
+                    is_private=True,
+                    acl_read=acl_read,
+                    acl_write=acl_write,
+                    created_dt=now,
+                    updated_dt=now,
+                )
+
+        # Acknowledgments on private-source flaws
+        private_flaws = [
+            f for f in flaws if f.source in (FlawSource.CUSTOMER, FlawSource.RESEARCHER)
+        ]
+        for pf in private_flaws[:2]:
+            acl_read, acl_write = _acls(pf.is_embargoed)
+            FlawAcknowledgment.objects.create(
+                flaw=pf,
+                name="Alice Doe",
+                affiliation="CERT/CC",
+                from_upstream=False,
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+            FlawAcknowledgment.objects.create(
+                flaw=pf,
+                name="Bob Chen",
+                affiliation="",
+                from_upstream=True,
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+
+        # References on first flaw
+        if flaws:
+            RT = FlawReference.FlawReferenceType
+            acl_read, acl_write = _acls(flaws[0].is_embargoed)
+            for ref_type, url in [
+                (RT.ARTICLE, "https://access.redhat.com/articles/12345"),
+                (
+                    RT.EXTERNAL,
+                    f"https://nvd.nist.gov/vuln/detail/{flaws[0].cve_id or 'sample'}",
+                ),
+                (RT.SOURCE, "https://git.kernel.org/stable/c/abc123"),
+            ]:
+                FlawReference.objects.create(
+                    flaw=flaws[0],
+                    type=ref_type,
+                    url=url,
+                    description="",
+                    acl_read=acl_read,
+                    acl_write=acl_write,
+                    created_dt=now,
+                    updated_dt=now,
+                )
+
+            pkg1 = Package.objects.create(
+                flaw=flaws[0],
+                package="kernel",
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+            PackageVer.objects.create(package=pkg1, version="5.14.0-362.el9")
+            PackageVer.objects.create(package=pkg1, version="5.14.0-284.el9")
+
+        if len(flaws) > 2:
+            RT = FlawReference.FlawReferenceType
+            acl_read, acl_write = _acls(flaws[2].is_embargoed)
+            FlawReference.objects.create(
+                flaw=flaws[2],
+                type=RT.UPSTREAM,
+                url=f"https://httpd.apache.org/security/{flaws[2].cve_id or 'sample'}",
+                description="",
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+            pkg2 = Package.objects.create(
+                flaw=flaws[2],
+                package="httpd",
+                acl_read=acl_read,
+                acl_write=acl_write,
+                created_dt=now,
+                updated_dt=now,
+            )
+            PackageVer.objects.create(package=pkg2, version="2.4.57-8.el9")
+
+    # ------------------------------------------------------------------
+    # Alerts
+    # ------------------------------------------------------------------
+    def _create_alerts(self, flaws, affects):
+        W, E = Alert.AlertType.WARNING, Alert.AlertType.ERROR
+
+        flaw_alerts = [
+            (
+                0,
+                "rh_nist_cvss_score_diff",
+                "RH and NIST CVSS scores differ significantly",
+                W,
+            ),
+            (
+                0,
+                "rh_nist_cvss_severity_diff",
+                "RH and NIST CVSS severity ratings differ",
+                W,
+            ),
+            (
+                1,
+                "private_source_no_ack",
+                "Flaw has a private source but no acknowledgment from upstream",
+                W,
+            ),
+            (
+                3,
+                "special_consideration_flaw_missing_statement",
+                "Special consideration flaw is missing a statement",
+                E,
+            ),
+            (
+                4,
+                "special_consideration_flaw_missing_cve_description",
+                "Special consideration flaw is missing a CVE description",
+                E,
+            ),
+            (
+                5,
+                "mi_article_missing",
+                "Major incident flaw is missing an article reference",
+                E,
+            ),
+            (
+                5,
+                "mi_statement_missing",
+                "Major incident flaw is missing a statement",
+                E,
+            ),
+            (
+                6,
+                "mi_cve_description_missing",
+                "Major incident flaw is missing a CVE description",
+                W,
+            ),
+            (
+                8,
+                "embargoed_source_public",
+                "Flaw source is marked as embargoed but flaw is public",
+                W,
+            ),
+            (
+                9,
+                "request_nist_cvss_validation",
+                "NIST CVSS validation has been requested",
+                W,
+            ),
+        ]
+        for idx, name, desc, atype in flaw_alerts:
+            if idx < len(flaws):
+                flaws[idx].alert(name, desc, atype)
+        if flaws:
+            flaws[-1].alert(
+                "unsupported_impact_change",
+                "Impact has changed for a flaw in an unsupported product",
+                W,
+            )
+
+        affect_alerts = [
+            (
+                5,
+                "flaw_affects_unknown_component",
+                "The affect component is not recognized in product definitions",
+                W,
+            ),
+            (
+                6,
+                "flaw_historical_affect_status",
+                "Affect uses a historical affectedness/resolution combination",
+                W,
+            ),
+            (
+                8,
+                "flaw_affects_unknown_component",
+                "The affect component is not recognized in product definitions",
+                W,
+            ),
+        ]
+        for idx, name, desc, atype in affect_alerts:
+            if idx < len(affects):
+                affects[idx].alert(name, desc, atype)
+        if len(affects) > 14:
+            affects[14].alert(
+                "old_flaw_affect_ps_module",
+                "Affect uses a deprecated PS module name",
+                W,
+            )

--- a/perf/silk_profiling.py
+++ b/perf/silk_profiling.py
@@ -1,0 +1,192 @@
+"""
+Locustfile for generating traffic against a local OSIDB instance with silk enabled.
+
+Usage:
+    # Generate sample data first:
+    python manage.py generate_sample_data
+
+    # Start the server with silk:
+    OSIDB_ENABLE_SILK=1 python manage.py runserver
+
+    # Run locust (headless, quick burst):
+    locust --headless -f perf/silk_profiling.py --host http://localhost:8000 \
+        --users 3 --spawn-rate 1 --run-time 30s
+
+    # Or with the web UI:
+    locust -f perf/silk_profiling.py --host http://localhost:8000 --modern-ui
+
+    # Then view profiling results at http://localhost:8000/silk/
+"""
+
+import os
+
+from locust import HttpUser, between, task
+
+LOCUST_USERNAME = os.environ.get("LOCUST_USERNAME", "testuser")
+LOCUST_PASSWORD = os.environ.get("LOCUST_PASSWORD", "password")  # noqa: S105
+
+
+class ProfilingUser(HttpUser):
+    wait_time = between(0.5, 2)
+    token = None
+
+    def on_start(self):
+        self.client.verify = False
+        resp = self.client.post(
+            "/auth/token",
+            json={"username": LOCUST_USERNAME, "password": LOCUST_PASSWORD},
+        )
+        if not resp.ok:
+            raise RuntimeError(f"Auth failed ({resp.status_code}): {resp.text[:200]}")
+        self.token = resp.json().get("access", "")
+        if not self.token:
+            raise RuntimeError(f"Auth response missing 'access' token: {resp.json()}")
+
+    @property
+    def auth_headers(self):
+        return {"Authorization": f"Bearer {self.token}"}
+
+    # ── Flaw endpoints ────────────────────────────────────────────────
+
+    @task(10)
+    def flaw_list(self):
+        self.client.get(
+            "/osidb/api/v1/flaws?limit=50&order=-created_dt",
+            headers=self.auth_headers,
+        )
+
+    @task(5)
+    def flaw_list_filtered(self):
+        self.client.get(
+            "/osidb/api/v1/flaws?impact=CRITICAL&limit=20",
+            headers=self.auth_headers,
+        )
+
+    @task(3)
+    def flaw_list_with_affects(self):
+        self.client.get(
+            "/osidb/api/v1/flaws?include_fields=cve_id,uuid,impact,title,affects&limit=20",
+            headers=self.auth_headers,
+        )
+
+    @task(3)
+    def flaw_list_embargoed(self):
+        self.client.get(
+            "/osidb/api/v1/flaws?embargoed=true&limit=20",
+            headers=self.auth_headers,
+        )
+
+    @task(8)
+    def flaw_detail(self):
+        self._flaw_subresource(None)
+
+    # ── Affect endpoints ──────────────────────────────────────────────
+
+    @task(5)
+    def affect_list(self):
+        self.client.get("/osidb/api/v1/affects?limit=50", headers=self.auth_headers)
+
+    @task(3)
+    def affect_list_filtered(self):
+        self.client.get(
+            "/osidb/api/v1/affects?affectedness=AFFECTED&limit=20",
+            headers=self.auth_headers,
+        )
+
+    # ── Tracker endpoints ─────────────────────────────────────────────
+
+    @task(4)
+    def tracker_list(self):
+        self.client.get("/osidb/api/v1/trackers?limit=50", headers=self.auth_headers)
+
+    @task(2)
+    def tracker_list_filtered(self):
+        self.client.get(
+            "/osidb/api/v1/trackers?type=JIRA&limit=20", headers=self.auth_headers
+        )
+
+    # ── Alert endpoints ───────────────────────────────────────────────
+
+    @task(3)
+    def alert_list(self):
+        self.client.get("/osidb/api/v1/alerts?limit=50", headers=self.auth_headers)
+
+    # ── Flaw sub-resource endpoints ───────────────────────────────────
+
+    def _flaw_subresource(self, sub):
+        suffix = f" ({sub})" if sub else ""
+        resp = self.client.get(
+            "/osidb/api/v1/flaws?include_fields=uuid&limit=1",
+            headers=self.auth_headers,
+            name=f"/osidb/api/v1/flaws (get uuid{suffix})",
+        )
+        if not resp.ok:
+            return
+        results = resp.json().get("results", [])
+        if results:
+            uuid = results[0]["uuid"]
+            path = f"/osidb/api/v1/flaws/{uuid}"
+            name = "/osidb/api/v1/flaws/[uuid]"
+            if sub:
+                path += f"/{sub}"
+                name += f"/{sub}"
+            self.client.get(path, headers=self.auth_headers, name=name)
+
+    @task(4)
+    def flaw_comments(self):
+        self._flaw_subresource("comments")
+
+    @task(3)
+    def flaw_cvss_scores(self):
+        self._flaw_subresource("cvss_scores")
+
+    @task(2)
+    def flaw_references(self):
+        self._flaw_subresource("references")
+
+    @task(2)
+    def flaw_acknowledgments(self):
+        self._flaw_subresource("acknowledgments")
+
+    @task(2)
+    def flaw_package_versions(self):
+        self._flaw_subresource("package_versions")
+
+    # ── Other endpoints ───────────────────────────────────────────────
+
+    @task(2)
+    def status(self):
+        self.client.get(
+            "/osidb/api/v1/status",
+            headers=self.auth_headers,
+        )
+
+    @task(1)
+    def whoami(self):
+        self.client.get(
+            "/osidb/whoami",
+            headers=self.auth_headers,
+        )
+
+    # ── v2 endpoints ──────────────────────────────────────────────────
+
+    @task(3)
+    def flaw_list_v2(self):
+        self.client.get(
+            "/osidb/api/v2/flaws?limit=20",
+            headers=self.auth_headers,
+        )
+
+    @task(2)
+    def affect_list_v2(self):
+        self.client.get(
+            "/osidb/api/v2/affects?limit=20",
+            headers=self.auth_headers,
+        )
+
+    @task(2)
+    def tracker_list_v2(self):
+        self.client.get(
+            "/osidb/api/v2/trackers?limit=20",
+            headers=self.auth_headers,
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,14 @@ dependencies = [
 [dependency-groups]
 dev = [
     "detect-secrets>=1.4.0",
+    "django-silk>=5.0.0",
     "django-extensions>=3.1.5",
     "django-stubs>=1.14.0",
     "djangorestframework-stubs>=1.8.0",
     "factory-boy>=3.2.1",
     "freezegun>=1.1.0",
     "k5test>=0.10.1",
+    "locust>=2.0",
     "lxml>=6.1.0",
     "mypy>=0.991",
     "openshift>=0.12.1",

--- a/uv.lock
+++ b/uv.lock
@@ -93,12 +93,48 @@ wheels = [
 ]
 
 [[package]]
+name = "bidict"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/6e/026678aa5a830e07cd9498a05d3e7e650a4f56a42f267a53d22bcda1bdc9/bidict-0.23.1.tar.gz", hash = "sha256:03069d763bc387bbd20e7d49914e75fc4132a41937fa3405417e1a5a2d006d71", size = 29093, upload-time = "2024-02-18T19:09:05.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/37/e8730c3587a65eb5645d4aba2d27aae48e8003614d6aaf15dda67f702f1f/bidict-0.23.1-py3-none-any.whl", hash = "sha256:5dae8d4d79b552a71cbabc7deb25dfe8ce710b17ff41711e13010ead2abfc3e5", size = 32764, upload-time = "2024-02-18T19:09:04.156Z" },
+]
+
+[[package]]
 name = "billiard"
 version = "4.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7c/58/1546c970afcd2a2428b1bfafecf2371d8951cc34b46701bea73f4280989e/billiard-4.2.1.tar.gz", hash = "sha256:12b641b0c539073fc8d3f5b8b7be998956665c4233c7c1fcd66a7e677c4fb36f", size = 155031, upload-time = "2024-09-21T13:40:22.491Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/30/da/43b15f28fe5f9e027b41c539abc5469052e9d48fd75f8ff094ba2a0ae767/billiard-4.2.1-py3-none-any.whl", hash = "sha256:40b59a4ac8806ba2c2369ea98d876bc6108b051c227baffd928c644d15d8f3cb", size = 86766, upload-time = "2024-09-21T13:40:20.188Z" },
+]
+
+[[package]]
+name = "blinker"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
 ]
 
 [[package]]
@@ -176,10 +212,19 @@ name = "cffi"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "pycparser" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz", hash = "sha256:1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824", size = 516621, upload-time = "2024-09-04T20:45:21.852Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/84/e94227139ee5fb4d600a7a4927f322e1d4aea6fdc50bd3fca8493caba23f/cffi-1.17.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:805b4371bf7197c329fcb3ead37e710d1bca9da5d583f5073b799d5c5bd1eee4", size = 183178, upload-time = "2024-09-04T20:44:12.232Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ee/fb72c2b48656111c4ef27f0f91da355e130a923473bf5ee75c5643d00cca/cffi-1.17.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:733e99bc2df47476e3848417c5a4540522f234dfd4ef3ab7fafdf555b082ec0c", size = 178840, upload-time = "2024-09-04T20:44:13.739Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b6/db007700f67d151abadf508cbfd6a1884f57eab90b1bb985c4c8c02b0f28/cffi-1.17.1-cp312-cp312-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1257bdabf294dceb59f5e70c64a3e2f462c30c7ad68092d01bbbfb1c16b1ba36", size = 454803, upload-time = "2024-09-04T20:44:15.231Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/f8d151540d8c200eb1c6fba8cd0dfd40904f1b0682ea705c36e6c2e97ab3/cffi-1.17.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da95af8214998d77a98cc14e3a3bd00aa191526343078b530ceb0bd710fb48a5", size = 478850, upload-time = "2024-09-04T20:44:17.188Z" },
+    { url = "https://files.pythonhosted.org/packages/28/c0/b31116332a547fd2677ae5b78a2ef662dfc8023d67f41b2a83f7c2aa78b1/cffi-1.17.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d63afe322132c194cf832bfec0dc69a99fb9bb6bbd550f161a49e9e855cc78ff", size = 485729, upload-time = "2024-09-04T20:44:18.688Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/9a1ddfa5c7f13cab007a2c9cc295b70fbbda7cb10a286aa6810338e60ea1/cffi-1.17.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f79fc4fc25f1c8698ff97788206bb3c2598949bfe0fef03d299eb1b5356ada99", size = 471256, upload-time = "2024-09-04T20:44:20.248Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d5/da47df7004cb17e4955df6a43d14b3b4ae77737dff8bf7f8f333196717bf/cffi-1.17.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b62ce867176a75d03a665bad002af8e6d54644fad99a3c70905c543130e39d93", size = 479424, upload-time = "2024-09-04T20:44:21.673Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/ac/2a28bcf513e93a219c8a4e8e125534f4f6db03e3179ba1c45e949b76212c/cffi-1.17.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:386c8bf53c502fff58903061338ce4f4950cbdcb23e2902d86c0f722b786bbe3", size = 484568, upload-time = "2024-09-04T20:44:23.245Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/38/ca8a4f639065f14ae0f1d9751e70447a261f1a30fa7547a828ae08142465/cffi-1.17.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:4ceb10419a9adf4460ea14cfd6bc43d08701f0835e979bf821052f1805850fe8", size = 488736, upload-time = "2024-09-04T20:44:24.757Z" },
     { url = "https://files.pythonhosted.org/packages/86/c5/28b2d6f799ec0bdecf44dced2ec5ed43e0eb63097b0f58c293583b406582/cffi-1.17.1-cp312-cp312-win32.whl", hash = "sha256:a08d7e755f8ed21095a310a693525137cfe756ce62d066e53f502a83dc550f65", size = 172448, upload-time = "2024-09-04T20:44:26.208Z" },
     { url = "https://files.pythonhosted.org/packages/50/b9/db34c4755a7bd1cb2d1603ac3863f22bcecbd1ba29e5ee841a4bc510b294/cffi-1.17.1-cp312-cp312-win_amd64.whl", hash = "sha256:51392eae71afec0d0c8fb1a53b204dbb3bcabcb3c9b807eedf3e1e6ccf2de903", size = 181976, upload-time = "2024-09-04T20:44:27.578Z" },
 ]
@@ -268,6 +313,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "configargparse"
+version = "1.7.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/0b/30328302903c55218ffc5199646d0e9d28348ff26c02ba77b2ffc58d294a/configargparse-1.7.5.tar.gz", hash = "sha256:e3f9a7bb6be34d66b2e3c4a2f58e3045f8dfae47b0dc039f87bcfaa0f193fb0f", size = 53548, upload-time = "2026-03-11T02:19:38.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/19/3ba5e1b0bcc7b91aeab6c258afd70e4907d220fed3972febe38feb40db30/configargparse-1.7.5-py3-none-any.whl", hash = "sha256:1e63fdffedf94da9cd435fc13a1cd24777e76879dd2343912c1f871d4ac8c592", size = 27692, upload-time = "2026-03-11T02:19:36.442Z" },
 ]
 
 [[package]]
@@ -511,6 +565,20 @@ wheels = [
 ]
 
 [[package]]
+name = "django-silk"
+version = "5.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "django" },
+    { name = "gprof2dot" },
+    { name = "sqlparse" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9c/3e/db3bda7cf1327aa3800d32dca80f0d077954b52f61dc32cf76f605a28767/django_silk-5.5.0.tar.gz", hash = "sha256:41fcabe65d59d31ccdb69daeb3c3e6d30879ab2c00b0875b111fda0f69aec065", size = 4495794, upload-time = "2026-03-08T05:00:57.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/54/c56950e8b9279d2c6156d46571a64c1a808c07bddde571819e2bdbb8d5e3/django_silk-5.5.0-py3-none-any.whl", hash = "sha256:82b5a690d623935be916dd145e2f605a4ac9454d54e03df6a7ffcf38333c8444", size = 1944887, upload-time = "2026-03-08T05:01:13.646Z" },
+]
+
+[[package]]
 name = "django-stubs"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -691,6 +759,49 @@ wheels = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.1.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "blinker" },
+    { name = "click" },
+    { name = "itsdangerous" },
+    { name = "jinja2" },
+    { name = "markupsafe" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/00/35d85dcce6c57fdc871f3867d465d780f302a175ea360f62533f12b27e2b/flask-3.1.3.tar.gz", hash = "sha256:0ef0e52b8a9cd932855379197dd8f94047b359ca0a78695144304cb45f87c9eb", size = 759004, upload-time = "2026-02-19T05:00:57.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/9c/34f6962f9b9e9c71f6e5ed806e0d0ff03c9d1b0b2340088a0cf4bce09b18/flask-3.1.3-py3-none-any.whl", hash = "sha256:f4bcbefc124291925f1a26446da31a5178f9483862233b23c0c96a20701f670c", size = 103424, upload-time = "2026-02-19T05:00:56.027Z" },
+]
+
+[[package]]
+name = "flask-cors"
+version = "6.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/03/4e464a50860f9adf08b5c1d3479cb8ea1f12af2aa69535c7042c6e628135/flask_cors-6.0.5.tar.gz", hash = "sha256:30c5031552cd59f620ac0c8211dac45b345d3b2df310e7721879e4f46ef9c601", size = 101386, upload-time = "2026-06-08T20:20:17.765Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/55/5bb1a2d918e9f02f131e47a59032bae70e48050e986e941511fd737a935c/flask_cors-6.0.5-py3-none-any.whl", hash = "sha256:68fcf75693e961f3af26683b23c4b9a8fb6b64de17d20d0c37b95e8de7ab2ed8", size = 16692, upload-time = "2026-06-08T20:20:16.247Z" },
+]
+
+[[package]]
+name = "flask-login"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flask" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/6e/2f4e13e373bb49e68c02c51ceadd22d172715a06716f9299d9df01b6ddb2/Flask-Login-0.6.3.tar.gz", hash = "sha256:5e23d14a607ef12806c699590b89d0f0e0d67baeec599d75947bf9c147330333", size = 48834, upload-time = "2023-10-30T14:53:21.151Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/f5/67e9cc5c2036f58115f9fe0f00d203cf6780c3ff8ae0e705e7a9d9e8ff9e/Flask_Login-0.6.3-py3-none-any.whl", hash = "sha256:849b25b82a436bf830a054e74214074af59097171562ab10bfa999e6b78aae5d", size = 17303, upload-time = "2023-10-30T14:53:19.636Z" },
+]
+
+[[package]]
 name = "flower"
 version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
@@ -720,7 +831,7 @@ wheels = [
 
 [[package]]
 name = "gevent"
-version = "23.9.1"
+version = "26.7.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cffi", marker = "platform_python_implementation == 'CPython' and sys_platform == 'win32'" },
@@ -728,17 +839,42 @@ dependencies = [
     { name = "zope-event" },
     { name = "zope-interface" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ce/d2b9a376ee010f6d548bf1b6b6eddc372a175e6e100896e607c57e37f7cf/gevent-23.9.1.tar.gz", hash = "sha256:72c002235390d46f94938a96920d8856d4ffd9ddf62a303a0d7c118894097e34", size = 5847705, upload-time = "2023-09-12T17:14:51.654Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/5c/92002455a57cb3634383e2b822e3bccf409f43cde34528e46428971475cf/gevent-26.7.0.tar.gz", hash = "sha256:5b333a556e38a302b1b8c80525bef16d437e16f1e7767947789406841856a102", size = 6729213, upload-time = "2026-07-22T20:16:04.713Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/38/796f4233ca509db402536b6e8f1feae7f47f8532d1cbfacf8a2787b55e16/gevent-23.9.1-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ed7a048d3e526a5c1d55c44cb3bc06cfdc1947d06d45006cc4cf60dedc628904", size = 2932425, upload-time = "2023-09-12T17:21:46.246Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/c4/1cad8a349456055bcc996c1587b1802b85bf10ead31ddf3f4b518121744f/gevent-23.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7c1abc6f25f475adc33e5fc2dbcc26a732608ac5375d0d306228738a9ae14d3b", size = 5181535, upload-time = "2023-09-12T18:26:47.095Z" },
-    { url = "https://files.pythonhosted.org/packages/25/75/c04b20b3e27278fb92a75a57daf6961a72884f6fd1da60b2da1f37a54474/gevent-23.9.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4368f341a5f51611411ec3fc62426f52ac3d6d42eaee9ed0f9eebe715c80184e", size = 5387767, upload-time = "2023-09-12T18:10:52.736Z" },
-    { url = "https://files.pythonhosted.org/packages/73/48/e2b89118f731a7783733e485b534928ed30318397f52370807acf47fa630/gevent-23.9.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:52b4abf28e837f1865a9bdeef58ff6afd07d1d888b70b6804557e7908032e599", size = 5487523, upload-time = "2023-09-12T18:19:05.738Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/04/07ec55cf891353f05d1fd173d5ef007bcb4cffd280716ec8adeb35693445/gevent-23.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:52e9f12cd1cda96603ce6b113d934f1aafb873e2c13182cf8e86d2c5c41982ea", size = 6621286, upload-time = "2023-09-12T17:48:56.681Z" },
-    { url = "https://files.pythonhosted.org/packages/22/f8/bdef615617c2b36fe4b411ce94f58f7357036bb4b5b89ce5fee6642d4d9c/gevent-23.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:de350fde10efa87ea60d742901e1053eb2127ebd8b59a7d3b90597eb4e586599", size = 6587178, upload-time = "2023-09-12T17:54:41.908Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/4f/cb6fded9aa92a76add5772fc29247c01b15ca561652302bf8b6fa61a3b4a/gevent-23.9.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:fde6402c5432b835fbb7698f1c7f2809c8d6b2bd9d047ac1f5a7c1d5aa569303", size = 5511046, upload-time = "2023-09-12T18:49:32.949Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/c9/d415c260f4e916b851ad2a4e504cfa3212c4a6d13358fd356a4ac6da9230/gevent-23.9.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:dd6c32ab977ecf7c7b8c2611ed95fa4aaebd69b74bf08f4b4960ad516861517d", size = 6663856, upload-time = "2023-09-12T18:00:29.142Z" },
-    { url = "https://files.pythonhosted.org/packages/43/9f/fc088a53e85b46630ac01af3247ccc4d14548cb9d9881705cc54f48543aa/gevent-23.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:455e5ee8103f722b503fa45dedb04f3ffdec978c1524647f8ba72b4f08490af1", size = 1522922, upload-time = "2023-09-12T17:21:38.858Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/66/104590ad3a9e671b3ef77ad19c1cc50e7f1c8c220b27ddfaf34e5f88bd9c/gevent-26.7.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:92f256285fb43a57f152bd2e51a59cde1cd0b20869ae1e6da583b6beab88ed8a", size = 2953977, upload-time = "2026-07-22T16:23:41.654Z" },
+    { url = "https://files.pythonhosted.org/packages/64/07/350d87161378633714184828bdc57c66f9b525eca5249ad1294dc7f8cf58/gevent-26.7.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:0e4fea187c5df7168b9538b4f543fcb0fcbaeb93be3d6cd499c324652c740704", size = 1800960, upload-time = "2026-07-22T18:11:27.242Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6c/ddfe298c2ecb1cfc72a03dd69ba751759f7e7835d3135f171b284eb09ed1/gevent-26.7.0-cp312-cp312-manylinux_2_28_ppc64le.whl", hash = "sha256:ce732fe08d0ea65de07eff6e46bade8ac6a6fdb65cc748c713f3d31ae122529e", size = 1900387, upload-time = "2026-07-22T18:10:42.973Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/89/2647bbbf1da35a1c271a54452e76065308cbaf684ee32a79f989ca4265f6/gevent-26.7.0-cp312-cp312-manylinux_2_28_s390x.whl", hash = "sha256:c25b3522072137aecf3389031039230190038f888e257f490b3897d0e0620f74", size = 1848046, upload-time = "2026-07-22T18:29:08.074Z" },
+    { url = "https://files.pythonhosted.org/packages/31/52/4f9b4c536b5a0424e328d5a5466640d185020f1f0b08b2de0ca939cc0a0b/gevent-26.7.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:eaaa75c9014df3f8c310c64f53f1152af8c6be32e82734396bed91e1d0e6f35c", size = 2132200, upload-time = "2026-07-22T16:48:31.203Z" },
+    { url = "https://files.pythonhosted.org/packages/42/88/1daffa63b257c381df68018e4d3da72b429955cf95a171a46d3220422c8d/gevent-26.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f1956032a9926ac9b4152b2a50bc5a2cc020722ec16928ccaf32e227ee0aae47", size = 1814237, upload-time = "2026-07-22T18:07:12.438Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4c/b996cdddca78eac435195cd97dff590c65a9e0052640bcb6f8b6f1e30b1d/gevent-26.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:d989a1ad6cc54f5c69bb7304360f98b4fda80da2b773f1047db9fba61ae7379a", size = 2157938, upload-time = "2026-07-22T17:02:14.887Z" },
+    { url = "https://files.pythonhosted.org/packages/08/fd/44419d7559a95e238ee45d29df30bad78a91d343cb27b13a6af552b907bb/gevent-26.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:e0c9ce2d80fc0f8894d748a1045ff26ad188e294bad656b29839271800827c85", size = 1685319, upload-time = "2026-07-22T16:26:13.954Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/7a/7df1762ccd9a40ce1ca626f50cb7a75758f2c930aabcc73c91cf00cb3448/gevent-26.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:959effe0c56cdee0bf761e5c4e78ab62880be147a2f2aa31112ca2f7e5754e53", size = 1558945, upload-time = "2026-07-22T16:26:56.737Z" },
+]
+
+[[package]]
+name = "geventhttpclient"
+version = "2.3.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "brotli" },
+    { name = "certifi" },
+    { name = "gevent" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/ff/cb3db11fca4223b2753ae170d1a09c9d32bfbfa3e8d4a6181324db686830/geventhttpclient-2.3.9.tar.gz", hash = "sha256:16807578dc4a175e8d97e6e39d65a10b04b5237a8c55f7a5ef39044e869baeb8", size = 84353, upload-time = "2026-03-03T08:09:03.336Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/8f/a6a787443af8defaae8bab96e056f2e0d48ffcb4eb2724d83727c465335f/geventhttpclient-2.3.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:39afb8046fe04358a85956555aa6a1d931710bac386a2fceb5c24bbd4d7c10e7", size = 70141, upload-time = "2026-03-03T08:08:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/18/c6/043e74e5ce9ce7cfd206f2ba572ded6bfe7278fb73d0d81aef0e913e9b5d/geventhttpclient-2.3.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:04b8feec69fd662eb46b4f81013206f5a23d179b195cbaf590d4a59f641ed0fc", size = 51776, upload-time = "2026-03-03T08:08:09.206Z" },
+    { url = "https://files.pythonhosted.org/packages/16/b2/f65c47ec71278f02c22e5d7120db855fe9c1d8034994c6c4ac8ed9b2328a/geventhttpclient-2.3.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5b542025a0c9905c847d1459e598ccbdcd21dc0dd050cc1d3813ce7e01bd350f", size = 51523, upload-time = "2026-03-03T08:08:10.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/12/bed280730e754bc8f1691481a58cff71eca16f439dc6629ad6843ffc9988/geventhttpclient-2.3.9-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c582a6697c82a948d3d42094da941544606a0ebee31fc0aa6731e248eeba0e9b", size = 115393, upload-time = "2026-03-03T08:08:11.239Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/eb/def9770ae049a64b698c78186ebe1281900da581401a043c206efe2957ca/geventhttpclient-2.3.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39011c8cdd7ef8b6ab07592525f83018cd1504e8133cce5114bfcee5547b9bb5", size = 116043, upload-time = "2026-03-03T08:08:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/62/50/877f2ddd8ebebb0e060bfc34ed5d3721689e96c6debb218f5bac9fa04339/geventhttpclient-2.3.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2b91fb31523725ddc777c14b444ccedaf2043dcb9af0ede29056a9b8146c79a7", size = 122061, upload-time = "2026-03-03T08:08:13.194Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/6ef955f9eb1cfd7412ee20e5f7bee2459f3a9aad3330b4c193729a968ee2/geventhttpclient-2.3.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d91139a4fafd77fa985535966d7a6c2e64753f340ab1395508ee83cd8de70c38", size = 111963, upload-time = "2026-03-03T08:08:15.33Z" },
+    { url = "https://files.pythonhosted.org/packages/28/10/965899a6c557055974b2aca048d478451aa144876171fbe023959fd8f42a/geventhttpclient-2.3.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0ff40ca5b848f96c6390bd8cc3a4c4598c119be08125cf1c30103201adc00940", size = 118841, upload-time = "2026-03-03T08:08:16.173Z" },
+    { url = "https://files.pythonhosted.org/packages/67/e1/e559f1ee8b0d26870cabae401bb32706390ade2f4e540695fbb6ed908bdb/geventhttpclient-2.3.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c9091db18eeb53626a81e9280d602ae9e29706ee4c1e7a05edc8b07cc632b3fc", size = 112618, upload-time = "2026-03-03T08:08:17.301Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/25/03b06f42ddb202f2a7da0f8dc3759ac4a09213bad6122e218397268832d0/geventhttpclient-2.3.9-cp312-cp312-win32.whl", hash = "sha256:4110273531fc9ac2ec197a44a90d9c7b4266b51a070747368e38213be281d5c2", size = 48750, upload-time = "2026-03-03T08:08:18.204Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/32/918822056ecc395a1f4e81e292a4549779fd255dd533b036aac80023b691/geventhttpclient-2.3.9-cp312-cp312-win_amd64.whl", hash = "sha256:98f3582a1c9effb56bc2db4f43d382cedd921217a139d5737eeaad3a1e307047", size = 49383, upload-time = "2026-03-03T08:08:19.157Z" },
 ]
 
 [[package]]
@@ -754,6 +890,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ef/77/eb1d3288dbe2ba6f4fe50b9bb41770bac514cd2eb91466b56d44a99e2f8d/google-auth-1.6.3.tar.gz", hash = "sha256:0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4", size = 80899, upload-time = "2019-02-19T21:14:58.34Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/9b/ed0516cc1f7609fb0217e3057ff4f0f9f3e3ce79a369c6af4a6c5ca25664/google_auth-1.6.3-py2.py3-none-any.whl", hash = "sha256:20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed", size = 73441, upload-time = "2019-02-19T21:14:56.623Z" },
+]
+
+[[package]]
+name = "gprof2dot"
+version = "2025.4.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/fd/cad13fa1f7a463a607176432c4affa33ea162f02f58cc36de1d40d3e6b48/gprof2dot-2025.4.14.tar.gz", hash = "sha256:35743e2d2ca027bf48fa7cba37021aaf4a27beeae1ae8e05a50b55f1f921a6ce", size = 39536, upload-time = "2025-04-14T07:21:45.76Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/ed/89d760cb25279109b89eb52975a7b5479700d3114a2421ce735bfb2e7513/gprof2dot-2025.4.14-py3-none-any.whl", hash = "sha256:0742e4c0b4409a5e8777e739388a11e1ed3750be86895655312ea7c20bd0090e", size = 37555, upload-time = "2025-04-14T07:21:43.319Z" },
 ]
 
 [[package]]
@@ -800,6 +945,15 @@ gevent = [
 ]
 setproctitle = [
     { name = "setproctitle" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
 ]
 
 [[package]]
@@ -863,6 +1017,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/23/a2/97899f6bd0e873fed3a7e67ae8d3a08b21799430fb4da15cfedf10d6e2c2/iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32", size = 8104, upload-time = "2020-10-14T10:20:18.572Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/dd/b3c12c6d707058fa947864b67f0c4e0c39ef8610988d7baea9578f3c48f3/iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3", size = 4990, upload-time = "2020-10-16T17:37:23.05Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]
@@ -958,6 +1121,32 @@ wheels = [
 ]
 
 [[package]]
+name = "locust"
+version = "2.46.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "configargparse" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "flask-login" },
+    { name = "gevent" },
+    { name = "geventhttpclient" },
+    { name = "msgpack" },
+    { name = "psutil" },
+    { name = "pytest" },
+    { name = "python-engineio" },
+    { name = "python-socketio", extra = ["client"] },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "pyzmq" },
+    { name = "requests" },
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/9a/477d75bb2f19e92b4996493519af3e36eaeb1248e1e94637817cf60b6201/locust-2.46.1.tar.gz", hash = "sha256:ed26148522522d13fb453c5e4e281a82650a3b2ec5ad5f00a738ff22a0944808", size = 1478138, upload-time = "2026-07-21T19:01:43.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/71/9f3e058c4afd09c100bd7da5a2f45f4fc86aac97139c3a11f55963119e1a/locust-2.46.1-py3-none-any.whl", hash = "sha256:5111b14e856ee1e570276fdd621acb3b534557f8f0feb348fcfefc0571c680f4", size = 1497688, upload-time = "2026-07-21T19:01:41.367Z" },
+]
+
+[[package]]
 name = "lxml"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -994,9 +1183,41 @@ wheels = [
 
 [[package]]
 name = "markupsafe"
-version = "2.0.1"
+version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bf/10/ff66fea6d1788c458663a84d88787bae15d45daa16f6b3ef33322a51fc7e/MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a", size = 18596, upload-time = "2021-05-18T17:18:22.856Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
+]
+
+[[package]]
+name = "msgpack"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f9/c0a1c127f9049db9155afc316952ea571720dd01833ff5e4d7e8e6352dbb/msgpack-1.2.1.tar.gz", hash = "sha256:04c721c2c7448767e9e3f2520a475663d8ee0f09c31890f6d2bd70fd636a9647", size = 183960, upload-time = "2026-06-18T16:13:52.594Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/dd/9e8cbd8f5582ca4b590336f2b91ee5662f6a6ca562b565abaf696a0f81ff/msgpack-1.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2ef59c659f289eddf8aa6623823f19fa2f40a4029266889eac7a2505dd210c35", size = 83531, upload-time = "2026-06-18T16:12:58.249Z" },
+    { url = "https://files.pythonhosted.org/packages/50/2e/ebdb85a8da151397a2790363676b7ed7c125924fe618e4c6d8befb0cc62c/msgpack-1.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d3567748a5107cb40cdf66a275430c2f87c07777698f4bfd25c35f44d533258c", size = 82657, upload-time = "2026-06-18T16:12:59.396Z" },
+    { url = "https://files.pythonhosted.org/packages/26/aa/753ad8b007b464e1d8aa0c8e650b9c5f4f725e658fc5ac8a7635c55b7f6e/msgpack-1.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60926b75d00c8e816ef98f3034f484a8bc64242d66839cef4cf7e503142316a0", size = 410634, upload-time = "2026-06-18T16:13:00.383Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fd/6adabd4f6d5e686f97dd02ce7fce3fe4cf672cbac36b8f67ff4040e8ad8b/msgpack-1.2.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:020e881a764b20d8d7ca1a54fc01b8175519d108e3c3f194fddc200bda95951a", size = 419989, upload-time = "2026-06-18T16:13:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/85039b7b0eb168aaad7383a23c97e291a11f08351cb45a606ce865e4e3f1/msgpack-1.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4202c74688ca06591f78cb18988228bd4cca2cc75d57b60008372892d2f1e6e6", size = 377544, upload-time = "2026-06-18T16:13:03.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/35963899493b32030c85fc513b723ae66144ac70c11ebc52e889e16e3d99/msgpack-1.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8b267ce94efb76fbd1b3373511420074ee3187f0f7811bf394531de13294735a", size = 400842, upload-time = "2026-06-18T16:13:05.012Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/df/8e2ac970c8f99264cd9997d1c73df5466bc19da3301d7dc5500862a9b089/msgpack-1.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f1d0f8f98ade9634e01fb704a408f9336c0a8f1117b369f5db83dc7551d8b1", size = 374108, upload-time = "2026-06-18T16:13:06.232Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dd/fa8bd265110dfa51c20cb529f9e6d240a16fafe7e645004c6af2d01353ba/msgpack-1.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f02cf17a6ca1abe29b5f980644f7551f94d71f2011509b26d8625ce038f0df64", size = 414939, upload-time = "2026-06-18T16:13:07.478Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b9/8377a5ad8953fc0437c70cc98d9ae29f27fe5ac5109fbec0812085865735/msgpack-1.2.1-cp312-cp312-win32.whl", hash = "sha256:0c0d9802354507bcba62af19c17918e3eb437cc25e6f50657d511b5856a77aac", size = 64504, upload-time = "2026-06-18T16:13:08.822Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7f/ce1e377df7e62461fefd9eb23bfb93a4a523f40a517b377b8f844d836828/msgpack-1.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:5c24aa15d5963051e1a5c62b12c50cd705992502b5ec1f3bece6046f33c9fc24", size = 71421, upload-time = "2026-06-18T16:13:09.828Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/32/ebfe84c9929f08f188d56c7a2fd913406a9ddad76a634697c1c43b8112e6/msgpack-1.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:4227224aaec8f7fbcbfbd4272319347b2bb4030366502600f8c45588c5187b07", size = 64775, upload-time = "2026-06-18T16:13:11.056Z" },
+]
 
 [[package]]
 name = "mypy"
@@ -1119,11 +1340,13 @@ dependencies = [
 dev = [
     { name = "detect-secrets" },
     { name = "django-extensions" },
+    { name = "django-silk" },
     { name = "django-stubs" },
     { name = "djangorestframework-stubs" },
     { name = "factory-boy" },
     { name = "freezegun" },
     { name = "k5test" },
+    { name = "locust" },
     { name = "lxml" },
     { name = "mypy" },
     { name = "openshift" },
@@ -1196,11 +1419,13 @@ requires-dist = [
 dev = [
     { name = "detect-secrets", specifier = ">=1.4.0" },
     { name = "django-extensions", specifier = ">=3.1.5" },
+    { name = "django-silk", specifier = ">=5.0.0" },
     { name = "django-stubs", specifier = ">=1.14.0" },
     { name = "djangorestframework-stubs", specifier = ">=1.8.0" },
     { name = "factory-boy", specifier = ">=3.2.1" },
     { name = "freezegun", specifier = ">=1.1.0" },
     { name = "k5test", specifier = ">=0.10.1" },
+    { name = "locust", specifier = ">=2.0" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "mypy", specifier = ">=0.991" },
     { name = "openshift", specifier = ">=0.12.1" },
@@ -1300,6 +1525,22 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/96/b3bff620964869c07252fc2eac4e7e2dd48aea07314d932d21cfd92428da/prompt_toolkit-3.0.22.tar.gz", hash = "sha256:449f333dd120bd01f5d296a8ce1452114ba3a71fae7288d2f0ae2c918764fa72", size = 3041540, upload-time = "2021-11-04T07:54:18.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/2a/456a7f1acbe89fc04607357b6351d5daa864843f8e1470edaa723254ca1e/prompt_toolkit-3.0.22-py3-none-any.whl", hash = "sha256:48d85cdca8b6c4f16480c7ce03fd193666b62b0a21667ca56b4bb5ad679d1170", size = 374307, upload-time = "2021-11-04T07:54:13.774Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1564,6 +1805,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-engineio"
+version = "4.13.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "simple-websocket" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/a0/f75491f942184d9960b15e763270f765fe9f239745ca5f9e16289011aed4/python_engineio-4.13.3.tar.gz", hash = "sha256:572b7783e341fed21edbc7cea297ccd378dad79265fdde96aa4664420a7c06c9", size = 79734, upload-time = "2026-06-20T22:53:52.197Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/96/82f6328e410515fab21d5602ba35b9377a47b5a141a0c1f9efa00ce21eb4/python_engineio-4.13.3-py3-none-any.whl", hash = "sha256:1f60ecaf1358190f0e26c48c578a60428dc02a8f1295bc3dbf53d1b31116821f", size = 59993, upload-time = "2026-06-20T22:53:50.775Z" },
+]
+
+[[package]]
 name = "python-ldap"
 version = "3.4.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1572,6 +1825,25 @@ dependencies = [
     { name = "pyasn1-modules" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0c/88/8d2797decc42e1c1cdd926df4f005e938b0643d0d1219c08c2b5ee8ae0c0/python_ldap-3.4.5.tar.gz", hash = "sha256:b2f6ef1c37fe2c6a5a85212efe71311ee21847766a7d45fcb711f3b270a5f79a", size = 388482, upload-time = "2025-10-10T20:00:39.06Z" }
+
+[[package]]
+name = "python-socketio"
+version = "5.16.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bidict" },
+    { name = "python-engineio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/2d/ffce71017c106b75099fea569df6518c63fee5d6202ce0cfe7b01e6f22c3/python_socketio-5.16.3.tar.gz", hash = "sha256:89b136f677ae65607a84cecda9b4d6c5377b40a97582c504c25df89af16d520e", size = 128095, upload-time = "2026-06-15T22:07:04.003Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/38/8c5e72d53ff8eb27497c4f268a7f6d9121e727a50b65248288ad79a93053/python_socketio-5.16.3-py3-none-any.whl", hash = "sha256:e7ad14202a5e6448824c7c2f86161d04e13dec05992257df5c709e6a2798c041", size = 82087, upload-time = "2026-06-15T22:07:02.498Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "requests" },
+    { name = "websocket-client" },
+]
 
 [[package]]
 name = "python-string-utils"
@@ -1592,6 +1864,16 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1606,6 +1888,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/1f/4f998c900485e5c0ef43838363ba4a9723ac0ad73a9dc42068b12aaba4e4/PyYAML-6.0.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8b9c7197f7cb2738065c481a0461e50ad02f18c78cd75775628afb4d7137fb3b", size = 756611, upload-time = "2024-08-06T20:32:38.898Z" },
     { url = "https://files.pythonhosted.org/packages/df/d1/f5a275fdb252768b7a11ec63585bc38d0e87c9e05668a139fea92b80634c/PyYAML-6.0.2-cp312-cp312-win32.whl", hash = "sha256:ef6107725bd54b262d6dedcc2af448a266975032bc85ef0172c5f059da6325b4", size = 140591, upload-time = "2024-08-06T20:32:40.241Z" },
     { url = "https://files.pythonhosted.org/packages/0c/e8/4f648c598b17c3d06e8753d7d13d57542b30d56e6c2dedf9c331ae56312e/PyYAML-6.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:7e7401d0de89a9a855c839bc697c079a4af81cf878373abd7dc625847d25cbd8", size = 156338, upload-time = "2024-08-06T20:32:41.93Z" },
+]
+
+[[package]]
+name = "pyzmq"
+version = "27.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "implementation_name == 'pypy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/92/e7/038aab64a946d535901103da16b953c8c9cc9c961dadcbf3609ed6428d23/pyzmq-27.1.0-cp312-abi3-macosx_10_15_universal2.whl", hash = "sha256:452631b640340c928fa343801b0d07eb0c3789a5ffa843f6e1a9cee0ba4eb4fc", size = 1306279, upload-time = "2025-09-08T23:08:03.807Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/5e/c3c49fdd0f535ef45eefcc16934648e9e59dace4a37ee88fc53f6cd8e641/pyzmq-27.1.0-cp312-abi3-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:1c179799b118e554b66da67d88ed66cd37a169f1f23b5d9f0a231b4e8d44a113", size = 895645, upload-time = "2025-09-08T23:08:05.301Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/b0b2504cb4e903a74dcf1ebae157f9e20ebb6ea76095f6cfffea28c42ecd/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3837439b7f99e60312f0c926a6ad437b067356dc2bc2ec96eb395fd0fe804233", size = 652574, upload-time = "2025-09-08T23:08:06.828Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/9b/c108cdb55560eaf253f0cbdb61b29971e9fb34d9c3499b0e96e4e60ed8a5/pyzmq-27.1.0-cp312-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43ad9a73e3da1fab5b0e7e13402f0b2fb934ae1c876c51d0afff0e7c052eca31", size = 840995, upload-time = "2025-09-08T23:08:08.396Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/bb/b79798ca177b9eb0825b4c9998c6af8cd2a7f15a6a1a4272c1d1a21d382f/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0de3028d69d4cdc475bfe47a6128eb38d8bc0e8f4d69646adfbcd840facbac28", size = 1642070, upload-time = "2025-09-08T23:08:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/80/2df2e7977c4ede24c79ae39dcef3899bfc5f34d1ca7a5b24f182c9b7a9ca/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_i686.whl", hash = "sha256:cf44a7763aea9298c0aa7dbf859f87ed7012de8bda0f3977b6fb1d96745df856", size = 2021121, upload-time = "2025-09-08T23:08:11.907Z" },
+    { url = "https://files.pythonhosted.org/packages/46/bd/2d45ad24f5f5ae7e8d01525eb76786fa7557136555cac7d929880519e33a/pyzmq-27.1.0-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:f30f395a9e6fbca195400ce833c731e7b64c3919aa481af4d88c3759e0cb7496", size = 1878550, upload-time = "2025-09-08T23:08:13.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/2f/104c0a3c778d7c2ab8190e9db4f62f0b6957b53c9d87db77c284b69f33ea/pyzmq-27.1.0-cp312-abi3-win32.whl", hash = "sha256:250e5436a4ba13885494412b3da5d518cd0d3a278a1ae640e113c073a5f88edd", size = 559184, upload-time = "2025-09-08T23:08:15.163Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/7f/a21b20d577e4100c6a41795842028235998a643b1ad406a6d4163ea8f53e/pyzmq-27.1.0-cp312-abi3-win_amd64.whl", hash = "sha256:9ce490cf1d2ca2ad84733aa1d69ce6855372cb5ce9223802450c9b2a7cba0ccf", size = 619480, upload-time = "2025-09-08T23:08:17.192Z" },
+    { url = "https://files.pythonhosted.org/packages/78/c2/c012beae5f76b72f007a9e91ee9401cb88c51d0f83c6257a03e785c81cc2/pyzmq-27.1.0-cp312-abi3-win_arm64.whl", hash = "sha256:75a2f36223f0d535a0c919e23615fc85a1e23b71f40c7eb43d7b1dedb4d8f15f", size = 552993, upload-time = "2025-09-08T23:08:18.926Z" },
 ]
 
 [[package]]
@@ -1736,6 +2039,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
+]
+
+[[package]]
+name = "simple-websocket"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wsproto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/d4/bfa032f961103eba93de583b161f0e6a5b63cebb8f2c7d0c6e6efe1e3d2e/simple_websocket-1.1.0.tar.gz", hash = "sha256:7939234e7aa067c534abdab3a9ed933ec9ce4691b0713c78acb195560aa52ae4", size = 17300, upload-time = "2024-10-10T22:39:31.412Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/59/0782e51887ac6b07ffd1570e0364cf901ebc36345fea669969d2084baebb/simple_websocket-1.1.0-py3-none-any.whl", hash = "sha256:4af6069630a38ed6c561010f0e11a5bc0d4ca569b36306eb257cd9a192497c8c", size = 13842, upload-time = "2024-10-10T22:39:29.645Z" },
 ]
 
 [[package]]
@@ -2060,10 +2375,34 @@ wheels = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
 name = "wrapt"
 version = "1.14.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/b4/3a937c7f8ee4751b38274c8542e02f42ebf3e080f1344c4a2aff6416630e/wrapt-1.14.0.tar.gz", hash = "sha256:8323a43bd9c91f62bb7d4be74cc9ff10090e7ef820e27bfe8815c57e68261311", size = 50796, upload-time = "2022-03-10T08:28:07.143Z" }
+
+[[package]]
+name = "wsproto"
+version = "1.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c7/79/12135bdf8b9c9367b8701c2c19a14c913c120b882d50b014ca0d38083c2c/wsproto-1.3.2.tar.gz", hash = "sha256:b86885dcf294e15204919950f666e06ffc6c7c114ca900b060d6e16293528294", size = 50116, upload-time = "2025-11-20T18:18:01.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/f5/10b68b7b1544245097b2a1b8238f66f2fc6dcaeb24ba5d917f52bd2eed4f/wsproto-1.3.2-py3-none-any.whl", hash = "sha256:61eea322cdf56e8cc904bd3ad7573359a242ba65688716b0710a5eb12beab584", size = 24405, upload-time = "2025-11-20T18:18:00.454Z" },
+]
 
 [[package]]
 name = "zope-event"


### PR DESCRIPTION
## Summary
- Add opt-in django-silk profiling gated behind `OSIDB_ENABLE_SILK` env var
- Add `generate_sample_data` management command to populate dev DB with realistic flaws, affects, trackers, and related objects
- Add locust load test script (`perf/silk_profiling.py`) for generating traffic against profiled endpoints
- Add `make apply-uv-dev-sync` target to install dev deps in the osidb-service container
- Add `django-silk` and `locust` as dev dependencies

Split into separate commits per concern for easier review/revert.

Assisted-By: Claude Opus 4.6
