### PR TITLE
OSIDB-5104 Add Observability for Upstream Maintainer Email Actions

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -227,6 +227,11 @@ LOGGING = {
             "handlers": ["console"],
         },
         "celery": {"handlers": ["celery"], "level": "INFO", "propagate": True},
+        "regulatory_reporting": {
+            "handlers": ["celery"],
+            "level": "INFO",
+            "propagate": False,
+        },
         "osidb": {"level": "WARNING", "handlers": ["console"], "propagate": False},
         "api_req": {"level": "INFO", "handlers": ["console"], "propagate": False},
         "django_auth_ldap": {"level": "WARNING", "handlers": ["console"]},

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Upstream Project Contact Endpoints (OSIDB-5084)
 - Add Flaw-to-Upstream Mapping Endpoints (OSIDB-5085)
 - Add Upstream Maintainer Send Email Action (OSIDB-5088)
+- Add Observability for Upstream Maintainer Email Actions (OSIDB-5104)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -105,6 +105,7 @@ class TrackingMixinManager(models.Manager):
         """
         filter out auto_timestamps from the defaults
         """
+        defaults = dict(defaults or {})
         defaults.pop("auto_timestamps", None)
         return super().get_or_create(defaults, **kwargs)
 

--- a/regulatory_reporting/models/upstream.py
+++ b/regulatory_reporting/models/upstream.py
@@ -4,7 +4,7 @@ import pghistory
 from django.conf import settings
 from django.db import models
 
-from osidb.mixins import ACLMixin, TrackingMixin
+from osidb.mixins import ACLMixin, ACLMixinManager, TrackingMixin, TrackingMixinManager
 from osidb.models.fields import PURLField
 
 
@@ -48,6 +48,36 @@ class UpstreamProject(TrackingMixin):
         return self.component_name
 
 
