### PR TITLE
OSIDB-5085 Add Flaw to upstream Mapping Endpoints

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Upstream Maintainer Notification Payload Preparation Service (OSIDB-5087)
 - Add SRP report endpoints (OSIDB-5073)
 - Add Upstream Project Contact Endpoints (OSIDB-5084)
+- Add Flaw-to-Upstream Mapping Endpoints (OSIDB-5085)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/openapi.yml
+++ b/openapi.yml
@@ -14026,6 +14026,87 @@ paths:
                     version:
                       type: string
           description: ''
+  /regulatory-reporting/api/v1/flaw-upstream-mappings/{mapping_uuid}:
+    put:
+      operationId: regulatory_reporting_api_v1_flaw_upstream_mappings_update
+      description: API endpoint for updating and deleting a single flaw-to-upstream
+        mapping.
+      parameters:
+      - in: path
+        name: mapping_uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Flaw Upstream Mapping.
+        required: true
+      tags:
+      - regulatory-reporting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlawUpstreamMappingRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FlawUpstreamMappingRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FlawUpstreamMappingRequest'
+        required: true
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/FlawUpstreamMapping'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+    delete:
+      operationId: regulatory_reporting_api_v1_flaw_upstream_mappings_destroy
+      description: API endpoint for updating and deleting a single flaw-to-upstream
+        mapping.
+      parameters:
+      - in: path
+        name: mapping_uuid
+        schema:
+          type: string
+          format: uuid
+        description: A UUID string identifying this Flaw Upstream Mapping.
+        required: true
+      tags:
+      - regulatory-reporting
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '204':
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dt:
+                    type: string
+                    format: date-time
+                  env:
+                    type: string
+                  revision:
+                    type: string
+                  version:
+                    type: string
+          description: ''
   /regulatory-reporting/api/v1/flaws/{flaw_id}/srp-reports:
     get:
       operationId: regulatory_reporting_api_v1_flaws_srp_reports_list
@@ -14230,6 +14311,98 @@ paths:
               schema:
                 allOf:
                 - $ref: '#/components/schemas/SRPReport'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+  /regulatory-reporting/api/v1/flaws/{flaw_uuid}/upstream-mappings:
+    get:
+      operationId: regulatory_reporting_api_v1_flaws_upstream_mappings_list
+      description: API endpoint for listing and creating flaw-to-upstream mappings
+      parameters:
+      - in: path
+        name: flaw_uuid
+        schema:
+          type: string
+          pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+        required: true
+      - name: limit
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: offset
+        required: false
+        in: query
+        description: The initial index from which to return the results.
+        schema:
+          type: integer
+      tags:
+      - regulatory-reporting
+      security:
+      - OsidbTokenAuthentication: []
+      - {}
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/PaginatedFlawUpstreamMappingList'
+                - type: object
+                  properties:
+                    dt:
+                      type: string
+                      format: date-time
+                    env:
+                      type: string
+                    revision:
+                      type: string
+                    version:
+                      type: string
+          description: ''
+    post:
+      operationId: regulatory_reporting_api_v1_flaws_upstream_mappings_create
+      description: API endpoint for listing and creating flaw-to-upstream mappings
+      parameters:
+      - in: path
+        name: flaw_uuid
+        schema:
+          type: string
+          pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$
+        required: true
+      tags:
+      - regulatory-reporting
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FlawUpstreamMappingRequest'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/FlawUpstreamMappingRequest'
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FlawUpstreamMappingRequest'
+        required: true
+      security:
+      - OsidbTokenAuthentication: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                allOf:
+                - $ref: '#/components/schemas/FlawUpstreamMapping'
                 - type: object
                   properties:
                     dt:
@@ -17993,6 +18166,55 @@ components:
             format: uuid
       required:
       - flaw_uuids
+    FlawUpstreamMapping:
+      type: object
+      description: TrackingMixin class serializer
+      properties:
+        created_dt:
+          type: string
+          format: date-time
+          readOnly: true
+        updated_dt:
+          type: string
+          format: date-time
+          description: The updated_dt timestamp attribute is mandatory on update as
+            it is used to detect mit-air collisions.
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        flaw_uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        upstream_project:
+          type: string
+          format: uuid
+        notes:
+          type: string
+      required:
+      - created_dt
+      - flaw_uuid
+      - updated_dt
+      - upstream_project
+      - uuid
+    FlawUpstreamMappingRequest:
+      type: object
+      description: TrackingMixin class serializer
+      properties:
+        updated_dt:
+          type: string
+          format: date-time
+          description: The updated_dt timestamp attribute is mandatory on update as
+            it is used to detect mit-air collisions.
+        upstream_project:
+          type: string
+          format: uuid
+        notes:
+          type: string
+      required:
+      - updated_dt
+      - upstream_project
     FlawV1:
       type: object
       description: Serializer for the flaw model adapted to affects v1
