### PR TITLE
OSIDB-5465: Fix embargoed filters

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - exclude pre-Argus and already done flaws from workflow re-classification (OSIDB-5406)
 
+### Fixed
+- Fix DjangoQL filter for `query=embargoed=True` (OSIDB-5465)
+
 ## [5.17.0] - 2026-08-26
 ### Added
 - Certain workflow labels now provide a `reason` attribute which can provide

--- a/osidb/djangoql.py
+++ b/osidb/djangoql.py
@@ -109,7 +109,9 @@ class FlawQLSchema(DjangoQLSchema):
     }
 
     def get_field_cls(self, field):
-        """Override to use RelativeDateTimeQLField for DateTimeField instances."""
+        """Map GeneratedField to its output type; use relative datetimes."""
+        if isinstance(field, models.GeneratedField):
+            field = field.output_field
         if isinstance(field, models.DateTimeField):
             return RelativeDateTimeQLField
         return super().get_field_cls(field)

--- a/osidb/filters.py
+++ b/osidb/filters.py
@@ -800,6 +800,7 @@ class FlawFilter(
             + LTE_GTE_LOOKUP_EXPRS
             + DATE_LOOKUP_EXPRS,
             "nist_cvss_validation": ["exact"],
+            "embargoed": ["exact"],
             # Workflow fields
             "workflow_name": ["exact"],
             "workflow_state": ["exact"],

--- a/osidb/tests/endpoints/flaws/test_query.py
+++ b/osidb/tests/endpoints/flaws/test_query.py
@@ -208,3 +208,39 @@ class TestQL(object):
             str(test_data["flaw4"].uuid),
         }
         assert returned_uuids == expected_uuids
+
+    def test_query_embargoed_true(self, auth_client, test_api_uri):
+        """DjangoQL must treat embargoed as a bool (GeneratedField)."""
+        FlawFactory(embargoed=False)
+        embargoed = FlawFactory(embargoed=True)
+
+        response = auth_client().get(f"{test_api_uri}/flaws?query=embargoed=True")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["results"][0]["uuid"] == str(embargoed.uuid)
+
+    def test_query_embargoed_false(self, auth_client, test_api_uri):
+        public = FlawFactory(embargoed=False)
+        FlawFactory(embargoed=True)
+
+        response = auth_client().get(f"{test_api_uri}/flaws?query=embargoed=False")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["results"][0]["uuid"] == str(public.uuid)
+
+    def test_query_visibility_embargoed(self, auth_client, test_api_uri):
+        FlawFactory(embargoed=False)
+        embargoed = FlawFactory(embargoed=True)
+
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=visibility="EMBARGOED"'
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["count"] == 1
+        assert body["results"][0]["uuid"] == str(embargoed.uuid)


### PR DESCRIPTION
Vincent reported that embargoed filter was not working in this [thread](https://redhat-internal.slack.com/archives/D096NBLMP6E/p1787816880833189). 

Checking how it works OSIM advanced filter calls OSIDB expecting DjangoQL to answer and while there is a REST api filter for embargoed there was none for DjangoQL. 

This PR adds this filter. 

 