### PR TITLE
 OSIDB-5238: Set RLS turned on for ACL in regulatory reporting

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Upstream Project Contact Endpoints (OSIDB-5084)
 - Add Flaw-to-Upstream Mapping Endpoints (OSIDB-5085)
 - Add Upstream Maintainer Send Email Action (OSIDB-5088)
+- Add RLS turned on for ACL in regulatory_reporting (OSIDB-5238)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/openapi.yml
+++ b/openapi.yml
@@ -20497,6 +20497,7 @@ components:
       properties:
         embargoed:
           type: boolean
+          readOnly: true
           description: The embargoed boolean attribute is technically read-only as
             it just indirectly modifies the ACLs but is mandatory as it controls the
             access to the resource.
@@ -20571,11 +20572,6 @@ components:
         ACLMixin class serializer
         translates embargoed boolean to ACLs
       properties:
-        embargoed:
-          type: boolean
-          description: The embargoed boolean attribute is technically read-only as
-            it just indirectly modifies the ACLs but is mandatory as it controls the
-            access to the resource.
         updated_dt:
           type: string
           format: date-time
@@ -20602,7 +20598,6 @@ components:
           - 'null'
           format: date-time
       required:
-      - embargoed
       - updated_dt
     UpstreamNotificationStatusEnum:
       enum:

--- a/regulatory_reporting/migrations/0006_enable_rls_regulatory_reporting.py
+++ b/regulatory_reporting/migrations/0006_enable_rls_regulatory_reporting.py
@@ -1,0 +1,147 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("regulatory_reporting", "0005_upstreamproject_purl"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            reverse_sql=migrations.RunSQL.noop,
+            sql="""
+    --enable row based security for srpreport entity table
+    ALTER TABLE regulatory_reporting_srpreport ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreport FORCE ROW LEVEL SECURITY;
+    --following policies define fine grained read/write control on srpreport entity
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreport_create on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_create
+    on regulatory_reporting_srpreport
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreport_select on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_select
+    on regulatory_reporting_srpreport
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+    --policy for entity update
+    DROP policy if exists acl_policy_srpreport_update on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_update
+    on regulatory_reporting_srpreport
+    for update
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity delete
+    DROP policy if exists acl_policy_srpreport_delete on regulatory_reporting_srpreport;
+    create policy acl_policy_srpreport_delete
+    on regulatory_reporting_srpreport
+    for delete
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for srpreportmilestone entity table
+    ALTER TABLE regulatory_reporting_srpreportmilestone ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportmilestone FORCE ROW LEVEL SECURITY;
+    --following policies define fine grained read/write control on srpreportmilestone entity
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreportmilestone_create on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_create
+    on regulatory_reporting_srpreportmilestone
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreportmilestone_select on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_select
+    on regulatory_reporting_srpreportmilestone
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+    --policy for entity update
+    DROP policy if exists acl_policy_srpreportmilestone_update on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_update
+    on regulatory_reporting_srpreportmilestone
+    for update
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity delete
+    DROP policy if exists acl_policy_srpreportmilestone_delete on regulatory_reporting_srpreportmilestone;
+    create policy acl_policy_srpreportmilestone_delete
+    on regulatory_reporting_srpreportmilestone
+    for delete
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for upstreamnotification entity table
+    ALTER TABLE regulatory_reporting_upstreamnotification ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_upstreamnotification FORCE ROW LEVEL SECURITY;
+    --following policies define fine grained read/write control on upstreamnotification entity
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_upstreamnotification_create on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_create
+    on regulatory_reporting_upstreamnotification
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_upstreamnotification_select on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_select
+    on regulatory_reporting_upstreamnotification
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+    --policy for entity update
+    DROP policy if exists acl_policy_upstreamnotification_update on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_update
+    on regulatory_reporting_upstreamnotification
+    for update
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[])
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity delete
+    DROP policy if exists acl_policy_upstreamnotification_delete on regulatory_reporting_upstreamnotification;
+    create policy acl_policy_upstreamnotification_delete
+    on regulatory_reporting_upstreamnotification
+    for delete
+    USING (acl_write::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for srpreportaudit entity table (append-only)
+    ALTER TABLE regulatory_reporting_srpreportaudit ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportaudit FORCE ROW LEVEL SECURITY;
+    --following policies define read/insert control on srpreportaudit entity (append-only)
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreportaudit_create on regulatory_reporting_srpreportaudit;
+    create policy acl_policy_srpreportaudit_create
+    on regulatory_reporting_srpreportaudit
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreportaudit_select on regulatory_reporting_srpreportaudit;
+    create policy acl_policy_srpreportaudit_select
+    on regulatory_reporting_srpreportaudit
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+
+    --enable row based security for srpreportmilestoneaudit entity table (append-only)
+    ALTER TABLE regulatory_reporting_srpreportmilestoneaudit ENABLE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportmilestoneaudit FORCE ROW LEVEL SECURITY;
+    --following policies define read/insert control on srpreportmilestoneaudit entity (append-only)
+    --policy for entity insert (eg. create)
+    DROP policy if exists acl_policy_srpreportmilestoneaudit_create on regulatory_reporting_srpreportmilestoneaudit;
+    create policy acl_policy_srpreportmilestoneaudit_create
+    on regulatory_reporting_srpreportmilestoneaudit
+    for INSERT
+    WITH CHECK (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]
+         AND   acl_write::uuid[] && string_to_array(current_setting('osidb.acl'), ',')::uuid[]);
+    --policy for entity select
+    DROP policy if exists acl_policy_srpreportmilestoneaudit_select on regulatory_reporting_srpreportmilestoneaudit;
+    create policy acl_policy_srpreportmilestoneaudit_select
+    on regulatory_reporting_srpreportmilestoneaudit
+    for select
+    USING (acl_read::uuid[] && string_to_array(current_setting('osidb.acl'),',')::uuid[]);
+            """,
+        ),
+    ]

