### PR TITLE
fix: process kernel affects as generic ecosystem (OSIDB-5248)

### DIFF
--- a/apps/ace/constants.py
+++ b/apps/ace/constants.py
@@ -14,6 +14,7 @@ OSV_ECOSYSTEM_MAP: dict[str, str] = {
     "bioconductor": "generic",
     "cran": "generic",
     "github actions": "generic",
+    "linux": "generic",
 }
 
 # From https://pkg.go.dev/std

--- a/apps/ace/osv_ranges.py
+++ b/apps/ace/osv_ranges.py
@@ -139,7 +139,12 @@ def match_component_to_upstream(
                 continue
 
         if ecosystem:
-            purl_type = parsed_purl.type if parsed_purl else ""
+            if parsed_purl:
+                purl_type = parsed_purl.type
+            else:
+                # For purl-less entries, derive ecosystem from OSV ecosystem field
+                raw_eco = (entry.get("ecosystem") or "").lower()
+                purl_type = OSV_ECOSYSTEM_MAP.get(raw_eco, raw_eco)
             if purl_type != ecosystem:
                 continue
 

--- a/apps/ace/tests/conftest.py
+++ b/apps/ace/tests/conftest.py
@@ -1,3 +1,5 @@
+import json
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -150,3 +152,14 @@ def chromium_streams(db):
     """Create PsUpdateStream records needed by the Chromium workflow."""
     PsUpdateStreamFactory(name="fedora-all")
     PsUpdateStreamFactory(name="epel-all")
+
+
+@pytest.fixture
+def cve_2026_64189_osv_payload():
+    """
+    Complete OSV payload for CVE-2026-64189 (Linux kernel purl-less entry).
+    Fetched from https://api.osv.dev/v1/vulns/CVE-2026-64189
+    """
+    fixture_path = Path(__file__).parent / "fixtures" / "cve-2026-64189-osv.json"
+    with open(fixture_path) as f:
+        return json.load(f)

--- a/apps/ace/tests/fixtures/cve-2026-64189-osv.json
+++ b/apps/ace/tests/fixtures/cve-2026-64189-osv.json
@@ -1,0 +1,147 @@
+{
+  "id": "CVE-2026-64189",
+  "summary": "netfilter: ipset: fix race between dump and ip_set_list resize",
+  "details": "In the Linux kernel, the following vulnerability has been resolved:\n\nnetfilter: ipset: fix race between dump and ip_set_list resize\n\nThe release path of ip_set_dump_do() and ip_set_dump_done() read\ninst->ip_set_list via ip_set_ref_netlink(), a plain rcu_dereference_raw()\nof the array pointer. These run from netlink_recvmsg() without the nfnl\nmutex and without an RCU read-side critical section.\n\nA concurrent ip_set_create() can grow the array: it publishes the new\narray, calls synchronize_net() and then kvfree()s the old one. Since the\ndump paths read the array outside any RCU reader, synchronize_net() does\nnot wait for them and the old array can be freed while they still index\ninto it, causing a use-after-free.\n\nThe dumped set itself stays pinned via set->ref_netlink, so only the\narray load needs protecting. Take rcu_read_lock() around it, matching\nip_set_get_byname() and __ip_set_put_byindex().\n\n  BUG: KASAN: slab-use-after-free in ip_set_dump_do (net/netfilter/ipset/ip_set_core.c:1697)\n  Read of size 8 at addr ffff88800b5c4018 by task exploit/150\n  Call Trace:\n   ...\n   kasan_report (mm/kasan/report.c:595)\n   ip_set_dump_do (net/netfilter/ipset/ip_set_core.c:1697)\n   netlink_dump (net/netlink/af_netlink.c:2325)\n   netlink_recvmsg (net/netlink/af_netlink.c:1976)\n   sock_recvmsg (net/socket.c:1159)\n   __sys_recvfrom (net/socket.c:2315)\n   ...\n  Oops: general protection fault, probably for non-canonical address ... KASAN NOPTI\n  KASAN: maybe wild-memory-access in range [0x02d6...d0-0x02d6...d7]\n  RIP: 0010:ip_set_dump_do (net/netfilter/ipset/ip_set_core.c:1698)\n  Kernel panic - not syncing: Fatal exception",
+  "modified": "2026-07-28T04:02:21.688862089Z",
+  "published": "2026-07-20T16:27:47.767Z",
+  "database_specific": {
+    "osv_generated_from": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/64xxx/CVE-2026-64189.json",
+    "cna_assigner": "Linux"
+  },
+  "references": [
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/1bc67c3fc98e9fc07032cc56afcdbc690c47d11e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/7cd9103283b26b917360ec99d7d2f2d761bcf1ab"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/81d54c766337b923eec26da0a13406760b091093"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/96fbafc20ebd9a613736c2998b89c539fe3042f5"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/a7a299277959683204d73333c32c092fd69327d4"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/e8a9976b61f1bc4aa7fd25fa26726dfdf2adf710"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/e8ee198bbc04a32d336e79160fde980e0235b39f"
+    },
+    {
+      "type": "WEB",
+      "url": "https://git.kernel.org/stable/c/ff86ea9b7fdf70564e60436fbee68c96bc459943"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/CVEProject/cvelistV5/tree/main/cves/2026/64xxx/CVE-2026-64189.json"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-64189"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "name": "Kernel",
+        "ecosystem": "Linux"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.20.0"
+            },
+            {
+              "fixed": "5.10.261"
+            }
+          ]
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.11.0"
+            },
+            {
+              "fixed": "5.15.212"
+            }
+          ]
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.16.0"
+            },
+            {
+              "fixed": "6.1.178"
+            }
+          ]
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.2.0"
+            },
+            {
+              "fixed": "6.6.145"
+            }
+          ]
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.7.0"
+            },
+            {
+              "fixed": "6.12.96"
+            }
+          ]
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.13.0"
+            },
+            {
+              "fixed": "6.18.39"
+            }
+          ]
+        },
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "6.19.0"
+            },
+            {
+              "fixed": "7.1.4"
+            }
+          ]
+        }
+      ],
+      "database_specific": {
+        "source": "https://storage.googleapis.com/cve-osv-conversion/osv-output/CVE-2026-64189.json"
+      }
+    }
+  ]
+}

