### PR TITLE
OSIDB-5436: Reference and url on report creation shouldn't be require

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Remove additional information from report type
+- Make reference id and url optional (OSIDB-5436).
 
 ## [5.17.0] - 2026-08-26
 ### Added

--- a/openapi.yml
+++ b/openapi.yml
@@ -19728,9 +19728,9 @@ components:
         Serializer for manually creating SRP Reports.
 
         Status is always PRE_REQUIRED. ACLs are inherited from the flaw in the
-        view's perform_create. evidence, srp_reference_id, and srp_reference_url
-        are required for manual create. timer_started_at is read-only and remains
-        null until the report transitions to REQUIRED.
+        view's perform_create. evidence is required for manual create.
+        srp_reference_id and srp_reference_url are optional. timer_started_at is
+        read-only and remains null until the report transitions to REQUIRED.
       properties:
         uuid:
           type: string
@@ -19810,8 +19810,6 @@ components:
       - flaw_id
       - milestones
       - reportable_event_type
-      - srp_reference_id
-      - srp_reference_url
       - status
       - timer_started_at
       - updated_dt
@@ -19822,9 +19820,9 @@ components:
         Serializer for manually creating SRP Reports.
 
         Status is always PRE_REQUIRED. ACLs are inherited from the flaw in the
-        view's perform_create. evidence, srp_reference_id, and srp_reference_url
-        are required for manual create. timer_started_at is read-only and remains
-        null until the report transitions to REQUIRED.
+        view's perform_create. evidence is required for manual create.
+        srp_reference_id and srp_reference_url are optional. timer_started_at is
+        read-only and remains null until the report transitions to REQUIRED.
       properties:
         flaw_id:
           type: string
@@ -19848,12 +19846,10 @@ components:
           minLength: 1
         srp_reference_id:
           type: string
-          minLength: 1
           maxLength: 255
         srp_reference_url:
           type: string
           format: uri
-          minLength: 1
           maxLength: 200
         member_states_available:
           type: array
@@ -19874,8 +19870,6 @@ components:
       - evidence
       - flaw_id
       - reportable_event_type
-      - srp_reference_id
-      - srp_reference_url
     SRPReportMilestone:
       type: object
       description: |-

--- a/regulatory_reporting/serializers/srp_serializers.py
+++ b/regulatory_reporting/serializers/srp_serializers.py
@@ -207,9 +207,9 @@ class SRPReportCreateSerializer(SRPReportSerializer):
     Serializer for manually creating SRP Reports.
 
     Status is always PRE_REQUIRED. ACLs are inherited from the flaw in the
-    view's perform_create. evidence, srp_reference_id, and srp_reference_url
-    are required for manual create. timer_started_at is read-only and remains
-    null until the report transitions to REQUIRED.
+    view's perform_create. evidence is required for manual create.
+    srp_reference_id and srp_reference_url are optional. timer_started_at is
+    read-only and remains null until the report transitions to REQUIRED.
     """
 
     flaw_id = serializers.PrimaryKeyRelatedField(
@@ -224,11 +224,16 @@ class SRPReportCreateSerializer(SRPReportSerializer):
     )
     evidence = serializers.CharField(allow_blank=False, trim_whitespace=True)
     srp_reference_id = serializers.CharField(
-        allow_blank=False,
+        required=False,
+        allow_blank=True,
         trim_whitespace=True,
         max_length=255,
     )
-    srp_reference_url = serializers.URLField(allow_blank=False, max_length=200)
+    srp_reference_url = serializers.URLField(
+        required=False,
+        allow_blank=True,
+        max_length=200,
+    )
     status = serializers.ChoiceField(
         choices=SRPReport.SRPReportStatus.choices,
         read_only=True,
@@ -258,9 +263,6 @@ class SRPReportCreateSerializer(SRPReportSerializer):
         return value.strip()
 
     def validate_evidence(self, value):
-        return self._require_nonblank(value)
-
-    def validate_srp_reference_id(self, value):
         return self._require_nonblank(value)
 
     def _validate_acl_write(self, flaw):

--- a/regulatory_reporting/tests/test_api_srp_reports.py
+++ b/regulatory_reporting/tests/test_api_srp_reports.py
@@ -243,10 +243,10 @@ class TestSRPReportCreate:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "evidence" in response.data
 
-    def test_create_report_missing_srp_reference_fields_fails(
+    def test_create_report_missing_srp_reference_fields_succeeds(
         self, authenticated_client
     ):
-        """srp_reference_id and srp_reference_url are required for manual create."""
+        """srp_reference_id and srp_reference_url are optional for manual create."""
         flaw = NonReportableFlawFactory()
         payload = self._create_payload(flaw)
         del payload["srp_reference_id"]
@@ -256,31 +256,31 @@ class TestSRPReportCreate:
             payload,
             format="json",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "srp_reference_id" in response.data
-        assert "srp_reference_url" in response.data
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        assert response.data["srp_reference_id"] == ""
+        assert response.data["srp_reference_url"] == ""
 
-    def test_create_report_blank_srp_reference_id_fails(self, authenticated_client):
-        """Blank srp_reference_id is rejected."""
+    def test_create_report_blank_srp_reference_id_succeeds(self, authenticated_client):
+        """Blank srp_reference_id is accepted on create."""
         flaw = NonReportableFlawFactory()
         response = authenticated_client.post(
             "/regulatory-reporting/api/v1/srp-reports",
             self._create_payload(flaw, srp_reference_id="   "),
             format="json",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "srp_reference_id" in response.data
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        assert response.data["srp_reference_id"] == ""
 
-    def test_create_report_blank_srp_reference_url_fails(self, authenticated_client):
-        """Blank srp_reference_url is rejected."""
+    def test_create_report_blank_srp_reference_url_succeeds(self, authenticated_client):
+        """Blank srp_reference_url is accepted on create."""
         flaw = NonReportableFlawFactory()
         response = authenticated_client.post(
             "/regulatory-reporting/api/v1/srp-reports",
             self._create_payload(flaw, srp_reference_url="   "),
             format="json",
         )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "srp_reference_url" in response.data
+        assert response.status_code == status.HTTP_201_CREATED, response.data
+        assert response.data["srp_reference_url"] == ""
 
     def test_create_report_srp_reference_url_too_long_fails(self, authenticated_client):
         """srp_reference_url longer than 200 characters is rejected."""


### PR DESCRIPTION
Makes reference id and reference url and optional field