### PR TITLE
OSIDB-5400, OSIDB-5343: Fix ACE false-positive AFFECTED for container PURLs and disjoint OSV ranges

### DIFF
--- a/apps/ace/osv_ranges.py
+++ b/apps/ace/osv_ranges.py
@@ -25,43 +25,80 @@ _RANGE_TYPES = {"semver", "ecosystem"}
 
 
 @dataclass
-class OsvPackageInfo:
-    """A single package entry extracted from an OSV upstream_purls record."""
+class _RangeGroup:
+    """A single (introduced, fixed/last_affected) pair from an OSV range."""
 
-    name: str
-    ecosystem: str  # normalised (e.g. "cargo", "maven", "rpm")
-    purl: str
-    introduced: str  # "" means "from the beginning"
-    fixed: str  # "" means "no fix yet / unknown"
-    last_affected: str  # alternative to fixed (inclusive upper bound)
+    introduced: str
+    fixed: str
+    last_affected: str
 
-    def affected_range(self) -> str | None:
-        """
-        Convert OSV events to a version.py range expression string.
-
-        Returns ``None`` when no meaningful range can be expressed (no fixed/last_affected
-        events were present in the OSV record).
-
-        Examples:
-          introduced="0",       fixed="2.15.0"           →  "< 2.15.0"
-          introduced="2.0-b9",  fixed="2.15.0"           →  ">= 2.0-b9, < 2.15.0"
-          introduced="0.1.0",   last_affected="0.10.65"  →  ">= 0.1.0, <= 0.10.65"
-          (no events)                                     →  None
-        """
+    def to_expr(self) -> str | None:
         parts = []
         intro = self.introduced.strip()
         fixed = self.fixed.strip()
         last = self.last_affected.strip()
 
-        if intro and intro not in ("0", "0.0", "0.0.0", ""):
+        is_zero_intro = intro in ("0", "0.0", "0.0.0")
+
+        if intro and not is_zero_intro:
             parts.append(f">= {intro}")
 
         if fixed:
             parts.append(f"< {fixed}")
         elif last:
             parts.append(f"<= {last}")
+        elif is_zero_intro:
+            # Unbounded: introduced from zero with no fix — all versions affected.
+            # Return ">= 0" so the group is not silently filtered out.
+            return ">= 0"
 
         return ", ".join(parts) or None
+
+
+@dataclass
+class OsvPackageInfo:
+    """Package info extracted from one or more OSV upstream_purls records.
+
+    Supports multiple disjoint version ranges (e.g. jackson-core has ranges
+    across 2.15.x, 2.19.x, and 3.x branches).  ``affected_range()`` emits
+    ``||``-separated OR groups that ``parse_version_range_or()`` can parse.
+    """
+
+    name: str
+    ecosystem: str  # normalised (e.g. "cargo", "maven", "rpm")
+    purl: str
+    # Legacy single-range fields kept for backward compatibility
+    introduced: str  # "" means "from the beginning"
+    fixed: str  # "" means "no fix yet / unknown"
+    last_affected: str  # alternative to fixed (inclusive upper bound)
+    range_groups: list[_RangeGroup] | None = None
+
+    def affected_range(self) -> str | None:
+        """
+        Convert OSV events to a version.py range expression string.
+
+        When multiple range groups exist, they are joined with ``||`` so that
+        ``parse_version_range_or()`` treats them as OR groups.
+
+        Examples:
+          Single:    introduced="0",   fixed="2.15.0"       →  "< 2.15.0"
+          Disjoint:  [2.15.0-<2.18.6, 2.19.0-<2.21.1]      →  ">= 2.15.0, < 2.18.6 || >= 2.19.0, < 2.21.1"
+          (no events)                                        →  None
+        """
+        if self.range_groups:
+            exprs = []
+            for rg in self.range_groups:
+                expr = rg.to_expr()
+                if expr:
+                    exprs.append(expr)
+            return " || ".join(exprs) or None
+
+        # Fallback: legacy single-range fields — reuse _RangeGroup.to_expr()
+        return _RangeGroup(
+            introduced=self.introduced,
+            fixed=self.fixed,
+            last_affected=self.last_affected,
+        ).to_expr()
 
 
 def osv_entry_to_package_info(entry: dict) -> OsvPackageInfo:
@@ -77,33 +114,96 @@ def osv_entry_to_package_info(entry: dict) -> OsvPackageInfo:
         "ranges":    [{"type": "ECOSYSTEM", "events": [...]}],
         "versions":  ["10.0.0", ...],
       }