@@ -18901,6 +19123,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FlawReportData'
+    PaginatedFlawUpstreamMappingList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=400&limit=100
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?offset=200&limit=100
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/FlawUpstreamMapping'
     PaginatedFlawV1List:
       type: object
       required:

--- a/regulatory_reporting/api_views/__init__.py
+++ b/regulatory_reporting/api_views/__init__.py
@@ -1,6 +1,10 @@
 from .flaw import FlawSRPReportMilestoneViewSet, FlawSRPReportViewSet
 from .srp_milestone import SRPReportMilestoneViewSet
 from .srp_report import SRPReportViewSet
+from .upstream_mappings import (
+    FlawUpstreamMappingDetailView,
+    FlawUpstreamMappingListCreateView,
+)
 from .upstream_notifications import UpstreamNotificationView, UpstreamProjectView
 
 __all__ = [
@@ -10,4 +14,6 @@ __all__ = [
     "SRPReportViewSet",
     "UpstreamNotificationView",
     "UpstreamProjectView",
+    "FlawUpstreamMappingListCreateView",
+    "FlawUpstreamMappingDetailView",
 ]

--- a/regulatory_reporting/api_views/upstream_mappings.py
+++ b/regulatory_reporting/api_views/upstream_mappings.py
@@ -1,0 +1,54 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import mixins, viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+from osidb.api_views import RudimentaryUserPathLoggingMixin, get_valid_http_methods
+from osidb.models import Flaw
+from regulatory_reporting.models.upstream import FlawUpstreamMapping
+from regulatory_reporting.serializers.upstream import FlawUpstreamMappingSerializer
+
+
+class FlawUpstreamMappingListCreateView(
+    RudimentaryUserPathLoggingMixin,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    viewsets.GenericViewSet,
+):
+    """
+    API endpoint for listing and creating flaw-to-upstream mappings
+    """
+
+    http_method_names = get_valid_http_methods(
+        viewsets.GenericViewSet, excluded=["put", "patch", "delete"]
+    )
+    serializer_class = FlawUpstreamMappingSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    def get_flaw(self):
+        return get_object_or_404(Flaw, uuid=self.kwargs["flaw_uuid"])
+
+    def get_queryset(self):
+        return FlawUpstreamMapping.objects.filter(flaw=self.get_flaw())
+
+    def perform_create(self, serializer):
+        serializer.save(flaw=self.get_flaw())
+
+
+class FlawUpstreamMappingDetailView(
+    RudimentaryUserPathLoggingMixin,
+    mixins.UpdateModelMixin,
+    mixins.DestroyModelMixin,
+    viewsets.GenericViewSet,
+):
+    """
+    API endpoint for updating and deleting a single flaw-to-upstream mapping.
+    """
+
+    http_method_names = get_valid_http_methods(
+        viewsets.GenericViewSet, excluded=["get", "post", "patch"]
+    )
+    queryset = FlawUpstreamMapping.objects.all()
+    serializer_class = FlawUpstreamMappingSerializer
+    permission_classes = [IsAuthenticatedOrReadOnly]
+    lookup_url_kwarg = "mapping_uuid"
+    lookup_field = "uuid"

--- a/regulatory_reporting/tests/test_upstream_mappings.py
+++ b/regulatory_reporting/tests/test_upstream_mappings.py
@@ -1,0 +1,101 @@
+import uuid
+
+from regulatory_reporting.models.upstream import FlawUpstreamMapping
+
+from .factories import (
+    FlawUpstreamMappingFactory,
+    UpstreamProjectFactory,
+)
+
+FLAW_UPSTREAM_MAPPINGS_URI = "/regulatory-reporting/api/v1/flaws"
+FLAW_UPSTREAM_MAPPING_DETAIL_URI = "/regulatory-reporting/api/v1/flaw-upstream-mappings"
+
+
+class TestFlawUpstreamMappingListCreateView:
+    def test_list_mappings_for_flaw(self, auth_client):
+        mapping = FlawUpstreamMappingFactory()
+        FlawUpstreamMappingFactory(flaw=mapping.flaw)
+        FlawUpstreamMappingFactory()  # different flaw, should not appear
+
+        response = auth_client().get(
+            f"{FLAW_UPSTREAM_MAPPINGS_URI}/{mapping.flaw.uuid}/upstream-mappings"
+        )
+        assert response.status_code == 200
+        assert response.json()["count"] == 2
+
+    def test_list_mappings_flaw_not_found(self, auth_client):
+        response = auth_client().get(
+            f"{FLAW_UPSTREAM_MAPPINGS_URI}/{uuid.uuid4()}/upstream-mappings"
+        )
+        assert response.status_code == 404
+
+    def test_create_mapping(self, auth_client):
+        flaw = FlawUpstreamMappingFactory().flaw
+        project = UpstreamProjectFactory()
+
+        response = auth_client().post(
+            f"{FLAW_UPSTREAM_MAPPINGS_URI}/{flaw.uuid}/upstream-mappings",
+            data={"upstream_project": str(project.uuid), "notes": "test note"},
+            format="json",
+        )
+        assert response.status_code == 201
+        assert response.json()["flaw_uuid"] == str(flaw.uuid)
+
+    def test_create_mapping_flaw_not_found(self, auth_client):
+        project = UpstreamProjectFactory()
+
+        response = auth_client().post(
+            f"{FLAW_UPSTREAM_MAPPINGS_URI}/{uuid.uuid4()}/upstream-mappings",
+            data={"upstream_project": str(project.uuid), "notes": "test"},
+            format="json",
+        )
+        assert response.status_code == 404
+
+
+class TestFlawUpstreamMappingDetailView:
+    def test_put_mapping_notes(self, auth_client):
+        mapping = FlawUpstreamMappingFactory(notes="original")
+
+        response = auth_client().put(
+            f"{FLAW_UPSTREAM_MAPPING_DETAIL_URI}/{mapping.uuid}",
+            data={
+                "upstream_project": str(mapping.upstream_project.uuid),
+                "notes": "updated",
+                "updated_dt": mapping.updated_dt.isoformat(),
+            },
+            format="json",
+        )
+        assert response.status_code == 200
+        mapping.refresh_from_db()
+        assert mapping.notes == "updated"
+
+    def test_put_mapping_not_found(self, auth_client):
+        response = auth_client().put(
+            f"{FLAW_UPSTREAM_MAPPING_DETAIL_URI}/{uuid.uuid4()}",
+            data={"notes": "updated"},
+            format="json",
+        )
+        assert response.status_code == 404
+
+    def test_delete_mapping(self, auth_client):
+        mapping = FlawUpstreamMappingFactory()
+
+        response = auth_client().delete(
+            f"{FLAW_UPSTREAM_MAPPING_DETAIL_URI}/{mapping.uuid}"
+        )
+        assert response.status_code == 204
+        assert not FlawUpstreamMapping.objects.filter(uuid=mapping.uuid).exists()
+
+    def test_delete_mapping_not_found(self, auth_client):
+        response = auth_client().delete(
+            f"{FLAW_UPSTREAM_MAPPING_DETAIL_URI}/{uuid.uuid4()}"
+        )
+        assert response.status_code == 404
+
+    def test_get_not_allowed_on_detail(self, auth_client):
+        mapping = FlawUpstreamMappingFactory()
+
+        response = auth_client().get(
+            f"{FLAW_UPSTREAM_MAPPING_DETAIL_URI}/{mapping.uuid}"
+        )
+        assert response.status_code == 405

--- a/regulatory_reporting/urls.py
+++ b/regulatory_reporting/urls.py
@@ -9,6 +9,8 @@ from rest_framework.routers import DefaultRouter
 from regulatory_reporting.api_views import (
     FlawSRPReportMilestoneViewSet,
     FlawSRPReportViewSet,
+    FlawUpstreamMappingDetailView,
+    FlawUpstreamMappingListCreateView,
     SRPReportMilestoneViewSet,
     SRPReportViewSet,
     UpstreamNotificationView,
@@ -56,4 +58,17 @@ router.register(
     basename="upstreamprojects",
 )
 
+# Flaw-to-upstream mappings (list/create)
+router.register(
+    rf"flaws/(?P<flaw_uuid>{UUID_PATH_REGEX})/upstream-mappings",
+    FlawUpstreamMappingListCreateView,
+    basename="flawupstreammappings",
+)
+
+# Flaw-to-upstream mappings (update/delete)
+router.register(
+    r"flaw-upstream-mappings",
+    FlawUpstreamMappingDetailView,
+    basename="flawupstreammappingdetail",
+)
 urlpatterns = router.urls


### PR DESCRIPTION
Added flaw-to-upstream mapping endpoints list/create, update/delete.
-Add `upstream_mappings.py` for `FlawUpstreamMappingDetailView` and `FlawUpstreamMappingListCreateView`.
- Export two views in `__init__.py`.
-Register routes in `urls.py`.
-Added tests in `test_upstream_mappings.py`.
-Added entry in `CHANGELOG.md`.
-Regenerated openapi.yml.
Closes:OSIDB-5085