### PR TITLE
implemented relation history events

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - exclude pre-Argus and already done flaws from workflow re-classification (OSIDB-5406)
 
+### Added
+- Add relation-aware flaw audit history backed by concrete affect and tracker
+  audit tables, including deleted affect history (OSIDB-4999)
+
 ## [5.17.0] - 2026-08-26
 ### Added
 - Certain workflow labels now provide a `reason` attribute which can provide

--- a/osidb/api_views.py
+++ b/osidb/api_views.py
@@ -2396,8 +2396,9 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
     def list(self, request, *args, **kwargs):
         limit = self._get_limit(request)
         offset = self._get_offset(request)
-        count = self._audit_count(request.query_params)
-        rows = self._audit_rows(request.query_params, limit, offset)
+        related_context = self._related_history_context(request.query_params)
+        count = self._audit_count(request.query_params, related_context)
+        rows = self._audit_rows(request.query_params, limit, offset, related_context)
         previous_rows = self._previous_rows_for_rows(rows)
         events = [
             self._event_from_row(
@@ -2418,7 +2419,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
         )
 
     def retrieve(self, request, *args, **kwargs):
-        event = self._event_by_slug(kwargs[self.lookup_field])
+        event = self._event_by_slug(kwargs[self.lookup_field], request.query_params)
         if event is None:
             return Response(status=status.HTTP_404_NOT_FOUND)
         return Response(event)
@@ -2457,7 +2458,7 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             return remove_query_param(url, "offset")
         return replace_query_param(url, "offset", previous_offset)
 
-    def _audit_count(self, params):
+    def _audit_count(self, params, related_context=None):
         pgh_slug = params.get("pgh_slug")
         if pgh_slug:
             return 1 if self._row_by_slug(pgh_slug, params) else 0
@@ -2472,10 +2473,13 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             # Exact counts on unfiltered audit feeds are expensive on large audit tables,
             # but are preserved for API compatibility with the existing /audit contract.
             count += self._audit_queryset(audit_table, params).count()
+        if self._include_relation_events(params):
+            count += self._related_history_count(params, related_context)
         return count
 
-    def _audit_rows(self, params, limit, offset):
+    def _audit_rows(self, params, limit, offset, related_context=None):
         rows = []
+        window = limit + offset
         pgh_slug = params.get("pgh_slug")
         if pgh_slug:
             if not limit or offset:
@@ -2490,21 +2494,26 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             ):
                 continue
 
-            window = limit + offset
             if not window:
                 continue
 
             rows.extend(
                 (audit_table, row)
                 for row in audit_rows_with_context(
-                    self._audit_queryset(audit_table, params).order_by("-pgh_id")[
-                        :window
-                    ],
+                    self._audit_queryset(audit_table, params).order_by(
+                        "-pgh_created_at", "-pgh_id"
+                    )[:window],
                     audit_table,
                 )
             )
 
-        rows.sort(key=lambda item: item[1]["pgh_created_at"], reverse=True)
+        if self._include_relation_events(params) and window:
+            rows.extend(self._related_history_rows(params, window, related_context))
+
+        rows.sort(
+            key=lambda item: (item[1]["pgh_created_at"], item[1]["pgh_id"]),
+            reverse=True,
+        )
         return rows[offset : offset + limit]
 
     def _audit_queryset(self, audit_table, params):
@@ -2517,8 +2526,8 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
             filters["pgh_created_at"] = params["pgh_created_at"]
         return audit_table["model"].objects.filter(**filters)
 
-    def _event_by_slug(self, pgh_slug):
-        row = self._row_by_slug(pgh_slug)
+    def _event_by_slug(self, pgh_slug, params=None):
+        row = self._row_by_slug(pgh_slug, params)
         if row is None:
             return None
         return self._event_from_row(*row)
@@ -2627,6 +2636,92 @@ class AuditView(RudimentaryUserPathLoggingMixin, ReadOnlyModelViewSet):
                     previous_rows[(audit_label, row["pgh_id"])] = previous
 
         return previous_rows