--- a/apps/ace/tests/test_osv_ranges.py
+++ b/apps/ace/tests/test_osv_ranges.py
@@ -253,3 +253,85 @@ def test_match_unknown_ecosystem_returns_none():
     purls = _make_multi_ecosystem_purls()
     result = match_component_to_upstream("redis", purls, ecosystem="maven")
     assert result is None
+
+
+# ── match_component_to_upstream purl-less entries ────────────────────────────
+
+
+def test_match_purl_less_entry_by_name():
+    """Purl-less entry with name+ecosystem matches by name without ecosystem filter."""
+    purls = [
+        {
+            "purl": "",
+            "name": "Kernel",
+            "ecosystem": "Linux",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "6.0.0"}],
+                }
+            ],
+            "versions": [],
+        }
+    ]
+    result = match_component_to_upstream("kernel", purls)
+    assert result is not None
+    assert result.name == "Kernel"
+    assert result.ecosystem == "generic"
+    assert result.fixed == "6.0.0"
+
+
+def test_match_purl_less_entry_with_ecosystem_filter():
+    """Purl-less entry with ecosystem matches when OSV ecosystem maps to filter."""
+    purls = [
+        {
+            "purl": "",
+            "name": "Kernel",
+            "ecosystem": "Linux",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "6.0.0"}],
+                }
+            ],
+            "versions": [],
+        }
+    ]
+    # OSV ecosystem "Linux" maps to "generic" in OSV_ECOSYSTEM_MAP
+    result = match_component_to_upstream("kernel", purls, ecosystem="generic")
+    assert result is not None
+    assert result.ecosystem == "generic"
+
+
+def test_match_purl_less_entry_wrong_ecosystem():
+    """Purl-less entry is skipped when mapped ecosystem doesn't match filter."""
+    purls = [
+        {
+            "purl": "",
+            "name": "Kernel",
+            "ecosystem": "Linux",
+            "ranges": [],
+            "versions": [],
+        }
+    ]
+    result = match_component_to_upstream("kernel", purls, ecosystem="npm")
+    assert result is None
+
+
+def test_entry_to_package_info_purl_less():
+    """Purl-less entry correctly extracts name, ecosystem, and ranges."""
+    entry = {
+        "purl": "",
+        "name": "Kernel",
+        "ecosystem": "Linux",
+        "ranges": [
+            {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "6.0.0"}]}
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.name == "Kernel"
+    assert info.ecosystem == "generic"
+    assert info.purl == ""
+    assert info.introduced == "0"
+    assert info.fixed == "6.0.0"

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -1156,3 +1156,91 @@ def test_handle_go_stdlib_phase4_creates_builder_affects(
         assert str(a.purl) == GO_STDLIB_BUILDER_PURL
         assert a.affectedness == Affect.AffectAffectedness.AFFECTED
         assert a.resolution == Affect.AffectResolution.DELEGATED
+
+
+# ── Purl-less OSV entries (Linux kernel CVE-2026-64189) ──────────────────────
+
+
+@pytest.mark.django_db
+def test_sync_passes_ecosystem_for_purl_less_entry(
+    monkeypatch, ace_enabled, mock_querier, cve_2026_64189_osv_payload, result
+):
+    """
+    End-to-end test for purl-less OSV entries (Linux kernel case).
+
+    CVE-2026-64189 has an OSV entry with name="Kernel", ecosystem="Linux" but no PURL.
+    This tests that:
+    1. OSV collector extracts the purl-less entry into upstream_purls
+    2. component_ecosystems derives ecosystem="generic" from ecosystem="Linux"
+    3. NewtopiaQuerier.search() receives ecosystem="generic" parameter
+    4. Affects are created correctly for kernel packages returned by lib-newtopia
+    """
+    from collectors.osv.collectors import OSVCollector
+
+    # Create flaw with kernel component
+    flaw = FlawFactory(components=["kernel"], embargoed=False, cve_id="CVE-2026-64189")
+
+    # Extract upstream_purls from the real OSV payload
+    _osv_id, _cve_ids, content = OSVCollector().extract_content(
+        cve_2026_64189_osv_payload
+    )
+
+    # Verify purl-less entry was extracted
+    assert len(content["upstream_purls"]) == 1
+    kernel_entry = content["upstream_purls"][0]
+    assert kernel_entry["purl"] == ""
+    assert kernel_entry["name"] == "Kernel"
+    assert kernel_entry["ecosystem"] == "Linux"
+    assert len(kernel_entry["ranges"]) == 7  # All 7 version ranges from OSV
+
+    # Store upstream data on the flaw
+    from osidb.models import UpstreamData
+
+    UpstreamData.objects.create(
+        flaw=flaw,
+        source=UpstreamData.Source.OSV,
+        upstream_purls=content["upstream_purls"],
+        acl_read=flaw.acl_read,
+        acl_write=flaw.acl_write,
+    )
+
+    # Verify component_ecosystems maps Linux -> generic
+    upstream = flaw.upstream_data.first()
+    assert upstream.component_ecosystems == {"kernel": ["generic"]}
+
+    # Mock lib-newtopia to return a kernel package
+    kernel_results = [
+        result("rhel-9.8.z", "pkg:rpm/redhat/kernel@6.5.0-1.el9?arch=src"),
+    ]
+
+    # Track what ecosystem parameter was passed to newtopia
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        component = terms[0]
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = (
+            kernel_results if component == "kernel" else []
+        )
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    # Run the sync
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    # Verify ecosystem="generic" was passed to newtopia
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == "generic"
+    assert search_kwargs[0]["strict"] is True
+
+    # Verify affect was created
+    assert stats["created"] == 1
+    assert flaw.affects.count() == 1
+    affect = flaw.affects.first()
+    assert affect.ps_component == "kernel"
+    assert affect.ps_update_stream == "rhel-9.8.z"
+    assert str(affect.purl) == "pkg:rpm/redhat/kernel@6.5.0-1.el9?arch=src"

--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -30,12 +30,12 @@ logger = get_task_logger(__name__)
 
 def _osv_upstream_purl_dedupe_key(item: Any) -> str | None:
     """Stable id for get_upstream_purls entries: {\"purl\", \"name\", \"ecosystem\", \"ranges\", \"versions\"}."""
-    if isinstance(item, dict) and item.get("purl"):
+    if isinstance(item, dict) and (item.get("purl") or item.get("name")):
         return json.dumps(
             {
-                "purl": item.get("purl"),
-                "name": item.get("name"),
-                "ecosystem": item.get("ecosystem"),
+                "purl": item.get("purl") or "",
+                "name": item.get("name") or "",
+                "ecosystem": item.get("ecosystem") or "",
                 "ranges": item.get("ranges") or [],
                 "versions": item.get("versions") or [],
             },
@@ -410,14 +410,13 @@ class OSVCollector(Collector):
             for affect in affected:
                 # https://ossf.github.io/osv-schema/#affectedpackage-field
                 package = affect.get("package") or {}
-                upstream_purl = package.get("purl", None)
-
-                # Skip filling in the field if there is no purl
-                if not upstream_purl:
-                    continue
-
+                upstream_purl = package.get("purl") or ""
                 name = package.get("name", None)
                 ecosystem = package.get("ecosystem", None)
+
+                # Skip if there is no purl AND no (name + ecosystem)
+                if not upstream_purl and not (name and ecosystem):
+                    continue
 
                 # https://ossf.github.io/osv-schema/#affectedranges-field
                 ranges = copy.deepcopy(affect.get("ranges", []))

--- a/collectors/tests/test_osv_upstream.py
+++ b/collectors/tests/test_osv_upstream.py
@@ -64,6 +64,45 @@ class TestMergeOsvUpstreamLists:
         )
         assert len(merged) == 2
 
+    def test_merge_purls_includes_purl_less_entries(self):
+        """Purl-less entries with name+ecosystem are merged, not dropped."""
+        existing = [
+            {
+                "purl": "",
+                "name": "linux",
+                "ecosystem": "Linux",
+                "ranges": [],
+                "versions": [],
+            }
+        ]
+        additions = [
+            dict(existing[0]),
+            {
+                "purl": "",
+                "name": "linux",
+                "ecosystem": "Linux",
+                "ranges": [{"type": "ECOSYSTEM"}],
+                "versions": [],
+            },
+            {
+                "purl": "pkg:npm/foo",
+                "name": "foo",
+                "ecosystem": "npm",
+                "ranges": [],
+                "versions": [],
+            },
+        ]
+        merged = _merge_osv_upstream_lists(
+            existing, additions, _osv_upstream_purl_dedupe_key
+        )
+        # exact duplicate removed, distinct-range purl-less + npm kept
+        assert len(merged) == 3
+        assert merged[0]["name"] == "linux"
+        assert merged[0]["ranges"] == []
+        assert merged[1]["name"] == "linux"
+        assert merged[1]["ranges"] == [{"type": "ECOSYSTEM"}]
+        assert merged[2]["purl"] == "pkg:npm/foo"
+
 
 class TestOSVCollectorExtractUpstreamFields:
     def test_extract_content_upstream_purls(self):
@@ -127,6 +166,53 @@ class TestOSVCollectorExtractUpstreamFields:
                 "versions": [],
             }
         ]
