### PR TITLE
OSIDB-5238: Set RLS turned on for ACL in regulatory reporting

### DIFF
--- a/regulatory_reporting/migrations/0006_enable_rls_regulatory_reporting.py
+++ b/regulatory_reporting/migrations/0006_enable_rls_regulatory_reporting.py
@@ -1,0 +1,147 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("regulatory_reporting", "0005_upstreamproject_purl"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            reverse_sql=migrations.RunSQL.noop,
+            sql="""
+    --enable row based security for srpreport entity table
+    ALTER TABLE regulatory_reporting_srpreport ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreport FORCE ROW LEVEL SECURITY;
+    --following policies define fine grained read/write control on srpreport entity
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreport_create on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_create
+    on regulatory_reporting_srpreport
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreport_select on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_select
+    on regulatory_reporting_srpreport
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+    --policy for entity update
+    DROP policy if exists acl_policy_srpreport_update on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_update
+    on regulatory_reporting_srpreport
+    for update
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity delete
+    DROP policy if exists acl_policy_srpreport_delete on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_delete
+    on regulatory_reporting_srpreport
+    for delete
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for srpreportmilestone entity table
+    ALTER TABLE regulatory_reporting_srpreportmilestone ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportmilestone FORCE ROW LEVEL SECURITY;
+    --following policies define fine grained read/write control on srpreportmilestone entity
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreportmilestone_create on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_create
+    on regulatory_reporting_srpreportmilestone
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreportmilestone_select on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_select
+    on regulatory_reporting_srpreportmilestone
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+    --policy for entity update
+    DROP policy if exists acl_policy_srpreportmilestone_update on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_update
+    on regulatory_reporting_srpreportmilestone
+    for update
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity delete
+    DROP policy if exists acl_policy_srpreportmilestone_delete on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_delete
+    on regulatory_reporting_srpreportmilestone
+    for delete
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for upstreamnotification entity table
+    ALTER TABLE regulatory_reporting_upstreamnotification ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_upstreamnotification FORCE ROW LEVEL SECURITY;
+    --following policies define fine grained read/write control on upstreamnotification entity
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_upstreamnotification_create on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_create
+    on regulatory_reporting_upstreamnotification
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_upstreamnotification_select on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_select
+    on regulatory_reporting_upstreamnotification
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+    --policy for entity update
+    DROP policy if exists acl_policy_upstreamnotification_update on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_update
+    on regulatory_reporting_upstreamnotification
+    for update
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity delete
+    DROP policy if exists acl_policy_upstreamnotification_delete on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_delete
+    on regulatory_reporting_upstreamnotification
+    for delete
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for srpreportaudit entity table (append-only)
+    ALTER TABLE regulatory_reporting_srpreportaudit ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportaudit FORCE ROW LEVEL SECURITY;
+    --following policies define read/insert control on srpreportaudit entity (append-only)
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreportaudit_create on regulatory_reporting_srpreportaudit;
+    create policy acl_policy_srpreportaudit_create
+    on regulatory_reporting_srpreportaudit
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreportaudit_select on regulatory_reporting_srpreportaudit;
+    create policy acl_policy_srpreportaudit_select
+    on regulatory_reporting_srpreportaudit
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for srpreportmilestoneaudit entity table (append-only)
+    ALTER TABLE regulatory_reporting_srpreportmilestoneaudit ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportmilestoneaudit FORCE ROW LEVEL SECURITY;
+    --following policies define read/insert control on srpreportmilestoneaudit entity (append-only)
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreportmilestoneaudit_create on regulatory_reporting_srpreportmilestoneaudit;
+    create policy acl_policy_srpreportmilestoneaudit_create
+    on regulatory_reporting_srpreportmilestoneaudit
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreportmilestoneaudit_select on regulatory_reporting_srpreportmilestoneaudit;
+    create policy acl_policy_srpreportmilestoneaudit_select
+    on regulatory_reporting_srpreportmilestoneaudit
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+            """,
+        ),
+    ]

