### PR TITLE
OSIDB-5070: Payload preparation service 

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Upstream Project Contact Endpoints (OSIDB-5084)
 - Add Flaw-to-Upstream Mapping Endpoints (OSIDB-5085)
 - Add Upstream Maintainer Send Email Action (OSIDB-5088)
+- Add report payloads in milestones (OSIDB-5070)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/regulatory_reporting/models/srp_report_milestone.py
+++ b/regulatory_reporting/models/srp_report_milestone.py
@@ -171,6 +171,54 @@ class SRPReportMilestone(SRPReportBase):
     def __str__(self):
         return f"{self.milestone_type} - {self.srp_report.flaw.cve_id or self.srp_report.flaw.uuid}"
 
+    def save(self, *args, **kwargs):
+        """
+        Persist the milestone, and prepare the SRP payload snapshot when
+        status transitions to SUBMITTED for builder-backed milestone types.
+        """
+        if getattr(self, "_preparing_payload", False):
+            return super().save(*args, **kwargs)
+
+        previous_status = None
+        if self.pk:
+            previous_status = (
+                type(self)
+                .objects.filter(pk=self.pk)
+                .values_list("status", flat=True)
+                .first()
+            )
+
+        super().save(*args, **kwargs)
+
+        should_prepare = (
+            self.status == self.SRPReportStatus.SUBMITTED
+            and previous_status != self.SRPReportStatus.SUBMITTED
+            and self.milestone_type
+            in {
+                self.MilestoneType.LEVEL_24H,
+                self.MilestoneType.LEVEL_72H,
+                self.MilestoneType.LEVEL_FINAL,
+            }
+        )
+        if should_prepare:
+            # Lazy import avoids circular dependency with services.py
+            from regulatory_reporting.services import prepare_payload
+
+            prepare_payload(self)
+            self._preparing_payload = True
+            try:
+                # force_insert must not carry over: the row was already
+                # inserted/updated above, so this second save is always an
+                # update.
+                save_kwargs = {**kwargs, "force_insert": False}
+                if save_kwargs.get("update_fields") is not None:
+                    save_kwargs["update_fields"] = list(
+                        save_kwargs["update_fields"]
+                    ) + ["meta_attr", "missing_required_fields"]
+                super().save(*args, **save_kwargs)
+            finally:
+                self._preparing_payload = False
+
     @validator
     def _validate_due_at_required(self, **kwargs):
         """

--- a/regulatory_reporting/services.py
+++ b/regulatory_reporting/services.py
@@ -1,8 +1,13 @@
-from django.template.loader import render_to_string
+import json
 
-from osidb.models import Flaw
+from django.template.loader import render_to_string
+from django.utils import timezone
+
+from osidb.models import Flaw, FlawCVSS
 from osidb.models.flaw import FlawSource
 
+from .models.srp_report import SRPReport
+from .models.srp_report_milestone import SRPReportMilestone
 from .models.upstream import UpstreamNotification
 
 REDHAT_IDENTIFIED_SOURCES = {FlawSource.REDHAT}
@@ -65,3 +70,427 @@ def render_upstream_notification_preview(
     )
 
     return {"text_body": text_body, "html_body": html_body}
+
+
+# --- SRP Payload Preparation ---
+
+
+class SRPPayloadBuilder:
+    """
+    Base class for building SRP payload snapshots.
+
+    Collects ENISA-required fields from OSIDB data and stores the result
+    in milestone.meta_attr as simple key-value pairs.
+
+    Subclass per milestone type to add stage-specific fields and required
+    field definitions. Set previous_milestone_type to carry forward fields
+    from an earlier milestone snapshot.
+
+    Generated with Claude Opus 4.6 (claude-opus-4-6).
+    """
+
+    REQUIRED_COMMON_FIELDS = [
+        "notification_type",
+        "notification_level",
+        "manufacturer_or_steward_name",
+        "report_title",
+        "product_identity",
+        "product_type",
+        "product_category",
+        "member_states_available",
+    ]
+
+    REQUIRED_VULNERABILITY_FIELDS = []
+    REQUIRED_INCIDENT_FIELDS = []
+
+    expected_milestone_type = None
+    previous_milestone_type = None
+
+    def __init__(self, milestone):
+        if (
+            self.expected_milestone_type
+            and milestone.milestone_type != self.expected_milestone_type
+        ):
+            raise ValueError(
+                f"Expected {self.expected_milestone_type} milestone, "
+                f"got {milestone.milestone_type}"
+            )
+        self.milestone = milestone
+        self.srp_report = milestone.srp_report
+        self.flaw = self.srp_report.flaw
+
+    def _build_common_fields(self):
+        fields = {}
+
+        fields["notification_type"] = self.srp_report.reportable_event_type
+        fields["notification_level"] = self.milestone.milestone_type
+        fields["manufacturer_or_steward_name"] = (
+            self.srp_report.manufacturer_or_steward_name or ""
+        )
+        fields["report_title"] = self.srp_report.title or ""
+        fields["product_identity"] = self._collect_product_identity()
+        fields["product_type"] = ""
+        fields["product_category"] = ""
+
+        member_states = self.srp_report.member_states_available or []
+        fields["member_states_available"] = json.dumps(member_states)
+
+        return fields
+
+    def _collect_product_identity(self):
+        products = []
+        for affect in self.flaw.affects.all():
+            products.append(
+                {
+                    "ps_product": affect.ps_product or "",
+                    "ps_module": affect.ps_module or "",
+                    "ps_component": affect.ps_component or "",
+                }
+            )
+        return json.dumps(products)
+
+    def _build_general_information(self):
+        parts = []
+        if self.flaw.title:
+            parts.append(self.flaw.title)
+        desc = self.flaw.selected_cve_description
+        if desc:
+            parts.append(desc)
+        if self.flaw.statement:
+            parts.append(self.flaw.statement)
+        return "\n\n".join(parts)
+
+    def _build_corrective_measures_taken(self):
+        parts = []
+        if self.flaw.mitigation:
+            parts.append(self.flaw.mitigation)
+        if self.flaw.statement:
+            parts.append(self.flaw.statement)
+
+        for affect in self.flaw.affects.all():
+            if affect.resolution and affect.resolution != "":
+                parts.append(
+                    f"{affect.ps_module}/{affect.ps_component}: {affect.resolution}"
+                )
+
+        return "\n\n".join(parts)
+
+    def _build_user_mitigations(self):
+        parts = []
+        if self.flaw.mitigation:
+            parts.append(self.flaw.mitigation)
+        if self.flaw.statement:
+            parts.append(self.flaw.statement)
+        return "\n\n".join(parts)
+
+    def _build_vulnerability_fields(self):
+        return {}
+
+    def _build_incident_fields(self):
+        return {}
+
+    def _get_required_fields(self):
+        required = list(self.REQUIRED_COMMON_FIELDS)
+        if (
+            self.srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY
+        ):
+            required += self.REQUIRED_VULNERABILITY_FIELDS
+        elif (
+            self.srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.SEVERE_INCIDENT
+        ):
+            required += self.REQUIRED_INCIDENT_FIELDS
+        return required
+
+    def _get_missing_required_fields(self, payload):
+        missing = []
+        for key in self._get_required_fields():
+            value = payload.get(key, "")
+            if not value or value == "[]":
+                missing.append(key)
+        return missing
+
+    def _get_previous_snapshot(self):
+        if not self.previous_milestone_type:
+            return {}
+        previous = self.srp_report.milestones.filter(
+            milestone_type=self.previous_milestone_type,
+        ).first()
+        if previous and previous.meta_attr.get("payload_snapshot"):
+            return json.loads(previous.meta_attr["payload_snapshot"])
+        return {}
+
+    def prepare(self):
+        """
+        Build the payload and store it in milestone.meta_attr.
+
+        Does NOT call milestone.save() -- caller is responsible for saving.
+        """
+        payload = self._build_common_fields()
+
+        if (
+            self.srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.ACTIVELY_EXPLOITED_VULNERABILITY
+        ):
+            payload.update(self._build_vulnerability_fields())
+        elif (
+            self.srp_report.reportable_event_type
+            == SRPReport.ReportableEventType.SEVERE_INCIDENT
+        ):
+            payload.update(self._build_incident_fields())
+
+        for key, value in self._get_previous_snapshot().items():
+            if key not in payload:
+                payload[key] = value
+
+        missing = self._get_missing_required_fields(payload)
+
+        self.milestone.meta_attr["payload_snapshot"] = json.dumps(payload)
+        self.milestone.meta_attr["prepared_at"] = timezone.now().isoformat()
+        self.milestone.missing_required_fields = json.dumps(missing)
+
+        return self.milestone
+
+
+class SRPPayloadBuilder24h(SRPPayloadBuilder):
+    """Payload builder for 24h early warning milestone."""
+
+    expected_milestone_type = SRPReportMilestone.MilestoneType.LEVEL_24H
+
+    REQUIRED_VULNERABILITY_FIELDS = ["cve_id"]
+    REQUIRED_INCIDENT_FIELDS = ["suspected_unlawful_or_malicious_acts"]
+
+    def _build_vulnerability_fields(self):
+        return {"cve_id": self.flaw.cve_id or ""}
+
+    def _build_incident_fields(self):
+        return {"suspected_unlawful_or_malicious_acts": ""}
+
+
+class SRPPayloadBuilder72h(SRPPayloadBuilder):
+    """Payload builder for 72h notification milestone.
+
+    Carries forward fields from the 24h milestone snapshot, then adds
+    72h-required fields from OSIDB data.
+    """
+
+    expected_milestone_type = SRPReportMilestone.MilestoneType.LEVEL_72H
+    previous_milestone_type = SRPReportMilestone.MilestoneType.LEVEL_24H
+
+    REQUIRED_VULNERABILITY_FIELDS = [
+        "cve_id",
+        "general_information",
+        "general_nature_of_vulnerability",
+        "general_nature_of_exploit",
+        "corrective_or_mitigating_measures_taken",
+        "corrective_or_mitigating_measures_users_can_take",
+    ]
+
+    REQUIRED_INCIDENT_FIELDS = [
+        "suspected_unlawful_or_malicious_acts",
+        "general_incident_information",
+        "incident_detected_at",
+        "incident_occurred_at",
+        "initial_incident_assessment",
+        "corrective_or_mitigating_measures_taken",
+        "corrective_or_mitigating_measures_users_can_take",
+    ]
+
+    def _build_vulnerability_fields(self):
+        fields = {}
+        fields["cve_id"] = self.flaw.cve_id or ""
+        fields["general_information"] = self._build_general_information()
+        cwe = self.flaw.cwe_id or ""
+        fields["general_nature_of_vulnerability"] = cwe
+        fields["general_nature_of_exploit"] = cwe
+        fields["corrective_or_mitigating_measures_taken"] = (
+            self._build_corrective_measures_taken()
+        )
+        fields["corrective_or_mitigating_measures_users_can_take"] = (
+            self._build_user_mitigations()
+        )
+        fields["information_sensitivity"] = ""
+        return fields
+
+    def _build_incident_fields(self):
+        fields = {}
+        fields["suspected_unlawful_or_malicious_acts"] = ""
+        fields["general_incident_information"] = self._build_general_information()
+        fields["incident_detected_at"] = ""
+        fields["incident_occurred_at"] = ""
+
+        parts = []
+        if self.flaw.comment_zero:
+            parts.append(self.flaw.comment_zero)
+        if self.flaw.statement:
+            parts.append(self.flaw.statement)
+        fields["initial_incident_assessment"] = "\n\n".join(parts)
+
+        fields["corrective_or_mitigating_measures_taken"] = (
+            self._build_corrective_measures_taken()
+        )
+        fields["corrective_or_mitigating_measures_users_can_take"] = (
+            self._build_user_mitigations()
+        )
+        fields["information_sensitivity"] = ""
+        return fields
+
+
+class SRPPayloadBuilderFinal(SRPPayloadBuilder):
+    """Payload builder for final report milestone.
+
+    Carries forward fields from the 72h milestone snapshot, then adds
+    final-report-required fields from OSIDB data.
+    """
+
+    expected_milestone_type = SRPReportMilestone.MilestoneType.LEVEL_FINAL
+    previous_milestone_type = SRPReportMilestone.MilestoneType.LEVEL_72H
+
+    REQUIRED_VULNERABILITY_FIELDS = [
+        "cve_id",
+        "general_information",
+        "general_nature_of_vulnerability",
+        "general_nature_of_exploit",
+        "corrective_or_mitigating_measures_taken",
+        "corrective_or_mitigating_measures_users_can_take",
+        "full_vulnerability_description",
+        "vulnerability_severity",
+        "vulnerability_impact",
+        "security_update_or_corrective_measure_details",
+    ]
+
+    REQUIRED_INCIDENT_FIELDS = [
+        "suspected_unlawful_or_malicious_acts",
+        "general_incident_information",
+        "incident_detected_at",
+        "incident_occurred_at",
+        "initial_incident_assessment",
+        "corrective_or_mitigating_measures_taken",
+        "corrective_or_mitigating_measures_users_can_take",
+        "detailed_incident_description",
+        "incident_severity",
+        "incident_impact",
+        "likely_threat_or_root_cause",
+        "applied_and_ongoing_mitigation_measures",
+    ]
+
+    def _build_full_description(self):
+        parts = []
+        if self.flaw.title:
+            parts.append(self.flaw.title)
+        desc = self.flaw.selected_cve_description
+        if desc:
+            parts.append(desc)
+        if self.flaw.comment_zero:
+            parts.append(self.flaw.comment_zero)
+        if self.flaw.statement:
+            parts.append(self.flaw.statement)
+        return "\n\n".join(parts)
+
+    def _build_severity(self):
+        parts = []
+        if self.flaw.impact:
+            parts.append(f"Impact: {self.flaw.impact}")
+
+        rh_cvss = (
+            self.flaw.cvss_scores.filter(issuer=FlawCVSS.CVSSIssuer.REDHAT)
+            .order_by("-version")
+            .first()
+        )
+        if rh_cvss:
+            parts.append(f"CVSS {rh_cvss.version}: {rh_cvss.score}")
+
+        return ", ".join(parts)
+
+    def _build_vulnerability_impact(self):
+        parts = []
+        if self.flaw.impact:
+            parts.append(f"Flaw impact: {self.flaw.impact}")
+        for affect in self.flaw.affects.all():
+            if affect.affectedness:
+                parts.append(
+                    f"{affect.ps_module}/{affect.ps_component}: {affect.affectedness}"
+                )
+        return "\n".join(parts)
+
+    def _build_vulnerability_fields(self):
+        fields = {}
+        fields["cve_id"] = self.flaw.cve_id or ""
+        fields["general_information"] = self._build_general_information()
+
+        cwe = self.flaw.cwe_id or ""
+        fields["general_nature_of_vulnerability"] = cwe
+        fields["general_nature_of_exploit"] = cwe
+
+        fields["corrective_or_mitigating_measures_taken"] = (
+            self._build_corrective_measures_taken()
+        )
+        fields["corrective_or_mitigating_measures_users_can_take"] = (
+            self._build_user_mitigations()
+        )
+        fields["information_sensitivity"] = ""
+        fields["corrective_or_mitigating_measure_available_at"] = ""
+        fields["full_vulnerability_description"] = self._build_full_description()
+        fields["vulnerability_severity"] = self._build_severity()
+        fields["vulnerability_impact"] = self._build_vulnerability_impact()
+        fields["known_or_suspected_malicious_actor"] = ""
+        fields["security_update_or_corrective_measure_details"] = ""
+        return fields
+
+    def _build_incident_fields(self):
+        fields = {}
+        fields["suspected_unlawful_or_malicious_acts"] = ""
+        fields["general_incident_information"] = self._build_general_information()
+        fields["incident_detected_at"] = ""
+        fields["incident_occurred_at"] = ""
+
+        parts = []
+        if self.flaw.comment_zero:
+            parts.append(self.flaw.comment_zero)
+        if self.flaw.statement:
+            parts.append(self.flaw.statement)
+        fields["initial_incident_assessment"] = "\n\n".join(parts)
+
+        fields["corrective_or_mitigating_measures_taken"] = (
+            self._build_corrective_measures_taken()
+        )
+        fields["corrective_or_mitigating_measures_users_can_take"] = (
+            self._build_user_mitigations()
+        )
+        fields["information_sensitivity"] = ""
+        fields["detailed_incident_description"] = self._build_full_description()
+        fields["incident_severity"] = self._build_severity()
+        fields["incident_impact"] = self._build_vulnerability_impact()
+        fields["likely_threat_or_root_cause"] = self.flaw.cwe_id or ""
+        fields["applied_and_ongoing_mitigation_measures"] = (
+            self._build_corrective_measures_taken()
+        )
+        return fields
+
+
+BUILDER_BY_MILESTONE_TYPE = {
+    SRPReportMilestone.MilestoneType.LEVEL_24H: SRPPayloadBuilder24h,
+    SRPReportMilestone.MilestoneType.LEVEL_72H: SRPPayloadBuilder72h,
+    SRPReportMilestone.MilestoneType.LEVEL_FINAL: SRPPayloadBuilderFinal,
+}
+
+
+def prepare_payload(milestone):
+    """Prepare the SRP payload for any milestone type."""
+    builder_cls = BUILDER_BY_MILESTONE_TYPE.get(milestone.milestone_type)
+    if not builder_cls:
+        raise ValueError(f"No builder for milestone type {milestone.milestone_type}")
+    return builder_cls(milestone).prepare()
+
+
+def prepare_24h_payload(milestone):
+    return SRPPayloadBuilder24h(milestone).prepare()
+
+
+def prepare_72h_payload(milestone):
+    return SRPPayloadBuilder72h(milestone).prepare()
+
+
+def prepare_final_payload(milestone):
+    return SRPPayloadBuilderFinal(milestone).prepare()

--- a/regulatory_reporting/tests/test_api_srp_milestones.py
+++ b/regulatory_reporting/tests/test_api_srp_milestones.py
@@ -279,6 +279,8 @@ class TestSRPMilestoneUpdate:
         assert milestone.status == SRPReportMilestone.SRPReportStatus.SUBMITTED
         assert milestone.request_source == "ENISA Portal"
         assert milestone.request_text == "Additional information requested"
+        assert milestone.meta_attr.get("payload_snapshot")
+        assert "prepared_at" in milestone.meta_attr
 
 
 @pytest.mark.django_db

--- a/regulatory_reporting/tests/test_srp_payload.py
+++ b/regulatory_reporting/tests/test_srp_payload.py
@@ -1,0 +1,899 @@
+import json
+
+import pytest
+from django.utils import timezone
+
+from osidb.models import Flaw, FlawCVSS
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawCVSSFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+)
+from regulatory_reporting.models import SRPReport, SRPReportMilestone
+from regulatory_reporting.services import (
+    SRPPayloadBuilder,
+    prepare_24h_payload,
+    prepare_72h_payload,
+    prepare_final_payload,
+    prepare_payload,
+)
+from regulatory_reporting.tests.factories import (
+    SRPReportMilestoneFactory,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.cra_reporting,
+    pytest.mark.no_cra_notifications,
+]
+
+# The cra_reporting marker enables the create_srp_report signal, so creating
+# a Flaw with major_incident_state=EXPLOITS_KEV_APPROVED or
+# MAJOR_INCIDENT_APPROVED auto-creates the SRPReport and its 24h/72h/final
+# milestones, just like production.
+
+
+def _create_vulnerability_report(report_attrs=None, **flaw_kwargs):
+    """Create a Flaw that triggers a vulnerability SRP report via signal."""
+    flaw_kwargs["major_incident_state"] = Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED
+    flaw_kwargs.setdefault("embargoed", False)
+    flaw_kwargs.setdefault("major_incident_start_dt", timezone.now())
+    flaw = FlawFactory(**flaw_kwargs)
+    report = SRPReport.objects.get(flaw=flaw)
+    if report_attrs:
+        for k, v in report_attrs.items():
+            setattr(report, k, v)
+        report.save()
+    return report
+
+
+def _create_incident_report(report_attrs=None, **flaw_kwargs):
+    """Create a Flaw that triggers an incident SRP report via signal."""
+    flaw_kwargs["major_incident_state"] = Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED
+    flaw_kwargs.setdefault("embargoed", False)
+    flaw_kwargs.setdefault("major_incident_start_dt", timezone.now())
+    flaw = FlawFactory(**flaw_kwargs)
+    report = SRPReport.objects.get(flaw=flaw)
+    if report_attrs:
+        for k, v in report_attrs.items():
+            setattr(report, k, v)
+        report.save()
+    return report
+
+
+def _get_milestone(report, milestone_type):
+    return report.milestones.get(milestone_type=milestone_type)
+
+
+def _clear_flaw_fields(report, **fields):
+    """Clear Flaw fields via queryset update to bypass blank=False validation.
+
+    Needed for missing-required-field tests: title/comment_zero cannot be
+    emptied through FlawFactory/save(), but payload builders must still handle
+    empty descriptive inputs.
+    """
+    Flaw.objects.filter(pk=report.flaw_id).update(**fields)
+    report.flaw.refresh_from_db()
+
+
+def _prepare_chain_up_to_72h(report):
+    """Prepare 24h snapshot so 72h can carry forward."""
+    m24 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+    prepare_24h_payload(m24)
+    m24.save()
+    return _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_72H)
+
+
+def _prepare_chain_up_to_final(report):
+    """Prepare 24h and 72h snapshots so final can carry forward."""
+    m24 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+    prepare_24h_payload(m24)
+    m24.save()
+    m72 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_72H)
+    prepare_72h_payload(m72)
+    m72.save()
+    return _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_FINAL)
+
+
+# ── 24h Milestone Tests ──
+
+
+class TestPrepare24hPayloadValidation:
+    def test_raises_for_72h_milestone(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_72H,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="Expected 24h milestone"):
+            prepare_24h_payload(milestone)
+
+    def test_raises_for_final_milestone(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_FINAL,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="Expected 24h milestone"):
+            prepare_24h_payload(milestone)
+
+
+class TestPrepare24hPayloadCommonFields:
+    def test_notification_type_from_report(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["notification_type"] == "actively_exploited_vulnerability"
+
+    def test_notification_level_is_24h(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "24h"
+
+    def test_report_title_matches_flaw_title(self):
+        report = _create_vulnerability_report(title="CVE-2026-99999 kernel: overflow")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["report_title"] == report.title
+        assert "kernel: overflow" in payload["report_title"]
+
+    def test_manufacturer_name_from_report(self):
+        report = _create_vulnerability_report(
+            report_attrs={"manufacturer_or_steward_name": "Red Hat, Inc."},
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["manufacturer_or_steward_name"] == "Red Hat, Inc."
+
+    def test_manufacturer_name_empty_when_not_set(self):
+        report = _create_vulnerability_report(
+            report_attrs={"manufacturer_or_steward_name": ""},
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["manufacturer_or_steward_name"] == ""
+
+    def test_product_type_is_empty(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["product_type"] == ""
+
+    def test_product_category_is_empty(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["product_category"] == ""
+
+    def test_member_states_from_report(self):
+        report = _create_vulnerability_report(
+            report_attrs={"member_states_available": ["IE", "DE"]},
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert json.loads(payload["member_states_available"]) == ["IE", "DE"]
+
+    def test_member_states_empty_list_when_not_set(self):
+        report = _create_vulnerability_report(
+            report_attrs={"member_states_available": []},
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert json.loads(payload["member_states_available"]) == []
+
+
+class TestPrepare24hPayloadProductIdentity:
+    def test_product_identity_from_affects(self):
+        report = _create_vulnerability_report()
+        ps_module = PsModuleFactory(name="rhel-9")
+        stream = PsUpdateStreamFactory(ps_module=ps_module)
+        AffectFactory(
+            flaw=report.flaw,
+            ps_update_stream=stream.name,
+            ps_component="kernel",
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        products = json.loads(payload["product_identity"])
+        assert len(products) == 1
+        assert products[0]["ps_module"] == "rhel-9"
+        assert products[0]["ps_component"] == "kernel"
+
+    def test_product_identity_multiple_affects(self):
+        report = _create_vulnerability_report()
+        AffectFactory(flaw=report.flaw, ps_module="rhel-9.5.0", ps_component="kernel")
+        AffectFactory(flaw=report.flaw, ps_module="rhel-8.10.0", ps_component="kernel")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        products = json.loads(payload["product_identity"])
+        assert len(products) == 2
+
+    def test_product_identity_empty_when_no_affects(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        products = json.loads(payload["product_identity"])
+        assert products == []
+
+
+class TestPrepare24hPayloadVulnerability:
+    def test_cve_id_from_flaw(self):
+        report = _create_vulnerability_report(cve_id="CVE-2026-12345")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["cve_id"] == "CVE-2026-12345"
+
+    def test_cve_id_empty_when_flaw_has_no_cve(self):
+        report = _create_vulnerability_report(cve_id="")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["cve_id"] == ""
+
+    def test_no_incident_fields_for_vulnerability(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert "suspected_unlawful_or_malicious_acts" not in payload
+
+
+class TestPrepare24hPayloadIncident:
+    def test_incident_fields_present(self):
+        report = _create_incident_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["suspected_unlawful_or_malicious_acts"] == ""
+
+    def test_no_cve_id_field_for_incident(self):
+        report = _create_incident_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert "cve_id" not in payload
+
+    def test_notification_type_is_severe_incident(self):
+        report = _create_incident_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["notification_type"] == "severe_incident"
+
+
+class TestPrepare24hPayloadMissingFields:
+    def test_manual_fields_listed_as_missing(self):
+        report = _create_vulnerability_report(
+            report_attrs={"manufacturer_or_steward_name": "Red Hat"},
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "product_type" in missing
+        assert "product_category" in missing
+
+    def test_empty_member_states_listed_as_missing(self):
+        report = _create_vulnerability_report(
+            report_attrs={"member_states_available": []},
+        )
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "member_states_available" in missing
+
+    def test_missing_cve_id_for_vulnerability(self):
+        report = _create_vulnerability_report(cve_id="")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "cve_id" in missing
+
+    def test_no_missing_cve_id_when_present(self):
+        report = _create_vulnerability_report(cve_id="CVE-2026-99999")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "cve_id" not in missing
+
+    def test_incident_missing_malicious_acts(self):
+        report = _create_incident_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "suspected_unlawful_or_malicious_acts" in missing
+
+    def test_no_missing_product_identity_when_affects_exist(self):
+        report = _create_vulnerability_report()
+        AffectFactory(flaw=report.flaw, ps_module="rhel-9", ps_component="kernel")
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "product_identity" not in missing
+
+    def test_missing_product_identity_when_no_affects(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        missing = json.loads(milestone.missing_required_fields)
+        assert "product_identity" in missing
+
+
+class TestPrepare24hPayloadMetaAttr:
+    def test_prepared_at_stored_in_meta_attr(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        assert "prepared_at" in milestone.meta_attr
+        assert milestone.meta_attr["prepared_at"]
+
+    def test_payload_snapshot_is_valid_json(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert isinstance(payload, dict)
+
+    def test_all_meta_attr_values_are_strings(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        for key, value in milestone.meta_attr.items():
+            assert isinstance(value, str), f"meta_attr[{key}] is {type(value)}, not str"
+
+    def test_does_not_call_save(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        original_pk = milestone.pk
+        prepare_24h_payload(milestone)
+        refreshed = SRPReportMilestone.objects.get(pk=original_pk)
+        assert refreshed.meta_attr.get("payload_snapshot") is None
+
+    def test_idempotent_produces_fresh_snapshot(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(milestone)
+        first_prepared_at = milestone.meta_attr["prepared_at"]
+        first_payload = milestone.meta_attr["payload_snapshot"]
+
+        prepare_24h_payload(milestone)
+        second_prepared_at = milestone.meta_attr["prepared_at"]
+        second_payload = milestone.meta_attr["payload_snapshot"]
+
+        assert second_prepared_at >= first_prepared_at
+        assert second_payload == first_payload
+
+
+# ── 72h Milestone Tests ──
+
+
+class TestPrepare72hPayloadValidation:
+    def test_raises_for_24h_milestone(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_24H,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="Expected 72h milestone"):
+            prepare_72h_payload(milestone)
+
+    def test_raises_for_final_milestone(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_FINAL,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="Expected 72h milestone"):
+            prepare_72h_payload(milestone)
+
+
+class TestPrepare72hPayloadCarryForward:
+    def test_carries_forward_common_fields_from_24h(self):
+        report = _create_vulnerability_report()
+        m24 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(m24)
+        snapshot = json.loads(m24.meta_attr["payload_snapshot"])
+        snapshot["only_in_24h"] = "kept"
+        m24.meta_attr["payload_snapshot"] = json.dumps(snapshot)
+        m24.save()
+
+        m72 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_72H)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["only_in_24h"] == "kept"
+
+    def test_72h_overrides_notification_level(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "72h"
+
+    def test_works_without_24h_snapshot(self):
+        report = _create_vulnerability_report()
+        m72 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_72H)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert isinstance(payload, dict)
+        assert "notification_type" in payload
+
+
+class TestPrepare72hPayloadVulnerability:
+    def test_cve_id_present(self):
+        report = _create_vulnerability_report(cve_id="CVE-2026-72001")
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["cve_id"] == "CVE-2026-72001"
+
+    def test_general_information_from_flaw(self):
+        report = _create_vulnerability_report(
+            title="Buffer overflow in libfoo",
+            cve_description="A buffer overflow vulnerability in libfoo allows...",
+            statement="This affects all versions prior to 2.0.",
+        )
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert "Buffer overflow in libfoo" in payload["general_information"]
+
+    def test_nature_of_vulnerability_from_cwe(self):
+        report = _create_vulnerability_report(cwe_id="CWE-79")
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["general_nature_of_vulnerability"] == "CWE-79"
+
+    def test_nature_of_vulnerability_empty_when_no_cwe(self):
+        report = _create_vulnerability_report(cwe_id="")
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["general_nature_of_vulnerability"] == ""
+
+    def test_corrective_measures_from_mitigation(self):
+        report = _create_vulnerability_report(mitigation="Apply patch 1.2.3")
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert "Apply patch 1.2.3" in payload["corrective_or_mitigating_measures_taken"]
+
+    def test_user_mitigations_from_mitigation(self):
+        report = _create_vulnerability_report(
+            mitigation="Disable feature X as workaround"
+        )
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert (
+            "Disable feature X"
+            in payload["corrective_or_mitigating_measures_users_can_take"]
+        )
+
+    def test_information_sensitivity_is_empty(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["information_sensitivity"] == ""
+
+    def test_no_incident_fields_for_vulnerability(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert "incident_detected_at" not in payload
+        assert "initial_incident_assessment" not in payload
+
+
+class TestPrepare72hPayloadIncident:
+    def test_incident_fields_present(self):
+        report = _create_incident_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert "suspected_unlawful_or_malicious_acts" in payload
+        assert "general_incident_information" in payload
+        assert "incident_detected_at" in payload
+        assert "incident_occurred_at" in payload
+        assert "initial_incident_assessment" in payload
+
+    def test_incident_timestamps_are_empty(self):
+        report = _create_incident_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["incident_detected_at"] == ""
+        assert payload["incident_occurred_at"] == ""
+
+    def test_initial_assessment_from_comment_zero(self):
+        report = _create_incident_report(comment_zero="Initial analysis shows...")
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert "Initial analysis shows" in payload["initial_incident_assessment"]
+
+    def test_no_cve_id_for_incident(self):
+        report = _create_incident_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert "cve_id" not in payload
+
+
+class TestPrepare72hPayloadMissingFields:
+    def test_missing_general_information_when_no_data(self):
+        report = _create_vulnerability_report()
+        _clear_flaw_fields(
+            report,
+            title="",
+            cve_description="",
+            mitre_cve_description="",
+            statement="",
+        )
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        missing = json.loads(m72.missing_required_fields)
+        assert "general_information" in missing
+
+    def test_missing_nature_of_vulnerability_when_no_cwe(self):
+        report = _create_vulnerability_report(cwe_id="")
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        missing = json.loads(m72.missing_required_fields)
+        assert "general_nature_of_vulnerability" in missing
+        assert "general_nature_of_exploit" in missing
+
+    def test_incident_timestamps_always_missing(self):
+        report = _create_incident_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        missing = json.loads(m72.missing_required_fields)
+        assert "incident_detected_at" in missing
+        assert "incident_occurred_at" in missing
+
+
+class TestPrepare72hPayloadMetaAttr:
+    def test_prepared_at_stored(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        assert "prepared_at" in m72.meta_attr
+
+    def test_all_values_are_strings(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        for key, value in m72.meta_attr.items():
+            assert isinstance(value, str), f"meta_attr[{key}] is {type(value)}"
+
+    def test_payload_is_valid_json(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_72h_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert isinstance(payload, dict)
+
+
+# ── Final Milestone Tests ──
+
+
+class TestPrepareFinalPayloadValidation:
+    def test_raises_for_24h_milestone(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_24H,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="Expected final milestone"):
+            prepare_final_payload(milestone)
+
+    def test_raises_for_72h_milestone(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_72H,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="Expected final milestone"):
+            prepare_final_payload(milestone)
+
+
+class TestPrepareFinalPayloadCarryForward:
+    def test_carries_forward_from_72h(self):
+        report = _create_vulnerability_report()
+        m24 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_24h_payload(m24)
+        m24.save()
+        m72 = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_72H)
+        prepare_72h_payload(m72)
+        snapshot = json.loads(m72.meta_attr["payload_snapshot"])
+        snapshot["only_in_72h"] = "kept"
+        m72.meta_attr["payload_snapshot"] = json.dumps(snapshot)
+        m72.save()
+
+        mfinal = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_FINAL)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["only_in_72h"] == "kept"
+
+    def test_final_overrides_notification_level(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "final"
+
+    def test_works_without_72h_snapshot(self):
+        report = _create_vulnerability_report()
+        mfinal = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_FINAL)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert isinstance(payload, dict)
+
+
+class TestPrepareFinalPayloadVulnerability:
+    def test_full_vulnerability_description(self):
+        report = _create_vulnerability_report(
+            title="Use-after-free in libbar",
+            cve_description="A use-after-free vulnerability...",
+            comment_zero="Detailed analysis of the vulnerability...",
+            statement="Red Hat recommends upgrading to version 3.0.",
+        )
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert "Use-after-free in libbar" in payload["full_vulnerability_description"]
+        assert "Detailed analysis" in payload["full_vulnerability_description"]
+
+    def test_vulnerability_severity_from_impact(self):
+        report = _create_vulnerability_report(impact="CRITICAL")
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert "CRITICAL" in payload["vulnerability_severity"]
+
+    def test_vulnerability_severity_prefers_highest_rh_cvss_version(self):
+        report = _create_vulnerability_report(impact="IMPORTANT")
+        FlawCVSSFactory(
+            flaw=report.flaw,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION3,
+            vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+        )
+        FlawCVSSFactory(
+            flaw=report.flaw,
+            issuer=FlawCVSS.CVSSIssuer.REDHAT,
+            version=FlawCVSS.CVSSVersion.VERSION4,
+            vector=("CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N"),
+        )
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert "CVSS V4:" in payload["vulnerability_severity"]
+        assert "CVSS V3:" not in payload["vulnerability_severity"]
+
+    def test_vulnerability_impact_from_affects(self):
+        report = _create_vulnerability_report(impact="IMPORTANT")
+        AffectFactory(
+            flaw=report.flaw,
+            ps_module="rhel-9",
+            ps_component="openssl",
+            affectedness="AFFECTED",
+        )
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert "IMPORTANT" in payload["vulnerability_impact"]
+        assert "openssl" in payload["vulnerability_impact"]
+
+    def test_known_malicious_actor_is_empty(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["known_or_suspected_malicious_actor"] == ""
+
+    def test_security_update_details_is_empty(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["security_update_or_corrective_measure_details"] == ""
+
+    def test_corrective_measure_available_at_is_empty(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["corrective_or_mitigating_measure_available_at"] == ""
+
+
+class TestPrepareFinalPayloadIncident:
+    def test_incident_fields_present(self):
+        report = _create_incident_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert "detailed_incident_description" in payload
+        assert "incident_severity" in payload
+        assert "incident_impact" in payload
+        assert "likely_threat_or_root_cause" in payload
+        assert "applied_and_ongoing_mitigation_measures" in payload
+
+    def test_incident_severity_from_impact(self):
+        report = _create_incident_report(impact="MODERATE")
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert "MODERATE" in payload["incident_severity"]
+
+    def test_likely_threat_from_cwe(self):
+        report = _create_incident_report(cwe_id="CWE-502")
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["likely_threat_or_root_cause"] == "CWE-502"
+
+    def test_likely_threat_empty_when_no_cwe(self):
+        report = _create_incident_report(cwe_id="")
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["likely_threat_or_root_cause"] == ""
+
+
+class TestPrepareFinalPayloadMissingFields:
+    def test_missing_full_description_when_empty(self):
+        report = _create_vulnerability_report()
+        _clear_flaw_fields(
+            report,
+            title="",
+            cve_description="",
+            mitre_cve_description="",
+            comment_zero="",
+            statement="",
+        )
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        missing = json.loads(mfinal.missing_required_fields)
+        assert "full_vulnerability_description" in missing
+
+    def test_missing_security_update_details(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        missing = json.loads(mfinal.missing_required_fields)
+        assert "security_update_or_corrective_measure_details" in missing
+
+    def test_missing_incident_fields(self):
+        report = _create_incident_report(cwe_id="")
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        missing = json.loads(mfinal.missing_required_fields)
+        assert "likely_threat_or_root_cause" in missing
+
+    def test_additional_information_request_uses_common_fields_only(self):
+        """ADDITIONAL_INFORMATION_REQUEST falls through to common fields only."""
+        report = _create_vulnerability_report(
+            report_attrs={
+                "reportable_event_type": (
+                    SRPReport.ReportableEventType.ADDITIONAL_INFORMATION_REQUEST
+                ),
+            },
+        )
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        missing = json.loads(mfinal.missing_required_fields)
+
+        assert payload["notification_type"] == "additional_information_request"
+        assert "cve_id" not in payload
+        assert "full_vulnerability_description" not in payload
+        assert "suspected_unlawful_or_malicious_acts" not in payload
+        assert "full_vulnerability_description" not in missing
+        assert "likely_threat_or_root_cause" not in missing
+        assert set(missing).issubset(set(SRPPayloadBuilder.REQUIRED_COMMON_FIELDS))
+
+
+class TestPrepareFinalPayloadMetaAttr:
+    def test_prepared_at_stored(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        assert "prepared_at" in mfinal.meta_attr
+
+    def test_all_values_are_strings(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_final_payload(mfinal)
+        for key, value in mfinal.meta_attr.items():
+            assert isinstance(value, str), f"meta_attr[{key}] is {type(value)}"
+
+
+# ── Generic prepare_payload() Tests ──
+
+
+class TestPreparePayloadDispatch:
+    def test_dispatches_24h(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        prepare_payload(milestone)
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "24h"
+
+    def test_dispatches_72h(self):
+        report = _create_vulnerability_report()
+        m72 = _prepare_chain_up_to_72h(report)
+        prepare_payload(m72)
+        payload = json.loads(m72.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "72h"
+
+    def test_dispatches_final(self):
+        report = _create_vulnerability_report()
+        mfinal = _prepare_chain_up_to_final(report)
+        prepare_payload(mfinal)
+        payload = json.loads(mfinal.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "final"
+
+    def test_raises_for_unknown_type(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+        )
+        with pytest.raises(ValueError, match="No builder"):
+            prepare_payload(milestone)
+
+
+class TestPreparePayloadOnSubmitted:
+    def test_prepares_payload_when_status_becomes_submitted(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        assert milestone.meta_attr.get("payload_snapshot") is None
+
+        milestone.status = SRPReportMilestone.SRPReportStatus.SUBMITTED
+        milestone.save()
+
+        milestone.refresh_from_db()
+        payload = json.loads(milestone.meta_attr["payload_snapshot"])
+        assert payload["notification_level"] == "24h"
+        assert "prepared_at" in milestone.meta_attr
+
+    def test_does_not_reprepare_when_already_submitted(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        milestone.status = SRPReportMilestone.SRPReportStatus.SUBMITTED
+        milestone.save()
+        first_prepared_at = milestone.meta_attr["prepared_at"]
+
+        milestone.request_source = "manual update"
+        milestone.save()
+        milestone.refresh_from_db()
+        assert milestone.meta_attr["prepared_at"] == first_prepared_at
+
+    def test_does_not_prepare_for_prepared_status(self):
+        report = _create_vulnerability_report()
+        milestone = _get_milestone(report, SRPReportMilestone.MilestoneType.LEVEL_24H)
+        milestone.status = SRPReportMilestone.SRPReportStatus.PREPARED
+        milestone.save()
+        milestone.refresh_from_db()
+        assert milestone.meta_attr.get("payload_snapshot") is None
+
+    def test_skips_additional_information_response(self):
+        milestone = SRPReportMilestoneFactory(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_ADDITIONAL_INFORMATION_RESPONSE,
+            srp_report__flaw__major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
+            status=SRPReportMilestone.SRPReportStatus.REQUIRED,
+        )
+        milestone.status = SRPReportMilestone.SRPReportStatus.SUBMITTED
+        milestone.save()
+        milestone.refresh_from_db()
+        assert milestone.meta_attr.get("payload_snapshot") is None


### PR DESCRIPTION
# Summary
Adds SRP milestone payload preparation (OSIDB-5070): builders that assemble ENISA-oriented field snapshots for 24h, 72h, and final milestones, plus an automatic trigger when a milestone is marked submitted.

**What it does**
Builds a payload_snapshot (and missing_required_fields / prepared_at) from Flaw / report / affect data
Milestone-specific builders for 24h, 72h, and final.

- Carry-forward: 72h fills gaps from 24h; final fills gaps from 72h
- On first transition to SUBMITTED (24h/72h/final only), prepare_payload() runs and the snapshot is saved
- Does not prepare on PREPARED, and skips additional_information_response (no builder yet) 

**Out of scope**
- No API to preview/edit the payload before submit
- No ENISA/SRP submission integration — this only prepares and stores the snapshot as there is api