+
+    Each OSV range object can contain multiple introduced/fixed pairs
+    representing disjoint vulnerable intervals.  All pairs are collected
+    into separate ``_RangeGroup`` instances so that ``affected_range()``
+    emits OR groups.
     """
     raw_eco = (entry.get("ecosystem") or "").lower()
     ecosystem = OSV_ECOSYSTEM_MAP.get(raw_eco, raw_eco)
 
-    introduced = ""
-    fixed = ""
-    last_affected = ""
+    range_groups: list[_RangeGroup] = []
 
     for r in entry.get("ranges", []):
         if r.get("type", "").lower() not in _RANGE_TYPES:
             continue
+        # OSV events are ordered pairs: introduced → fixed/last_affected.
+        # Walk events and emit a _RangeGroup for each complete pair.
+        # An introduced without a subsequent fixed/last_affected represents
+        # an open-ended range (no fix released yet) — emit it as well.
+        current_intro = ""
+        has_intro = False
         for evt in r.get("events", []):
-            if "introduced" in evt and not introduced:
-                introduced = evt["introduced"]
-            if "fixed" in evt and not fixed:
-                fixed = evt["fixed"]
-            if "last_affected" in evt and not last_affected:
-                last_affected = evt["last_affected"]
+            if "introduced" in evt:
+                # Flush a pending open-ended introduced before starting a new one
+                if has_intro:
+                    range_groups.append(
+                        _RangeGroup(
+                            introduced=current_intro, fixed="", last_affected=""
+                        )
+                    )
+                current_intro = evt["introduced"]
+                has_intro = True
+            elif "fixed" in evt:
+                range_groups.append(
+                    _RangeGroup(
+                        introduced=current_intro,
+                        fixed=evt["fixed"],
+                        last_affected="",
+                    )
+                )
+                current_intro = ""
+                has_intro = False
+            elif "last_affected" in evt:
+                range_groups.append(
+                    _RangeGroup(
+                        introduced=current_intro,
+                        fixed="",
+                        last_affected=evt["last_affected"],
+                    )
+                )
+                current_intro = ""
+                has_intro = False
+        # Flush trailing open-ended introduced (no fix released)
+        if has_intro:
+            range_groups.append(
+                _RangeGroup(introduced=current_intro, fixed="", last_affected="")
+            )
+
+    # Legacy single-range fields from the first group (backward compat)
+    first = range_groups[0] if range_groups else _RangeGroup("", "", "")
 
     return OsvPackageInfo(
         name=entry.get("name", ""),
         ecosystem=ecosystem,
         purl=entry.get("purl", ""),
-        introduced=introduced,
-        fixed=fixed,
-        last_affected=last_affected,
+        introduced=first.introduced,
+        fixed=first.fixed,
+        last_affected=first.last_affected,
+        range_groups=range_groups or None,
     )
+
+
+def _entry_matches(needle: str, entry: dict, parsed_purl, ecosystem: str) -> bool:
+    """Check if an upstream_purls entry matches the component name and ecosystem."""
+    if ecosystem:
+        if parsed_purl:
+            purl_type = parsed_purl.type
+        else:
+            raw_eco = (entry.get("ecosystem") or "").lower()
+            purl_type = OSV_ECOSYSTEM_MAP.get(raw_eco, raw_eco)
+        if purl_type != ecosystem:
+            return False
+
+    entry_name = (entry.get("name") or "").strip().lower()
+    if entry_name and entry_name == needle:
+        return True
+
+    if parsed_purl and parsed_purl.name.lower() == needle:
+        return True
+
+    return False
 
 
 def match_component_to_upstream(
@@ -112,7 +212,11 @@ def match_component_to_upstream(
     ecosystem: str = "",
 ) -> OsvPackageInfo | None:
     """
-    Find the upstream_purls entry whose package name matches ``component``.
+    Find upstream_purls entries whose package name matches ``component``.
+
+    When multiple entries match (e.g. disjoint version ranges for the same
+    component across different ``affected[]`` blocks), their ranges are merged
+    into a single ``OsvPackageInfo`` with OR-group support.
 
     When ``ecosystem`` is provided, only entries whose PURL type matches the
     ecosystem are considered. This prevents selecting the wrong OSV range when