+
+    def _include_relation_events(self, params):
+        value = params.get("include_relation_events")
+        return isinstance(value, str) and value.lower() in {"1", "true", "yes"}
+
+    def _related_history_context(self, params):
+        if not self._include_relation_events(params):
+            return None
+        if params.get("pgh_obj_model") != Flaw._meta.label or not params.get(
+            "pgh_obj_id"
+        ):
+            return None
+
+        affect_table = audit_table_for_model(Affect)
+        if affect_table is None:
+            return None
+
+        tracker_ids = set(
+            affect_table["model"]
+            .objects.filter(flaw_id=params["pgh_obj_id"])
+            .exclude(tracker_id__isnull=True)
+            .values_list("tracker_id", flat=True)
+            .distinct()
+        )
+        return {
+            "flaw_id": params["pgh_obj_id"],
+            "affect_table": affect_table,
+            "tracker_table": audit_table_for_model(Tracker),
+            "tracker_ids": tracker_ids,
+        }
+
+    def _related_history_querysets(self, params, related_context):
+        if related_context is None:
+            return []
+
+        querysets = [
+            (
+                related_context["affect_table"],
+                related_context["affect_table"]["model"].objects.filter(
+                    flaw_id=related_context["flaw_id"]
+                ),
+            )
+        ]
+        if (
+            related_context["tracker_table"] is not None
+            and related_context["tracker_ids"]
+        ):
+            querysets.append(
+                (
+                    related_context["tracker_table"],
+                    related_context["tracker_table"]["model"].objects.filter(
+                        pgh_obj_id__in=related_context["tracker_ids"]
+                    ),
+                )
+            )
+        return [
+            (audit_table, self._filter_related_history_queryset(queryset, params))
+            for audit_table, queryset in querysets
+        ]
+
+    def _filter_related_history_queryset(self, queryset, params):
+        if params.get("pgh_label"):
+            queryset = queryset.filter(pgh_label=params["pgh_label"])
+        if params.get("pgh_created_at"):
+            queryset = queryset.filter(pgh_created_at=params["pgh_created_at"])
+        return queryset
+
+    def _related_history_count(self, params, related_context):
+        return sum(
+            queryset.count()
+            for _, queryset in self._related_history_querysets(params, related_context)
+        )
+
+    def _related_history_rows(self, params, window, related_context):
+        rows = []
+        for audit_table, queryset in self._related_history_querysets(
+            params, related_context
+        ):
+            rows.extend(
+                (audit_table, row)
+                for row in audit_rows_with_context(
+                    queryset.order_by("-pgh_created_at", "-pgh_id")[:window],
+                    audit_table,
+                )
+            )
+        return rows
 
 
 # NOTE: Purpose of this custom class is for Kerberos authenticated