+
+    def test_extract_content_upstream_purls_accepts_purl_less_entries(self):
+        """Test entries with name+ecosystem but no purl are accepted."""
+        osv_vuln = {
+            "id": "CVE-2026-64189",
+            "aliases": [],
+            "summary": "Linux kernel vulnerability",
+            "details": "",
+            "published": None,
+            "affected": [
+                {
+                    "package": {
+                        "name": "Kernel",
+                        "ecosystem": "Linux",
+                    },
+                    "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+                    "versions": [],
+                },
+                {
+                    "package": {
+                        "purl": "pkg:npm/foo",
+                        "name": "foo",
+                        "ecosystem": "npm",
+                    },
+                    "ranges": [],
+                    "versions": [],
+                },
+                {
+                    "package": {},
+                    "ranges": [],
+                    "versions": [],
+                },
+            ],
+            "references": [],
+        }
+        _osv_id, _cve_ids, content = OSVCollector().extract_content(osv_vuln)
+        # Should include purl-less entry with name+ecosystem, and entry with purl
+        # Should skip entry with no purl and no name+ecosystem
+        assert len(content["upstream_purls"]) == 2
+        assert content["upstream_purls"][0] == {
+            "purl": "",
+            "name": "Kernel",
+            "ecosystem": "Linux",
+            "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+            "versions": [],
+        }
+        assert content["upstream_purls"][1]["purl"] == "pkg:npm/foo"
 
 
 @pytest.mark.django_db
