### PR TITLE
fix: Update label filter to support FlawLabelsV2

### DIFF
--- a/osidb/djangoql.py
+++ b/osidb/djangoql.py
@@ -1,6 +1,7 @@
 from django.db import models
 from django.db.models import Q
 from django.utils import timezone
+from djangoql.exceptions import DjangoQLSchemaError
 from djangoql.schema import (
     BoolField,
     DateTimeField,
@@ -113,8 +114,23 @@ class FlawQLSchema(DjangoQLSchema):
             return RelativeDateTimeQLField
         return super().get_field_cls(field)
 
+    def resolve_name(self, name):
+        """
+        Allow dotted access to FlawLabel fields that aren't reachable through
+        the flat "labels" relation otherwise: "name"/"type" live on the base
+        FlawLabel, and "contributor"/"state"/"relevant" only exist on some
+        subclasses. Anything else on the FlawLabel relation graph stays
+        unknown (whitelist via FLAW_LABEL_PROPERTY_FIELDS).
+        """
+        if len(name.parts) == 2 and name.parts[0] == "labels":
+            field = FLAW_LABEL_PROPERTY_FIELDS.get(name.parts[1])
+            if field:
+                return field
+
+        return super().resolve_name(name)
+
     def get_fields(self, model):
-        fields = super(FlawQLSchema, self).get_fields(model)
+        fields = super().get_fields(model)
         exclude = ["acl_read", "acl_write"]
         if model == Flaw:
             exclude += ["snippets", "local_updated_dt"]
@@ -136,7 +152,7 @@ class FlawComponentField(StrField):
     suggest_options = True
 
     def get_options(self, search):
-        options = super(FlawComponentField, self).get_options(search)
+        options = super().get_options(search)
         flat_list = []
         for option in options:
             flat_list += option
@@ -226,22 +242,156 @@ class FlawLabelsField(StrField):
             labels not in ("label_a", "label_b") - flaws without label_a OR without label_b
         """
 
-        if operator == "=":
-            return Q(labels__name=value)
-        elif operator == "!=":
-            return ~Q(labels__name=value)
+        if operator in ("in", "not in"):
+            # Dedupe repeated operands (e.g. labels in ("a", "a")), otherwise
+            # num_labels overcounts and the AND semantics below never match.
+            unique_values = set(value)
+            num_labels = len(unique_values)
 
-        num_labels = len(value)
+            flaw_ids = (
+                FlawLabel.objects.filter(name__in=unique_values)
+                .values("flaw_id")
+                .annotate(label_count=models.Count("name", distinct=True))
+                .filter(label_count=num_labels)
+                .values_list("flaw_id", flat=True)
+            )
 
-        flaw_ids = (
-            FlawLabel.objects.filter(name__in=value)
-            .values("flaw_id")
-            .annotate(label_count=models.Count("name", distinct=True))
-            .filter(label_count=num_labels)
-            .values_list("flaw_id", flat=True)
-        )
+            if operator == "in":
+                return Q(uuid__in=flaw_ids)
+            return ~Q(uuid__in=flaw_ids)
 
-        if operator == "in":
-            return Q(uuid__in=list(flaw_ids))
-        elif operator == "not in":
-            return ~Q(uuid__in=list(flaw_ids))
+        op, invert = self.get_operator(operator)
+        q = Q(**{f"labels__name{op}": value})
+        return ~q if invert else q
+
+
+class FlawLabelPropertyField:
+    """
+    Mixin for fields that only exist on FlawLabel subclasses, reachable via
+    dotted access on the flat "labels" field, e.g. "labels.contributor".
+
+    Plain mixin (not a DjangoQLField subclass) so the concrete field's own
+    base (StrField/BoolField) decides its "type" for value validation.
+    """
+
+    model = FlawLabel
+    subclasses = ()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.subclasses:
+            # Fail loudly at import time rather than silently matching
+            # everything (positive comparison) or nothing (negated) below.
+            raise ValueError(
+                f"{type(self).__name__} has no FlawLabel subclasses defining "
+                f"{self.name!r}; check the field name."
+            )
+
+    def get_lookup(self, path, operator, value):
+        op, invert = self.get_operator(operator)
+        lookup_value = self.get_lookup_value(value)
+        q = Q()
+        for subclass in self.subclasses:
+            search = "__".join(path + [subclass, self.name])
+            q |= Q(**{f"{search}{op}": lookup_value})
+        return ~q if invert else q
+
+
+def _label_subclasses_with_field(field_name):
+    """
+    Related-model accessor names (e.g. "collaboratorlabel") of FlawLabel
+    subclasses that define field_name, derived from FlawLabel.TYPE_TO_MODEL
+    instead of hard-coding the list, so new/changed label types stay in sync.
+    """
+    return tuple(
+        model._meta.model_name
+        for model in FlawLabel.TYPE_TO_MODEL.values()
+        if field_name in {f.name for f in model._meta.get_fields()}
+    )
+
+
+class FlawLabelContributorField(FlawLabelPropertyField, StrField):
+    name = "contributor"
+    subclasses = _label_subclasses_with_field("contributor")
+
+
+class FlawLabelStateField(FlawLabelPropertyField, StrField):
+    name = "state"
+    subclasses = _label_subclasses_with_field("state")
+
+
+class FlawLabelRelevantField(FlawLabelPropertyField, BoolField):
+    name = "relevant"
+    subclasses = _label_subclasses_with_field("relevant")
+
+
+class FlawLabelUuidField(StrField):
+    """
+    "uuid" identifies a single label row, unlike "name" it has no
+    AND-across-multiple-labels semantics, so it doesn't need FlawLabelsField's
+    special "in"/"not in" handling - the plain generic operator lookup is
+    enough. Whitelisted explicitly so "labels.uuid" doesn't silently fall
+    back to matching Flaw's own "uuid" field via resolve_name()'s default
+    (non-relation) dotted-access resolution.
+    """
+
+    model = FlawLabel
+    name = "uuid"
+
+    def get_lookup(self, path, operator, value):
+        op, invert = self.get_operator(operator)
+        q = Q(**{f"labels__uuid{op}": value})
+        return ~q if invert else q
+
+
+class FlawLabelTypeField(StrField):
+    """
+    "type" isn't a real column: django-polymorphic tracks the concrete
+    subclass via the "polymorphic_ctype" relation, not a plain field. Map
+    the LabelType enum value (e.g. "context_based") to the corresponding
+    subclass's content type "model" name (e.g. "collaboratorlabel") instead.
+    """
+
+    model = FlawLabel
+    name = "type"
+    suggest_options = True
+
+    def get_options(self, search):
+        return list(FlawLabel.LabelType.values)
+
+    def validate(self, value):
+        super().validate(value)
+        if value is not None and value not in FlawLabel.LabelType.values:
+            raise DjangoQLSchemaError(
+                'Field "type" can be compared to one of %s, but not to %r'
+                % (list(FlawLabel.LabelType.values), value)
+            )
+
+    def _model_name(self, value):
+        return FlawLabel.TYPE_TO_MODEL[FlawLabel.LabelType(value)]._meta.model_name
+
+    def get_lookup(self, path, operator, value):
+        search = "__".join(path + ["polymorphic_ctype__model"])
+
+        if operator in ("in", "not in"):
+            model_names = [self._model_name(v) for v in value]
+            q = Q(**{f"{search}__in": model_names})
+            return q if operator == "in" else ~q
+
+        op, invert = self.get_operator(operator)
+        if op != "":
+            raise DjangoQLSchemaError(
+                'Field "type" only supports "=", "!=", "in" and "not in"'
+            )
+        q = Q(**{search: self._model_name(value)})
+        return ~q if invert else q
+
+
+FLAW_LABEL_PROPERTY_FIELDS = {
+    "name": FlawLabelsField(),
+    "uuid": FlawLabelUuidField(),
+    "type": FlawLabelTypeField(),
+    "contributor": FlawLabelContributorField(),
+    "state": FlawLabelStateField(),
+    "relevant": FlawLabelRelevantField(),
+}

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -3,11 +3,15 @@ import uuid
 import pytest
 
 from osidb.models import (
+    AliasLabel,
+    BULabel,
+    BULabelDefinition,
     CollaboratorLabel,
     CollaboratorLabelDefinition,
     Flaw,
     FlawSource,
     Impact,
+    ProductFamilyLabel,
 )
 
 from .factories import AffectFactory, FlawFactory
@@ -471,13 +475,221 @@ class TestSearch:
         body = response.json()
         assert body["count"] == 0
 
+        # Repeated operands must not inflate the required label count.
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=labels in ("label_a","label_a")'
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 3
+        assert {flaw["cve_id"] for flaw in body["results"]} == {
+            flaw1.cve_id,
+            flaw2.cve_id,
+            flaw3.cve_id,
+        }
+
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=labels not in ("label_c","label_c")'
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 2
+        assert {flaw["cve_id"] for flaw in body["results"]} == {
+            flaw1.cve_id,
+            flaw2.cve_id,
+        }
+
     def test_search_labels_not_exposed(self, auth_client, test_api_uri):
-        """Test that dotted label access (labels.name) is not exposed as a DjangoQL field"""
+        """Fields not whitelisted in FLAW_LABEL_PROPERTY_FIELDS stay unreachable via dotted access"""
         FlawFactory(embargoed=False)
 
-        response = auth_client().get(f'{test_api_uri}/flaws?query=labels.name = "test"')
+        # Note: this must be a name that also doesn't happen to be a real
+        # field on Flaw itself. resolve_name()'s fallback for dotted access
+        # doesn't treat the flat "labels" field as a relation, so on the 2nd
+        # segment it re-checks against Flaw's own fields (e.g. "labels.foo"
+        # would wrongly resolve to Flaw.foo if such a field existed). "uuid"
+        # is whitelisted precisely to avoid that trap (see FlawLabelUuidField).
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=labels.nonexistent = "test"'
+        )
         assert response.status_code == 400
-        assert "Unknown field: name" in response.json()["detail"]
+        assert "Unknown field: nonexistent" in response.json()["detail"]
+
+    def test_search_flaws_by_label_name_and_type(self, auth_client, test_api_uri):
+        """
+        "labels.name" and "labels.type" are queryable via dotted access, same as
+        "labels.contributor"/"labels.state"/"labels.relevant". Unlike those,
+        "name" and "type" live on the base FlawLabel rather than a subclass:
+        "name" behaves exactly like the bare "labels" field, and "type" maps
+        the LabelType enum value (e.g. "context_based") to the polymorphic
+        content type of the matching subclass, since it isn't a real column.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+
+        flaw1 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw1)
+        CollaboratorLabel.objects.create(
+            flaw=flaw1, name="collab-a", state=CollaboratorLabel.State.NEW
+        )
+
+        flaw2 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw2)
+        alias_label = AliasLabel.objects.create(flaw=flaw2, name="CVE-1234-ALIAS")
+
+        cases = [
+            ('labels.name = "collab-a"', {flaw1.cve_id}),
+            ('labels.type = "context_based"', {flaw1.cve_id}),
+            ('labels.type = "alias"', {flaw2.cve_id}),
+            ('labels.type != "alias"', {flaw1.cve_id}),
+            (f'labels.uuid = "{alias_label.uuid}"', {flaw2.cve_id}),
+        ]
+        for query, expected_cve_ids in cases:
+            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+            assert response.status_code == 200, (query, response.json())
+            body = response.json()
+            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
+                query,
+                body,
+            )
+
+        # Values outside the LabelType enum are rejected rather than
+        # silently matching nothing.
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=labels.type = "bogus"'
+        )
+        assert response.status_code == 400
+
+    def test_search_flaws_by_labels_query_operators(self, auth_client, test_api_uri):
+        """
+        The "labels" DjangoQL field is a StrField, so the UI/schema legally offers
+        the full set of string operators (~, !~, startswith, endswith and their
+        "not" variants), not just "=", "!=", "in" and "not in".
+
+        FlawLabelsField.get_lookup() routes all of them through the shared
+        StrField operator mapping, so each must filter by label name correctly.
+        """
+        CollaboratorLabelDefinition.objects.create(name="kernel-fix")
+        CollaboratorLabelDefinition.objects.create(name="other")
+
+        flaw1 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw1)
+        CollaboratorLabel.objects.create(
+            flaw=flaw1, name="kernel-fix", state=CollaboratorLabel.State.NEW
+        )
+
+        flaw2 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw2)
+        CollaboratorLabel.objects.create(
+            flaw=flaw2, name="other", state=CollaboratorLabel.State.NEW
+        )
+
+        cases = [
+            ('labels ~ "kernel"', {flaw1.cve_id}),
+            ('labels !~ "kernel"', {flaw2.cve_id}),
+            ('labels startswith "kernel"', {flaw1.cve_id}),
+            ('labels not startswith "kernel"', {flaw2.cve_id}),
+            ('labels endswith "fix"', {flaw1.cve_id}),
+            ('labels not endswith "fix"', {flaw2.cve_id}),
+        ]
+        for query, expected_cve_ids in cases:
+            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+            assert response.status_code == 200, (query, response.json())
+            body = response.json()
+            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
+                query,
+                body,
+            )
+
+    def test_search_flaws_by_label_properties(self, auth_client, test_api_uri):
+        """
+        Fields that only exist on FlawLabel subclasses (contributor, state, relevant)
+        are queryable via DjangoQL through dotted access on the flat "labels"
+        field, e.g. "labels.contributor = ...", including their "!=" negation.
+
+        FlawQLSchema.resolve_name() routes these dotted names to
+        FlawLabelPropertyField, which OR's the lookup across whichever FlawLabel
+        subclasses actually define the property. "labels.name" and
+        "labels.type" are covered separately in
+        test_search_flaws_by_label_name_and_type; fields not whitelisted at
+        all stay unreachable (see test_search_labels_not_exposed).
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        CollaboratorLabelDefinition.objects.create(name="collab-b")
+
+        flaw1 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw1)
+        CollaboratorLabel.objects.create(
+            flaw=flaw1,
+            name="collab-a",
+            contributor="alice@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        # A second matching label on the same flaw, so a query joining
+        # through "labels" fans out to multiple rows before dedup.
+        CollaboratorLabel.objects.create(
+            flaw=flaw1,
+            name="collab-b",
+            contributor="alice@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        flaw2 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw2)
+        CollaboratorLabel.objects.create(
+            flaw=flaw2,
+            name="collab-a",
+            contributor="bob@example.com",
+            state=CollaboratorLabel.State.DONE,
+            relevant=False,
+        )
+
+        # A flaw with no CollaboratorLabel at all, only BULabel and
+        # ProductFamilyLabel, so the OR-across-subclasses lookup in
+        # FlawLabelPropertyField is actually exercised for those subclasses
+        # too, not just CollaboratorLabel.
+        BULabelDefinition.objects.create(name="bu-a")
+        flaw3 = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw3)
+        BULabel.objects.create(
+            flaw=flaw3,
+            name="bu-a",
+            contributor="carol@example.com",
+            state=BULabel.State.REQ,
+            relevant=True,
+        )
+        ProductFamilyLabel.objects.create(flaw=flaw3, name="pf-a", relevant=True)
+
+        cases = [
+            ('labels.contributor = "alice@example.com"', {flaw1.cve_id}),
+            ('labels.contributor = "bob@example.com"', {flaw2.cve_id}),
+            # BULabel-only flaw: proves the "bulabel" branch of the OR works.
+            ('labels.contributor = "carol@example.com"', {flaw3.cve_id}),
+            ('labels.state = "DONE"', {flaw2.cve_id}),
+            ('labels.state = "REQ"', {flaw3.cve_id}),
+            # flaw3 is relevant via its BULabel/ProductFamilyLabel rows.
+            ("labels.relevant = True", {flaw1.cve_id, flaw3.cve_id}),
+            ("labels.relevant = False", {flaw2.cve_id}),
+            # "!=" exercises the invert branch of
+            # FlawLabelPropertyField.get_lookup(). flaw3 has no
+            # CollaboratorLabel/BULabel contributor/state equal to the
+            # excluded value, so it satisfies these negations too.
+            ('labels.contributor != "alice@example.com"', {flaw2.cve_id, flaw3.cve_id}),
+            ('labels.state != "DONE"', {flaw1.cve_id, flaw3.cve_id}),
+            ("labels.relevant != True", {flaw2.cve_id}),
+        ]
+        for query, expected_cve_ids in cases:
+            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+            assert response.status_code == 200, (query, response.json())
+            body = response.json()
+            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
+                query,
+                body,
+            )
+            # flaw1 has two matching labels for some of these queries; make
+            # sure the fan-out join is deduplicated before pagination.
+            assert body["count"] == len(expected_cve_ids), (query, body)
 
     def test_search_websearch_exclusion(self, auth_client, test_api_uri):
         """websearch_to_tsquery supports -exclusion, verify it works after query refactor."""


### PR DESCRIPTION
## Summary

Fixes broken DjangoQL filters for the `labels` field and its FlawLabel-subclass properties:

- `labels` is a `StrField`, so DjangoQL's UI/schema legally offers `~`, `!~`, `startswith`, `endswith` and their negated variants in addition to `=`/`!=`/`in`/`not in`. `FlawLabelsField.get_lookup()` only handled the latter four and silently returned `None` for the rest, causing an unhandled `TypeError` (500) instead of filtering.
- Fields that only exist on `FlawLabel` subclasses (`contributor`, `state`, `relevant`) were completely unreachable via DjangoQL (`Unknown field: contributor`), since the `labels` relation was severed from the schema graph in favor of the flat name-matching field.

## Changes

- `FlawLabelsField.get_lookup()` now routes all string operators through the shared `get_operator()` mapping instead of only handling `=`/`!=` explicitly.
- Added `FlawQLSchema.resolve_name()` override to allow dotted access to `labels.contributor` / `labels.state` / `labels.relevant`, without reopening the full `FlawLabel` relation graph (`labels.name` stays unreachable — `labels` alone already matches by name).
- New `FlawLabelPropertyField` mixin + concrete fields build an OR'd query across the `FlawLabel` subclasses that actually define each property, derived from `FlawLabel.TYPE_TO_MODEL` so new/changed label types stay in sync automatically. Fails loudly (`ValueError`) at import time if a field name matches no subclass.
- Tests: `test_search_flaws_by_labels_query_operators`, `test_search_flaws_by_label_properties`.

## Test plan

```
podman exec -it testrunner tox -e tests -- osidb/tests/test_search.py::TestSearch
```