--- a/osidb/migrations/0267_relation_audit_indexes.py
+++ b/osidb/migrations/0267_relation_audit_indexes.py
@@ -1,0 +1,63 @@
+# Generated manually for OSIDB-4999.
+
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("osidb", "0266_manual_triage_kernel_flaws"),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_affectaudit_flaw_history
+                ON osidb_affectaudit (flaw_id, pgh_created_at DESC, pgh_id DESC)
+                WHERE flaw_id IS NOT NULL
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS idx_affectaudit_flaw_history
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_affectaudit_flaw_tracker_history
+                ON osidb_affectaudit (
+                    flaw_id, tracker_id, pgh_created_at DESC, pgh_id DESC
+                )
+                WHERE flaw_id IS NOT NULL AND tracker_id IS NOT NULL
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS idx_affectaudit_flaw_tracker_history
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_affectaudit_obj_prev
+                ON osidb_affectaudit (pgh_obj_id, pgh_id DESC)
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS idx_affectaudit_obj_prev
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_trackeraudit_obj_prev
+                ON osidb_trackeraudit (pgh_obj_id, pgh_id DESC)
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS idx_trackeraudit_obj_prev
+            """,
+        ),
+        migrations.RunSQL(
+            sql="""
+                CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_trackeraudit_obj_history
+                ON osidb_trackeraudit (pgh_obj_id, pgh_created_at DESC, pgh_id DESC)
+            """,
+            reverse_sql="""
+                DROP INDEX CONCURRENTLY IF EXISTS idx_trackeraudit_obj_history
+            """,
+        ),
+    ]

--- a/osidb/mixins.py
+++ b/osidb/mixins.py
@@ -747,6 +747,104 @@ class ACLMixin(models.Model):
                     acl_write=acl_write,
                 )
 
+        self._set_related_acls_history(acl_read, acl_write)
+
+    def _set_related_acls_history(self, acl_read, acl_write, max_chunk_size=5000):
+        """Set ACLs on audited rows related through ACL-managed models."""
+        if self.pk is None:
+            return
+
+        from osidb.models.audit_history import audit_model_for_model
+
+        target_ids_by_model = defaultdict(set)
+        for relation in self._meta.related_objects:
+            relation_field = getattr(relation, "field", None)
+            related_model = relation.related_model
+            if (
+                relation.related_name is None
+                or relation.related_name == "+"
+                or relation.related_name == "snippets"
+                or getattr(relation, "hidden", False)
+                or not isinstance(
+                    relation_field, (models.ForeignKey, models.OneToOneField)
+                )
+                or not issubclass(related_model, ACLMixin)
+            ):
+                continue
+
+            audit_model = audit_model_for_model(related_model)
+            if audit_model is None:
+                continue
+
+            audit_field_names = {
+                field.attname for field in audit_model._meta.concrete_fields
+            }
+            relation_field_name = relation_field.attname
+            if relation_field_name not in audit_field_names:
+                continue
+
+            audit_queryset = audit_model.objects.filter(
+                **{relation_field_name: self.pk}
+            )
+            self._update_audit_history_acls(
+                audit_model, audit_queryset, acl_read, acl_write
+            )
+
+            for field in related_model._meta.concrete_fields:
+                if (
+                    field.attname == relation_field_name
+                    or not isinstance(field, (models.ForeignKey, models.OneToOneField))
+                    or field.attname not in audit_field_names
+                    or not issubclass(field.related_model, ACLMixin)
+                    or field.related_model._meta.concrete_model
+                    == self._meta.concrete_model
+                ):
+                    continue
+
+                target_ids_by_model[field.related_model].update(
+                    audit_queryset.exclude(**{f"{field.attname}__isnull": True})
+                    .values_list(field.attname, flat=True)
+                    .distinct()
+                )
+
+        for target_model, target_ids in target_ids_by_model.items():
+            audit_model = audit_model_for_model(target_model)
+            if audit_model is None:
+                continue
+
+            safe_target_ids = self._safe_related_acl_history_target_ids(
+                target_model, target_ids
+            )
+            with pgtrigger.ignore(f"{audit_model._meta.label}:append_only"):
+                for target_id_chunk in batched(safe_target_ids, max_chunk_size):
+                    audit_model.objects.filter(pgh_obj_id__in=target_id_chunk).update(
+                        acl_read=acl_read,
+                        acl_write=acl_write,
+                    )
+
+    def _update_audit_history_acls(
+        self, audit_model, audit_queryset, acl_read, acl_write
+    ):
+        with pgtrigger.ignore(f"{audit_model._meta.label}:append_only"):
+            audit_queryset.update(
+                acl_read=acl_read,
+                acl_write=acl_write,
+            )
+
+    def _safe_related_acl_history_target_ids(self, target_model, target_ids):
+        queryset = target_model.objects.filter(pk__in=target_ids)
+        for relation in target_model._meta.related_objects:
+            if (
+                relation.related_name is not None
+                and relation.related_name != "+"
+                and not getattr(relation, "hidden", False)
+                and issubclass(relation.related_model, ACLMixin)
+            ):
+                queryset = queryset.exclude(
+                    **{f"{relation.related_name}__embargoed": True}
+                )
+        return queryset.values_list("pk", flat=True).distinct()
+
     def unembargo(self):
         """
         unembargo the whole instance context internally

--- a/osidb/tests/endpoints/test_audit.py
+++ b/osidb/tests/endpoints/test_audit.py
@@ -1,9 +1,19 @@
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pghistory
 import pytest
+from django.conf import settings
 
