### PR TITLE
OSIDB-5318: Fix Jira Target Release field being ignored

### DIFF
--- a/apps/trackers/jira/constants.py
+++ b/apps/trackers/jira/constants.py
@@ -24,8 +24,6 @@ JIRA_FIELD_OVERRIDES = get_env("JIRA_FIELD_OVERRIDES", default="{}", is_json=Tru
 PS_ADDITIONAL_FIELD_TO_JIRA = {
     "fixVersions": "fixVersions",
     "release_blocker": "customfield_10847",
-    "target_release": "customfield_10813",
-    "target_version": "customfield_10855",
 }
 
 

--- a/apps/trackers/jira/query.py
+++ b/apps/trackers/jira/query.py
@@ -587,34 +587,25 @@ class OldTrackerJiraQueryBuilder(TrackerQueryBuilder):
         if not value:
             return
 
-        # Try to use Jira field "Target Release"
-        field_name = "Target Release"
-        field_id = PS_ADDITIONAL_FIELD_TO_JIRA["target_release"]
-        field_obj = JiraProjectFields.objects.filter(
-            project_key=self.ps_module.bts_key, field_id=field_id
-        ).first()
-        if field_obj is None:
-            # Use field "Target Version" as fallback option
-            field_name = "Target Version"
-            field_id = PS_ADDITIONAL_FIELD_TO_JIRA["target_version"]
-            field_obj = JiraProjectFields.objects.filter(
-                project_key=self.ps_module.bts_key, field_id=field_id
-            ).first()
-        if field_obj is None:
-            # The fields are not available for this project
+        # Prefer "Target Release" field; fall back to "Target Version"
+        field_obj = self.get_jira_field("Target Release", required=False)
+        if field_obj is not None:
+            if field_obj.allowed_values and value not in field_obj.allowed_values:
+                raise MissingTargetReleaseVersionError(
+                    f"Jira project {self.ps_module.bts_key} does not have Target Release with value "
+                    f"{value} available; allowed values are: {', '.join(field_obj.allowed_values)}"
+                )
+            self._query["fields"][field_obj.field_id] = {"name": value}
             return
 
-        allowed_values = field_obj.allowed_values
-        if allowed_values and value in allowed_values:
-            query_value = (
-                {"name": value} if field_name == "Target Release" else [{"name": value}]
-            )
-            self._query["fields"][field_id] = query_value
-        else:
-            raise MissingTargetReleaseVersionError(
-                f"Jira project {self.ps_module.bts_key} does not have {field_name} with value "
-                f"{value} available; allowed values values are: {', '.join(allowed_values)}"
-            )
+        field_obj = self.get_jira_field("Target Version", required=False)
+        if field_obj is not None:
+            if field_obj.allowed_values and value not in field_obj.allowed_values:
+                raise MissingTargetReleaseVersionError(
+                    f"Jira project {self.ps_module.bts_key} does not have Target Version with value "
+                    f"{value} available; allowed values are: {', '.join(field_obj.allowed_values)}"
+                )
+            self._query["fields"][field_obj.field_id] = [{"name": value}]
 
     @property
     def query_comment(self):

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -816,17 +816,14 @@ class TestBothNewOldTrackerJiraQueryBuilder:
             embargoed=flaw.embargoed,
         )
 
-        # Create mock field
+        jira_field = None
         if available_field:
             if target_release is not None:
-                field_id = "customfield_10813"
                 field_name = "Target Release"
             else:
-                field_id = "customfield_10855"
                 field_name = "Target Version"
-            JiraProjectFieldsFactory(
+            jira_field = JiraProjectFieldsFactory(
                 project_key=ps_module.bts_key,
-                field_id=field_id,
                 field_name=field_name,
                 allowed_values=[
                     "4.1.0",
@@ -837,13 +834,11 @@ class TestBothNewOldTrackerJiraQueryBuilder:
         query_builder = querybuilder_class(tracker)
         query_builder._query = {"fields": {}}
         if not available_field:
-            # If the field is not available in the project, nothing is generated
             query_builder.generate_target_release()
-            assert "customfield_10813" not in query_builder.query["fields"]
-            assert "customfield_10855" not in query_builder.query["fields"]
+            assert not query_builder.query["fields"]
         elif valid_jira_field:
             query_builder.generate_target_release()
-            query_value = query_builder.query["fields"].get(field_id)
+            query_value = query_builder.query["fields"].get(jira_field.field_id)
             if target_release is not None:
                 assert query_value == {"name": target_release}
             elif target_version is not None:
@@ -851,6 +846,53 @@ class TestBothNewOldTrackerJiraQueryBuilder:
         else:
             with pytest.raises(MissingTargetReleaseVersionError):
                 query_builder.generate_target_release()
+
+    def test_generate_target_release_prefers_target_release(
+        self,
+        querybuilder_class,
+    ):
+        """
+        Regression test for OSIDB-5318: when a project has both Target Release
+        and Target Version fields, the value must go to Target Release.
+        """
+        target_release_value = "odf-4.21.z"
+
+        ps_module = PsModuleFactory(bts_name="jboss")
+        ps_update_stream = PsUpdateStreamFactory(
+            ps_module=ps_module,
+            target_release=target_release_value,
+        )
+        flaw = FlawFactory()
+        affect = AffectFactory(
+            flaw=flaw,
+            ps_update_stream=ps_update_stream.name,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+        )
+        tracker = TrackerFactory(
+            affects=[affect],
+            type=Tracker.TrackerType.JIRA,
+            ps_update_stream=ps_update_stream.name,
+            embargoed=flaw.embargoed,
+        )
+
+        target_release_field = JiraProjectFieldsFactory(
+            project_key=ps_module.bts_key,
+            field_name="Target Release",
+            allowed_values=[target_release_value],
+        )
+        target_version_field = JiraProjectFieldsFactory(
+            project_key=ps_module.bts_key,
+            field_name="Target Version",
+            allowed_values=[target_release_value],
+        )
+
+        query_builder = querybuilder_class(tracker)
+        query_builder._query = {"fields": {}}
+        query_builder.generate_target_release()
+
+        fields = query_builder.query["fields"]
+        assert fields[target_release_field.field_id] == {"name": target_release_value}
+        assert target_version_field.field_id not in fields
 
     def test_generate_target_release_empty_string(
         self,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Fix tracker target_release value being written to Target Version field
+  instead of Target Release when the Jira project uses a non-default custom
+  field ID (OSIDB-5318)
+
 ## [5.16.3] - 2026-08-13
 ### Fixed
 - fix disabled automatic timestamp update on task creation/update (OSIDB-5387)


### PR DESCRIPTION
This PR fixes Jira field Target Release being ignored and field Target Version being used instead. Hardcoded ID values of Target Relase field got stale and thus OSIDB failed to find it and since some of the Jira projects can have both Target Relase and Target Version available at the same time, at fallback wrongly to Target Version.