### PR TITLE
feat: add vendor-neutral OpenTelemetry tracing with embargo redaction

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -256,7 +256,7 @@
         "filename": "docker-compose.yml",
         "hashed_secret": "7c6a61c68ef8b9b6b061b28c348bc1ed7921cb53",
         "is_verified": false,
-        "line_number": 133,
+        "line_number": 136,
         "is_secret": false
       }
     ],

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -11,6 +11,12 @@ import os
 
 from django.core.asgi import get_asgi_application
 
+from osidb.telemetry import instrument_django
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+# Must run before get_asgi_application() builds the handler, see
+# instrument_django()'s docstring.
+instrument_django()
 
 application = get_asgi_application()

--- a/config/celery.py
+++ b/config/celery.py
@@ -1,7 +1,13 @@
+import logging
+
 from celery import Celery, signals
 from django.conf import settings
 from kombu import Queue
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from osidb.telemetry import OtelSettings, configure_telemetry, safe_instrument
+
+logger = logging.getLogger(__name__)
 
 
 class CelerySettings(BaseSettings):
@@ -62,6 +68,25 @@ app.conf.task_queues = [
 ]
 app.conf.task_default_queue = "default"
 app.conf.task_routes = ("config.celery.FIFORouter",)
+
+
+@signals.worker_process_init.connect
+def on_worker_process_init(**kwargs):
+    # CeleryInstrumentor is wired here rather than in _instrument_all()
+    # because that helper also runs from gunicorn's post_fork, i.e. in web
+    # workers. Folding it in there would make every web worker connect
+    # Celery's task signals too (harmless, but broadens instrumentation to
+    # processes that only publish tasks, not run them). Keep it scoped to
+    # actual Celery workers here instead.
+    try:
+        if not OtelSettings().enabled:
+            return
+        configure_telemetry()
+        from opentelemetry.instrumentation.celery import CeleryInstrumentor
+
+        safe_instrument(CeleryInstrumentor())
+    except Exception:
+        logger.exception("Failed to configure telemetry")
 
 
 @signals.setup_logging.connect

--- a/config/wsgi.py
+++ b/config/wsgi.py
@@ -11,6 +11,12 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+from osidb.telemetry import instrument_django
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+
+# Must run before get_wsgi_application() builds WSGIHandler, see
+# instrument_django()'s docstring.
+instrument_django()
 
 application = get_wsgi_application()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,6 +108,9 @@ services:
         OSIDB_ROLE_ID: ${OSIDB_ROLE_ID}
         OSIDB_SECRET_ID: ${OSIDB_SECRET_ID}
         OSIDB_ENABLE_SILK: ${OSIDB_ENABLE_SILK}
+        OSIDB_OTEL_ENABLED: ${OSIDB_OTEL_ENABLED:-false}
+        OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT: ${OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT}
+        OSIDB_OTEL_SERVICE_NAME: ${OSIDB_OTEL_SERVICE_NAME}
       command: ./scripts/setup-osidb-service.sh
       volumes:
         - ${PWD}:/opt/app-root/src:z
@@ -186,6 +189,9 @@ services:
         PRODUCT_DEF_BRANCH: ${PRODUCT_DEF_BRANCH}
         PRODUCT_DEF_URL: ${PRODUCT_DEF_URL}
         PS_CONSTANTS_URL: ${PS_CONSTANTS_URL}
+        OSIDB_OTEL_ENABLED: ${OSIDB_OTEL_ENABLED:-false}
+        OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT: ${OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT}
+        OSIDB_OTEL_SERVICE_NAME: ${OSIDB_OTEL_SERVICE_NAME}
       depends_on: ["osidb-data", "osidb-service", "redis"]
       # See "NOTE about healthchecks":
       # depends_on:
@@ -265,6 +271,9 @@ services:
         OSV_COLLECTOR_ENABLED: ${OSV_COLLECTOR_ENABLED}
         JIRA_USER_MAPPING_COLLECTOR_ENABLED: ${JIRA_USER_MAPPING_COLLECTOR_ENABLED}
         JIRA_USER_MAPPING_COLLECTOR_URL: ${JIRA_USER_MAPPING_COLLECTOR_URL}
+        OSIDB_OTEL_ENABLED: ${OSIDB_OTEL_ENABLED:-false}
+        OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT: ${OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT}
+        OSIDB_OTEL_SERVICE_NAME: ${OSIDB_OTEL_SERVICE_NAME}
       depends_on: ["osidb-data", "osidb-service", "redis"]
       # See "NOTE about healthchecks":
       # depends_on:
@@ -293,6 +302,31 @@ services:
         PS_CONSTANTS_URL: ${PS_CONSTANTS_URL}
         FLAW_LABELS_URL: ${FLAW_LABELS_URL}
       depends_on: ["redis", "osidb-data"]
