### PR TITLE
OSIDB-5087 Add upstream maintainer notification payload preparation

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add SRP report serializer (OSIDB-5072)
 - Add Upstream Maintainer Notification Subresource Endpoints (OSIDB-5083)
 - Add Upstream Maintainer Email Template (OSIDB-5086)
+- Add Upstream Maintainer Notification Payload Preparation Service (OSIDB-5087)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/openapi.yml
+++ b/openapi.yml
@@ -12917,6 +12917,42 @@ paths:
                     version:
                       type: string
           description: ''
+  /osidb/api/v2/notifications/upstream/{notification_uuid}/preview:
+    get:
+      operationId: osidb_api_v2_notifications_upstream_preview_retrieve
+      description: Live render the maintainer notification preview without persisting
+        it.
+      parameters:
+      - in: path
+        name: notification_uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Upstream Notification.
+        required: true
+      tags:
+      - osidb
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/UpstreamNotificationPreview'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
   /osidb/api/v2/notifications/upstream/{notification_uuid}/send-email:
     post:
       operationId: osidb_api_v2_notifications_upstream_send_email_create
@@ -18868,6 +18904,18 @@ components:
       - updated_dt
       - uuid
       - visibility
+    UpstreamNotificationPreview:
+      type: object
+      properties:
+        text_body:
+          type: string
+          readOnly: true
+        html_body:
+          type: string
+          readOnly: true
+      required:
+      - html_body
+      - text_body
     UpstreamNotificationRequest:
       type: object
       description: |-

--- a/regulatory_reporting/serializers/upstream.py
+++ b/regulatory_reporting/serializers/upstream.py
@@ -74,3 +74,8 @@ class UpstreamNotificationSerializer(
                 "last_error",
             ]
         )
+
+
+class UpstreamNotificationPreviewSerializer(serializers.Serializer):
+    text_body = serializers.CharField(read_only=True)
+    html_body = serializers.CharField(read_only=True)

--- a/regulatory_reporting/services.py
+++ b/regulatory_reporting/services.py
@@ -1,5 +1,9 @@
+from django.template.loader import render_to_string
+
 from osidb.models import Flaw
 from osidb.models.flaw import FlawSource
+
+from .models.upstream import UpstreamNotification
 
 REDHAT_IDENTIFIED_SOURCES = {FlawSource.REDHAT}
 
@@ -19,3 +23,45 @@ def is_flaw_upstream_notifiable(flaw: Flaw) -> bool:
         return False
 
     return False
+
+
+def build_upstream_notification_context(notification: UpstreamNotification) -> dict:
+    """
+    Build the template context for a maintainer notification email
+    """
+    flaw = notification.flaw
+    upstream_project = notification.upstream_project
+
+    flaw_id = flaw.cve_id or flaw.uuid
+
+    return {
+        "flaw_id": flaw_id,
+        "vulnerability_summary": flaw.cve_description,
+        "upstream_component": upstream_project.component_name,
+        "impact": flaw.impact,
+        "corrective_measure": flaw.mitigation,
+        "contact_info": upstream_project.security_contact,
+        "confidentiality_notice": (
+            "This information is confidential until public disclosure."
+            if flaw.is_embargoed
+            else ""
+        ),
+    }
+
+
+def render_upstream_notification_preview(
+    notification: UpstreamNotification,
+) -> dict:
+    """
+    Live rendering the maintainer notification email
+    """
+    context = build_upstream_notification_context(notification)
+
+    text_body = render_to_string(
+        "email/upstream_maintainer_notification.txt", context=context
+    )
+    html_body = render_to_string(
+        "email/upstream_maintainer_notification.html", context=context
+    )
+
+    return {"text_body": text_body, "html_body": html_body}

--- a/regulatory_reporting/tests/test_views.py
+++ b/regulatory_reporting/tests/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from rest_framework.test import APIClient
 
 from osidb.models.abstract import Impact
 from osidb.models.flaw import FlawSource
@@ -84,6 +85,54 @@ class TestUpstreamNotificationView:
         )
         assert response.status_code == 200
         assert response.json()["count"] == 1
