### PR TITLE
OSIDB-5189: fix workflow task creation latency (queue isolation + schedule dedup)

### DIFF
--- a/collectors/framework/models.py
+++ b/collectors/framework/models.py
@@ -535,6 +535,10 @@ def collector(
             data_models=data_models,
             depends_on=depends_on,
             dry_run=dry_run,
+            # Periodic/bulk collector imports run on a dedicated queue so a
+            # long-running import can't starve latency-sensitive interactive
+            # tasks (e.g. Jira task sync) queued on "default".
+            queue="collectors",
         )
         # wraps is necessary to set the correct collector name
         # which should correspond to collector module and fuction name

--- a/config/celery.py
+++ b/config/celery.py
@@ -50,6 +50,11 @@ app.config_from_object("django.conf:settings", namespace="CELERY")
 app.autodiscover_tasks(lambda: settings.INSTALLED_APPS)
 app.conf.task_queues = [
     Queue("default", routing_key="default"),
+    # Bulk/periodic collector tasks (Bugzilla, Jira, CVE.org, etc. imports) are
+    # routed here so they don't starve latency-sensitive tasks (Jira task
+    # sync/transition) waiting on the "default" queue behind long-running
+    # imports.
+    Queue("collectors", routing_key="collectors"),
     *[
         Queue(f"fifo.{i}", routing_key=f"fifo.{i}")
         for i in range(CelerySettings().fifo_pool_size)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -194,6 +194,23 @@ services:
       #     condition: service_healthy
       #   redis:
       #     condition: service_started
+    # Dedicated worker for the "collectors" queue (periodic/bulk imports:
+    # Bugzilla, Jira, CVE.org, NVD, OSV, product-definitions, ...) so those
+    # long-running jobs can't starve the "default" queue used by
+    # latency-sensitive interactive tasks (Jira task sync/transition).
+    celery-collectors:
+      image: localhost/osidb-service
+      pull_policy: never
+      command:
+        celery -A config worker --pidfile /tmp/celery_worker.pid --loglevel DEBUG -Q collectors --concurrency=5 -E
+      deploy:
+        mode: replicated
+        replicas: ${OSIDB_CELERY_COLLECTORS_WORKERS_NO:-1}
+      volumes:
+        - ${PWD}:/opt/app-root/src:z
+      environment: *celery-env
+      depends_on: ["osidb-data", "osidb-service", "redis"]
+
     # WARNING: The amount of instances of celery-fifo pods must be equal or greater
     # than the environment variable OSIDB_CELERY_FIFO_POOL_SIZE, this is because
     # each of these pods listens to a single queue and if the application spawns 3

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db import models, transaction
 from django.db.models import F, Q
 from django.utils import timezone
+from rhubarb.exceptions import ConcurrentExecutionException
 from rhubarb.tasks import LockableTaskWithArgs
 
 from config.celery import app
@@ -151,27 +152,72 @@ class SyncManager(models.Model):
         if schedule_options is None:
             schedule_options = {}
 
-        _, created = SyncManager.objects.update_or_create(
-            name=cls.__name__,
-            sync_id=sync_id,
-            defaults={"last_scheduled_dt": timezone.now()},
-        )
+        if cls.MODE != cls.SyncManagerMode.EXCLUSIVE:
+            # No dedup decision to make, no need for locking.
+            SyncManager.objects.get_or_create(name=cls.__name__, sync_id=sync_id)
+            cls._enqueue(sync_id, *args, schedule_options=schedule_options, **kwargs)
+            return
 
-        if not created and cls.MODE == cls.SyncManagerMode.EXCLUSIVE:
-            # Check if the task needs to be rescheduled
-            if not cls.is_scheduled(sync_id):
-                logger.info(
-                    f"{cls.__name__} {sync_id}: Task already in progress"
-                    f", postponing for {schedule_options.get('countdown', cls.COUNTDOWN)} seconds"
-                )
-                if "countdown" not in schedule_options:
-                    schedule_options["countdown"] = cls.COUNTDOWN
-                cls.reschedule(
-                    sync_id,
-                    "Task already in progress",
-                    schedule_options=schedule_options,
-                )
-                return
+        # select_for_update() serializes concurrent schedule() calls for the
+        # same sync_id: without it, two callers could both pass the
+        # is_scheduled()/is_in_progress() checks below before either's
+        # write lands, and both end up enqueuing a duplicate task. The row
+        # lock is released on commit of the outermost transaction, not on
+        # return from this atomic() block: this method can run inside
+        # Flaw.tasksync()'s transaction.atomic(), and ATOMIC_REQUESTS wraps
+        # the whole request in an outer transaction too, so the lock stays
+        # held (and other schedule() calls for the same sync_id stay
+        # blocked) until that outermost transaction commits, well after
+        # _enqueue()/reschedule() return.
+        with transaction.atomic():
+            _, created = SyncManager.objects.select_for_update().get_or_create(
+                name=cls.__name__, sync_id=sync_id
+            )
+
+            if not created:
+                if cls.is_scheduled(sync_id):
+                    # A fresh schedule or a pending reschedule already
+                    # exists (e.g. a previous call already deferred a
+                    # retry) - queuing another one here would just be a
+                    # duplicate task.
+                    logger.info(
+                        f"{cls.__name__} {sync_id}: Already scheduled, skipping"
+                    )
+                    return
+
+                if cls.is_in_progress(sync_id):
+                    countdown = schedule_options.get("countdown", cls.COUNTDOWN)
+                    logger.info(
+                        f"{cls.__name__} {sync_id}: Task already in progress"
+                        f", postponing for {countdown} seconds"
+                    )
+                    # Copy so we don't mutate the caller's dict.
+                    reschedule_options = {**schedule_options, "countdown": countdown}
+                    cls.reschedule(
+                        sync_id,
+                        "Task already in progress",
+                        *args,
+                        schedule_options=reschedule_options,
+                        **kwargs,
+                    )
+                    return
+
+            cls._enqueue(sync_id, *args, schedule_options=schedule_options, **kwargs)
+
+    @classmethod
+    def _enqueue(cls, sync_id, *args, schedule_options=None, **kwargs):
+        """
+        Record the schedule timestamp and actually put sync_task on the
+        Celery queue, bypassing the EXCLUSIVE-mode dedup checks in
+        schedule(). Used both for genuinely new schedules and by
+        reschedule(), which has already decided a new run is warranted.
+        """
+        if schedule_options is None:
+            schedule_options = {}
+
+        SyncManager.objects.filter(name=cls.__name__, sync_id=sync_id).update(
+            last_scheduled_dt=timezone.now()
+        )
 
         # Create model linkage if possible to make checking for conflicting
         # sync managers possible
@@ -319,7 +365,15 @@ class SyncManager(models.Model):
             last_rescheduled_reason=reason,
             last_consecutive_reschedules=updated_last_consecutive_reschedules,
         )
-        cls.schedule(sync_id, *args, **kwargs)
+        if cls.MODE == cls.SyncManagerMode.EXCLUSIVE:
+            # Bypass schedule()'s EXCLUSIVE dedup check: we've just recorded
+            # the reschedule above, so this must actually enqueue the task.
+            cls._enqueue(sync_id, *args, **kwargs)
+        else:
+            # Non-EXCLUSIVE managers may override schedule() with their own
+            # policy (e.g. BZSyncManager's duplicate-schedule window and
+            # mandatory countdown=20) that a bare _enqueue() would skip.
+            cls.schedule(sync_id, *args, **kwargs)
         logger.info(f"{cls.__name__} {sync_id}: Sync re-scheduled ({reason})")
 
     @classmethod
@@ -741,6 +795,32 @@ class BZSyncManager(SyncManager):
             BZSyncManager.finished(flaw_id)
 
 
+class RetryOnLockContention(LockableTaskWithArgs):
+    """
+    LockableTaskWithArgs rejects a task outright when it can't acquire the
+    lock (another execution for the same args is already running), and
+    that rejection is a Celery Reject(requeue=False): it's never retried,
+    leaving recovery entirely to check_for_reschedules()'s 24h
+    MAX_SCHEDULE_DELAY safety net.
+
+    Retry a bounded number of times with a short delay instead: lock
+    contention is almost always short-lived (the other run finishes
+    normally within minutes), and even in the worst case (the lock holder
+    crashed without releasing it) the lock's TTL guarantees it clears
+    within SyncManager.MAX_RUN_LENGTH - comfortably inside these retries'
+    total window, well before MAX_SCHEDULE_DELAY would otherwise kick in.
+    """
+
+    default_retry_delay = 30
+    max_retries = int(SyncManager.MAX_RUN_LENGTH.total_seconds() // 30) + 10
+
+    def before_start(self, task_id, args, kwargs):
+        try:
+            super().before_start(task_id, args, kwargs)
+        except ConcurrentExecutionException as exc:
+            raise self.retry(exc=exc, countdown=self.default_retry_delay)
+
+
 class JiraTaskSyncManager(SyncManager):
     """
     Sync manager class for OSIDB => Jira Task synchronization.
@@ -748,6 +828,15 @@ class JiraTaskSyncManager(SyncManager):
 
     class Meta:
         proxy = True
+
+    # Multiple flaw saves in quick succession (e.g. creation immediately
+    # followed by field autofill) each call schedule() for the same flaw.
+    # The task always re-fetches the flaw's current state and uses the
+    # service account token, so a schedule while one is already running
+    # carries no extra payload - collapse it into a single reschedule
+    # instead of queuing a redundant duplicate (mirrors
+    # JiraTaskTransitionManager).
+    MODE = SyncManager.SyncManagerMode.EXCLUSIVE
 
     def __str__(self):
         from osidb.models import Flaw
@@ -760,7 +849,16 @@ class JiraTaskSyncManager(SyncManager):
         return result
 
     @staticmethod
-    @app.task(name="sync_manager.jira_task_sync", bind=True)
+    @app.task(
+        base=RetryOnLockContention,
+        name="sync_manager.jira_task_sync",
+        bind=True,
+        # Must last at least MAX_RUN_LENGTH - the same threshold
+        # is_in_progress()/check_for_reschedules() use to decide a run is
+        # stuck - or the Redis lock could expire while a still-legitimate
+        # run is in flight, letting a concurrent duplicate through.
+        lock_ttl=int(SyncManager.MAX_RUN_LENGTH.total_seconds()),
+    )
     def sync_task(task, flaw_id, **kwargs):
         """
         perform the sync of the task of the given flaw to Jira

--- a/osidb/tests/test_celery_routing.py
+++ b/osidb/tests/test_celery_routing.py
@@ -1,0 +1,73 @@
+"""
+Tests for Celery queue routing.
+
+These exercise the exact routing pipeline Celery uses at apply_async() time
+(app.amqp.router.route) without needing a running broker/worker, so they
+work as a red/green check for queue-topology changes: change where a task
+is routed and these fail until config/celery.py + the task's `queue=`/
+`task_routes` are updated to match.
+"""
+
+import pytest
+from celery.app.task import extract_exec_options
+
+from config.celery import app
+
+pytestmark = pytest.mark.unit
+
+
+def _route(task_name, kwargs=None):
+    """
+    Resolve the queue Celery would actually publish `task_name` to, without
+    a broker: reproduces what Task.apply_async() does internally (merge the
+    task's own exec options - e.g. its `queue=` default - then run them
+    through the configured task_routes router).
+    """
+    task_obj = app.tasks[task_name]
+    preopts = extract_exec_options(task_obj)
+    return app.amqp.router.route(preopts, task_name, args=(), kwargs=kwargs or {})
+
+
+class TestCeleryRouting:
+    def test_periodic_collector_tasks_use_collectors_queue(self):
+        """
+        Bulk/periodic collector tasks must not share the "default" queue
+        with latency-sensitive interactive tasks.
+        """
+        import collectors.bzimport.tasks  # noqa: F401 ensure task is registered
+
+        options = _route("collectors.bzimport.tasks.bztracker_collector")
+        assert options["queue"].name == "collectors"
+
+    @pytest.mark.parametrize(
+        "task_name",
+        [
+            "sync_manager.jira_task_sync",
+            "sync_manager.jira_task_transition",
+            "sync_manager.bzsync",
+        ],
+    )
+    def test_interactive_sync_manager_tasks_use_default_queue(self, task_name):
+        """
+        Interactive, per-object sync tasks stay on "default" so they aren't
+        queued behind long-running collector imports.
+        """
+        options = _route(task_name)
+        assert options["queue"].name == "default"
+
+    def test_object_id_tasks_use_fifo_queue_when_enabled(self, monkeypatch):
+        """
+        The per-object FIFO pool routing (used for ordering guarantees) must
+        keep taking precedence over any per-task default queue.
+        """
+        from config.celery import CelerySettings
+
+        monkeypatch.setattr(
+            "config.celery.CelerySettings",
+            lambda: CelerySettings(enable_fifo=True, fifo_pool_size=2),
+        )
+
+        options = _route(
+            "sync_manager.jira_task_sync", kwargs={"object_id": "some-uuid"}
+        )
+        assert options["queue"].name.startswith("fifo.")

--- a/osidb/tests/test_sync_manager.py
+++ b/osidb/tests/test_sync_manager.py
@@ -1,10 +1,18 @@
+import threading
+import time
 from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
 
 import pytest
-from django.test import TestCase
+from celery.exceptions import Retry
+from django.db import connection
+from django.test import TestCase, TransactionTestCase
 from freezegun import freeze_time
+from rhubarb.exceptions import ConcurrentExecutionException
+from rhubarb.tasks import LockableTaskWithArgs
 
 from osidb.sync_manager import (
+    JiraTaskSyncManager,
     JiraTaskTransitionManager,
     SyncManager,
 )
@@ -118,6 +126,79 @@ class TestSyncManager(TestCase):
             transition_manager2.last_scheduled_dt > transition_manager.last_scheduled_dt
         )
 
+    @freeze_time(datetime(2025, 6, 24))
+    def test_jira_task_sync_manager_reschedule(self):
+        """
+        A flaw save that arrives while a JiraTaskSyncManager run is already
+        in progress for the same flaw must be collapsed into a reschedule
+        instead of enqueuing a second, redundant Celery task (OSIDB latency
+        investigation: duplicate schedules were stacking up on the shared
+        queue).
+        """
+        flaw = FlawFactory(embargoed=False)
+
+        sync_manager = JiraTaskSyncManager.objects.create(
+            name=JiraTaskSyncManager.__name__, sync_id=flaw.uuid
+        )
+
+        # simulate schedule call
+        sync_manager.last_scheduled_dt = datetime.now(timezone.utc)
+        sync_manager.last_started_dt = datetime.now(timezone.utc) + timedelta(seconds=1)
+        sync_manager.save()
+
+        # schedule second call while the first is still running
+        with self.captureOnCommitCallbacks(execute=False):
+            with freeze_time(datetime(2025, 6, 24) + timedelta(seconds=5)):
+                JiraTaskSyncManager.schedule(flaw.uuid)
+
+        sync_manager2 = JiraTaskSyncManager.objects.get(
+            name=JiraTaskSyncManager.__name__, sync_id=flaw.uuid
+        )
+
+        assert sync_manager2.last_consecutive_reschedules == 1
+        assert sync_manager2.last_rescheduled_reason == "Task already in progress"
+        assert sync_manager2.last_scheduled_dt > sync_manager.last_scheduled_dt
+
+    @freeze_time(datetime(2025, 6, 24))
+    def test_jira_task_sync_manager_no_duplicate_on_third_schedule(self):
+        """
+        A third schedule() call arriving while a reschedule is already
+        pending (the task is still in progress from the first run, and a
+        retry was already deferred by a second call) must be a no-op: it
+        must not enqueue yet another Celery task on top of the one already
+        deferred.
+        """
+        flaw = FlawFactory(embargoed=False)
+
+        sync_manager = JiraTaskSyncManager.objects.create(
+            name=JiraTaskSyncManager.__name__, sync_id=flaw.uuid
+        )
+
+        # first run starts
+        sync_manager.last_scheduled_dt = datetime.now(timezone.utc)
+        sync_manager.last_started_dt = datetime.now(timezone.utc) + timedelta(seconds=1)
+        sync_manager.save()
+
+        # second call while the first run is still in progress: this must
+        # defer a single retry
+        with freeze_time(datetime(2025, 6, 24) + timedelta(seconds=5)):
+            with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                JiraTaskSyncManager.schedule(flaw.uuid)
+        assert len(callbacks) == 1
+
+        # third call while the deferred retry is still pending: must not
+        # queue an additional task
+        with freeze_time(datetime(2025, 6, 24) + timedelta(seconds=10)):
+            with self.captureOnCommitCallbacks(execute=False) as callbacks:
+                JiraTaskSyncManager.schedule(flaw.uuid)
+        assert len(callbacks) == 0
+
+        sync_manager2 = JiraTaskSyncManager.objects.get(
+            name=JiraTaskSyncManager.__name__, sync_id=flaw.uuid
+        )
+        # no extra reschedule was recorded for the third, no-op call either
+        assert sync_manager2.last_consecutive_reschedules == 1
+
 
 class TestSyncManagerFailed(TestCase):
     """Test cases for SyncManager.failed() method"""
@@ -190,3 +271,113 @@ class TestSyncManagerFailed(TestCase):
         assert manager.last_consecutive_failures == 6
         # Verify it becomes permanent when at or above threshold
         assert manager.permanently_failed is True
+
+
+class TestSyncManagerConcurrency(TransactionTestCase):
+    """
+    Exercises the select_for_update() locking added to schedule() for
+    EXCLUSIVE-mode managers. This needs real, separately-committed
+    transactions on two threads to observe actual blocking, so it can't
+    use the savepoint-based TestCase like the rest of this file.
+    """
+
+    def test_concurrent_schedule_calls_do_not_double_enqueue(self):
+        flaw = FlawFactory(embargoed=False)
+
+        JiraTaskSyncManager.objects.create(
+            name=JiraTaskSyncManager.__name__,
+            sync_id=flaw.uuid,
+            last_scheduled_dt=datetime.now(timezone.utc),
+            last_started_dt=datetime.now(timezone.utc),
+        )
+
+        original_is_scheduled = JiraTaskSyncManager.is_scheduled.__func__
+
+        def slow_is_scheduled(cls, sync_id):
+            # Holds the row lock (already acquired by schedule() before
+            # this call) long enough that, without select_for_update(),
+            # the other thread would clearly race past this check instead
+            # of blocking on it.
+            result = original_is_scheduled(cls, sync_id)
+            time.sleep(0.2)
+            return result
+
+        enqueued = []
+
+        def fake_apply_async(*args, **kwargs):
+            enqueued.append((args, kwargs))
+
+        errors = []
+
+        def worker():
+            try:
+                JiraTaskSyncManager.schedule(flaw.uuid)
+            except Exception as e:
+                # Captured so the test fails loudly instead of a bare
+                # threading.Thread swallowing it silently.
+                errors.append(e)
+            finally:
+                # Each thread gets its own DB connection; nothing else
+                # closes it once the thread exits.
+                connection.close()
+
+        with (
+            patch.object(
+                JiraTaskSyncManager, "is_scheduled", classmethod(slow_is_scheduled)
+            ),
+            patch.object(
+                JiraTaskSyncManager.sync_task,
+                "apply_async",
+                side_effect=fake_apply_async,
+            ),
+        ):
+            threads = [threading.Thread(target=worker) for _ in range(2)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=5)
+
+        assert all(not t.is_alive() for t in threads), "a worker thread did not finish"
+        assert not errors, f"worker thread(s) raised: {errors}"
+
+        # Without select_for_update(), both threads could pass the
+        # is_scheduled()/is_in_progress() checks before either write
+        # landed, and both would enqueue a deferred retry - the exact
+        # duplicate-enqueue bug the lock closes.
+        assert len(enqueued) == 1
+
+
+class TestRetryOnLockContention:
+    def test_before_start_retries_instead_of_dropping_on_lock_contention(self):
+        """
+        LockableTaskWithArgs.before_start() raises ConcurrentExecutionException
+        (a Reject, requeue=False) when it can't acquire the lock, which
+        Celery just drops - no retry. RetryOnLockContention must convert
+        that into a Celery Retry instead, so recovery doesn't wait for the
+        24h check_for_reschedules() safety net.
+        """
+        task = JiraTaskSyncManager.sync_task
+        task.push_request(
+            called_directly=False,
+            retries=0,
+            id="task-id",
+            args=("some-flaw-uuid",),
+            kwargs={},
+        )
+        try:
+            with (
+                patch.object(
+                    LockableTaskWithArgs,
+                    "before_start",
+                    side_effect=ConcurrentExecutionException("locked"),
+                ),
+                # retry() re-publishes the task itself; avoid needing a
+                # live broker for what we're actually asserting here.
+                patch.object(task, "apply_async"),
+                pytest.raises(Retry) as exc_info,
+            ):
+                task.before_start("task-id", ("some-flaw-uuid",), {})
+
+            assert exc_info.value.when == task.default_retry_delay
+        finally:
+            task.pop_request()


### PR DESCRIPTION
## Summary

Celery-backed workflow task creation (Jira task on the OSIM Jira project) was taking 10-30 minutes instead of the required <1 minute SLA. Verified the actual root causes against real evidence (not just the ticket's suggested fix) and addressed the two confirmed ones:

1. **Head-of-line blocking on a shared queue.** Interactive, per-flaw tasks (Jira task sync/transition, BZ sync) shared the single `default` Celery queue with long-running periodic/bulk collector imports (Bugzilla, Jira, CVE.org, NVD, OSV, product-definitions, ...). A bulk import could occupy every worker slot, delaying interactive tasks behind it even though the interactive work itself only takes a couple of seconds.
2. **Redundant/duplicate task scheduling.** `JiraTaskSyncManager` didn't dedup like its siblings (`JiraTaskTransitionManager`), so a burst of saves on the same flaw could enqueue several redundant sync tasks, adding to the queue congestion. The dedup logic itself then had its own bug (a stale timestamp corrupting the "already scheduled" check) and a check-then-act race under real concurrency, both fixed here.

## Changes

- Route periodic/bulk collector tasks to a new `collectors` Celery queue, backed by a dedicated worker, so they can no longer starve interactive syncs on `default`.
- `JiraTaskSyncManager` now uses `SyncManagerMode.EXCLUSIVE` + the same `LockableTaskWithArgs` lock already used by `JiraTaskTransitionManager`, collapsing redundant schedules for the same flaw into a single reschedule instead of duplicate tasks.
- Fixed `SyncManager.schedule()`'s dedup check, which only worked for the first duplicate call in a burst (a stale `last_scheduled_dt` write corrupted the `is_scheduled()` check for subsequent calls).
- Serialized `schedule()`'s check-then-act sequence with `select_for_update()` so two truly concurrent calls for the same sync_id can't both pass the checks and both enqueue.

## Tests

- `osidb/tests/test_celery_routing.py`: routing-table tests (no broker needed) proving collector tasks route to `collectors` and interactive sync tasks stay on `default`.
- `osidb/tests/test_sync_manager.py`: reschedule/dedup tests for `JiraTaskSyncManager`, including a third-schedule-call regression test and a `TransactionTestCase` with two real threads proving the `select_for_update()` locking actually serializes concurrent callers.

## Not included (kept out of scope, flagged for follow-up)

- Bumping worker count / concurrency (the ticket's suggested fix) — treats the symptom, not the two root causes above; can still be layered on top if needed.
- Removing the redundant per-save `check_for_reschedules()` calls in `Flaw` (duplicates the 10-min periodic beat safety net).
- Alerting on schedule-to-start latency exceeding the 1-minute SLA.
