### PR TITLE
make sure that the flaw impact is always at or above any affect override

### DIFF
--- a/apps/sla/tests/test_framework.py
+++ b/apps/sla/tests/test_framework.py
@@ -776,6 +776,7 @@ slo:
                 (
                     {
                         "major_incident_state": Flaw.FlawMajorIncident.NOVALUE,
+                        "impact": Impact.CRITICAL,
                     },
                     {
                         "impact": Impact.CRITICAL,
@@ -795,6 +796,7 @@ slo:
                 (
                     {
                         "major_incident_state": Flaw.FlawMajorIncident.NOVALUE,
+                        "impact": Impact.IMPORTANT,
                     },
                     {
                         "impact": Impact.IMPORTANT,
@@ -814,6 +816,7 @@ slo:
                 (
                     {
                         "major_incident_state": Flaw.FlawMajorIncident.NOVALUE,
+                        "impact": Impact.MODERATE,
                     },
                     {
                         "impact": Impact.MODERATE,
@@ -833,6 +836,7 @@ slo:
                 (
                     {
                         "major_incident_state": Flaw.FlawMajorIncident.NOVALUE,
+                        "impact": Impact.LOW,
                     },
                     {
                         "impact": Impact.LOW,

--- a/apps/sla/tests/test_models.py
+++ b/apps/sla/tests/test_models.py
@@ -825,7 +825,7 @@ class TestSLOPolicy:
                 components=["dnf"],
                 embargoed=False,
                 major_incident_state=Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
-                impact=Impact.LOW,
+                impact=Impact.MODERATE,
             )
             ps_product = PsProductFactory(business_unit="Community")
             ps_module = PsModuleFactory(ps_product=ps_product)
@@ -883,7 +883,7 @@ class TestSLOPolicy:
                 components=["dnf"],
                 embargoed=False,
                 major_incident_state=Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
-                impact=Impact.LOW,
+                impact=Impact.MODERATE,
                 title="real flaw",
             )
             flaw2 = FlawFactory(
@@ -978,7 +978,7 @@ class TestSLOPolicy:
             }
             policy = SLOPolicy.create_from_description(policy_desc)
 
-            flaw = FlawFactory()
+            flaw = FlawFactory(impact=Impact.MODERATE)
             ps_module = PsModuleFactory()
             ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
             affect = AffectFactory(
@@ -1040,7 +1040,7 @@ class TestSLOPolicy:
             ps_product = PsProductFactory(short_name="valid", name=valid_case)
             ps_module = PsModuleFactory(bts_name="bugzilla", ps_product=ps_product)
             ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
-            flaw = FlawFactory(embargoed=False)
+            flaw = FlawFactory(embargoed=False, impact=Impact.MODERATE)
 
             # Test 1: Affect that SHOULD match the policy (Magic on RHEL)
             valid_affect = AffectFactory(
@@ -1080,7 +1080,7 @@ class TestSLOPolicy:
                 ps_module=invalid_ps_module
             )
 
-            invalid_flaw = FlawFactory(embargoed=False)
+            invalid_flaw = FlawFactory(embargoed=False, impact=Impact.MODERATE)
             invalid_affect = AffectFactory(
                 flaw=invalid_flaw,
                 affectedness=Affect.AffectAffectedness.AFFECTED,

--- a/apps/taskman/tests/test_flaw_model_integration.py
+++ b/apps/taskman/tests/test_flaw_model_integration.py
@@ -170,7 +170,8 @@ class TestFlawModelIntegration(object):
         monkeypatch.setattr(JiraTaskmanQuerier, "transition_task", mock)
 
         flaw = FlawFactory(embargoed=False, impact=Impact.IMPORTANT)
-        AffectFactory(flaw=flaw)
+        # no impact override so the flaw impact can later be lowered freely
+        AffectFactory(flaw=flaw, impact=Impact.NOVALUE)
         flaw.task_key = "TASK-123"
         flaw.save()
         response = auth_client().get(f"{test_osidb_api_v2_uri}/flaws/{flaw.uuid}")

--- a/apps/trackers/tests/test_jira.py
+++ b/apps/trackers/tests/test_jira.py
@@ -78,8 +78,8 @@ class TestOldTrackerJiraQueryBuilder:
             (Impact.CRITICAL, Impact.NOVALUE, JiraPriority.CRITICAL),
             (Impact.CRITICAL, Impact.LOW, JiraPriority.MINOR),
             (Impact.LOW, Impact.LOW, JiraPriority.MINOR),
-            (Impact.LOW, Impact.MODERATE, JiraPriority.NORMAL),
-            (Impact.LOW, Impact.CRITICAL, JiraPriority.CRITICAL),
+            (Impact.MODERATE, Impact.MODERATE, JiraPriority.NORMAL),
+            (Impact.CRITICAL, Impact.CRITICAL, JiraPriority.CRITICAL),
         ],
     )
     def test_generate_query(self, flaw_impact, affect_impact, expected_impact):
@@ -1349,8 +1349,8 @@ class TestTrackerJiraQueryBuilder:
             (Impact.CRITICAL, Impact.NOVALUE, JiraSeverity.CRITICAL),
             (Impact.CRITICAL, Impact.LOW, JiraSeverity.LOW),
             (Impact.LOW, Impact.LOW, JiraSeverity.LOW),
-            (Impact.LOW, Impact.MODERATE, JiraSeverity.MODERATE),
-            (Impact.LOW, Impact.CRITICAL, JiraSeverity.CRITICAL),
+            (Impact.MODERATE, Impact.MODERATE, JiraSeverity.MODERATE),
+            (Impact.CRITICAL, Impact.CRITICAL, JiraSeverity.CRITICAL),
         ],
     )
     def test_generate_query(self, flaw_impact, affect_impact, expected_severity):
@@ -1539,12 +1539,12 @@ class TestTrackerJiraQueryBuilder:
         "missing,wrong,flaw_impact,affect_impact,expected_severity",
         [
             (False, False, Impact.LOW, Impact.LOW, JiraSeverity.LOW),
-            (False, False, Impact.LOW, Impact.MODERATE, JiraSeverity.MODERATE),
-            (False, False, Impact.LOW, Impact.IMPORTANT, JiraSeverity.IMPORTANT),
-            (False, False, Impact.LOW, Impact.CRITICAL, JiraSeverity.CRITICAL),
+            (False, False, Impact.MODERATE, Impact.MODERATE, JiraSeverity.MODERATE),
+            (False, False, Impact.IMPORTANT, Impact.IMPORTANT, JiraSeverity.IMPORTANT),
+            (False, False, Impact.CRITICAL, Impact.CRITICAL, JiraSeverity.CRITICAL),
             (False, False, Impact.NOVALUE, Impact.NOVALUE, None),
-            (True, False, Impact.LOW, Impact.CRITICAL, None),
-            (False, True, Impact.LOW, Impact.CRITICAL, None),
+            (True, False, Impact.CRITICAL, Impact.CRITICAL, None),
+            (False, True, Impact.CRITICAL, Impact.CRITICAL, None),
         ],
     )
     def test_severity_field(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- make sure that the flaw impact is always at or above any affect override (OSIDB-5389)
+
 ### Changed
 - exclude pre-Argus and already done flaws from workflow re-classification (OSIDB-5406)
 

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -478,6 +478,21 @@ class Affect(
             )
 
     @validator
+    def _validate_impact_not_above_flaw(self, **kwargs):
+        """
+        Check that an affect's impact override is never higher than its flaw's impact.
+        """
+        if not self.flaw or not self.impact:
+            return
+
+        if Impact(self.impact) > Impact(self.flaw.impact):
+            raise ValidationError(
+                f"Affect impact ({self.impact}) cannot be higher than the flaw "
+                f"impact ({self.flaw.impact or 'NOVALUE'}). Raise the flaw "
+                f"impact first, then raise the affect impact override."
+            )
+
+    @validator
     def _validate_notaffected_open_tracker(self, **kwargs):
         """
         Check whether notaffected products have open trackers.

--- a/osidb/models/flaw/flaw.py
+++ b/osidb/models/flaw/flaw.py
@@ -765,6 +765,31 @@ class Flaw(
             )
 
     @validator
+    def _validate_impact_not_below_affects(self, **kwargs):
+        """
+        Check that the flaw's impact is always at or above any affect impact override
+        """
+        if self._state.adding:
+            return
+
+        highest = max(
+            (
+                Impact(impact)
+                for impact in self.affects.exclude(impact="").values_list(
+                    "impact", flat=True
+                )
+            ),
+            default=Impact.NOVALUE,
+        )
+        if highest > Impact(self.impact):
+            raise ValidationError(
+                f"Flaw impact ({self.impact or 'NOVALUE'}) cannot be lower than the "
+                f"impact of its affects. The highest affect impact override is "
+                f"{highest.value}. Raise the flaw impact to at least "
+                f"{highest.value}, or lower the affect impact overrides."
+            )
+
+    @validator
     def _validate_no_placeholder(self, **kwargs):
         """
         restrict any write operations on placeholder flaws

--- a/osidb/models/tests/test_affect.py
+++ b/osidb/models/tests/test_affect.py
@@ -60,7 +60,7 @@ class TestAffect:
         test resolve_dt is null when an affect is unresolved and is
         automatically updated when first entered in a resolved state
         """
-        flaw = FlawFactory()
+        flaw = FlawFactory(impact=Impact.MODERATE)
 
         # Check factory behavior
         affect = AffectFactory(

--- a/osidb/tests/endpoints/flaws/test_flaws.py
+++ b/osidb/tests/endpoints/flaws/test_flaws.py
@@ -1480,7 +1480,7 @@ class TestEndpointsFlaws:
         ps_update_stream = PsUpdateStreamFactory(
             name="rhel-7.0", active_to_ps_module=ps_module, ps_module=ps_module
         )
-        flaw = FlawFactory()
+        flaw = FlawFactory(impact=Impact.MODERATE)
         delegated_affect = AffectFactory(
             flaw=flaw,
             impact=Impact.MODERATE,
@@ -1823,6 +1823,9 @@ class TestEndpointsFlaws:
             embargoed=True,
             workflow_state="TRIAGE",
             reported_dt=datetime(2025, 1, 1, tzinfo=timezone.utc),
+            # pin the impact so the MODERATE affect override below never exceeds
+            # the (otherwise random) flaw impact
+            impact="MODERATE",
         )
 
         flaw.unembargo_dt = datetime(2024, 1, 1, tzinfo=timezone.utc)

--- a/osidb/tests/endpoints/flaws/test_update_trackers.py
+++ b/osidb/tests/endpoints/flaws/test_update_trackers.py
@@ -291,6 +291,7 @@ class TestEndpointsFlawsUpdateTrackers:
             affectedness=Affect.AffectAffectedness.AFFECTED,
             resolution=Affect.AffectResolution.DELEGATED,
             ps_update_stream=ps_update_stream.name,
+            impact=Impact.NOVALUE,
         )
         TrackerFactory(
             affects=[affect],

--- a/osidb/tests/endpoints/test_affects.py
+++ b/osidb/tests/endpoints/test_affects.py
@@ -1513,7 +1513,7 @@ class TestEndpointsAffectsUpdateTrackers:
         """
         test that the tracker update is triggered when expected only
         """
-        flaw = FlawFactory(impact="LOW")
+        flaw = FlawFactory(impact="MODERATE")
         ps_product1 = PsProductFactory(business_unit="Corporate")
         ps_module1 = PsModuleFactory(ps_product=ps_product1)
         ps_update_stream11 = PsUpdateStreamFactory(ps_module=ps_module1)
@@ -1640,7 +1640,7 @@ class TestEndpointsAffectsUpdateTrackers:
         """
         test that the tracker update is triggered when expected only
         """
-        flaw = FlawFactory(impact="LOW")
+        flaw = FlawFactory(impact="IMPORTANT")
         ps_module = PsModuleFactory()
         ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         affect = AffectFactory(
@@ -1687,7 +1687,7 @@ class TestEndpointsAffectsUpdateTrackers:
         """
         test that the tracker update is triggered when an affect-flaw link is modified
         """
-        flaw1 = FlawFactory()
+        flaw1 = FlawFactory(impact="MODERATE")
         ps_module = PsModuleFactory()
         ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
         affect = AffectFactory(
@@ -1703,7 +1703,7 @@ class TestEndpointsAffectsUpdateTrackers:
             type=Tracker.BTS2TYPE[ps_module.bts_name],
         )
 
-        flaw2 = FlawFactory(embargoed=flaw1.embargoed)
+        flaw2 = FlawFactory(embargoed=flaw1.embargoed, impact="MODERATE")
         affect_data = {
             "embargoed": flaw2.embargoed,
             "flaw": flaw2.uuid,  # re-link the affect

--- a/osidb/tests/factories.py
+++ b/osidb/tests/factories.py
@@ -272,13 +272,9 @@ class AffectFactory(BaseFactory):
         yes_declaration="",
         no_declaration=factory.Sequence(lambda n: f"ps-component-{n}"),
     )
-    impact = factory.Faker(
-        "random_element",
-        elements=(
-            filter(lambda i: i != "LOW", list(Impact))
-            if resolution == "DEFER"
-            else list(Impact)
-        ),
+    # an affect impact override must never exceed its flaw's impact
+    impact = factory.LazyAttribute(
+        lambda a: choice([i for i in Impact if Impact(i) <= Impact(a.flaw.impact)])
     )
 
     created_dt = factory.Faker("date_time", tzinfo=UTC)

--- a/osidb/tests/test_flaw.py
+++ b/osidb/tests/test_flaw.py
@@ -321,6 +321,7 @@ class TestFlaw:
             resolution=Affect.AffectResolution.DELEGATED,
             ps_update_stream=ps_update_stream.name,
             flaw__embargoed=False,
+            flaw__impact=Impact.MODERATE,
             # prevent LOW special handling
             impact=Impact.MODERATE,
         )
@@ -795,6 +796,86 @@ class TestImpact:
         test that the maximum is correctly identified
         """
         assert Impact(maximum) == max(Impact(impact) for impact in impacts)
+
+
+class TestAffectImpactValidation:
+    """
+    test that an Affect's impact override can never exceed its Flaw's impact
+    (the Flaw impact is never raised automatically as a side effect)
+    """
+
+    def test_affect_override_above_flaw_is_rejected(self):
+        """
+        test that creating an affect with an impact override higher than the
+        flaw's impact is rejected
+        """
+        flaw = FlawFactory(impact=Impact.LOW)
+
+        with pytest.raises(
+            ValidationError,
+            match="cannot be higher than the flaw impact",
+        ):
+            AffectFactory(flaw=flaw, impact=Impact.CRITICAL)
+
+    def test_affect_override_equal_to_flaw_is_allowed(self):
+        """
+        test that an affect impact override equal to the flaw's impact is allowed
+        """
+        flaw = FlawFactory(impact=Impact.IMPORTANT)
+        affect = AffectFactory(flaw=flaw, impact=Impact.IMPORTANT)
+
+        assert affect.impact == Impact.IMPORTANT
+
+    def test_affect_override_below_flaw_is_allowed(self):
+        """
+        test that an affect impact override below the flaw's impact is allowed
+        """
+        flaw = FlawFactory(impact=Impact.IMPORTANT)
+        affect = AffectFactory(flaw=flaw, impact=Impact.LOW)
+
+        assert affect.impact == Impact.LOW
+
+    def test_blank_affect_impact_is_allowed(self):
+        """
+        test that a blank affect impact override (which inherits the flaw's
+        impact) is always allowed
+        """
+        flaw = FlawFactory(impact=Impact.LOW)
+        affect = AffectFactory(flaw=flaw, impact=Impact.NOVALUE)
+
+        assert affect.impact == Impact.NOVALUE
+
+    def test_raising_affect_override_above_flaw_is_rejected(self):
+        """
+        test that raising an existing affect's impact override above the flaw's
+        impact is rejected
+        """
+        flaw = FlawFactory(impact=Impact.LOW)
+        affect = AffectFactory(flaw=flaw, impact=Impact.LOW)
+
+        affect.impact = Impact.IMPORTANT
+        with pytest.raises(
+            ValidationError,
+            match="cannot be higher than the flaw impact",
+        ):
+            affect.save()
+
+    def test_affect_override_after_raising_flaw_is_allowed(self):
+        """
+        test the intended workflow: raise the flaw impact first, then the affect
+        override can be raised to match
+        """
+        flaw = FlawFactory(impact=Impact.LOW)
+        affect = AffectFactory(flaw=flaw, impact=Impact.LOW)
+
+        flaw.impact = Impact.IMPORTANT
+        flaw.save()
+
+        affect.impact = Impact.IMPORTANT
+        affect.save()
+
+        affect.refresh_from_db()
+        assert affect.impact == Impact.IMPORTANT
 
 
 class TestFlawValidators:
@@ -1847,6 +1928,7 @@ class TestFlawValidators:
                 flaw=flaw,
                 ps_update_stream=ps_update_stream.name,
                 affectedness=Affect.AffectAffectedness.NEW,
+                impact=Impact.NOVALUE,
             )
             TrackerFactory(
                 embargoed=False,
@@ -1861,6 +1943,64 @@ class TestFlawValidators:
         assert should_raise == bool(
             flaw.valid_alerts.filter(name="unsupported_impact_change").exists()
         )
+
+    def test_validate_impact_not_below_affects_raises(self):
+        """
+        test that lowering a flaw's impact below an affect's explicit impact
+        override is rejected
+        """
+        flaw = FlawFactory(impact=Impact.IMPORTANT)
+        AffectFactory(flaw=flaw, impact=Impact.IMPORTANT)
+
+        flaw.impact = Impact.LOW
+        with pytest.raises(
+            ValidationError,
+            match="cannot be lower than the impact of its affects",
+        ):
+            flaw.save()
+
+    def test_validate_impact_not_below_affects_allows_equal(self):
+        """
+        test that lowering a flaw's impact to exactly the highest affect impact
+        override is allowed
+        """
+        flaw = FlawFactory(impact=Impact.CRITICAL)
+        AffectFactory(flaw=flaw, impact=Impact.IMPORTANT)
+
+        flaw.impact = Impact.IMPORTANT
+        flaw.save()
+
+        flaw.refresh_from_db()
+        assert flaw.impact == Impact.IMPORTANT
+
+    def test_validate_impact_not_below_affects_ignores_blank_affects(self):
+        """
+        test that affects without an explicit impact override (which inherit the
+        flaw's impact) never block lowering the flaw's impact
+        """
+        flaw = FlawFactory(impact=Impact.IMPORTANT)
+        AffectFactory(flaw=flaw, impact=Impact.NOVALUE)
+
+        flaw.impact = Impact.LOW
+        flaw.save()
+
+        flaw.refresh_from_db()
+        assert flaw.impact == Impact.LOW
+
+    def test_validate_impact_not_below_affects_alerts_on_internal_save(self):
+        """
+        test that an internal save (raise_validation_error=False) records an
+        error alert instead of raising
+        """
+        flaw = FlawFactory(impact=Impact.IMPORTANT)
+        AffectFactory(flaw=flaw, impact=Impact.IMPORTANT)
+
+        flaw.impact = Impact.LOW
+        flaw.save(raise_validation_error=False)
+
+        assert flaw.valid_alerts.filter(
+            name="_validate_impact_not_below_affects"
+        ).exists()
 
     @pytest.mark.parametrize(
         "was_major,is_major,tracker_statuses,should_raise",

--- a/osidb/tests/test_query_regresion.py
+++ b/osidb/tests/test_query_regresion.py
@@ -49,7 +49,7 @@ class TestQuerySetRegression:
         for _ in range(3):
             flaw = FlawFactory(
                 embargoed=embargoed,
-                impact=Impact.LOW,
+                impact=Impact.MODERATE,
                 major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
             )
             AffectFactory.create_batch(
@@ -73,7 +73,7 @@ class TestQuerySetRegression:
         for _ in range(3):
             flaw = FlawFactory(
                 embargoed=embargoed,
-                impact=Impact.LOW,
+                impact=Impact.MODERATE,
                 major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
             )
             AffectFactory.create_batch(
@@ -107,7 +107,7 @@ class TestQuerySetRegression:
     ):
         flaw = FlawFactory(
             embargoed=embargoed,
-            impact=Impact.LOW,
+            impact=Impact.MODERATE,
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
         )
         AffectFactory.create_batch(
@@ -128,7 +128,7 @@ class TestQuerySetRegression:
     ):
         flaw = FlawFactory(
             embargoed=embargoed,
-            impact=Impact.LOW,
+            impact=Impact.MODERATE,
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
         )
         AffectFactory.create_batch(
@@ -151,7 +151,7 @@ class TestQuerySetRegression:
     ):
         flaw = FlawFactory(
             embargoed=embargoed,
-            impact=Impact.LOW,
+            impact=Impact.MODERATE,
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
         )
         AffectFactory.create_batch(
@@ -185,7 +185,7 @@ class TestQuerySetRegression:
     ):
         flaw = FlawFactory(
             embargoed=embargoed,
-            impact=Impact.LOW,
+            impact=Impact.MODERATE,
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
         )
         AffectFactory.create_batch(
@@ -223,7 +223,7 @@ class TestQuerySetRegression:
     ):
         flaw = FlawFactory(
             embargoed=embargoed,
-            impact=Impact.LOW,
+            impact=Impact.MODERATE,
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
         )
         for _ in range(3):
@@ -331,7 +331,7 @@ class TestQuerySetRegression:
         """
         flaw = FlawFactory(
             embargoed=False,
-            impact=Impact.LOW,
+            impact=Impact.MODERATE,
             major_incident_state=Flaw.FlawMajorIncident.NOVALUE,
         )
         AffectFactory.create_batch(

--- a/osidb/tests/test_tracker.py
+++ b/osidb/tests/test_tracker.py
@@ -24,8 +24,8 @@ class TestTracker:
     @pytest.mark.parametrize(
         "flaw1_impact,flaw2_impact,affect1_impact,affect2_impact,expected_impact",
         [
-            ("LOW", "MODERATE", "IMPORTANT", "CRITICAL", "CRITICAL"),
-            ("LOW", "IMPORTANT", "MODERATE", "MODERATE", "MODERATE"),
+            ("IMPORTANT", "CRITICAL", "IMPORTANT", "CRITICAL", "CRITICAL"),
+            ("MODERATE", "IMPORTANT", "MODERATE", "MODERATE", "MODERATE"),
             ("LOW", "IMPORTANT", "", "", "IMPORTANT"),
             ("LOW", "LOW", "", "LOW", "LOW"),
         ],
@@ -77,8 +77,10 @@ class TestTracker:
         """
         ps_module = PsModuleFactory()
         ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
-        flaw1 = FlawFactory(embargoed=False)
-        flaw2 = FlawFactory(embargoed=flaw1.embargoed)
+        # pin the flaw impacts so the affect overrides can later be raised to
+        # MODERATE without exceeding their flaw impact
+        flaw1 = FlawFactory(embargoed=False, impact="MODERATE")
+        flaw2 = FlawFactory(embargoed=flaw1.embargoed, impact="MODERATE")
         affect1 = AffectFactory(
             affectedness=Affect.AffectAffectedness.AFFECTED,
             flaw=flaw1,


### PR DESCRIPTION
This PR introduces two new validations (affect and flaw side) to ensure that a flaw impact is always at or above the most impactful impact override. I was thinking about making a data migration but at the end I do not think it is a good idea to make such serious change automatically. There are consequences to the engineering and potentially customers and I do not think the automation should initiate them. It is about 200 flaws so if they want, people can fix them.

Number of tests had to be updated too as they mostly had random impacts which would violate the new restriction.

Closes OSIDB-5389