+class UpstreamNotificationQuerySet(models.QuerySet):
+    OPEN_STATUSES = [
+        "required",
+        "contact_needed",
+        "prepared",
+        "reviewed",
+        "queued",
+        "deferred",
+        "blocked",
+        "failed",
+    ]
+
+    def open(self):
+        """Notifications not yet terminally resolved."""
+        return self.filter(status__in=self.OPEN_STATUSES)
+
+    def stale(self, since):
+        """Notifications not updated since the given datetime."""
+        return self.filter(updated_dt__lt=since)
+
+
+class UpstreamNotificationManager(ACLMixinManager, TrackingMixinManager):
+    pass
+
+
+UpstreamNotificationManager = UpstreamNotificationManager.from_queryset(
+    UpstreamNotificationQuerySet
+)
+
+
 @pghistory.track(
     pghistory.InsertEvent(),
     pghistory.UpdateEvent(),
@@ -83,6 +113,7 @@ class UpstreamNotification(ACLMixin, TrackingMixin):
         OTHER_MANUAL = "other_manual"
 
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    objects = UpstreamNotificationManager()
     flaw = models.ForeignKey(
         "osidb.Flaw",
         on_delete=models.CASCADE,

--- a/regulatory_reporting/tasks.py
+++ b/regulatory_reporting/tasks.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.conf import settings
 from django.utils import timezone
 
@@ -6,6 +8,8 @@ from osidb.core import set_user_acls
 
 from .models.upstream import UpstreamNotification
 
+logger = logging.getLogger(__name__)
+
 
 @app.task
 def mark_upstream_notification_sent(result, notification_uuid):
@@ -13,7 +17,7 @@ def mark_upstream_notification_sent(result, notification_uuid):
     Success callback once async_send_email completes successfully.
     """
     set_user_acls(settings.ALL_GROUPS)
-    UpstreamNotification.objects.filter(
+    updated = UpstreamNotification.objects.filter(
         uuid=notification_uuid,
         status=UpstreamNotification.NotificationStatus.QUEUED,
     ).update(
@@ -21,6 +25,8 @@ def mark_upstream_notification_sent(result, notification_uuid):
         last_error="",
         sent_at=timezone.now(),
     )
+    if updated:
+        logger.info("Upstream maintainer notification %s sent", notification_uuid)
 
 
 @app.task
@@ -29,10 +35,16 @@ def mark_upstream_notification_failed(request, exc, traceback, notification_uuid
     Failure callback that records the error if async_send_email raises.
     """
     set_user_acls(settings.ALL_GROUPS)
-    UpstreamNotification.objects.filter(
+    updated = UpstreamNotification.objects.filter(
         uuid=notification_uuid,
         status=UpstreamNotification.NotificationStatus.QUEUED,
     ).update(
         status=UpstreamNotification.NotificationStatus.FAILED,
         last_error=str(exc),
     )
+    if updated:
+        logger.error(
+            "Upstream maintainer notification %s failed to send: %s",
+            notification_uuid,
+            type(exc).__name__,
+        )

--- a/regulatory_reporting/tests/test_upstream_notifications.py
+++ b/regulatory_reporting/tests/test_upstream_notifications.py
@@ -1,7 +1,10 @@
+import logging
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -387,6 +390,78 @@ class TestUpstreamNotificationTasks:
         notification.refresh_from_db()
         assert notification.status == UpstreamNotification.NotificationStatus.SENT
         assert notification.last_error == ""
+
+    def test_mark_upstream_notification_sent_logs_success(self, caplog):
+        """Test for success callback logs an info message."""
+        notification = UpstreamNotificationFactory(
+            status=UpstreamNotification.NotificationStatus.QUEUED
+        )
+        task_logger = logging.getLogger("regulatory_reporting.tasks")
+        task_logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level(logging.INFO, logger="regulatory_reporting.tasks"):
+                mark_upstream_notification_sent(None, notification.uuid)
+        finally:
+            task_logger.removeHandler(caplog.handler)
+        notification.refresh_from_db()
+        assert notification.status == UpstreamNotification.NotificationStatus.SENT
+        assert any(
+            str(notification.uuid) in record.getMessage() and record.levelname == "INFO"
+            for record in caplog.records
+        )
+
+    def test_mark_upstream_notification_failed_logs_error(self, caplog):
+        """Test for failure callback logs an error message."""
+        notification = UpstreamNotificationFactory(
+            status=UpstreamNotification.NotificationStatus.QUEUED
+        )
+        exc = Exception("SMTP connection refused")
+        task_logger = logging.getLogger("regulatory_reporting.tasks")
+        task_logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level(logging.ERROR, logger="regulatory_reporting.tasks"):
+                mark_upstream_notification_failed(None, exc, None, notification.uuid)
+        finally:
+            task_logger.removeHandler(caplog.handler)
+        notification.refresh_from_db()
+        assert notification.status == UpstreamNotification.NotificationStatus.FAILED
+        assert any(
+            str(notification.uuid) in record.getMessage()
+            and "Exception" in record.getMessage()
+            and record.levelname == "ERROR"
+            for record in caplog.records
+        )
+
+    def test_open_excludes_terminal_statuses(self):
+        """Test for open() excludes notifications in terminal statuses."""
+        open_notification = UpstreamNotificationFactory(
+            status=UpstreamNotification.NotificationStatus.REQUIRED
+        )
+        for terminal_status in [
+            UpstreamNotification.NotificationStatus.NOT_APPLICABLE,
+            UpstreamNotification.NotificationStatus.NOT_REQUIRED,
+            UpstreamNotification.NotificationStatus.SENT,
+        ]:
+            UpstreamNotificationFactory(status=terminal_status)
+
+        result = UpstreamNotification.objects.open()
+
+        assert open_notification in result
+        assert result.count() == 1
+
+    def test_stale_excludes_recently_updated(self):
+        """Test for stale() only returns notifications not updated since the given time."""
+        old_notification = UpstreamNotificationFactory()
+        UpstreamNotification.objects.filter(uuid=old_notification.uuid).update(
+            updated_dt=timezone.now() - timedelta(days=10)
+        )
+        recent_notification = UpstreamNotificationFactory()
+
+        cutoff = timezone.now() - timedelta(days=7)
+        result = UpstreamNotification.objects.stale(cutoff)
+
+        assert old_notification in result
+        assert recent_notification not in result
 
 
 class TestUpstreamProjectView:


### PR DESCRIPTION
Added logging and queryset to identify failed, error-logged or stuck upstream maintainer notification emails.
- Added module level `logger` and log calls in two email callbacks in `regulatory_reporting/tasks.py`.
- Added `UpstreamNotificationQuerySet` with `open()` and `stale()` methods in `regulatory_reporting/models/upstream.py`.
- Added tests in `regulatory_reporting/tests/test_upstream_notifications.py`.
- Added `regulatory_reporting` entry to 'LOGGING' in `config/settings.py`.
- Added entry in `CHANGELOG.md`.