@@ -225,3 +311,25 @@ class TestOsvUpstreamContentWrittenToFlaw:
         upstream = flaw.upstream_data.first()
         assert upstream.upstream_purls == content["upstream_purls"]
         assert Flaw.objects.filter(uuid=flaw.uuid).count() == 1
+
+    def test_append_osv_upstream_to_flaw_preserves_purl_less_entries(self):
+        """Test that purl-less entries with name survive the append/merge process."""
+        flaw = FlawFactory(embargoed=False)
+        content = {
+            "upstream_purls": [
+                {
+                    "purl": "",
+                    "name": "linux",
+                    "ecosystem": "Linux",
+                    "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}]}],
+                    "versions": [],
+                }
+            ],
+        }
+        OSVCollector()._append_osv_upstream_to_flaw(flaw, content)
+        flaw.refresh_from_db()
+        upstream = flaw.upstream_data.first()
+        assert len(upstream.upstream_purls) == 1
+        assert upstream.upstream_purls[0]["name"] == "linux"
+        assert upstream.upstream_purls[0]["ecosystem"] == "Linux"
+        assert upstream.upstream_purls[0]["purl"] == ""

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - introduce true labels and deprecate collaborator-centric pseudo-labels (OSIDB-5191)
 - mod7 check no longer influences hummingbird affects
 - mod7 check no longer influences ubi affects (OSIDB-5047)