@@ -122,11 +226,13 @@ def match_component_to_upstream(
       1. ``entry["name"]`` directly
       2. The ``name`` part of ``entry["purl"]`` (via PackageURL)
 
-    Returns the first matching OsvPackageInfo, or None if no entry matches.
+    Returns a merged OsvPackageInfo, or None if no entry matches.
     """
     needle = component.strip().lower()
     if not needle:
         return None
+
+    matches: list[OsvPackageInfo] = []
 
     for entry in upstream_purls or []:
         purl_str = entry.get("purl") or ""
@@ -138,21 +244,47 @@ def match_component_to_upstream(
                 log.debug("Skipping malformed upstream PURL %r", purl_str)
                 continue
 
-        if ecosystem:
-            if parsed_purl:
-                purl_type = parsed_purl.type
-            else:
-                # For purl-less entries, derive ecosystem from OSV ecosystem field
-                raw_eco = (entry.get("ecosystem") or "").lower()
-                purl_type = OSV_ECOSYSTEM_MAP.get(raw_eco, raw_eco)
-            if purl_type != ecosystem:
-                continue
+        if _entry_matches(needle, entry, parsed_purl, ecosystem):
+            matches.append(osv_entry_to_package_info(entry))
 
-        entry_name = (entry.get("name") or "").strip().lower()
-        if entry_name and entry_name == needle:
-            return osv_entry_to_package_info(entry)
+    if not matches:
+        return None
 
-        if parsed_purl and parsed_purl.name.lower() == needle:
-            return osv_entry_to_package_info(entry)
+    # Multiple matches may span different ecosystems even when an explicit
+    # ecosystem is passed (e.g. purl type vs entry ecosystem can disagree).
+    # Only merge entries that share the same normalized ecosystem as the
+    # first match, so that version comparison uses the correct algorithm.
+    first = matches[0]
+    matches = [m for m in matches if m.ecosystem == first.ecosystem]
 
-    return None
+    if len(matches) == 1:
+        return matches[0]
+
+    # Merge ranges from all matching entries into a single OsvPackageInfo.
+    # Every entry contributes its range_groups (or a single-range fallback).
+    # Introduced-only entries (no fix yet) are included — they represent
+    # open-ended "still vulnerable" intervals.
+    all_groups: list[_RangeGroup] = []
+    for info in matches:
+        if info.range_groups:
+            all_groups.extend(info.range_groups)
+        else:
+            all_groups.append(
+                _RangeGroup(
+                    introduced=info.introduced,
+                    fixed=info.fixed,
+                    last_affected=info.last_affected,
+                )
+            )
+
+    # Derive legacy fields from the first collected group
+    first_group = all_groups[0] if all_groups else _RangeGroup("", "", "")
+    return OsvPackageInfo(
+        name=first.name,
+        ecosystem=first.ecosystem,
+        purl=first.purl,
+        introduced=first_group.introduced,
+        fixed=first_group.fixed,
+        last_affected=first_group.last_affected,
+        range_groups=all_groups or None,
+    )

--- a/apps/ace/tasks.py
+++ b/apps/ace/tasks.py
@@ -446,7 +446,7 @@ def _handle_go_stdlib(
         "marked_notaffected": 0,
     }
 
-    def _run_phase(phase_description, results):
+    def _run_phase(phase_description, results, query_name=""):
         stats = _sync_affects_from_results(
             flaw,
             results,
@@ -454,6 +454,7 @@ def _handle_go_stdlib(
             ps_modules,
             ecosystem="golang",
             upstream_purls=upstream_purls,
+            resolved_name=query_name or component,
         )
         for key in stats:
             totals[key] += stats[key]
@@ -472,7 +473,7 @@ def _handle_go_stdlib(
             builds_only=True,
             no_community=True,
         )
-        _run_phase("Phase 1 (golang builds)", results)
+        _run_phase("Phase 1 (golang builds)", results, query_name="golang")
     except Exception as exc:
         logger.warning("Go stdlib Phase 1 failed for flaw=%s: %s", flaw.uuid, exc)
 
@@ -593,9 +594,70 @@ def _ace_tool_name() -> str:
         return f"osidb {osidb_version}"
 
 
+def _extract_version_from_result(
+    purl_str: str, result, query_component: str = ""
+) -> str | None:
+    """Extract a meaningful package version from a lib_newtopia result.
+
+    Priority:
+      1. PURL version — used for every PURL type that carries an explicit version
+         (rpm, npm, pypi, maven, generic, github, etc.).  Only OCI PURLs are
+         expected to lack a meaningful package version.
+      2. ``sources[].dependencies[].version`` — for container/OCI PURLs where the
+         real dependency version lives inside the build manifest.  When
+         *query_component* is given, only the dependency whose name matches is
+         used (prevents picking an unrelated dependency's version).
+      3. ``build_nvr`` minus ``build_name`` prefix — last-resort heuristic
+
+    Returns ``None`` when no version can be determined.
+    """
+    try:
+        purl_obj = PackageURL.from_string(purl_str)
+        purl_type = purl_obj.type
+        purl_version = purl_obj.version
+    except Exception:
+        return None
+
+    if purl_version and purl_type != "oci":
+        return purl_version
+
+    # Container/build PURLs — recover version from sources.dependencies
+    _arch_suffixes = (".x86_64", ".aarch64", ".ppc64le", ".s390x", ".noarch", ".i686")
+    needle = query_component.strip().lower()
+    sources = getattr(result, "sources", None) or []
+    for src in sources:
+        for dep in getattr(src, "dependencies", None) or []:
+            # When we know the query component, only match that dependency
+            if needle:
+                dep_name = (getattr(dep, "name", "") or "").strip().lower()
+                if dep_name != needle:
+                    continue
+            raw_ver = getattr(dep, "version", "") or ""
+            if not raw_ver:
+                continue
+            for suf in _arch_suffixes:
+                if raw_ver.endswith(suf):
+                    raw_ver = raw_ver[: -len(suf)]
+                    break
+            return raw_ver
+
+    # Fallback: build_nvr minus build_name prefix.
+    # Only trust build_nvr when the build describes the queried component,
+    # otherwise the version belongs to an unrelated container build.
+    build_name = getattr(result, "build_name", "") or ""
+    build_nvr = getattr(result, "build_nvr", "") or ""
+    if build_nvr and build_name and build_nvr.startswith(build_name + "-"):
+        if not needle or build_name.strip().lower() == needle:
+            return build_nvr[len(build_name) + 1 :]
+
+    return None
+
+
 def _osv_version_status(
     purl_str: str,
     pkg_info: OsvPackageInfo | None,
+    result=None,
+    query_component: str = "",
 ) -> tuple[OsvStatus, str | None, str | None]:
     """
     Determine the OSV affectedness status for a single lib_newtopia result purl.
@@ -614,12 +676,10 @@ def _osv_version_status(
     if range_str is None:
         return OsvStatus.NO_RANGE, None, None
 
-    try:
-        purl_version = PackageURL.from_string(purl_str).version
-    except Exception:
-        purl_version = None
-
-    upstream_version = extract_upstream_version(purl_version, pkg_info.ecosystem)
+    version_str = _extract_version_from_result(
+        purl_str, result, query_component=query_component
+    )
+    upstream_version = extract_upstream_version(version_str, pkg_info.ecosystem)
     if upstream_version is None:
         return OsvStatus.NO_VERSION, range_str, None
 
@@ -636,6 +696,7 @@ def _sync_affects_from_results(
     ps_modules: list[str] | None = None,
     ecosystem: str = "",
     upstream_purls: list[dict] | None = None,
+    resolved_name: str = "",
 ) -> dict[str, int]:
     """Create affects on ``flaw`` for each entry in ``results``.
 
@@ -685,7 +746,10 @@ def _sync_affects_from_results(
                 continue
 
             osv_status, range_str, version_checked = _osv_version_status(
-                purl_str, pkg_info
+                purl_str,
+                pkg_info,
+                result=result,
+                query_component=resolved_name or flaw_component,
             )
 
             affect = Affect(
@@ -720,6 +784,10 @@ def _sync_affects_from_results(
                     NotAffectedJustification.VULN_CODE_NOT_PRESENT
                 )
                 marked_notaffected += 1
+            elif osv_status is OsvStatus.NO_VERSION:
+                affect.affectedness = Affect.AffectAffectedness.NEW
+                affect.resolution = Affect.AffectResolution.NOVALUE
+                _apply_label(flaw, LABEL_MANUAL_TRIAGE)
             else:
                 affect.auto_resolve(flaw_has_high_cvss_score=flaw_has_high_cvss_score)
 
@@ -853,6 +921,7 @@ def sync_flaw_affects_from_newcli(flaw_id: str) -> dict[str, Any]:
                 ps_modules,
                 ecosystem=ecosystem,
                 upstream_purls=upstream_purls,
+                resolved_name=resolved_name,
             )
             for key in stats:
                 totals[key] += stats[key]

--- a/apps/ace/tests/conftest.py
+++ b/apps/ace/tests/conftest.py
@@ -8,12 +8,21 @@ import pytest
 from osidb.tests.factories import PsUpdateStreamFactory
 
 
-def _result(ps_update_stream: str, purl: str) -> SimpleNamespace:
+def _result(
+    ps_update_stream: str,
+    purl: str,
+    *,
+    sources=None,
+    build_nvr=None,
+    build_name=None,
+) -> SimpleNamespace:
     """Minimal stand-in for NewcliBuildResult / NewcliDepResult."""
     return SimpleNamespace(
         ps_update_stream=ps_update_stream,
         purls=[purl],
-        build_nvr=None,
+        sources=sources,
+        build_nvr=build_nvr,
+        build_name=build_name,
     )
 
 

--- a/apps/ace/tests/test_osv_ranges.py
+++ b/apps/ace/tests/test_osv_ranges.py
@@ -335,3 +335,348 @@ def test_entry_to_package_info_purl_less():
     assert info.purl == ""
     assert info.introduced == "0"
     assert info.fixed == "6.0.0"
+
+
+# ── Disjoint range support (OSIDB-5343) ──────────────────────────────────────
+
+
+def test_entry_disjoint_ranges_within_single_entry():
+    """
+    A single upstream_purls entry with multiple introduced/fixed pairs
+    in its events list must produce OR groups.
+
+    jackson-core example: events=[introduced:2.15.0, fixed:2.18.6,
+    introduced:2.19.0, fixed:2.21.1] → ">= 2.15.0, < 2.18.6 || >= 2.19.0, < 2.21.1"
+    """
+    entry = {
+        "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core",
+        "name": "jackson-core",
+        "ecosystem": "Maven",
+        "ranges": [
+            {
+                "type": "ECOSYSTEM",
+                "events": [
+                    {"introduced": "2.15.0"},
+                    {"fixed": "2.18.6"},
+                    {"introduced": "2.19.0"},
+                    {"fixed": "2.21.1"},
+                ],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.affected_range() == ">= 2.15.0, < 2.18.6 || >= 2.19.0, < 2.21.1"
+
+
+def test_entry_single_range_no_or_groups():
+    """A single introduced/fixed pair should not produce OR groups."""
+    entry = {
+        "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core",
+        "name": "jackson-core",
+        "ecosystem": "Maven",
+        "ranges": [
+            {
+                "type": "ECOSYSTEM",
+                "events": [{"introduced": "0"}, {"fixed": "2.18.6"}],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert len(info.range_groups) == 1
+    assert info.affected_range() == "< 2.18.6"
+
+
+def test_match_merges_disjoint_entries():
+    """
+    When multiple upstream_purls entries match the same component name,
+    their ranges must be merged with OR groups.
+
+    This is the jackson-core CVE-2026-18401 scenario: three separate
+    affected[] blocks produce three upstream_purls entries.
+    """
+    upstream_purls = [
+        {
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core",
+            "name": "jackson-core",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "2.15.0"}, {"fixed": "2.18.6"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core",
+            "name": "jackson-core",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "2.19.0"}, {"fixed": "2.21.1"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:maven/tools.jackson.core/jackson-core",
+            "name": "jackson-core",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "3.0.0"}, {"fixed": "3.1.0"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+    result = match_component_to_upstream("jackson-core", upstream_purls)
+    assert result is not None
+    range_str = result.affected_range()
+    assert ">= 2.15.0, < 2.18.6" in range_str
+    assert ">= 2.19.0, < 2.21.1" in range_str
+    assert ">= 3.0.0, < 3.1.0" in range_str
+    assert "||" in range_str
+
+
+def test_match_disjoint_version_outside_all_ranges():
+    """
+    A version outside all disjoint ranges must be NOT_AFFECTED.
+
+    jackson-core 2.21.4 is above the fix for the second range (2.21.1)
+    and below the third range's start (3.0.0) → not affected.
+    """
+    from apps.ace.version import (
+        OsvStatus,
+        determine_status,
+        parse_version_range_or,
+    )
+
+    upstream_purls = [
+        {
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core",
+            "name": "jackson-core",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "2.15.0"}, {"fixed": "2.18.6"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:maven/com.fasterxml.jackson.core/jackson-core",
+            "name": "jackson-core",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "2.19.0"}, {"fixed": "2.21.1"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+    info = match_component_to_upstream("jackson-core", upstream_purls)
+    range_str = info.affected_range()
+    constraints = parse_version_range_or(range_str, "maven")
+
+    # 2.21.4 is above 2.21.1 fix → not affected
+    assert determine_status("2.21.4", constraints) == OsvStatus.NOT_AFFECTED
+    # 2.18.6 is at the fix boundary → not affected
+    assert determine_status("2.18.6", constraints) == OsvStatus.NOT_AFFECTED
+    # 2.17.0 is inside first range → affected
+    assert determine_status("2.17.0", constraints) == OsvStatus.AFFECTED
+    # 2.20.0 is inside second range → affected
+    assert determine_status("2.20.0", constraints) == OsvStatus.AFFECTED
+    # 2.14.0 is below first range's start → not affected
+    assert determine_status("2.14.0", constraints) == OsvStatus.NOT_AFFECTED
+
+
+def test_entry_introduced_only_no_fix():
+    """
+    An entry with only 'introduced' and no 'fixed' or 'last_affected' represents
+    an open-ended range (no fix released yet).  It must produce '>= introduced'
+    and not be silently dropped.
+    """
+    entry = {
+        "purl": "pkg:pypi/some-lib",
+        "name": "some-lib",
+        "ecosystem": "PyPI",
+        "ranges": [
+            {
+                "type": "ECOSYSTEM",
+                "events": [{"introduced": "2.15.0"}],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.affected_range() == ">= 2.15.0"
+
+
+def test_match_merges_introduced_only_entry():
+    """
+    When merging multiple matching entries, an entry with only 'introduced'
+    (no fix released) must be included in the merged range groups.
+    """
+    from apps.ace.version import (
+        OsvStatus,
+        determine_status,
+        parse_version_range_or,
+    )
+
+    upstream_purls = [
+        {
+            "purl": "pkg:maven/com.example/mylib",
+            "name": "mylib",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "1.0.0"}, {"fixed": "1.2.0"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:maven/com.example/mylib",
+            "name": "mylib",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "2.0.0"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+    info = match_component_to_upstream("mylib", upstream_purls)
+    assert info is not None
+    range_str = info.affected_range()
+    assert ">= 1.0.0, < 1.2.0" in range_str
+    assert ">= 2.0.0" in range_str
+    assert "||" in range_str
+
+    constraints = parse_version_range_or(range_str, "maven")
+    assert determine_status("1.1.0", constraints) == OsvStatus.AFFECTED
+    assert determine_status("2.5.0", constraints) == OsvStatus.AFFECTED
+    assert determine_status("1.3.0", constraints) == OsvStatus.NOT_AFFECTED
+
+
+def test_unbounded_range_group_not_filtered():
+    """
+    An entry with introduced=0 and no fixed/last_affected represents
+    'all versions affected'.  to_expr() must return '>= 0' (not None)
+    so that affected_range() does not silently drop it.
+    """
+    entry = {
+        "purl": "pkg:pypi/vuln-lib",
+        "name": "vuln-lib",
+        "ecosystem": "PyPI",
+        "ranges": [
+            {
+                "type": "ECOSYSTEM",
+                "events": [{"introduced": "0"}],
+            }
+        ],
+        "versions": [],
+    }
+    info = osv_entry_to_package_info(entry)
+    assert info.affected_range() == ">= 0"
+
+
+def test_merge_unbounded_with_bounded_range():
+    """
+    When merging an unbounded entry (introduced=0, no fix) with a bounded
+    entry, versions below the bounded interval must still be AFFECTED
+    because the unbounded range covers all versions.
+    """
+    from apps.ace.version import (
+        OsvStatus,
+        determine_status,
+        parse_version_range_or,
+    )
+
+    upstream_purls = [
+        {
+            "purl": "pkg:pypi/vuln-lib",
+            "name": "vuln-lib",
+            "ecosystem": "PyPI",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:pypi/vuln-lib",
+            "name": "vuln-lib",
+            "ecosystem": "PyPI",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "2.0.0"}, {"fixed": "2.5.0"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+    info = match_component_to_upstream("vuln-lib", upstream_purls)
+    assert info is not None
+    range_str = info.affected_range()
+    assert ">= 0" in range_str
+    assert ">= 2.0.0, < 2.5.0" in range_str
+
+    constraints = parse_version_range_or(range_str, "pypi")
+    # 0.5.0 is below the bounded range but inside the unbounded one → AFFECTED
+    assert determine_status("0.5.0", constraints) == OsvStatus.AFFECTED
+    # 2.3.0 is inside the bounded range → AFFECTED
+    assert determine_status("2.3.0", constraints) == OsvStatus.AFFECTED
+
+
+def test_match_mixed_ecosystems_not_merged():
+    """
+    When ecosystem is not specified, same-name entries from different ecosystems
+    must not be merged together — only entries matching the first match's
+    ecosystem are included, so version comparison uses the correct algorithm.
+    """
+    upstream_purls = [
+        {
+            "purl": "pkg:maven/com.example/demo",
+            "name": "demo",
+            "ecosystem": "Maven",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "3.0"}, {"fixed": "4.0"}],
+                }
+            ],
+            "versions": [],
+        },
+        {
+            "purl": "pkg:npm/demo",
+            "name": "demo",
+            "ecosystem": "npm",
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [{"introduced": "0"}, {"fixed": "1.0"}],
+                }
+            ],
+            "versions": [],
+        },
+    ]
+    info = match_component_to_upstream("demo", upstream_purls)
+    assert info is not None
+    # Only the first ecosystem (Maven) entries should be included
+    assert info.ecosystem == "maven"
+    assert "||" not in (info.affected_range() or "")

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -510,6 +510,207 @@ def test_sync_returns_marked_notaffected_count(
     }
 
 
+# ── NO_VERSION fallback tests ──────────────────────────────────────────────────
+
+
+def test_sync_container_purl_extracts_dep_version(
+    monkeypatch, ace_enabled, mock_querier, upstream_purls_openssl_rpm, result
+):
+    """
+    Container/OCI PURLs carry no package version — the real dependency version
+    lives in sources[].dependencies[].  ACE must extract it and compare against
+    the OSV range.  openssl 3.5.1 is outside "< 3.0.9" → NOTAFFECTED.
+    """
+    flaw = FlawFactory(
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+    )
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    dep = SimpleNamespace(
+        version="3.5.1-7.el9_7.x86_64", name="openssl", ecosystem="rpm"
+    )
+    src = SimpleNamespace(dependencies=[dep])
+    results = [
+        result(
+            "hummingbird-1",
+            "pkg:oci/openssl-container?repository_url=registry.redhat.io/openssl",
+            sources=[src],
+        ),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["marked_notaffected"] == 1
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.NOTAFFECTED
+    assert affect.assist_meta["osv_status"] == "not_affected"
+    assert affect.assist_meta["osv_version_checked"] == "3.5.1-7.el9_7"
+
+
+def test_sync_container_purl_dep_version_in_range_affected(
+    monkeypatch, ace_enabled, mock_querier, upstream_purls_openssl_rpm, result
+):
+    """
+    Container PURL with dependency version inside the range → AFFECTED.
+    openssl 3.0.7 is inside "< 3.0.9".
+    """
+    PsUpdateStreamFactory(name="hummingbird-1")
+    flaw = FlawFactory(
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+    )
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    dep = SimpleNamespace(version="3.0.7-18.el9_2", name="openssl", ecosystem="rpm")
+    src = SimpleNamespace(dependencies=[dep])
+    results = [
+        result(
+            "hummingbird-1",
+            "pkg:oci/openssl-container?repository_url=registry.redhat.io/openssl",
+            sources=[src],
+        ),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["marked_notaffected"] == 0
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
+    assert affect.assist_meta["osv_status"] == "affected"
+
+
+def test_sync_build_nvr_fallback_version_extraction(
+    monkeypatch, ace_enabled, mock_querier, upstream_purls_openssl_rpm, result
+):
+    """
+    When neither PURL version nor sources.dependencies are available, fall back
+    to build_nvr for version extraction.
+    """
+    flaw = FlawFactory(
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+    )
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result(
+            "hummingbird-1",
+            "pkg:oci/openssl-container?repository_url=registry.redhat.io/openssl",
+            build_nvr="openssl-3.5.1-7.el9_7",
+            build_name="openssl",
+        ),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["marked_notaffected"] == 1
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.NOTAFFECTED
+    assert affect.assist_meta["osv_version_checked"] == "3.5.1-7.el9_7"
+
+
+def test_sync_no_version_creates_new_affect(
+    monkeypatch, ace_enabled, mock_querier, upstream_purls_openssl_rpm, result
+):
+    """
+    When no version can be extracted at all (no PURL version, no dependencies,
+    no build_nvr), the affect must be created as NEW — not AFFECTED/DELEGATED.
+    This prevents false-positive trackers for components outside the range.
+    """
+    flaw = FlawFactory(
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+    )
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result(
+            "hummingbird-1",
+            "pkg:oci/openssl-container?repository_url=registry.redhat.io/openssl",
+        ),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["created"] == 1
+    assert stats["marked_notaffected"] == 0
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.NEW
+    assert affect.resolution == Affect.AffectResolution.NOVALUE
+    assert affect.assist_meta["osv_status"] == "no_version"
+
+
+def test_sync_no_version_applies_manual_triage_label(
+    monkeypatch, ace_enabled, mock_querier, upstream_purls_openssl_rpm, result
+):
+    """
+    When an affect is created as NEW due to NO_VERSION, the manual-triage
+    label must be applied so analysts can pick up the flaw.
+    """
+    from osidb.models.flaw.label import WorkflowLabel
+
+    flaw = FlawFactory(
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+    )
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result(
+            "hummingbird-1",
+            "pkg:oci/openssl-container?repository_url=registry.redhat.io/openssl",
+        ),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert WorkflowLabel.objects.filter(flaw=flaw, name=LABEL_MANUAL_TRIAGE).exists()
+
+
+def test_sync_unrelated_build_nvr_returns_no_version(
+    monkeypatch, ace_enabled, mock_querier, upstream_purls_openssl_rpm, result
+):
+    """
+    When build_name does not match the queried component, build_nvr must
+    not be used for version extraction — the affect should be NEW, not
+    NOTAFFECTED with the container build's version.
+    """
+    flaw = FlawFactory(
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+    )
+    UpstreamDataFactory(flaw=flaw, upstream_purls=upstream_purls_openssl_rpm)
+
+    results = [
+        result(
+            "hummingbird-1",
+            "pkg:oci/openssl-container?repository_url=registry.redhat.io/openssl",
+            build_nvr="python-cryptography-container-42.0.8-1.hum1",
+            build_name="python-cryptography-container",
+        ),
+    ]
+    monkeypatch.setattr(
+        "apps.ace.tasks.NewtopiaQuerier", mock_querier({"openssl": results})
+    )
+
+    stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert stats["created"] == 1
+    affect = flaw.affects.get()
+    assert affect.affectedness == Affect.AffectAffectedness.NEW
+    assert affect.assist_meta["osv_status"] == "no_version"
+
+
 # ── Ecosystem scoping tests ────────────────────────────────────────────────────
 
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix tracker target_release value being written to Target Version field
   instead of Target Release when the Jira project uses a non-default custom
   field ID (OSIDB-5318)
+- ACE: extract dependency version from sources.dependencies and build_nvr for
+  container/OCI PURLs, and treat NO_VERSION as NEW instead of AFFECTED/DELEGATED
+  to prevent false-positive trackers (OSIDB-5400)
+- ACE: handle disjoint OSV version ranges correctly instead of collapsing
+  multiple affected[] blocks into a single range, preventing false-positive
+  AFFECTED entries (OSIDB-5343)
 
 ## [5.16.3] - 2026-08-13
 ### Fixed


### PR DESCRIPTION
## Summary

This PR fixes two distinct ACE bugs that caused false-positive affects.

**OSIDB-5400: Container/OCI PURLs with no extractable version**

- `_osv_version_status()` only extracted version from `purls[0]`, which is empty for container/OCI PURLs. The actual dependency version in `sources[].dependencies[].version` was never checked, leading to `osv_status=no_version`.
- The `NO_VERSION` status fell through to `auto_resolve()` → `AFFECTED/DELEGATED`, creating false-positive trackers for components outside the affected range.
- Adds `_extract_version_from_result()` to extract versions from `sources.dependencies` (filtered by query component name) and `build_nvr` as fallbacks, and treats `NO_VERSION` as `NEW/NOVALUE` instead of `AFFECTED/DELEGATED`.
- Only OCI PURLs skip the PURL version; `generic` and `github` PURLs use their version directly when present.

**OSIDB-5343: Disjoint OSV version ranges silently dropped**

- `osv_entry_to_package_info()` only captured the first introduced/fixed pair per range object. Multiple disjoint intervals within the same advisory (e.g. jackson-core across 2.15.x, 2.19.x, and 3.x) were lost.
- `match_component_to_upstream()` only returned the first matching entry, discarding ranges from other `affected[]` blocks for the same component.
- Introduces `_RangeGroup` dataclass and collects all introduced/fixed pairs (including open-ended introduced-only entries with no fix yet). `affected_range()` emits `||`-separated OR groups that `parse_version_range_or()` can parse.
- Merges range groups across multiple matching upstream_purls entries into a single `OsvPackageInfo`.