### PR TITLE
set potential-rejection label as additional MANUAL workflow condition

### DIFF
--- a/apps/workflows/tests/test_workflows.py
+++ b/apps/workflows/tests/test_workflows.py
@@ -320,6 +320,90 @@ class TestDefaultWorkflow:
         flaw.save(raise_validation_error=False)
         assert flaw.workflow_state == "PRE_SECONDARY_ASSESSMENT"
 
+
+class TestManualWorkflow:
+    """
+    Test the MANUAL workflow conditions — flaws with manual-triage or
+    potential-rejection labels should be classified under MANUAL.
+    """
+
+    @pytest.mark.enable_signals
+    def test_manual_triage_label_triggers_manual_workflow(self):
+        """
+        A flaw with a manual-triage label should be classified under the
+        MANUAL workflow instead of DEFAULT.
+        """
+        flaw = FlawFactory(
+            embargoed=False,
+            task_key="TASK-MANUAL-1",
+        )
+        assert flaw.workflow_name == "DEFAULT"
+
+        WorkflowLabel.objects.create(flaw=flaw, name="manual-triage")
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "MANUAL"
+        assert flaw.workflow_state == "NEW"
+
+    @pytest.mark.enable_signals
+    def test_potential_rejection_label_triggers_manual_workflow(self):
+        """
+        A flaw with a potential-rejection label (set by ACE) should be
+        classified under the MANUAL workflow for human review.
+        """
+        flaw = FlawFactory(
+            embargoed=False,
+            task_key="TASK-MANUAL-2",
+        )
+        assert flaw.workflow_name == "DEFAULT"
+
+        WorkflowLabel.objects.create(flaw=flaw, name="potential-rejection")
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "MANUAL"
+        assert flaw.workflow_state == "NEW"
+
+    @pytest.mark.enable_signals
+    def test_removing_label_reverts_to_default_workflow(self):
+        """
+        Removing the potential-rejection label should reclassify the flaw
+        back to the DEFAULT workflow.
+        """
+        flaw = FlawFactory(
+            embargoed=False,
+            task_key="TASK-MANUAL-3",
+        )
+        label = WorkflowLabel.objects.create(flaw=flaw, name="potential-rejection")
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "MANUAL"
+
+        label.delete()
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "DEFAULT"
+
+    @pytest.mark.enable_signals
+    def test_either_label_satisfies_manual_condition(self):
+        """
+        The MANUAL workflow condition is an OR — either manual-triage or
+        potential-rejection is sufficient. Having both should also work.
+        """
+        flaw = FlawFactory(
+            embargoed=False,
+            task_key="TASK-MANUAL-4",
+        )
+        label1 = WorkflowLabel.objects.create(flaw=flaw, name="manual-triage")
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "MANUAL"
+
+        WorkflowLabel.objects.create(flaw=flaw, name="potential-rejection")
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "MANUAL"
+
+        # removing one label should keep it MANUAL (the other still satisfies)
+        label1.delete()
+        flaw.refresh_from_db()
+        assert flaw.workflow_name == "MANUAL"
+
+
+class TestNoClassification:
     @pytest.mark.enable_signals
     def test_no_classification_without_task_key(self):
         """

--- a/apps/workflows/workflows/manual.yml
+++ b/apps/workflows/workflows/manual.yml
@@ -5,7 +5,10 @@ description: >
   Applies to flaws that require human triage.
 priority: 1
 conditions:
-  - has label manual-triage
+  - condition: OR
+    requirements:
+      - has label manual-triage
+      - has label potential-rejection
 states:
   - name: NEW
     description: >

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+- set potential-rejection label as additional MANUAL workflow condition
+
 ## [5.13.1] - 2026-08-03
 ### Added
 - add workflow related indexes


### PR DESCRIPTION
as the potential rejection has to be confirmed by a human and human actions should ideally not happen in the automated DEFAULT workflow but rather in for example MANUAL one