### PR TITLE
OSIDB- 5103-Add upstream maintainer notifications query

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Flaw-to-Upstream Mapping Endpoints (OSIDB-5085)
 - Add Upstream Maintainer Send Email Action (OSIDB-5088)
 - Add Observability for Upstream Maintainer Email Actions (OSIDB-5104)
+- Add Upstream Maintainer Notifications Query (OSIDB-5103)
 
 ### Changed
 - align existing workflows with workflow framework concepts

--- a/openapi.yml
+++ b/openapi.yml
@@ -14468,6 +14468,10 @@ paths:
         schema:
           type: integer
       - in: query
+        name: owner
+        schema:
+          type: string
+      - in: query
         name: status
         schema:
           type: string

--- a/regulatory_reporting/api_views/upstream_notifications.py
+++ b/regulatory_reporting/api_views/upstream_notifications.py
@@ -153,6 +153,10 @@ class UpstreamNotificationView(
         preview_data = render_upstream_notification_preview(notification)
         return Response(preview_data, status=200)
 
+    def initialize_request(self, request, *args, **kwargs):
+        with _redact_query_string_for_logging(request):
+            return super().initialize_request(request, *args, **kwargs)
+
 
 @contextmanager
 def _redact_query_string_for_logging(request):

--- a/regulatory_reporting/filters.py
+++ b/regulatory_reporting/filters.py
@@ -2,6 +2,8 @@
 Filters for regulatory reporting API endpoints.
 """
 
+from typing import ClassVar
+
 from django_filters import ChoiceFilter
 from django_filters.rest_framework import (
     CharFilter,
@@ -32,6 +34,17 @@ class UpstreamNotificationFilter(FilterSet):
     )
     upstream_project = UUIDFilter(field_name="upstream_project__uuid")
     flaw = UUIDFilter(field_name="flaw__uuid")
+    owner = CharFilter(field_name="actor__username", lookup_expr="exact")
+
+    class Meta:
+        model = UpstreamNotification
+        fields: ClassVar[list[str]] = [
+            "status",
+            "method",
+            "upstream_project",
+            "flaw",
+            "owner",
+        ]
 
 
 class SRPReportQLSchema(DjangoQLSchema):

--- a/regulatory_reporting/tests/test_upstream_notifications.py
+++ b/regulatory_reporting/tests/test_upstream_notifications.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import pytest
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -146,6 +147,27 @@ class TestUpstreamNotificationView:
         )
 
         assert response.status_code == 401
+
+
+class TestUpstreamNotificationFiltering:
+    def test_filter_by_owner(self, auth_client):
+        """Test that notifications can be filtered by owner (actor username)."""
+        User = get_user_model()
+        owner = User.objects.create(username="notification-owner")
+        other_owner = User.objects.create(username="someone")
+
+        target = UpstreamNotificationFactory(actor=owner)
+        UpstreamNotificationFactory(actor=other_owner)
+        UpstreamNotificationFactory()
+
+        response = auth_client().get(
+            "/regulatory-reporting/api/v1/notifications/upstream?owner=notification-owner"
+        )
+
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert len(results) == 1
+        assert results[0]["uuid"] == str(target.uuid)
 
 
 @pytest.mark.no_cra_notifications


### PR DESCRIPTION
Add filtering support to the existing upstream notifications list endpoint
-Added `owner` filter and `Meta` class in `filters.py`.
- Added tests in `test_upstream_notification.py`
- Added entry in `CHANGELOG.md`
- Regenerated `openapi.yml`