+
+    # OpenTelemetry tracing is inert until OSIDB_OTEL_ENABLED is set and
+    # OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT points to a collector, e.g. a local
+    # Jaeger container or the Datadog Agent. Note osidb-service here runs
+    # `manage.py runserver` (setup-osidb-service.sh), which never forks, so
+    # the post_fork hook in gunicorn_config.py that sets up the exporter
+    # never fires. To actually exercise tracing locally, run the app via
+    # Gunicorn instead (scripts/run-service.sh / start-local-gunicorn):
+    #
+    #   jaeger:
+    #     image: mirror.gcr.io/jaegertracing/all-in-one:1
+    #     ports:
+    #       - "16686:16686"  # UI at http://localhost:16686
+    #       - "4317"
+    #
+    #   datadog-agent:
+    #     image: gcr.io/datadoghq/agent:7
+    #     environment:
+    #       DD_API_KEY: ${DD_API_KEY}
+    #       DD_OTLP_CONFIG_RECEIVER_PROTOCOLS_GRPC_ENDPOINT: "0.0.0.0:4317"
+    #       DD_APM_ENABLED: "true"
+    #     ports:
+    #       - "4317"
+    #
+    # Then set OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT=http://<service>:4317 in .env.
 
     redis:
       container_name: redis

--- a/gunicorn_config.py
+++ b/gunicorn_config.py
@@ -1,4 +1,5 @@
 from osidb.helpers import get_execution_env
+from osidb.telemetry import configure_telemetry
 
 bind = "0.0.0.0:8000"
 worker_class = "gthread"
@@ -25,3 +26,18 @@ if get_execution_env() in ["stage", "prod", "ci"]:
 else:
     # Support hot-reloading of Gunicorn / Django when files change in dev/local/shell
     reload = True
+
+
+def post_fork(server, worker):
+    # Runs once per worker right after fork, for both preload_app=True and
+    # False. Configuring telemetry here (rather than at wsgi/asgi import
+    # time) avoids setting up the OTLP exporter's background thread/gRPC
+    # channel in the preloaded master process, where it wouldn't survive
+    # the subsequent fork into workers. (Django's own instrumentation is
+    # registered earlier, in wsgi.py, since it must run before
+    # get_wsgi_application() builds WSGIHandler.)
+    try:
+        configure_telemetry()
+    except Exception:
+        # Don't take a worker down over telemetry; run without it instead.
+        worker.log.exception("Failed to configure telemetry")

--- a/osidb/telemetry.py
+++ b/osidb/telemetry.py
@@ -1,0 +1,106 @@
+"""
+Vendor-neutral OpenTelemetry setup.
+
+No span redaction: traces go to the same RH-approved vendor we already
+send logs to, under the same trust relationship, so holding them to a
+stricter bar than logs isn't consistent, and it would leave every span
+attribute (SQL, URLs, routes) hidden.
+
+Gated on OSIDB_OTEL_ENABLED — completely inert when disabled.
+Swap tracing vendors by changing OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT alone.
+"""
+
+import logging
+import os
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class OtelSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix="OSIDB_OTEL_")
+
+    enabled: bool = False
+    exporter_otlp_endpoint: str = ""
+    service_name: str = "osidb"
+
+
+def instrument_django():
+    """
+    Register Django's OTEL instrumentation.
+
+    DjangoInstrumentor works by inserting itself into settings.MIDDLEWARE,
+    which Django only reads once, when WSGIHandler is constructed. That
+    construction happens in get_wsgi_application(), which (with
+    preload_app=True) runs in the master process before post_fork. So this
+    must be called before get_wsgi_application(), not from post_fork like
+    the rest of telemetry setup (which needs to run per-worker instead).
+    Safe to call before the real TracerProvider exists: OTEL's tracer is a
+    lazy proxy that binds to whatever provider is configured later.
+    """
+    if not OtelSettings().enabled:
+        return
+    try:
+        from opentelemetry.instrumentation.django import DjangoInstrumentor
+
+        instrumentor = DjangoInstrumentor()
+    except Exception:
+        logger.exception("Failed to instrument DjangoInstrumentor")
+        return
+    safe_instrument(instrumentor)
+
+
+def configure_telemetry():
+    settings = OtelSettings()
+    if not settings.enabled:
+        return
+
+    # Conservative default so flipping OSIDB_OTEL_ENABLED=true doesn't spike
+    # ingestion volume before we've tuned a real ratio. Auto-instrumentation
+    # emits one span per SQL query, so unsampled export gets noisy/expensive
+    # fast. Env vars below still take precedence if set per-environment.
+    os.environ.setdefault("OTEL_TRACES_SAMPLER", "parentbased_traceidratio")
+    os.environ.setdefault("OTEL_TRACES_SAMPLER_ARG", "0.1")
+
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    resource = Resource.create({"service.name": settings.service_name})
+    provider = TracerProvider(resource=resource)
+    exporter = OTLPSpanExporter(endpoint=settings.exporter_otlp_endpoint)
+    provider.add_span_processor(BatchSpanProcessor(exporter))
+    trace.set_tracer_provider(provider)
+
+    _instrument_all()
+    logger.info("OpenTelemetry configured")
+
+
+def _instrument_all():
+    # Django is registered separately, pre-fork, by instrument_django().
+    from opentelemetry.instrumentation.psycopg2 import Psycopg2Instrumentor
+    from opentelemetry.instrumentation.redis import RedisInstrumentor
+    from opentelemetry.instrumentation.requests import RequestsInstrumentor
+
+    for instrumentor_cls in (
+        Psycopg2Instrumentor,
+        RequestsInstrumentor,
+        RedisInstrumentor,
+    ):
+        safe_instrument(instrumentor_cls())
+
+
+def safe_instrument(instrumentor):
+    # Shared by instrument_django(), _instrument_all() and Celery's
+    # on_worker_process_init hook: register an instrumentor once, and never
+    # let a broken/incompatible one take the process down.
+    name = type(instrumentor).__name__
+    try:
+        if not instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.instrument()
+            logger.info("Instrumented %s", name)
+    except Exception:
+        logger.exception("Failed to instrument %s", name)

