### PR TITLE
Improve debuggability of malformed OSV CVSS

### DIFF
--- a/collectors/osv/collectors.py
+++ b/collectors/osv/collectors.py
@@ -380,7 +380,10 @@ class OSVCollector(Collector):
                 try:
                     score = self.CVSS_TO_CVSSLIB[cvss["type"]](vector).base_score
                 except Exception as exc:
-                    logger.error(f"Failed to proces CVSS for {cvss}. Error: {exc}.")
+                    logger.error(
+                        f"Failed to process CVSS ({cvss}) for OSV vulnerability "
+                        f"with id {osv_id}. Error: {exc}."
+                    )
                     # TODO: Recheck invalid CVSS once SyncManager gets implemented
                     continue
                 cvss_data.append(

--- a/collectors/osv/tests/test_collectors.py
+++ b/collectors/osv/tests/test_collectors.py
@@ -181,3 +181,24 @@ class TestOSVCollectorException:
 
         assert Snippet.objects.all().count() == 0
         assert Flaw.objects.all().count() == 0
+
+    def test_malformed_cvss_logs_error_with_osv_id(self, caplog):
+        """
+        Test that a malformed CVSS vector is gracefully skipped and the
+        original parsing error (not a KeyError) is logged with the OSV ID.
+        """
+        osv_vuln = {
+            "id": "GHSA-xxxx-xxxx-xxxx",
+            "aliases": [],
+            "severity": [
+                {"type": "CVSS_V3", "score": "not-a-valid-cvss-vector"},
+            ],
+        }
+
+        osvc = OSVCollector()
+        osv_id, cve_ids, content = osvc.extract_content(osv_vuln)
+
+        assert content["cvss_scores"] == []
+        assert "GHSA-xxxx-xxxx-xxxx" in caplog.text
+        assert "not-a-valid-cvss-vector" in caplog.text
+        assert "KeyError" not in caplog.text


### PR DESCRIPTION
There are quite a few malformed CVSS stemming from OSV records, but because we don't log the source it is impossible to do anything about it.