--- a/regulatory_reporting/migrations/0007_enable_rls_regulatory_reporting.py
+++ b/regulatory_reporting/migrations/0007_enable_rls_regulatory_reporting.py
@@ -12,7 +12,43 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunSQL(
-            reverse_sql=migrations.RunSQL.noop,
+            reverse_sql="""
+    --drop policies and disable row based security for srpreport entity table
+    DROP policy if exists acl_policy_srpreport_create on regulatory_reporting_srpreport;
+    DROP policy if exists acl_policy_srpreport_select on regulatory_reporting_srpreport;
+    DROP policy if exists acl_policy_srpreport_update on regulatory_reporting_srpreport;
+    DROP policy if exists acl_policy_srpreport_delete on regulatory_reporting_srpreport;
+    ALTER TABLE regulatory_reporting_srpreport NO FORCE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreport DISABLE ROW LEVEL SECURITY;
+
+    --drop policies and disable row based security for srpreportmilestone entity table
+    DROP policy if exists acl_policy_srpreportmilestone_create on regulatory_reporting_srpreportmilestone;
+    DROP policy if exists acl_policy_srpreportmilestone_select on regulatory_reporting_srpreportmilestone;
+    DROP policy if exists acl_policy_srpreportmilestone_update on regulatory_reporting_srpreportmilestone;
+    DROP policy if exists acl_policy_srpreportmilestone_delete on regulatory_reporting_srpreportmilestone;
+    ALTER TABLE regulatory_reporting_srpreportmilestone NO FORCE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportmilestone DISABLE ROW LEVEL SECURITY;
+
+    --drop policies and disable row based security for upstreamnotification entity table
+    DROP policy if exists acl_policy_upstreamnotification_create on regulatory_reporting_upstreamnotification;
+    DROP policy if exists acl_policy_upstreamnotification_select on regulatory_reporting_upstreamnotification;
+    DROP policy if exists acl_policy_upstreamnotification_update on regulatory_reporting_upstreamnotification;
+    DROP policy if exists acl_policy_upstreamnotification_delete on regulatory_reporting_upstreamnotification;
+    ALTER TABLE regulatory_reporting_upstreamnotification NO FORCE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_upstreamnotification DISABLE ROW LEVEL SECURITY;
+
+    --drop policies and disable row based security for srpreportaudit entity table (append-only)
+    DROP policy if exists acl_policy_srpreportaudit_create on regulatory_reporting_srpreportaudit;
+    DROP policy if exists acl_policy_srpreportaudit_select on regulatory_reporting_srpreportaudit;
+    ALTER TABLE regulatory_reporting_srpreportaudit NO FORCE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportaudit DISABLE ROW LEVEL SECURITY;
+
+    --drop policies and disable row based security for srpreportmilestoneaudit entity table (append-only)
+    DROP policy if exists acl_policy_srpreportmilestoneaudit_create on regulatory_reporting_srpreportmilestoneaudit;
+    DROP policy if exists acl_policy_srpreportmilestoneaudit_select on regulatory_reporting_srpreportmilestoneaudit;
+    ALTER TABLE regulatory_reporting_srpreportmilestoneaudit NO FORCE ROW LEVEL SECURITY;
+    ALTER TABLE regulatory_reporting_srpreportmilestoneaudit DISABLE ROW LEVEL SECURITY;
+            """,
             sql="""
     --enable row based security for srpreport entity table
     ALTER TABLE regulatory_reporting_srpreport ENABLE ROW LEVEL SECURITY;

--- a/regulatory_reporting/migrations/0007_enable_rls_regulatory_reporting.py
+++ b/regulatory_reporting/migrations/0007_enable_rls_regulatory_reporting.py
@@ -4,7 +4,10 @@ from django.db import migrations
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("regulatory_reporting", "0005_upstreamproject_purl"),
+        (
+            "regulatory_reporting",
+            "0006_remove_upstreamnotification_insert_insert_and_more",
+        ),
     ]
 
     operations = [

--- a/regulatory_reporting/serializers/upstream.py
+++ b/regulatory_reporting/serializers/upstream.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 
 from osidb.serializer import (
     ACLMixinSerializer,
+    EmbargoedField,
     IncludeExcludeFieldsMixin,
     TrackingMixinSerializer,
 )
@@ -65,6 +66,20 @@ class UpstreamNotificationSerializer(
     uuid = serializers.UUIDField(read_only=True)
     flaw_uuid = serializers.UUIDField(read_only=True, source="flaw.uuid")
     last_error = serializers.CharField(read_only=True)
+    # ACLs are inherited from the parent flaw (see signals.py); not mutable via
+    # this API. Must be declared read_only: Meta.read_only_fields does not
+    # apply to fields declared on ACLMixinSerializer. update() also skips
+    # ACLMixinSerializer.update() so an omitted/spoofed embargoed value cannot
+    # desynchronize this notification's ACLs from its parent flaw's.
+    embargoed = EmbargoedField(
+        source="*",
+        read_only=True,
+        help_text=(
+            "The embargoed boolean attribute is technically read-only as it just "
+            "indirectly modifies the ACLs but is mandatory as it controls the access "
+            "to the resource."
+        ),
+    )
 
     class Meta(ACLMixinSerializer.Meta, TrackingMixinSerializer.Meta):
         model = UpstreamNotification
@@ -81,6 +96,21 @@ class UpstreamNotificationSerializer(
                 "timer_started_at",
                 "last_error",
             ]
+        )
+
+    def update(self, instance, validated_data, *args, **kwargs):
+        """
+        Preserve ACLs on update.
+
+        ACLMixinSerializer.update() reads request.data.get("embargoed") and
+        rewrites ACLs; omitting embargoed resolves as public. Notification
+        ACLs are inherited from the parent flaw and are not mutable via this
+        API.
+        """
+        validated_data["acl_read"] = instance.acl_read
+        validated_data["acl_write"] = instance.acl_write
+        return super(ACLMixinSerializer, self).update(
+            instance, validated_data, *args, **kwargs
         )
 
 

--- a/regulatory_reporting/tests/conftest.py
+++ b/regulatory_reporting/tests/conftest.py
@@ -1,6 +1,8 @@
 from typing import Callable, Optional
 
 import pytest
+from django.conf import settings
+from django.contrib.auth.models import Group
 from django.utils import timezone
 from rest_framework.test import APIClient
 
@@ -82,8 +84,12 @@ def api_client():
 
 @pytest.fixture
 def authenticated_client(api_client, django_user_model):
-    """Authenticated API client."""
+    """Authenticated API client with public ACL groups."""
     user = django_user_model.objects.create_user(username="testuser")
+    for group_name in [*settings.PUBLIC_READ_GROUPS, settings.PUBLIC_WRITE_GROUP]:
+        group, _ = Group.objects.get_or_create(name=group_name)
+        user.groups.add(group)
+    api_client.force_login(user)
     api_client.force_authenticate(user=user)
     return api_client
 

--- a/regulatory_reporting/tests/test_models.py
+++ b/regulatory_reporting/tests/test_models.py
@@ -216,6 +216,8 @@ class TestUpstreamNotification(TestCase):
         notification = UpstreamNotification.objects.create(
             flaw=flaw,
             upstream_project=project,
+            acl_read=flaw.acl_read,
+            acl_write=flaw.acl_write,
         )
         assert notification.uuid is not None
         assert notification.status == UpstreamNotification.NotificationStatus.REQUIRED

--- a/regulatory_reporting/tests/test_rls.py
+++ b/regulatory_reporting/tests/test_rls.py
@@ -1,0 +1,262 @@
+import pytest
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import connections, transaction
+from django.db.utils import ProgrammingError
+
+from osidb.core import set_user_acls
+from regulatory_reporting.models import (
+    SRPReport,
+    SRPReportMilestone,
+    UpstreamNotification,
+)
+from regulatory_reporting.tests.factories import (
+    SRPReportFactory,
+    SRPReportMilestoneFactory,
+    UpstreamNotificationFactory,
+)
+
+pytestmark = pytest.mark.enable_rls
+
+
+@pytest.fixture(autouse=True)
+def reset_acl():
+    for db_alias in connections:
+        with connections[db_alias].cursor() as cursor:
+            cursor.execute("RESET osidb.acl")
+
+
+class TestSRPReportRLS:
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_create(self, embargoed, acls):
+        with transaction.atomic():
+            with pytest.raises(
+                ProgrammingError, match="violates row-level security policy"
+            ):
+                SRPReportFactory(flaw__embargoed=embargoed)
+        set_user_acls(acls)
+        assert SRPReportFactory(flaw__embargoed=embargoed)
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_read(self, embargoed, acls):
+        assert SRPReport.objects.count() == 0
+        set_user_acls(acls)
+        report = SRPReportFactory(flaw__embargoed=embargoed)
+        assert report
+
+        set_user_acls(acls[:1])
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.first().pk == report.pk
+
+    def test_read_multiple(self):
+        assert SRPReport.objects.count() == 0
+        set_user_acls(settings.ALL_GROUPS)
+        public_pk = SRPReportFactory(flaw__embargoed=False).pk
+        embargo_pk = SRPReportFactory(flaw__embargoed=True).pk
+        assert SRPReport.objects.count() == 2
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.first().pk == public_pk
+
+        set_user_acls([settings.EMBARGO_READ_GROUP])
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.first().pk == embargo_pk
+
+    def test_update(self):
+        set_user_acls(settings.ALL_GROUPS)
+        r1 = SRPReportFactory(flaw__embargoed=False)
+        r2 = SRPReportFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        r1.title = "updated"
+        r1.save(raise_validation_error=False)
+        assert r1.title == "updated"
+        r2.title = "should fail"
+
+        with transaction.atomic():
+            with pytest.raises((SRPReport.DoesNotExist, ValidationError)):
+                r2.save(raise_validation_error=False)
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        r2 = SRPReport.objects.first()
+        r2.title = "updated"
+        r2.save(raise_validation_error=False)
+        assert r2.title == "updated"
+
+    def test_delete(self):
+        set_user_acls(settings.ALL_GROUPS)
+        r1 = SRPReportFactory(flaw__embargoed=False)
+        r2 = SRPReportFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        assert SRPReport.objects.count() == 1
+        assert r1.delete()
+        assert SRPReport.objects.count() == 0
+
+        with transaction.atomic():
+            with pytest.raises(SRPReport.DoesNotExist):
+                SRPReport.objects.get(pk=r2.pk).delete()
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        assert SRPReport.objects.count() == 1
+        assert SRPReport.objects.get(pk=r2.pk).delete()
+        assert SRPReport.objects.count() == 0
+
+
+class TestSRPReportMilestoneRLS:
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_create(self, embargoed, acls):
+        with transaction.atomic():
+            with pytest.raises(
+                ProgrammingError, match="violates row-level security policy"
+            ):
+                SRPReportMilestoneFactory(
+                    srp_report__flaw__embargoed=embargoed,
+                )
+        set_user_acls(acls)
+        assert SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=embargoed,
+        )
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_read(self, embargoed, acls):
+        assert SRPReportMilestone.objects.count() == 0
+        set_user_acls(acls)
+        milestone = SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=embargoed,
+        )
+        assert milestone
+
+        set_user_acls(acls[:1])
+        assert SRPReportMilestone.objects.count() == 1
+
+    def test_read_multiple(self):
+        assert SRPReportMilestone.objects.count() == 0
+        set_user_acls(settings.ALL_GROUPS)
+        public_pk = SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=False,
+        ).pk
+        embargo_pk = SRPReportMilestoneFactory(
+            srp_report__flaw__embargoed=True,
+        ).pk
+        assert SRPReportMilestone.objects.count() == 2
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        assert SRPReportMilestone.objects.count() == 1
+        assert SRPReportMilestone.objects.first().pk == public_pk
+
+        set_user_acls([settings.EMBARGO_READ_GROUP])
+        assert SRPReportMilestone.objects.count() == 1
+        assert SRPReportMilestone.objects.first().pk == embargo_pk
+
+    def test_delete(self):
+        set_user_acls(settings.ALL_GROUPS)
+        m1 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=False)
+        m2 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        assert SRPReportMilestone.objects.count() == 1
+        assert m1.delete()
+        assert SRPReportMilestone.objects.count() == 0
+
+        with transaction.atomic():
+            with pytest.raises(SRPReportMilestone.DoesNotExist):
+                SRPReportMilestone.objects.get(pk=m2.pk).delete()
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        assert SRPReportMilestone.objects.count() == 1
+        assert SRPReportMilestone.objects.get(pk=m2.pk).delete()
+        assert SRPReportMilestone.objects.count() == 0
+
+
+class TestUpstreamNotificationRLS:
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_create(self, embargoed, acls):
+        with transaction.atomic():
+            with pytest.raises(
+                ProgrammingError, match="violates row-level security policy"
+            ):
+                UpstreamNotificationFactory(flaw__embargoed=embargoed)
+        set_user_acls(acls)
+        assert UpstreamNotificationFactory(flaw__embargoed=embargoed)
+
+    @pytest.mark.parametrize(
+        "embargoed,acls",
+        [
+            (False, settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP]),
+            (True, [settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP]),
+        ],
+    )
+    def test_read(self, embargoed, acls):
+        assert UpstreamNotification.objects.count() == 0
+        set_user_acls(acls)
+        notification = UpstreamNotificationFactory(flaw__embargoed=embargoed)
+        assert notification
+
+        set_user_acls(acls[:1])
+        assert UpstreamNotification.objects.count() == 1
+
+    def test_read_multiple(self):
+        assert UpstreamNotification.objects.count() == 0
+        set_user_acls(settings.ALL_GROUPS)
+        public_pk = UpstreamNotificationFactory(flaw__embargoed=False).pk
+        embargo_pk = UpstreamNotificationFactory(flaw__embargoed=True).pk
+        assert UpstreamNotification.objects.count() == 2
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        assert UpstreamNotification.objects.count() == 1
+        assert UpstreamNotification.objects.first().pk == public_pk
+
+        set_user_acls([settings.EMBARGO_READ_GROUP])
+        assert UpstreamNotification.objects.count() == 1
+        assert UpstreamNotification.objects.first().pk == embargo_pk
+
+    def test_delete(self):
+        set_user_acls(settings.ALL_GROUPS)
+        n1 = UpstreamNotificationFactory(flaw__embargoed=False)
+        n2 = UpstreamNotificationFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        assert UpstreamNotification.objects.count() == 1
+        assert n1.delete()
+        assert UpstreamNotification.objects.count() == 0
+
+        with transaction.atomic():
+            with pytest.raises(UpstreamNotification.DoesNotExist):
+                UpstreamNotification.objects.get(pk=n2.pk).delete()
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        assert UpstreamNotification.objects.count() == 1
+        assert UpstreamNotification.objects.get(pk=n2.pk).delete()
+        assert UpstreamNotification.objects.count() == 0

--- a/regulatory_reporting/tests/test_rls.py
+++ b/regulatory_reporting/tests/test_rls.py
@@ -1,6 +1,5 @@
 import pytest
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db import connections, transaction
 from django.db.utils import ProgrammingError
 
@@ -84,14 +83,12 @@ class TestSRPReportRLS:
         r1.title = "updated"
         r1.save(raise_validation_error=False)
         assert r1.title == "updated"
-        r2.title = "should fail"
 
-        with transaction.atomic():
-            with pytest.raises((SRPReport.DoesNotExist, ValidationError)):
-                r2.save(raise_validation_error=False)
+        assert SRPReport.objects.filter(pk=r2.pk).update(title="should fail") == 0
 
         set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
-        r2 = SRPReport.objects.first()
+        r2 = SRPReport.objects.get(pk=r2.pk)
+        assert r2.title != "should fail"
         r2.title = "updated"
         r2.save(raise_validation_error=False)
         assert r2.title == "updated"

--- a/regulatory_reporting/tests/test_rls.py
+++ b/regulatory_reporting/tests/test_rls.py
@@ -1,4 +1,5 @@
 import pytest
+from django.apps import apps
 from django.conf import settings
 from django.db import connections, transaction
 from django.db.utils import ProgrammingError
@@ -171,6 +172,30 @@ class TestSRPReportMilestoneRLS:
         assert SRPReportMilestone.objects.count() == 1
         assert SRPReportMilestone.objects.first().pk == embargo_pk
 
+    def test_update(self):
+        set_user_acls(settings.ALL_GROUPS)
+        m1 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=False)
+        m2 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        m1.request_source = "updated"
+        m1.save(raise_validation_error=False)
+        assert m1.request_source == "updated"
+
+        assert (
+            SRPReportMilestone.objects.filter(pk=m2.pk).update(
+                request_source="should fail"
+            )
+            == 0
+        )
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        m2 = SRPReportMilestone.objects.get(pk=m2.pk)
+        assert m2.request_source != "should fail"
+        m2.request_source = "updated"
+        m2.save(raise_validation_error=False)
+        assert m2.request_source == "updated"
+
     def test_delete(self):
         set_user_acls(settings.ALL_GROUPS)
         m1 = SRPReportMilestoneFactory(srp_report__flaw__embargoed=False)
@@ -239,6 +264,30 @@ class TestUpstreamNotificationRLS:
         assert UpstreamNotification.objects.count() == 1
         assert UpstreamNotification.objects.first().pk == embargo_pk
 
+    def test_update(self):
+        set_user_acls(settings.ALL_GROUPS)
+        n1 = UpstreamNotificationFactory(flaw__embargoed=False)
+        n2 = UpstreamNotificationFactory(flaw__embargoed=True)
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + [settings.PUBLIC_WRITE_GROUP])
+        n1.last_error = "updated"
+        n1.save()
+        assert n1.last_error == "updated"
+
+        assert (
+            UpstreamNotification.objects.filter(pk=n2.pk).update(
+                last_error="should fail"
+            )
+            == 0
+        )
+
+        set_user_acls([settings.EMBARGO_READ_GROUP, settings.EMBARGO_WRITE_GROUP])
+        n2 = UpstreamNotification.objects.get(pk=n2.pk)
+        assert n2.last_error != "should fail"
+        n2.last_error = "updated"
+        n2.save()
+        assert n2.last_error == "updated"
+
     def test_delete(self):
         set_user_acls(settings.ALL_GROUPS)
         n1 = UpstreamNotificationFactory(flaw__embargoed=False)
@@ -257,3 +306,59 @@ class TestUpstreamNotificationRLS:
         assert UpstreamNotification.objects.count() == 1
         assert UpstreamNotification.objects.get(pk=n2.pk).delete()
         assert UpstreamNotification.objects.count() == 0
+
+
+class TestAuditTablesRLS:
+    """
+    The pghistory-generated audit tables (regulatory_reporting_srpreportaudit,
+    regulatory_reporting_srpreportmilestoneaudit) only have SELECT and INSERT
+    RLS policies (see migration 0007). With no UPDATE/DELETE policy defined,
+    Postgres RLS denies those operations unconditionally - even for a session
+    holding every ACL group - which is what makes these tables append-only.
+
+    The `pgh_obj` foreign key is also configured with `on_delete=DO_NOTHING`
+    and `db_constraint=False` (see settings.PGHISTORY_OBJ_FIELD), so deleting
+    the tracked parent row must succeed and leave the audit trail behind.
+    """
+
+    def test_srp_report_audit_is_append_only(self):
+        SRPReportAudit = apps.get_model("regulatory_reporting", "SRPReportAudit")
+
+        set_user_acls(settings.ALL_GROUPS)
+        report = SRPReportFactory(flaw__embargoed=False)
+        report_pk = report.pk
+        events = SRPReportAudit.objects.filter(pgh_obj=report_pk)
+        assert events.filter(pgh_label="insert").count() == 1
+
+        assert events.update(title="tampered") == 0
+        assert events.delete() == (0, {})
+        assert not events.filter(title="tampered").exists()
+
+        assert report.delete()
+        assert (
+            SRPReportAudit.objects.filter(pgh_obj=report_pk, pgh_label="delete").count()
+            == 1
+        )
+
+    def test_srp_report_milestone_audit_is_append_only(self):
+        SRPReportMilestoneAudit = apps.get_model(
+            "regulatory_reporting", "SRPReportMilestoneAudit"
+        )
+
+        set_user_acls(settings.ALL_GROUPS)
+        milestone = SRPReportMilestoneFactory(srp_report__flaw__embargoed=False)
+        milestone_pk = milestone.pk
+        events = SRPReportMilestoneAudit.objects.filter(pgh_obj=milestone_pk)
+        assert events.filter(pgh_label="insert").count() == 1
+
+        assert events.update(request_source="tampered") == 0
+        assert events.delete() == (0, {})
+        assert not events.filter(request_source="tampered").exists()
+
+        assert milestone.delete()
+        assert (
+            SRPReportMilestoneAudit.objects.filter(
+                pgh_obj=milestone_pk, pgh_label="delete"
+            ).count()
+            == 1
+        )

--- a/regulatory_reporting/tests/test_upstream_notifications.py
+++ b/regulatory_reporting/tests/test_upstream_notifications.py
@@ -96,6 +96,68 @@ class TestUpstreamNotificationView:
         assert response.status_code == 200
         assert response.json()["count"] == 1
 
+    def test_update_does_not_change_acls_when_embargoed(self, auth_client):
+        """
+        Regression test for parent-authorization: updating a notification
+        must not let the request desynchronize its ACLs from the parent
+        flaw's, even when the request includes an `embargoed` value that
+        contradicts the flaw's actual classification.
+        """
+        flaw = NonReportableFlawFactory(embargoed=True)
+        notification = UpstreamNotificationFactory(
+            flaw=flaw, status=UpstreamNotification.NotificationStatus.REQUIRED
+        )
+        assert notification.acl_read == flaw.acl_read
+        assert notification.acl_write == flaw.acl_write
+
+        response = auth_client().put(
+            f"/regulatory-reporting/api/v1/notifications/upstream/{notification.uuid}",
+            {
+                "status": UpstreamNotification.NotificationStatus.PREPARED,
+                "embargoed": False,
+                "updated_dt": notification.updated_dt.isoformat(),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        notification.refresh_from_db()
+        assert notification.status == UpstreamNotification.NotificationStatus.PREPARED
+        assert notification.acl_read == flaw.acl_read
+        assert notification.acl_write == flaw.acl_write
+        assert notification.is_embargoed
+
+    def test_update_does_not_change_acls_when_public(self, auth_client):
+        """
+        Parity check: updating a public notification must not let the
+        request move its ACLs away from the parent flaw's, even when the
+        request includes an `embargoed` value that contradicts the flaw's
+        actual classification.
+        """
+        flaw = NonReportableFlawFactory(embargoed=False)
+        notification = UpstreamNotificationFactory(
+            flaw=flaw, status=UpstreamNotification.NotificationStatus.REQUIRED
+        )
+        assert notification.acl_read == flaw.acl_read
+        assert notification.acl_write == flaw.acl_write
+
+        response = auth_client().put(
+            f"/regulatory-reporting/api/v1/notifications/upstream/{notification.uuid}",
+            {
+                "status": UpstreamNotification.NotificationStatus.PREPARED,
+                "embargoed": True,
+                "updated_dt": notification.updated_dt.isoformat(),
+            },
+            format="json",
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        notification.refresh_from_db()
+        assert notification.status == UpstreamNotification.NotificationStatus.PREPARED
+        assert notification.acl_read == flaw.acl_read
+        assert notification.acl_write == flaw.acl_write
+        assert not notification.is_embargoed
+
     def test_preview_returns_rendered_bodies(self, auth_client):
         """Test preview endpoint returns live rendered email."""
         flaw = NonReportableFlawFactory(cve_description="A test vulnerability.")

--- a/tox.ini
+++ b/tox.ini
@@ -46,8 +46,8 @@ commands =
         pytest --record-mode=rewrite {posargs}
 
 [testenv:rls]
-commands = 
-        pytest osidb/tests/test_rls.py
+commands =
+        pytest osidb/tests/test_rls.py regulatory_reporting/tests/test_rls.py
 
 [testenv:ci-osidb]
 setenv =


### PR DESCRIPTION
## Summary

Enable PostgreSQL Row-Level Security (RLS) on all ACL-bearing `regulatory_reporting` tables, ensuring rows are filtered by user ACL groups — consistent with how RLS is enforced on `osidb` tables (e.g. Flaw).

### Tables and policies

| Table | Policies |
|---|---|
| `regulatory_reporting_srpreport` | SELECT / INSERT / UPDATE / DELETE |
| `regulatory_reporting_srpreportmilestone` | SELECT / INSERT / UPDATE / DELETE |
| `regulatory_reporting_upstreamnotification` | SELECT / INSERT / UPDATE / DELETE |
| `regulatory_reporting_srpreportaudit` | SELECT / INSERT (append-only) |
| `regulatory_reporting_srpreportmilestoneaudit` | SELECT / INSERT (append-only) |

### Changes

- **New migration** (`0006_enable_rls_regulatory_reporting.py`): enables `ROW LEVEL SECURITY` + `FORCE ROW LEVEL SECURITY` and creates ACL policies on all 5 tables, following the exact SQL pattern from `osidb/migrations/0145_audit_history.py`.
- **New RLS tests** (`test_rls.py`): 19 tests across `TestSRPReportRLS`, `TestSRPReportMilestoneRLS`, and `TestUpstreamNotificationRLS` covering create/read/read_multiple/update/delete with public and embargoed ACLs.
- **Fixed `authenticated_client` fixture** (`conftest.py`): added public ACL groups to the test user and added `force_login()` so that Django's `AuthenticationMiddleware` recognises the user before `PgCommon` middleware sets `osidb.acl`. Without `force_login`, `force_authenticate` only works at the DRF level, leaving `PgCommon` to set read-only ACLs — which causes UPDATE/INSERT RLS violations.
- **Fixed `test_create_upstream_notification`** (`test_models.py`): passed `acl_read`/`acl_write` from the parent flaw so the row satisfies RLS policies.
- **Updated `tox.ini`**: added `regulatory_reporting/tests/test_rls.py` to the `[testenv:rls]` target.
- Fixes a bug where embargoed was editable via PUT on notifications, which could unintentionally make an embargoed notification public.

## Test plan

- [x] All 206 `regulatory_reporting/tests/` pass (including 19 new RLS tests)
- [x] RLS tests verify that rows with mismatched ACLs are invisible / blocked for create, read, update, and delete
- [x] Audit tables enforce append-only (SELECT + INSERT only)
- [ ] Run `make testrunner.rls` to confirm both `osidb` and `regulatory_reporting` RLS suites pass together

## Clarification 

There are other PR's with their own migration so most likely later It will need to update this migration.