-from osidb.tests.factories import AffectFactory, FlawFactory
+from osidb.core import set_user_acls
+from osidb.models import Affect, PsModule, Tracker
+from osidb.tests.factories import (
+    AffectFactory,
+    FlawFactory,
+    PsModuleFactory,
+    PsUpdateStreamFactory,
+    TrackerFactory,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -132,3 +142,198 @@ class TestEndpointsAudit:
         for result in body_affect["results"]:
             assert result["pgh_obj_id"] == str(affect.uuid)
             assert "Affect" in result["pgh_obj_model"]
+
+    def test_audit_related_history_unaudited_model_returns_empty_page(
+        self, auth_client, test_api_uri
+    ):
+        """Unaudited pgh_obj_model with related history returns an empty page."""
+        response = auth_client().get(
+            f"{test_api_uri}/audit?include_relation_events=true"
+            "&pgh_obj_model=osidb.PsUpdateStream"
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 0
+        assert body["results"] == []
+
+    def test_audit_includes_affect_history_from_flaw_context(
+        self, auth_client, test_api_uri
+    ):
+        """GET /audit can expose affect history from the flaw context."""
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(flaw=flaw)
+
+        response = auth_client().get(
+            f"{test_api_uri}/audit?include_relation_events=true"
+            f"&pgh_obj_model=osidb.Flaw&pgh_obj_id={flaw.uuid}"
+        )
+
+        assert response.status_code == 200
+        affect_events = [
+            result
+            for result in response.json()["results"]
+            if result["pgh_obj_model"] == "osidb.Affect"
+            and result["pgh_obj_id"] == str(affect.uuid)
+        ]
+        assert affect_events
+        assert affect_events[0]["pgh_label"] == "insert"
+        assert affect_events[0]["pgh_slug"].startswith("osidb.AffectAudit:")
+        assert affect_events[0]["pgh_data"]["flaw_id"] == str(flaw.uuid)
+
+    def test_audit_includes_deleted_affect_history_from_flaw_context(
+        self, auth_client, test_api_uri
+    ):
+        """Deleted affects remain visible from the flaw audit feed."""
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(flaw=flaw)
+        affect_id = affect.uuid
+
+        affect.delete()
+
+        response = auth_client().get(
+            f"{test_api_uri}/audit?include_relation_events=true"
+            f"&pgh_obj_model=osidb.Flaw&pgh_obj_id={flaw.uuid}"
+        )
+
+        assert response.status_code == 200
+        delete_events = [
+            result
+            for result in response.json()["results"]
+            if result["pgh_obj_model"] == "osidb.Affect"
+            and result["pgh_obj_id"] == str(affect_id)
+            and result["pgh_label"] == "delete"
+        ]
+        assert delete_events
+        assert delete_events[0]["pgh_data"]["flaw_id"] == str(flaw.uuid)
+
+    def test_audit_includes_tracker_history_from_flaw_context(
+        self, auth_client, test_api_uri
+    ):
+        """Tracker history linked through an affect is visible from the flaw feed."""
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(
+            flaw=flaw, tracker=None, affectedness=Affect.AffectAffectedness.NEW
+        )
+        ps_module = PsModule.objects.get(name=affect.ps_module)
+        tracker = TrackerFactory(
+            embargoed=False,
+            affects=[affect],
+            ps_update_stream=affect.ps_update_stream,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+
+        response = auth_client().get(
+            f"{test_api_uri}/audit?include_relation_events=true"
+            f"&pgh_obj_model=osidb.Flaw&pgh_obj_id={flaw.uuid}"
+        )
+
+        assert response.status_code == 200
+        results = response.json()["results"]
+        tracker_events = [
+            result
+            for result in results
+            if result["pgh_obj_model"] == "osidb.Tracker"
+            and result["pgh_obj_id"] == str(tracker.uuid)
+        ]
+        assert tracker_events
+        assert tracker_events[0]["pgh_label"] == "insert"
+        assert tracker_events[0]["pgh_slug"].startswith("osidb.TrackerAudit:")
+
+        affect_tracker_events = [
+            result
+            for result in results
+            if result["pgh_obj_model"] == "osidb.Affect"
+            and result["pgh_obj_id"] == str(affect.uuid)
+            and result["pgh_data"].get("tracker_id") == str(tracker.uuid)
+        ]
+        assert affect_tracker_events
+        assert affect_tracker_events[0]["pgh_diff"]["tracker_id"] == [
+            None,
+            str(tracker.uuid),
+        ]
+
+    def test_audit_does_not_release_mixed_visibility_tracker_history(
+        self, auth_client, test_api_uri
+    ):
+        """A public flaw feed must not expose an embargoed shared tracker."""
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+        flaw = FlawFactory(embargoed=True)
+        embargoed_flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_update_stream=ps_update_stream.name,
+            ps_component="kernel",
+        )
+        embargoed_affect = AffectFactory(
+            flaw=embargoed_flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_update_stream=affect.ps_update_stream,
+            ps_component=affect.ps_component,
+        )
+        tracker = TrackerFactory(
+            embargoed=True,
+            affects=[affect, embargoed_affect],
+            ps_update_stream=affect.ps_update_stream,
+            type=Tracker.BTS2TYPE[ps_module.bts_name],
+        )
+
+        set_user_acls(settings.ALL_GROUPS)
+        flaw.unembargo_dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        flaw.unembargo()
+        tracker.refresh_from_db()
+
+        assert tracker.is_embargoed
+
+        response = auth_client("pubread").get(
+            f"{test_api_uri}/audit?include_relation_events=true"
+            f"&pgh_obj_model=osidb.Flaw&pgh_obj_id={flaw.uuid}"
+        )
+
+        assert response.status_code == 200
+        results = response.json()["results"]
+        assert not any(
+            result["pgh_obj_model"] == "osidb.Tracker"
+            and result["pgh_obj_id"] == str(tracker.uuid)
+            for result in results
+        )
+
+    def test_audit_retrieves_related_audit_slug_without_flag(
+        self, auth_client, test_api_uri
+    ):
+        """Related audit slugs should be retrievable as normal audit events."""
+        flaw = FlawFactory(embargoed=False)
+        affect = AffectFactory(flaw=flaw)
+
+        response_related = auth_client().get(
+            f"{test_api_uri}/audit?include_relation_events=true"
+            f"&pgh_obj_model=osidb.Flaw&pgh_obj_id={flaw.uuid}"
+        )
+        assert response_related.status_code == 200
+        event = next(
+            result
+            for result in response_related.json()["results"]
+            if result["pgh_obj_model"] == "osidb.Affect"
+            and result["pgh_obj_id"] == str(affect.uuid)
+        )
+        pgh_slug = event["pgh_slug"]
+
+        response_list = auth_client().get(f"{test_api_uri}/audit?pgh_slug={pgh_slug}")
+
+        assert response_list.status_code == 200
+        list_body = response_list.json()
+        assert list_body["count"] == 1
+        assert list_body["results"][0]["pgh_slug"] == pgh_slug
+
+        response = auth_client().get(f"{test_api_uri}/audit/{pgh_slug}")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["pgh_slug"] == pgh_slug
+        assert body["pgh_obj_id"] == str(affect.uuid)
+        assert body["pgh_obj_model"] == "osidb.Affect"
+        assert body["pgh_data"]["flaw_id"] == str(flaw.uuid)

--- a/osidb/tests/test_audit.py
+++ b/osidb/tests/test_audit.py
@@ -3,10 +3,19 @@ from datetime import datetime, timezone
 
 import pghistory
 import pytest
+from django.conf import settings
 from django.db import transaction
 
 from osidb.core import set_user_acls
-from osidb.models import Affect, Flaw, FlawCVSS, FlawSource, Impact, Tracker
+from osidb.models import (
+    Affect,
+    Flaw,
+    FlawCVSS,
+    FlawSource,
+    Impact,
+    Tracker,
+)
+from osidb.models.audit_history import audit_model_for_model
 from osidb.tests.factories import (
     AffectCVSSFactory,
     AffectFactory,
@@ -218,6 +227,91 @@ class TestAuditFlaw:
             assert pghistory.models.Events.objects.tracks(flaw_cvss).count() == 0
         with transaction.atomic():
             assert pghistory.models.Events.objects.tracks(affect_cvss).count() == 0
+
+    def test_affect_audit_acls_follow_flaw_release(
+        self,
+        public_read_groups,
+        public_write_groups,
+        embargoed_read_groups,
+        embargoed_write_groups,
+    ):
+        """Affect audit rows must be released with the parent flaw."""
+        flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(flaw=flaw)
+        affect_audit_model = audit_model_for_model(Affect)
+        affect_event = affect_audit_model.objects.get(
+            pgh_obj_id=affect.uuid,
+            pgh_label="insert",
+        )
+
+        assert affect_event.acl_read == embargoed_read_groups
+        assert affect_event.acl_write == embargoed_write_groups
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + settings.PUBLIC_WRITE_GROUPS)
+        with transaction.atomic():
+            assert (
+                affect_audit_model.objects.filter(pgh_id=affect_event.pgh_id).count()
+                == 0
+            )
+
+        set_user_acls(settings.ALL_GROUPS)
+        flaw.unembargo_dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        flaw.unembargo()
+
+        affect_event.refresh_from_db()
+        assert affect_event.acl_read == public_read_groups
+        assert affect_event.acl_write == public_write_groups
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        with transaction.atomic():
+            assert (
+                affect_audit_model.objects.filter(pgh_id=affect_event.pgh_id).count()
+                == 1
+            )
+
+    def test_deleted_affect_audit_acls_follow_flaw_release(
+        self,
+        public_read_groups,
+        public_write_groups,
+        embargoed_read_groups,
+        embargoed_write_groups,
+    ):
+        """Deleted affect audit rows must be released with the parent flaw."""
+        flaw = FlawFactory(embargoed=True)
+        affect = AffectFactory(flaw=flaw)
+        affect_id = affect.uuid
+
+        affect.delete()
+        affect_audit_model = audit_model_for_model(Affect)
+        affect_event = affect_audit_model.objects.get(
+            pgh_obj_id=affect_id,
+            pgh_label="delete",
+        )
+
+        assert affect_event.acl_read == embargoed_read_groups
+        assert affect_event.acl_write == embargoed_write_groups
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS + settings.PUBLIC_WRITE_GROUPS)
+        with transaction.atomic():
+            assert (
+                affect_audit_model.objects.filter(pgh_id=affect_event.pgh_id).count()
+                == 0
+            )
+
+        set_user_acls(settings.ALL_GROUPS)
+        flaw.unembargo_dt = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        flaw.unembargo()
+
+        affect_event.refresh_from_db()
+        assert affect_event.acl_read == public_read_groups
+        assert affect_event.acl_write == public_write_groups
+
+        set_user_acls(settings.PUBLIC_READ_GROUPS)
+        with transaction.atomic():
+            assert (
+                affect_audit_model.objects.filter(pgh_id=affect_event.pgh_id).count()
+                == 1
+            )
 
     def test_audit_api_cleansing(self, auth_client, test_api_uri):
         """


### PR DESCRIPTION
This PR adds relation-aware audit history for flaw audit views.

When `/audit` is queried with `include_relation_events=true&pgh_obj_model=osidb.Flaw&pgh_obj_id=<flaw_uuid>`, the response now includes related native audit rows for the flaw context:

- `AffectAudit` rows whose historical `flaw_id` matches the requested flaw, including deleted affects.
- `TrackerAudit` rows for trackers discovered through matching historical `AffectAudit.tracker_id` values.

This does not add a derived `RelationHistoryEvent` table. Related entries are returned as normal concrete audit events with their existing slugs, for example:

- `osidb.AffectAudit:<pgh_id>`
- `osidb.TrackerAudit:<pgh_id>`

The existing audit endpoint handles filtering, sorting, pagination, counts, and direct slug retrieval for these related audit rows.

ACL behavior was updated so audit history follows visibility changes. The ACL propagation is generic in `ACLMixin`: it discovers related audited ACL models through Django relation metadata and updates direct and one-hop related audit histories. Secondary targets, such as trackers, are only released when they are not still connected to embargoed ACL-managed rows, preventing mixed-visibility tracker history leaks.

The PR also adds database indexes for relation-aware audit lookups and regression tests for deleted affects, related audit slug retrieval, and mixed public/embargoed tracker visibility.

For OSIM, a follow-up task can add UI affordances around affect or tracker rows in the flaw detail page to surface this related history.

Closes OSIDB-4999.