--- a/osidb/tests/test_telemetry.py
+++ b/osidb/tests/test_telemetry.py
@@ -1,0 +1,62 @@
+import pytest
+from django.conf import settings
+
+from osidb import telemetry
+
+pytestmark = pytest.mark.unit
+
+
+class TestInstrumentDjango:
+    """
+    instrument_django() must register before get_wsgi_application() builds
+    WSGIHandler (which reads settings.MIDDLEWARE once, at construction
+    time). Covers both preload_app=True (master builds the app before
+    fork/post_fork runs) and preload_app=False (worker builds it after
+    post_fork), since in both cases wsgi.py calls it ahead of
+    get_wsgi_application().
+    """
+
+    def teardown_method(self):
+        from opentelemetry.instrumentation.django import DjangoInstrumentor
+
+        if DjangoInstrumentor().is_instrumented_by_opentelemetry:
+            DjangoInstrumentor().uninstrument()
+
+    def test_disabled_is_noop(self, monkeypatch):
+        monkeypatch.setenv("OSIDB_OTEL_ENABLED", "false")
+        middleware_before = list(settings.MIDDLEWARE)
+        telemetry.instrument_django()
+        assert settings.MIDDLEWARE == middleware_before
+
+    def test_enabled_registers_middleware_before_wsgi_app_exists(self, monkeypatch):
+        # Simulates wsgi.py: instrument_django() must run, and must have an
+        # effect on settings.MIDDLEWARE, before get_wsgi_application() (not
+        # called here) would read it.
+        monkeypatch.setenv("OSIDB_OTEL_ENABLED", "true")
+        telemetry.instrument_django()
+        assert any("opentelemetry" in mw for mw in settings.MIDDLEWARE)
+
+
+class TestPostForkTelemetryFailure:
+    def test_post_fork_survives_configure_telemetry_failure(self, monkeypatch):
+        import gunicorn_config
+
+        monkeypatch.setattr(
+            gunicorn_config,
+            "configure_telemetry",
+            lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+
+        class FakeLog:
+            def __init__(self):
+                self.exceptions = []
+
+            def exception(self, msg, *args):
+                self.exceptions.append(msg)
+
+        worker = type("Worker", (), {"log": FakeLog()})()
+
+        # Must not raise, worker startup should continue without telemetry.
+        gunicorn_config.post_fork(server=None, worker=worker)
+
+        assert worker.log.exceptions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,17 @@ dependencies = [
     "requests-cache>=0.9.1",
     "requests-gssapi>=1.2.3",
     "rhubarb>=0.2.0",
+    # opentelemetry-instrumentation-* packages track a 0.xxb0 pre-release
+    # version scheme upstream (separate from the stable 1.x core SDK/exporter);
+    # there is no stable-versioned alternative. Exact versions are pinned in
+    # uv.lock.
+    "opentelemetry-distro>=0.50b0",
+    "opentelemetry-exporter-otlp>=1.29.0",
+    "opentelemetry-instrumentation-django>=0.50b0",
+    "opentelemetry-instrumentation-celery>=0.50b0",
+    "opentelemetry-instrumentation-psycopg2>=0.50b0",
+    "opentelemetry-instrumentation-requests>=0.50b0",
+    "opentelemetry-instrumentation-redis>=0.50b0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -893,6 +893,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
+]
+
+[[package]]
 name = "gprof2dot"
 version = "2025.4.14"
 source = { registry = "https://pypi.org/simple" }
@@ -916,6 +928,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/82/d022cf25ca39cf1200650fc58c52af32c90f80479c25d1cbf57980ec3065/greenlet-3.2.3-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:419e60f80709510c343c57b4bb5a339d8767bf9aef9b8ce43f4f143240f88b7c", size = 1121190, upload-time = "2025-06-05T16:36:48.59Z" },
     { url = "https://files.pythonhosted.org/packages/f5/e1/25297f70717abe8104c20ecf7af0a5b82d2f5a980eb1ac79f65654799f9f/greenlet-3.2.3-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:93d48533fade144203816783373f27a97e4193177ebaaf0fc396db19e5d61163", size = 1149055, upload-time = "2025-06-05T16:12:40.457Z" },
     { url = "https://files.pythonhosted.org/packages/1f/8f/8f9e56c5e82eb2c26e8cde787962e66494312dc8cb261c460e1f3a9c88bc/greenlet-3.2.3-cp312-cp312-win_amd64.whl", hash = "sha256:7454d37c740bb27bdeddfc3f358f26956a07d5220818ceb467a483197d84f849", size = 297817, upload-time = "2025-06-05T16:29:49.244Z" },
+]
+
+[[package]]
+name = "grpcio"
+version = "1.83.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0c/98/304898ac4e04e2d5e4e4c2eadc178b1f2a16d5f4bc2f91306c87d64680b9/grpcio-1.83.0.tar.gz", hash = "sha256:7674587248fbbb2ac6e4eecf83a8a0f3d91a928f941de571acfd3a2f007fbc24", size = 13428824, upload-time = "2026-07-23T15:20:37.759Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/2b/51e32514a4e9b715375c99721aadff0f24164cc2049b8269eda4de82a814/grpcio-1.83.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:28f6c35ac8fcf10e4594f138e468f194360089dde40d126a7033e863fc479930", size = 6303167, upload-time = "2026-07-23T15:19:33.78Z" },
+    { url = "https://files.pythonhosted.org/packages/39/33/b5b50fc2c6fbe350e04814047bb2d409feec7b36ef8b170254c050e06bc0/grpcio-1.83.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:33898e6a28e4ae598f1577cb1c4fec2a15c033d0ec52b9b45a09610dd045b9da", size = 12160538, upload-time = "2026-07-23T15:19:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5f/734e72e7b9f79bcf0b2c270b8d3bca0e4ebb97a27a50d06240b145f6d41e/grpcio-1.83.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6fb8a1dd0c6f0f931e69e9d0dc6d1c406ed2a44fa963414eafba07b7fb685d16", size = 6869310, upload-time = "2026-07-23T15:19:38.607Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/17/a1735f215b2a5cd43c38b79eac072ad197e61be9829905b6b29550abd0db/grpcio-1.83.0-cp312-cp312-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:2b5e75c34842cd9c1b95285ca395c6a569664b81e3ffa6b714125922942abaaf", size = 7613472, upload-time = "2026-07-23T15:19:40.645Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/78/c9e81f806ac704b6b145cb01628db398985b1f8dfdc10e23b55fb0902b3d/grpcio-1.83.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:aeb339838db07600481ef869507279b75326c75eac6d10f7afa62a0da1d2bcdd", size = 7040616, upload-time = "2026-07-23T15:19:42.349Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ba/94cd5af859876049d340480acbb61a959096c84b567f215534faa78d0424/grpcio-1.83.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f47d62808b4c0a97b78bff88a6d4ca283a2a492b9a04a87d814af95ca3b9c19c", size = 7570491, upload-time = "2026-07-23T15:19:44.357Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/15/108d30d5a5c964312ae8b9cb0e8cc5b3c1cc68d8f757cca52b3565534d26/grpcio-1.83.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62003babc444a606dcd1f009cd16391ce23669ae4ad6ec267a873da7937a69f5", size = 8605036, upload-time = "2026-07-23T15:19:46.454Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/23/3828ae13c3db8233d123ad612747665817b952d8a954f32390230b582336/grpcio-1.83.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:1aa567f8c3f19850ffd5d2858c9a8ea7c80f0db6c01186b71eb31e923ec984f5", size = 7981587, upload-time = "2026-07-23T15:19:48.913Z" },
+    { url = "https://files.pythonhosted.org/packages/17/5b/77af31228f55f55a2a5112bb0077ad0a1c4d23dbb0c2853a62475bbdcc14/grpcio-1.83.0-cp312-cp312-win32.whl", hash = "sha256:cb2906c61db4f9c64cc360054b5df70eeb81846228e9e56a4944bd415a63dadc", size = 4394004, upload-time = "2026-07-23T15:19:50.618Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/da/f706e39550e7a3732ce2b9c5926107a93d74a802775b19b642a6df27dc96/grpcio-1.83.0-cp312-cp312-win_amd64.whl", hash = "sha256:1c699bbb20f143c8f2bff219de578aa2dc1f919399d67dc702b038b986ee62df", size = 5158525, upload-time = "2026-07-23T15:19:52.246Z" },
 ]
 
 [[package]]