+- Auto-affect creation no longer overrides Affect.impact
+- replace env-specific settings files with one configurable (OSIDB-5186)
 
 ### Fixed
 - Enable RLS on FlawCollaborator and FlawLabelV2 (OSIDB-5128)
@@ -37,17 +39,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Return descriptive 400 error instead of 500 on malformed bulk affects requests (OSIDB-3134)
 - Fix collectors being blocked by duplicated related model entries (OSIDB-5221)
 - Filter windows-only Flaws by leveraging CPEs in addition to keywords / blocklist (OSIDB-5235)
+- Linux kernel flaws get correct affects added (OSIDB-5248)
 
 ### Removed
 - deprecate workflow manipulation endpoints
 - disconnect OSIDB workflow:state from the Jira
 - stop classifying legacy flaws
-
-### Changed
-- Auto-affect creation no longer overrides Affect.impact
-
-### Changed
-- replace env-specific settings files with one configurable (OSIDB-5186)
 
 ## [5.12.0] - 2026-06-25
 ### Added

--- a/osidb/models/tests/test_upstream.py
+++ b/osidb/models/tests/test_upstream.py
@@ -108,3 +108,21 @@ class TestComponentEcosystems:
         result = upstream.component_ecosystems
 
         assert result == {"redis": ["npm", "pypi"]}
+
+    def test_component_ecosystems_purl_less_entry(self):
+        """Purl-less entry with name+ecosystem maps via OSV_ECOSYSTEM_MAP."""
+        flaw = FlawFactory()
+        upstream = UpstreamData(
+            flaw=flaw,
+            source=UpstreamData.Source.OSV,
+            upstream_purls=[
+                {"purl": "", "name": "Kernel", "ecosystem": "Linux"},
+            ],
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
+        )
+
+        result = upstream.component_ecosystems
+
+        # "Linux" ecosystem maps to "generic" via OSV_ECOSYSTEM_MAP
+        assert result == {"kernel": ["generic"]}


### PR DESCRIPTION
When ACE encounters a Flaw whose components includes the Linux Kernel, it doesn't do any special routing and instead performs a pretty naive lib-newtopia query which returns a lot of results for non-linux kernel ecosystems (e.g. cargo).

The fix in this scenario would be to simply map the "linux" ecosystem (OSV ecosystem unique to the Linux Kernel) to the "generic" lib-newtopia ecosystem which correctly returns _only_ linux kernel results.

However, OSV Linux Kernel records are special in that they rarely, if at all, provide a PURL which is the basis of all the UpstreamData data gathering.

That said, affected package name, ecosystem, version and other information can be obtained from either the PURL and/or other fields available in the OSV record itself, so in order to still be able to correctly process Linux Kernel Flaws, we create PURL-less UpstreamData objects using the other available information.

With package name and ecosystem obtained, it's then easy to further filter the lib-newtopia query to the "generic" ecosystem.

This approach has the benefit of working with e.g. the cargo kernel package, among others, behavior does not depend solely on package name.