--- a/regulatory_reporting/tests/conftest.py
+++ b/regulatory_reporting/tests/conftest.py
@@ -1,6 +1,8 @@
 from typing import Callable, Optional
 
 import pytest
+from django.conf import settings
+from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
@@ -82,8 +84,12 @@ def api_client():
 
 @pytest.fixture
 def authenticated_client(api_client, django_user_model):
-    """Authenticated API client."""
+    """Authenticated API client with public ACL groups."""
     user = django_user_model.objects.create_user(username="testuser")
+    for group_name in [*settings.PUBLIC_READ_GROUPS, settings.PUBLIC_WRITE_GROUP]:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    api_client.force_login(user)
     api_client.force_authenticate(user=user)
     return api_client
 

--- a/regulatory_reporting/tests/test_models.py
+++ b/regulatory_reporting/tests/test_models.py
@@ -216,6 +216,8 @@ class TestUpstreamNotification(TestCase):
         notification = UpstreamNotification.objects.create(
             flaw=flaw,
             upstream_project=project,
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
         )
         assert notification.uuid is not None
         assert notification.status == UpstreamNotification.NotificationStatus.REQUIRED

--- a/regulatory_reporting/tests/test_rls.py
+++ b/regulatory_reporting/tests/test_rls.py
@@ -1,0 +1,273 @@
+import pytest
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import connections, transaction
+from django.db.utils import ProgrammingError
+
+from osidb.core import set_user_acls
+from regulatory_reporting.models import (
+    SRPReport,
+    SRPReportMilestone,
+    UpstreamNotification,
+)
+from regulatory_reporting.tests.factories import (
+    SRPReportFactory,
+    SRPReportMilestoneFactory,
+    UpstreamNotificationFactory,
+)
+
+pytestmark = pytest.mark.enable_rls
+
+
+class TestSRPReportRLS:
+    @pytest.fixture(autouse=True)
+    def reset_acl(self):
+        for db_alias in connections:
+            with connections[db_alias].cursor() as cursor:
+                cursor.execute("RESET osidb.acl")
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_create(self, embargoed, acls):
+        with transaction.atomic():
+            with pytest.raises(
+                ProgrammingError, match="violates row-level security policy"
+            ):
+                SRPReportFactory(flaw__embargoed=embargoed)
+        set_user_acls(acls)
+        assert SRPReportFactory(flaw__embargoed=embargoed)
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_read(self, embargoed, acls):
+        assert SRPReport.objects.count() == 0
+        set_user_acls(acls)
+        report = SRPReportFactory(flaw__embargoed=embargoed)
+        assert report
+
+        set_user_acls(acls[:1])
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.first().pk == report.pk
+
+    def test_read_multiple(self):
+        assert SRPReport.objects.count() == 0
+        set_user_acls(settings.ALL_GROUPS)
+        public_pk = SRPReportFactory(flaw__embargoed=False).pk
+        embargo_pk = SRPReportFactory(flaw__embargoed=True).pk
+        assert SRPReport.objects.count() == 2
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.first().pk == public_pk
+
+        set_user_acls([settings.EMBARGO_READ_GROUP])
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.first().pk == embargo_pk
+
+    def test_update(self):
+        set_user_acls(settings.ALL_GROUPS)
+        r1 = SRPReportFactory(flaw__embargoed=False)
+        r2 = SRPReportFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        r1.title = "updated"
+        r1.save(raise_validation_error=False)
+        assert r1.title == "updated"
+        r2.title = "should fail"
+
+        with transaction.atomic():
+            with pytest.raises((SRPReport.DoesNotExist, ValidationError)):
+                r2.save(raise_validation_error=False)
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        r2 = SRPReport.objects.first()
+        r2.title = "updated"
+        r2.save(raise_validation_error=False)
+        assert r2.title == "updated"
+
+    def test_delete(self):
+        set_user_acls(settings.ALL_GROUPS)
+        r1 = SRPReportFactory(flaw__embargoed=False)
+        r2 = SRPReportFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        assert SRPReport.objects.count() == 1
+        assert r1.delete()
+        assert SRPReport.objects.count() == 0
+
+        with transaction.atomic():
+            with pytest.raises(SRPReport.DoesNotExist):
+                SRPReport.objects.get(pk=r2.pk).delete()
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.get(pk=r2.pk).delete()
+        assert SRPReport.objects.count() == 0
+
+
+class TestSRPReportMilestoneRLS:
+    @pytest.fixture(autouse=True)
+    def reset_acl(self):
+        for db_alias in connections:
+            with connections[db_alias].cursor() as cursor:
+                cursor.execute("RESET osidb.acl")
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_create(self, embargoed, acls):
+        with transaction.atomic():
+            with pytest.raises(
+                ProgrammingError, match="violates row-level security policy"
+            ):
+                SRPReportMilestoneFactory(
+                    srp_report__flaw__embargoed=embargoed,
+                )
+        set_user_acls(acls)
+        assert SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=embargoed,
+        )
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_read(self, embargoed, acls):
+        assert SRPReportMilestone.objects.count() == 0
+        set_user_acls(acls)
+        milestone = SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=embargoed,
+        )
+        assert milestone
+
+        set_user_acls(acls[:1])
+        assert SRPReportMilestone.objects.count() == 1
+
+    def test_read_multiple(self):
+        assert SRPReportMilestone.objects.count() == 0
+        set_user_acls(settings.ALL_GROUPS)
+        public_pk = SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=False,
+        ).pk
+        embargo_pk = SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=True,
+        ).pk
+        assert SRPReportMilestone.objects.count() == 2
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        assert SRPReportMilestone.objects.count() == 1
+        assert SRPReportMilestone.objects.first().pk == public_pk
+
+        set_user_acls([settings.EMBARGO_READ_GROUP])
+        assert SRPReportMilestone.objects.count() == 1
+        assert SRPReportMilestone.objects.first().pk == embargo_pk
+
+    def test_delete(self):
+        set_user_acls(settings.ALL_GROUPS)
+        m1 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=False)
+        m2 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        assert SRPReportMilestone.objects.count() == 1
+        assert m1.delete()
+        assert SRPReportMilestone.objects.count() == 0
+
+        with transaction.atomic():
+            with pytest.raises(SRPReportMilestone.DoesNotExist):
+                SRPReportMilestone.objects.get(pk=m2.pk).delete()
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        assert SRPReportMilestone.objects.count() == 1
+        assert SRPReportMilestone.objects.get(pk=m2.pk).delete()
+        assert SRPReportMilestone.objects.count() == 0
+
+
+class TestUpstreamNotificationRLS:
+    @pytest.fixture(autouse=True)
+    def reset_acl(self):
+        for db_alias in connections:
+            with connections[db_alias].cursor() as cursor:
+                cursor.execute("RESET osidb.acl")
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_create(self, embargoed, acls):
+        with transaction.atomic():
+            with pytest.raises(
+                ProgrammingError, match="violates row-level security policy"
+            ):
+                UpstreamNotificationFactory(flaw__embargoed=embargoed)
+        set_user_acls(acls)
+        assert UpstreamNotificationFactory(flaw__embargoed=embargoed)
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_read(self, embargoed, acls):
+        assert UpstreamNotification.objects.count() == 0
+        set_user_acls(acls)
+        notification = UpstreamNotificationFactory(flaw__embargoed=embargoed)
+        assert notification
+
+        set_user_acls(acls[:1])
+        assert UpstreamNotification.objects.count() == 1
+
+    def test_read_multiple(self):
+        assert UpstreamNotification.objects.count() == 0
+        set_user_acls(settings.ALL_GROUPS)
+        public_pk = UpstreamNotificationFactory(flaw__embargoed=False).pk
+        embargo_pk = UpstreamNotificationFactory(flaw__embargoed=True).pk
+        assert UpstreamNotification.objects.count() == 2
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        assert UpstreamNotification.objects.count() == 1
+        assert UpstreamNotification.objects.first().pk == public_pk
+
+        set_user_acls([settings.EMBARGO_READ_GROUP])
+        assert UpstreamNotification.objects.count() == 1
+        assert UpstreamNotification.objects.first().pk == embargo_pk
+
+    def test_delete(self):
+        set_user_acls(settings.ALL_GROUPS)
+        n1 = UpstreamNotificationFactory(flaw__embargoed=False)
+        n2 = UpstreamNotificationFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        assert UpstreamNotification.objects.count() == 1
+        assert n1.delete()
+        assert UpstreamNotification.objects.count() == 0
+
+        with transaction.atomic():
+            with pytest.raises(UpstreamNotification.DoesNotExist):
+                UpstreamNotification.objects.get(pk=n2.pk).delete()
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        assert UpstreamNotification.objects.count() == 1
+        assert UpstreamNotification.objects.get(pk=n2.pk).delete()
+        assert UpstreamNotification.objects.count() == 0

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,8 @@ commands =
         pytest --record-mode=rewrite {posargs}
 
 [testenv:rls]