+
+    def test_preview_returns_rendered_bodies(self, auth_client, test_api_v2_uri):
+        """Test preview endpoint returns live rendered email."""
+        flaw = FlawFactory(cve_description="A test vulnerability.")
+        upstream_project = UpstreamProjectFactory(
+            component_name="example-lib",
+            security_contact="security@example.com",
+        )
+        notification = UpstreamNotificationFactory(
+            flaw=flaw,
+            upstream_project=upstream_project,
+        )
+
+        response = auth_client().get(
+            f"{test_api_v2_uri}/notifications/upstream/{notification.uuid}/preview"
+        )
+
+        assert response.status_code == 200
+        assert "text_body" in response.json()
+        assert "html_body" in response.json()
+        assert flaw.cve_description in response.json()["text_body"]
+        assert upstream_project.component_name in response.json()["text_body"]
+
+    def test_preview_without_upstream_project_fails(self, auth_client, test_api_v2_uri):
+        """Test preview fails validation if no upstream project is linked."""
+        flaw = FlawFactory(cve_description="A test vulnerability.")
+        notification = UpstreamNotificationFactory(
+            flaw=flaw,
+            upstream_project=None,
+        )
+
+        response = auth_client().get(
+            f"{test_api_v2_uri}/notifications/upstream/{notification.uuid}/preview"
+        )
+
+        assert response.status_code == 400
+        assert "upstream_project" in response.json()
+
+    def test_preview_requires_authentication(self, test_api_v2_uri):
+        """Test  anonymous requests to preview are rejected."""
+
+        notification = UpstreamNotificationFactory()
+
+        response = APIClient().get(
+            f"{test_api_v2_uri}/notifications/upstream/{notification.uuid}/preview"
+        )
+
+        assert response.status_code == 401
 
 
 @pytest.mark.no_cra_reporting
@@ -212,4 +261,7 @@ class TestSendEmailAction:
 
         assert response.status_code == 200
         notification.refresh_from_db()
-        assert "This flaw is currently embargoed." in notification.payload_text
+        assert (
+            "This information is confidential until public disclosure."
+            in notification.payload_text
+        )

--- a/regulatory_reporting/views.py
+++ b/regulatory_reporting/views.py
@@ -5,7 +5,7 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import mixins, viewsets
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
 
 from osidb.api_views import (
@@ -17,7 +17,14 @@ from osidb.tasks import async_send_email
 
 from .filters import UpstreamNotificationFilter
 from .models.upstream import UpstreamNotification
-from .serializers.upstream import UpstreamNotificationSerializer
+from .serializers.upstream import (
+    UpstreamNotificationPreviewSerializer,
+    UpstreamNotificationSerializer,
+)
+from .services import (
+    build_upstream_notification_context,
+    render_upstream_notification_preview,
+)
 from .tasks import mark_upstream_notification_failed, mark_upstream_notification_sent
 
 
@@ -41,7 +48,7 @@ class UpstreamNotificationView(
     filter_backends = (DjangoFilterBackend,)
     filterset_class = UpstreamNotificationFilter
     lookup_url_kwarg = "notification_uuid"
-    permission_classes = [IsAuthenticatedOrReadOnly]
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     @extend_schema(request=None)
     @action(detail=True, methods=["post"], url_path="send-email")
@@ -64,17 +71,7 @@ class UpstreamNotificationView(
         flaw = notification.flaw
         flaw_id = flaw.cve_id or flaw.uuid
 
-        context = {
-            "flaw_id": flaw_id,
-            "vulnerability_summary": flaw.title,
-            "upstream_component": upstream_project.component_name,
-            "impact": flaw.impact,
-            "confidentiality_notice": (
-                "This flaw is currently embargoed." if flaw.is_embargoed else ""
-            ),
-            "corrective_measure": flaw.mitigation,
-            "contact_info": upstream_project.security_contact,
-        }
+        context = build_upstream_notification_context(notification)
 
         text_body = render_to_string(
             "email/upstream_maintainer_notification.txt", context=context
@@ -123,3 +120,23 @@ class UpstreamNotificationView(
             raise
 
         return Response(self.get_serializer(notification).data, status=200)
+
+    @extend_schema(
+        request=None,
+        responses=UpstreamNotificationPreviewSerializer,
+        description="Live render the maintainer notification preview without persisting it.",
+    )
+    @action(
+        detail=True,
+        methods=["get"],
+        url_path="preview",
+        permission_classes=[IsAuthenticated],
+    )
+    def preview(self, request, notification_uuid=None):
+        notification = self.get_object()
+        if not notification.upstream_project:
+            raise ValidationError(
+                {"upstream_project": "Notification has no linked upstream project."}
+            )
+        preview_data = render_upstream_notification_preview(notification)
+        return Response(preview_data, status=200)


### PR DESCRIPTION
Add a read only preview action for maintainer notification emails.
-Add `render_upstream_notification_preview()` in `services.py` which builds email context, renders both templates.
-Add `preview` GET action on `UpstreamNotficationView` in `views.py`
-Add tests
-Add entry in `CHANGELOG.md`
-Generated `openapi.yml`
Closes:OSIDB-5087