### PR TITLE
feat: add mechanism to bypass automated workflow (OSIDB-5370)

### DIFF
--- a/apps/ace/tasks.py
+++ b/apps/ace/tasks.py
@@ -137,6 +137,25 @@ def _is_verified_mapping(component: str, resolved: list[str]) -> bool:
     return False
 
 
+def _is_manual_triage_component(resolved: list[str], ecosystem: str) -> bool:
+    """
+    Check whether any of the resolved upstream names is configured
+    (via ``OSIDB_AFFECTS_MANUAL_TRIAGE_COMPONENTS``) to require manual
+    triage, optionally restricted to specific ecosystems.
+    """
+    manual_triage_components = AffectSettings().manual_triage_components
+    ecosystem_lower = ecosystem.strip().lower()
+    for name in resolved:
+        allowed_ecosystems = manual_triage_components.get(name.strip().lower())
+        if allowed_ecosystems is None:
+            continue
+        if not allowed_ecosystems:
+            return True
+        if ecosystem_lower in (eco.lower() for eco in allowed_ecosystems):
+            return True
+    return False
+
+
 def _apply_label(flaw: Flaw, label: str) -> None:
     if not label:
         return
@@ -155,11 +174,12 @@ def _pre_filter_component(
       2. Go stdlib -> special workflow
       3. Chromium -> special workflow
       4. Resolve component name
-      5. Verified mapping guard -> manual triage if unverified
-      6. Cross-ecosystem guard -> manual triage if ambiguous
-      7. Semi-strict review -> manual triage if unresolved
-      8. Confidence check -> potential-rejection if low confidence
-      9. All checks pass -> search (auto-affects)
+      5. Manual-triage guard -> manual triage if configured (e.g. kernel)
+      6. Verified mapping guard -> manual triage if unverified
+      7. Cross-ecosystem guard -> manual triage if ambiguous
+      8. Semi-strict review -> manual triage if unresolved
+      9. Confidence check -> potential-rejection if low confidence
+      10. All checks pass -> search (auto-affects)
     """
     component_lower = component.strip().lower()
 
@@ -195,6 +215,17 @@ def _pre_filter_component(
         )
 
     resolved, has_custom_mapping = _resolve_component(component)
+
+    # Manual-triage guard (e.g. Linux kernel: ACE is not equipped yet
+    # for its special handling), configurable via
+    # OSIDB_AFFECTS_MANUAL_TRIAGE_COMPONENTS.
+    if _is_manual_triage_component(resolved, ecosystem):
+        return PreFilterResult(
+            action=PreFilterAction.MANUAL,
+            label=LABEL_MANUAL_TRIAGE,
+            resolved_names=resolved,
+            reason=f"Component '{component}' is configured for manual triage",
+        )
 
     # Verified mapping guard
     if has_custom_mapping and not _is_verified_mapping(component, resolved):

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -895,6 +895,67 @@ def test_pre_filter_verified_mapping_proceeds():
     assert result.action is PreFilterAction.SEARCH
 
 
+# ── Manual-triage components guard ──────────────────────────────────────────
+
+
+class _FakeAffectSettingsUnrestricted:
+    manual_triage_components = {"kernel": []}
+
+
+class _FakeAffectSettingsEcosystemRestricted:
+    manual_triage_components = {"kernel": ["Linux", "cargo"]}
+
+
+@pytest.mark.django_db
+def test_pre_filter_manual_triage_component_unrestricted(monkeypatch):
+    """An empty ecosystem list means the component is routed regardless of ecosystem."""
+    monkeypatch.setattr(
+        "apps.ace.tasks.AffectSettings", _FakeAffectSettingsUnrestricted
+    )
+    flaw = FlawFactory(components=["kernel"], embargoed=False)
+
+    result = _pre_filter_component(flaw, "kernel", "pypi")
+
+    assert result.action is PreFilterAction.MANUAL
+    assert result.label == LABEL_MANUAL_TRIAGE
+    assert "manual triage" in result.reason
+
+
+@pytest.mark.django_db
+def test_pre_filter_manual_triage_component_kernel_subpackage(monkeypatch):
+    """Kernel subpackages resolving to 'kernel' are also routed to manual triage."""
+    from collectors.component_mapping.models import ComponentMapEntry
+
+    monkeypatch.setattr(
+        "apps.ace.tasks.AffectSettings", _FakeAffectSettingsUnrestricted
+    )
+    ComponentMapEntry.objects.create(name="kernel-devel", upstream_packages="kernel")
+    flaw = FlawFactory(components=["kernel-devel"], embargoed=False)
+
+    result = _pre_filter_component(flaw, "kernel-devel", "")
+
+    assert result.action is PreFilterAction.MANUAL
+    assert result.label == LABEL_MANUAL_TRIAGE
+    assert "configured for manual triage" in result.reason
+
+
+@pytest.mark.django_db
+def test_pre_filter_manual_triage_component_ecosystem_restricted(monkeypatch):
+    """Restricting to specific ecosystems only routes matching ecosystems."""
+    monkeypatch.setattr(
+        "apps.ace.tasks.AffectSettings", _FakeAffectSettingsEcosystemRestricted
+    )
+    flaw = FlawFactory(components=["kernel"], embargoed=False)
+
+    linux = _pre_filter_component(flaw, "kernel", "Linux")
+    cargo = _pre_filter_component(flaw, "kernel", "cargo")
+    pypi = _pre_filter_component(flaw, "kernel", "pypi")
+
+    assert linux.action is PreFilterAction.MANUAL
+    assert cargo.action is PreFilterAction.MANUAL
+    assert pypi.action is not PreFilterAction.MANUAL
+
+
 # ── Semi-strict review ───────────────────────────────────────────────────────
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Added
 - Affects that impact UBI components are labeled as such (OSIDB-5279)
+- Introduced a mechanism for bypassing automated workflow based on
+  component/ecosystem combination (OSIDB-5370)
 
 ### Fixed
 - surface DjangoQL errors as 400 instead of 500 (OSIDB-5316)

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -47,6 +47,11 @@ class AffectSettings(BaseSettings):
     auto_create_ps_modules: list[str] = Field(
         default_factory=lambda: ["hummingbird-1"],
     )
+    # Resolved upstream component names (see collectors.component_mapping)
+    # that ACE should route to manual triage instead of auto-creating affects.
+    # Maps a lowercase component name to the lowercase ecosystems it should
+    # apply to; an empty ecosystem list means "any ecosystem".
+    manual_triage_components: dict[str, list[str]] = Field(default_factory=dict)
 
 
 class NotAffectedJustification(models.TextChoices):


### PR DESCRIPTION
This mechanism looks at component/ecosystem combinations and if configured and matched, flaws with said component/ecosystem combination will be routed straight into the `MANUAL` workflow and skip the automated (`DEFAULT`) workflow.

Especially useful for the linux kernel which has special handling considerations not yet implemented by ACE.