-commands = 
-        pytest osidb/tests/test_rls.py
+commands =
+        pytest osidb/tests/test_rls.py regulatory_reporting/tests/test_rls.py
 
 [testenv:ci-osidb]
 setenv =


### PR DESCRIPTION
## Summary

Enable PostgreSQL Row-Level Security (RLS) on all ACL-bearing `regulatory_reporting` tables, ensuring rows are filtered by user ACL groups — consistent with how RLS is enforced on `osidb` tables (e.g. Flaw).

### Tables and policies

| Table | Policies |
|---|---|
| `regulatory_reporting_srpreport` | SELECT / INSERT / UPDATE / DELETE |
| `regulatory_reporting_srpreportmilestone` | SELECT / INSERT / UPDATE / DELETE |
| `regulatory_reporting_upstreamnotification` | SELECT / INSERT / UPDATE / DELETE |
| `regulatory_reporting_srpreportaudit` | SELECT / INSERT (append-only) |
| `regulatory_reporting_srpreportmilestoneaudit` | SELECT / INSERT (append-only) |

### Changes

- **New migration** (`0006_enable_rls_regulatory_reporting.py`): enables `ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` and creates ACL policies on all 5 tables, following the exact SQL pattern from `osidb/migrations/0145_audit_history.py`.
- **New RLS tests** (`test_rls.py`): 19 tests across `TestSRPReportRLS`, `TestSRPReportMilestoneRLS`, and `TestUpstreamNotificationRLS` covering create/read/read_multiple/update/delete with public and embargoed ACLs.
- **Fixed `authenticated_client` fixture** (`conftest.py`): added public ACL groups to the test user and added `force_login()` so that Django's `AuthenticationMiddleware` recognises the user before `PgCommon` middleware sets `osidb.acl`. Without `force_login`, `force_authenticate` only works at the DRF level, leaving `PgCommon` to set read-only ACLs — which causes UPDATE/INSERT RLS violations.
- **Fixed `test_create_upstream_notification`** (`test_models.py`): passed `acl_read`/`acl_write` from the parent flaw so the row satisfies RLS policies.
- **Updated `tox.ini`**: added `regulatory_reporting/tests/test_rls.py` to the `[testenv:rls]` target.

## Test plan

- [x] All 206 `regulatory_reporting/tests/` pass (including 19 new RLS tests)
- [x] RLS tests verify that rows with mismatched ACLs are invisible / blocked for create, read, update, and delete
- [x] Audit tables enforce append-only (SELECT + INSERT only)
- [ ] Run `make testrunner.rls` to confirm both `osidb` and `regulatory_reporting` RLS suites pass together