@@ -1284,6 +1317,260 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/bf/61/395013f4378b12f4755522d50fc3649a774a1d6b1d95d4682bade4abeba1/openshift-0.12.1.tar.gz", hash = "sha256:a38957684b17ad0e140a87226249bf26de7267db0c83a6d512b48be258052e1a", size = 24338, upload-time = "2021-06-23T17:18:45.038Z" }
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-distro"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-sdk" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/61/29e94c78299b173486e6e3b10d63e89cbe340745743c6ed6ae2055433743/opentelemetry_distro-0.65b0.tar.gz", hash = "sha256:e2fef26fdf72978ab172530c13338aff367edae41ae8d90b7f6133efedde10ab", size = 2334, upload-time = "2026-07-16T15:25:47.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/d5/603a29962542152331c6e37a121129a26e24917daa4298ca00bea97571bb/opentelemetry_distro-0.65b0-py3-none-any.whl", hash = "sha256:0e15bb1a54c638e6c361bc66bc43e9de9ead442e1ae06f8099a2c1d27b6ef845", size = 2775, upload-time = "2026-07-16T15:24:47.562Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-exporter-otlp-proto-grpc" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/45/7af37fe54e5d3e66e7dcd7ba8b8aeee73f202bfac909cc94b8c4e428f9ac/opentelemetry_exporter_otlp-1.44.0.tar.gz", hash = "sha256:af1cde7c33ea8ed624bf04ac49a885730fe44c1f1ad698656e592c38f70ce106", size = 6090, upload-time = "2026-07-16T15:25:34.585Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/c3/7b466a9463944e70b37b744072a0c1b88a425dade3fff0631adec66c9bcc/opentelemetry_exporter_otlp-1.44.0-py3-none-any.whl", hash = "sha256:4a498fa8d8fd8be9e8e2d175fe5524a3fe581ccffadd8509db86526a5fb97051", size = 6727, upload-time = "2026-07-16T15:25:14.445Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/09/4d717852c1cf3f854b76c7110a5d00883bc3c99288b9b0dbcbeb9e306eb6/opentelemetry_exporter_otlp_proto_common-1.44.0.tar.gz", hash = "sha256:dc87a5a5bc58f149a56d1547e4691588fa12994cdc3bc039a694ccb3375862ac", size = 20202, upload-time = "2026-07-16T15:25:37.658Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/71/65fd9d54c10b860f87c045ccee1264cab7011268895d3528818a29c1172a/opentelemetry_exporter_otlp_proto_common-1.44.0-py3-none-any.whl", hash = "sha256:9a9fe61bba73d802904bc989f1d6b4a7b1ee40f06c40e98d6f85af65aaebb694", size = 17045, upload-time = "2026-07-16T15:25:18.201Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-grpc"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/47/80d9e9d468dc5de3af5096f5ccdb065fa4dd1470f74495cc53e59e397f47/opentelemetry_exporter_otlp_proto_grpc-1.44.0.tar.gz", hash = "sha256:40d1ae9e03fcc36de3cbac610cc99f35894938bff9cfd90fc4ec68bd85448463", size = 27225, upload-time = "2026-07-16T15:25:38.308Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/29/6ae42ba32b153ae0a44ae125f0caff2188bbe62d99c82d1768da30864e72/opentelemetry_exporter_otlp_proto_grpc-1.44.0-py3-none-any.whl", hash = "sha256:6a1a645ea182a2f59440c51fa8301d309f3324a8f9d65f8395584b064b67ee4e", size = 19624, upload-time = "2026-07-16T15:25:19.096Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/87/95e2a5aaa795b4e2260d74e16df2d5541deb2ea9de010bcd615f4dee2654/opentelemetry_exporter_otlp_proto_http-1.44.0.tar.gz", hash = "sha256:c633d7270ad6b57cd4cfbe8b0007a9e2e7c0cb50bd6c50fe2a7b245f721a09d8", size = 25806, upload-time = "2026-07-16T15:25:39.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/d0/fdeb1a98d8d3a6205f5f297c51b4a9bfe65126ab60339669bbe3dd54c2e2/opentelemetry_exporter_otlp_proto_http-1.44.0-py3-none-any.whl", hash = "sha256:838592fce774c1c8bb7b9a0a7facbfa82e17be5a8a4e94cef10cb84ae026bae3", size = 21850, upload-time = "2026-07-16T15:25:20.006Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "packaging" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/91/3c58961cb0360cd60509064734f0be4275383c8681d73c580a40ca83ddce/opentelemetry_instrumentation-0.65b0.tar.gz", hash = "sha256:071d9d9eced9bd6460444ec3b0c77229870ed05a881c22c84fdede58e4eed09b", size = 42689, upload-time = "2026-07-16T15:25:50.275Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/40/7b/85eab1215f72adf0e68d3dc4a679b9bff993fa679ff34cd8dd378e2659fd/opentelemetry_instrumentation-0.65b0-py3-none-any.whl", hash = "sha256:ea967a72b9939b5fcfdad572753b4306c59dcb99e3f382d95dae04286805e137", size = 36717, upload-time = "2026-07-16T15:24:51.424Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-celery"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/ba/c4ef088927a6bf1b75916b3bfca93552526f0e3e85d19557666f858fc5b6/opentelemetry_instrumentation_celery-0.65b0.tar.gz", hash = "sha256:ff4d192b6371cfe06969005862dc558cc8b79b03b0bbdfbf65b9a59e4dcd7fee", size = 16071, upload-time = "2026-07-16T15:26:00.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/3a/3a53db4c82bd42f67a16c846aa972aef75043557e26e9d6a4ca8ffac9699/opentelemetry_instrumentation_celery-0.65b0-py3-none-any.whl", hash = "sha256:8510357a6a9e2cb1a6485fe98642a39f06c2970eb58656de06260b922ffe7888", size = 13556, upload-time = "2026-07-16T15:25:05.427Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-dbapi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/97/b2e0ae6951cbf93c0c211910077cb50f9478fb4b7e89a402800b9a98151c/opentelemetry_instrumentation_dbapi-0.65b0.tar.gz", hash = "sha256:da048bb683347ddad2f47344bacfe1e111bf7bfb2e5a39796b1083679ad4f0f3", size = 20247, upload-time = "2026-07-16T15:26:02.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/e3/106953cea1d7f9318a4b56827ad10839fda3d033ecea2db717c051bf6a60/opentelemetry_instrumentation_dbapi-0.65b0-py3-none-any.whl", hash = "sha256:50b662578a6903b028e09b73f604de687752f5f904aa0ca032969157b29d60f2", size = 14815, upload-time = "2026-07-16T15:25:08.361Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-django"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-wsgi" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/91/2ce18c8ace56c846a094bce126b8248f3820e366c157e7ca367679715552/opentelemetry_instrumentation_django-0.65b0.tar.gz", hash = "sha256:f79914e03ccf7f34a4dfd257ea9fa1236a6568cd1756e5f969dc026252fad6e9", size = 25386, upload-time = "2026-07-16T15:26:03.668Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/e4/f458cc6acc5b130ecf91da50ade9c04ff8b93d374a8f6ee7538f0fb10be2/opentelemetry_instrumentation_django-0.65b0-py3-none-any.whl", hash = "sha256:915117536c421c3e61e34dadbd373fc404447c7a786303e02f732bc8860e3ba0", size = 18936, upload-time = "2026-07-16T15:25:09.343Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-psycopg2"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-instrumentation-dbapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/98/9593c81b7bec220b9de8e72802eabcc9e0623b34edbb331c8a5d9d7a8955/opentelemetry_instrumentation_psycopg2-0.65b0.tar.gz", hash = "sha256:4eba60bef5f25d163a098109c2960773f3753e0b7e39824b9f398ba49ffab783", size = 12065, upload-time = "2026-07-16T15:26:13.788Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/40/51f948b7953aefc506d866a862de90c960e6d5e2117850e2900c9220e3ef/opentelemetry_instrumentation_psycopg2-0.65b0-py3-none-any.whl", hash = "sha256:91880c7dbcd2b9cc62694894abed7f69fdad4bae472d1d3664a82650294f9836", size = 10787, upload-time = "2026-07-16T15:25:23.367Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-redis"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/e5/b369897a9ff902eb028f1f999c9f9a4602f0b30fe1e97298d2c15fe5b8b0/opentelemetry_instrumentation_redis-0.65b0.tar.gz", hash = "sha256:f16409f189092984ff922f26939e7be79509365f5c9d202308c13fddf1368147", size = 17218, upload-time = "2026-07-16T15:26:17.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/5b874bf8824e7cb995b22e1e61e1b5bc42810023d81612c44edbfd2c48a3/opentelemetry_instrumentation_redis-0.65b0-py3-none-any.whl", hash = "sha256:7d135f61db9d72416e1f382012fbc13de6f5e726491bebd0344a9c42a60e6769", size = 14658, upload-time = "2026-07-16T15:25:29.146Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-requests"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c8/84/f46bf7976a81827419b085c9ed14562410c7599e07509786e9f6eb3c5438/opentelemetry_instrumentation_requests-0.65b0.tar.gz", hash = "sha256:1d601548f89236d5ab373c7208a2e1e162a8d6462b5b972f9ad8fb0ed82d7438", size = 18107, upload-time = "2026-07-16T15:26:18.532Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/45/6201afe846263d775cd4fc8d6a87dc8c15eb7921cdade4dca1e1227b04b6/opentelemetry_instrumentation_requests-0.65b0-py3-none-any.whl", hash = "sha256:91688ec0d4d1fed75ea8d026ef2c66274ed9868c22b6be211ef85d832d16f957", size = 13386, upload-time = "2026-07-16T15:25:31.093Z" },
+]
+
+[[package]]
+name = "opentelemetry-instrumentation-wsgi"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-instrumentation" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "opentelemetry-util-http" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/f7/bfe74ba3baea8c61290c3ab1d692f841b695ccb6e40faf5ad55fd5412cf2/opentelemetry_instrumentation_wsgi-0.65b0.tar.gz", hash = "sha256:d4a62ae98667ddfe04fe538c3c54abad538feb8c9c7a407ba19f016e1ce4a89a", size = 19666, upload-time = "2026-07-16T15:26:25.485Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/af/9dfe500d3b816e4bd65f467c6275688744ed8186894c73223f7e3d6d9745/opentelemetry_instrumentation_wsgi-0.65b0-py3-none-any.whl", hash = "sha256:af23e6686c7cd2abcd7d14ac03fb7e3b438273eb2d54a8f8dc401dc71bc52a9f", size = 13787, upload-time = "2026-07-16T15:25:42.876Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/01/40ac4ae9a149263cc52c2cee200ddd80cb6d8db1a4610abf8eabce0fe771/opentelemetry_proto-1.44.0.tar.gz", hash = "sha256:c547a79c2f8c0c515d31509154682e5921c7cfd5ca67b70e1f9266e2c3e103f3", size = 46488, upload-time = "2026-07-16T15:25:45.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7c/8be563d68e93bbefa5c8affb82ddcff91b3ad858ce49957ba7b16fd3e0ab/opentelemetry_proto-1.44.0-py3-none-any.whl", hash = "sha256:898b155a0e1557afd867478fb6158e8122a46329ca0bb8dc53cc55e98f017f56", size = 72483, upload-time = "2026-07-16T15:25:28.429Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/77/a6592cbc7c8d9bcc9d6757a9df45e04a7c585e3e6e7a13456da522b21109/opentelemetry_sdk-1.44.0.tar.gz", hash = "sha256:cebe7f65dc12f26ead75c6064de12fd2a9052e5060c0272d402cfa203aae123b", size = 208624, upload-time = "2026-07-16T15:25:46.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/23/ff077e61886ee020a17ce9c8b6fa11c601c8d8345b09ea24f605445df62a/opentelemetry_sdk-1.44.0-py3-none-any.whl", hash = "sha256:df081c4c6bcfdb1211e3e86140376792643128a25f8d72d1d27675936e7e96ad", size = 137221, upload-time = "2026-07-16T15:25:29.534Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/73/0cbdebcb4cf545fdd328da14f5137e37d0770c3f26185e478b0d15d94f50/opentelemetry_semantic_conventions-0.65b0.tar.gz", hash = "sha256:f9b2b81e9d5b64f11bc952075e7e9c7fb0aab075c7fd1c46d597f1b919852d60", size = 148774, upload-time = "2026-07-16T15:25:46.902Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/0e/49df70d9b81fb5cbae4bbf2a49d865b09bcbcbc4eb53f5851b1027738d78/opentelemetry_semantic_conventions-0.65b0-py3-none-any.whl", hash = "sha256:1cacde7b0ad306f84c5ef08c3dbe1bbaf20165bba6f8bff43b670e555a086bcb", size = 204645, upload-time = "2026-07-16T15:25:30.688Z" },
+]
+
+[[package]]
+name = "opentelemetry-util-http"
+version = "0.65b0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/a9/d7525a59fdd240e69b5af4a6338e78fafa1b4203394122cbd6701fb5f84a/opentelemetry_util_http-0.65b0.tar.gz", hash = "sha256:84f82d826978bba416ab453460ff6a7391cdc3534c93a786595e4068680016b7", size = 11243, upload-time = "2026-07-16T15:26:27.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/3f/ab8d29df207ce5f470a07fa96ebb48af4e95b7fab7e7635311b9a32f2fab/opentelemetry_util_http-0.65b0-py3-none-any.whl", hash = "sha256:7553b606f963097cb190536dc30556cce85090692e471a422fff30ca29b04348", size = 8245, upload-time = "2026-07-16T15:25:46.482Z" },
+]
+
+[[package]]
 name = "osidb"
 version = "5.16.3"
 source = { virtual = "." }
@@ -1321,6 +1608,13 @@ dependencies = [
     { name = "kerberos" },
     { name = "markdown" },
     { name = "nvdlib" },
+    { name = "opentelemetry-distro" },
+    { name = "opentelemetry-exporter-otlp" },
+    { name = "opentelemetry-instrumentation-celery" },
+    { name = "opentelemetry-instrumentation-django" },
+    { name = "opentelemetry-instrumentation-psycopg2" },
+    { name = "opentelemetry-instrumentation-redis" },
+    { name = "opentelemetry-instrumentation-requests" },
     { name = "packageurl-python" },
     { name = "psycogreen" },
     { name = "psycopg2" },
@@ -1400,6 +1694,13 @@ requires-dist = [
     { name = "kerberos", specifier = ">=1.3.1" },
     { name = "markdown", specifier = ">=3.3.6" },
     { name = "nvdlib", specifier = ">=0.7.6" },
+    { name = "opentelemetry-distro", specifier = ">=0.50b0" },
+    { name = "opentelemetry-exporter-otlp", specifier = ">=1.29.0" },
+    { name = "opentelemetry-instrumentation-celery", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-django", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-psycopg2", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-redis", specifier = ">=0.50b0" },
+    { name = "opentelemetry-instrumentation-requests", specifier = ">=0.50b0" },
     { name = "packageurl-python", specifier = ">=0.17.6" },
     { name = "psycogreen", specifier = ">=1.0.2" },
     { name = "psycopg2", specifier = ">=2.9.2" },
@@ -1525,6 +1826,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/53/96/b3bff620964869c07252fc2eac4e7e2dd48aea07314d932d21cfd92428da/prompt_toolkit-3.0.22.tar.gz", hash = "sha256:449f333dd120bd01f5d296a8ce1452114ba3a71fae7288d2f0ae2c918764fa72", size = 3041540, upload-time = "2021-11-04T07:54:18.278Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/2a/456a7f1acbe89fc04607357b6351d5daa864843f8e1470edaa723254ca1e/prompt_toolkit-3.0.22-py3-none-any.whl", hash = "sha256:48d85cdca8b6c4f16480c7ce03fd193666b62b0a21667ca56b4bb5ad679d1170", size = 374307, upload-time = "2021-11-04T07:54:13.774Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.35.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/01/9ef0afd7999eb9badb3a768b4aedd78c86d4c65cfaf1958ab276199e76b4/protobuf-7.35.1.tar.gz", hash = "sha256:ce115a26fe0c39a2c29973d914d327e516a6455464489fe3cd1e51a1b354f81a", size = 458717, upload-time = "2026-06-11T21:55:40.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/03/8aeeb7458d22546bf64b5250ca1daeb5ff757d900e8e4a7476c6f0db843e/protobuf-7.35.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:24f857477359a85c0c235261b8ba905fd51b2562f4a64ca1df5473f29850cbf6", size = 433226, upload-time = "2026-06-11T21:55:31.719Z" },
+    { url = "https://files.pythonhosted.org/packages/37/4b/dfb89eb0e652a1ff073c39a59fb5e3a83cfe9b57a2c83fa6d78270101767/protobuf-7.35.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:11d6b0ec246892d85215b0a13ca6e0233cf5284b68f0ac02646427f4ff88a799", size = 328847, upload-time = "2026-06-11T21:55:34.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/58/dc12f2cd484951524af6e3382c785869b9b3fb5e52ee95ae23add53ee8f9/protobuf-7.35.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:b73f9489a4b8b1c9cb1f8ed951c736392592edb24b9d6819f36d2e10b171d5b4", size = 344030, upload-time = "2026-06-11T21:55:34.941Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/be/5b3cfe508bfab6761414ff944e3366eb13be4fd71efcd69450f89ba39f43/protobuf-7.35.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:74758715c53d7158fb76caf4f0cfdacc5329a4b1bb994f865d6cf302d413a1c4", size = 327130, upload-time = "2026-06-11T21:55:35.921Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/bc/6d6c7ba8709c85f8f2c390b2b118d6fb08a783676a572271851bf45a7d22/protobuf-7.35.1-cp310-abi3-win32.whl", hash = "sha256:353652e4efd0bca5b5fc2656abf8307ef351f0cf938c9eba09f0e09c20a25c30", size = 428945, upload-time = "2026-06-11T21:55:37.034Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/19/8d0cb6f20a1ef7b18f1c8986ad5783f22f84cce39c6ce9a6e645ea55192e/protobuf-7.35.1-cp310-abi3-win_amd64.whl", hash = "sha256:230a75ddfc2de4806e56696ce9640c1cdfdb6543b7cfce98d42a4c0a0e7bdb87", size = 439996, upload-time = "2026-06-11T21:55:38.123Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl", hash = "sha256:4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9", size = 171659, upload-time = "2026-06-11T21:55:39.155Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds OpenTelemetry (OTel) tracing to OSIDB with a vendor-neutral architecture. This is an **exploratory spike** to evaluate distributed tracing for production observability.

- Instruments Django, psycopg2, requests, Redis, and Celery via OTel auto-instrumentation
- Vendor-neutral: any OTLP-compatible backend (Datadog Agent, Jaeger, Grafana Tempo, ...) works — swap by changing one env var. No collector is shipped with this PR (see "No collector included" below)
- Gated behind `OSIDB_OTEL_ENABLED` (default: `false`) — completely inert when disabled
- Ships a conservative default trace sampling ratio (10%, via `OTEL_TRACES_SAMPLER`/`OTEL_TRACES_SAMPLER_ARG`) so enabling tracing doesn't spike ingestion volume before it's tuned per-environment

## Why OpenTelemetry over ddtrace

We don't want vendor lock-in. OTel is the CNCF standard for observability — Datadog, Grafana, Jaeger, and every major vendor accept OTLP natively. Switching vendors means changing `OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT`, nothing else. No Datadog-specific code anywhere in the codebase.

## No collector included

This PR ships only the producer side (SDK setup, instrumentation). It does **not** include a Jaeger/collector service — standing up and operating the OTLP backend (Datadog Agent or otherwise) is devops' call, so it's left out of `docker-compose.yml` on purpose rather than guessing at their setup.

Until a collector exists somewhere and `OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT` is pointed at it, this has **no functional impact**: `OSIDB_OTEL_ENABLED` defaults to `false`, so `configure_telemetry()` is a no-op. If someone opts in locally without a reachable collector, span export just fails/retries in `BatchSpanProcessor`'s background thread — it doesn't block requests or crash the app, it just won't produce visible traces.

## What about profiling?

OTel covers **tracing** (where time is spent across services/queries), not **profiling** (which Python code path is slow). These are complementary:

- **Local profiling**: we have `django-silk` for local per-request SQL profiling with full Python stack traces
- **Production profiling**: OTel's profiling signal is still experimental (no stable Python SDK). Options like Pyroscope (Grafana, open-source) exist but are a separate initiative. Not needed right now

## Files changed

| File | Change |
|---|---|
| `pyproject.toml` | OTel dependencies (distro, exporter, 5 instrumentors) |
| `osidb/telemetry.py` | **New** — `OtelSettings` + `instrument_django()` + `configure_telemetry()` + `_instrument_all()` |
| `config/wsgi.py` / `config/asgi.py` | Call `instrument_django()` before the WSGI/ASGI app is built, since `DjangoInstrumentor` must register before Django reads `settings.MIDDLEWARE` |
| `gunicorn_config.py` | `post_fork` hook calls `configure_telemetry()` per worker (psycopg2/requests/redis instrumentation + the OTLP exporter must be set up after fork, not in the preloaded master) |
| `config/celery.py` | `worker_process_init` hook calls `configure_telemetry()` + `CeleryInstrumentor` per worker |
| `docker-compose.yml` | `OSIDB_OTEL_*` env vars passed through to services (`OSIDB_OTEL_ENABLED` defaults to `false` when unset, so an unset env var doesn't fail `OtelSettings` validation); commented example Jaeger/Datadog Agent services for local testing |
| `osidb/tests/test_telemetry.py` | **New** — covers `instrument_django()` gating and `gunicorn_config.post_fork` surviving a `configure_telemetry()` failure |

## How to test locally

Point `OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT` at any OTLP collector you have available (e.g. run your own `jaegertracing/all-in-one` container and add it to your local compose override):

```bash
# Set in .env
OSIDB_OTEL_ENABLED=true
OSIDB_OTEL_EXPORTER_OTLP_ENDPOINT=http://<your-collector>:4317
OSIDB_OTEL_SERVICE_NAME=osidb

# Rebuild and start
make build && make start-local
```

## Caveats

- **Only wired up for Gunicorn**: `osidb-service` in `docker-compose.yml` runs via `manage.py runserver`, which never forks, so the `post_fork` hook that sets up the exporter never fires there. Tracing only works when the app is served via Gunicorn (`scripts/run-service.sh` / `start-local-gunicorn`)
- **No custom spans**: this PR only adds auto-instrumentation. Manual spans for business logic (e.g. "flaw validation", "embargo check") would be a follow-up
- **No redaction**: traces go to the same RH-approved vendor we already send logs to, under the same trust relationship, so no span-attribute scrubbing is applied (see `osidb/telemetry.py` docstring)

## Open questions for the team

1. Is 10% the right default sample ratio, or should it start lower/higher until we've seen real volume?
2. Any concerns about the OTel dependency footprint? (7 new packages)
3. Who owns standing up the OTLP collector (devops), and on what timeline?

---

Assisted-By: Claude Code (claude-opus-4-6)

