### PR TITLE
fix: limit is_ubi to latest z-stream and next y-stream (OSIDB-5459)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix DjangoQL filter for `query=embargoed=True` (OSIDB-5465)
+- Fix UBI label incorrectly applied to older EUS/AUS RHEL streams — now only
+  applies to latest Z-stream and next Y-stream (e.g., rhel-9.8.z and rhel-9.9,
+  not rhel-9.2.z or rhel-9.10) (OSIDB-5459)
 
 ## [5.17.0] - 2026-08-26
 ### Added

--- a/osidb/helpers.py
+++ b/osidb/helpers.py
@@ -266,19 +266,6 @@ class TaskFormatter(logging.Formatter):
         return super().format(record)
 
 
-def ps_update_stream_natural_keys(values):
-    """Sort alphanumeric strings
-    http://nedbatchelder.com/blog/200712/human_sorting.html
-    """
-    if not values:
-        return []
-
-    def atoi(text):
-        return int(text) if text.isdigit() else text
-
-    return [atoi(c) for c in re.split(r"(\d+)", values.name)]
-
-
 # Part of the following code is subject to a different license and copyright
 # holder:
 

--- a/osidb/migrations/0222_auto_20260123_2125.py
+++ b/osidb/migrations/0222_auto_20260123_2125.py
@@ -6,11 +6,23 @@ a PS module. This migration finds the correct module from
 product definitions and updates the affects.
 """
 
+import re
+
 from django.conf import settings
 from django.db import migrations
 
 from osidb.core import set_user_acls
-from osidb.helpers import ps_update_stream_natural_keys
+
+
+def ps_update_stream_natural_keys(values):
+    """Sort alphanumeric strings (natural/human sorting)"""
+    if not values:
+        return []
+
+    def atoi(text):
+        return int(text) if text.isdigit() else text
+
+    return [atoi(c) for c in re.split(r"(\d+)", values.name)]
 
 
 PS_MODULES_LIST = [

--- a/osidb/migrations/0223_fix_update_stream.py
+++ b/osidb/migrations/0223_fix_update_stream.py
@@ -8,11 +8,23 @@ corresponding module (based on product definitions)
 """
 
 
+import re
+
 from django.conf import settings
 from django.db import migrations
 
 from osidb.core import set_user_acls
-from osidb.helpers import ps_update_stream_natural_keys
+
+
+def ps_update_stream_natural_keys(values):
+    """Sort alphanumeric strings (natural/human sorting)"""
+    if not values:
+        return []
+
+    def atoi(text):
+        return int(text) if text.isdigit() else text
+
+    return [atoi(c) for c in re.split(r"(\d+)", values.name)]
 
 
 PS_UPDATE_STREAM_LIST = [

--- a/osidb/migrations/0268_create_natural_collation.py
+++ b/osidb/migrations/0268_create_natural_collation.py
@@ -1,0 +1,26 @@
+"""
+Create natural sort collation for version string sorting.
+
+This collation enables natural/numeric sorting where '9.9' < '9.10'
+instead of lexicographic sorting where '9.10' < '9.9'.
+
+Used for sorting ps_update_stream names like rhel-9.9, rhel-9.10, etc.
+"""
+
+from django.contrib.postgres.operations import CreateCollation
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("osidb", "0267_psproduct_team"),
+    ]
+
+    operations = [
+        CreateCollation(
+            name="natural",
+            provider="icu",
+            locale="en-u-kn-true",
+            deterministic=False,
+        ),
+    ]

--- a/osidb/models/affect.py
+++ b/osidb/models/affect.py
@@ -7,6 +7,7 @@ from django.contrib.postgres import fields
 from django.contrib.postgres.indexes import GinIndex
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db import models
+from django.db.models import CharField, Exists, F, OuterRef, Q, Subquery
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from psqlextra.fields import HStoreField
@@ -930,20 +931,50 @@ class Affect(
 
     def is_ubi(self) -> bool:
         """
-        check and return whether the given affect's component is a UBI package
-        for the matching ps_module (e.g. rhel-8, rhel-9, rhel-10)
+        Check whether this affect's component is a UBI package AND
+        the update stream is a current UBI stream (latest Z or next Y).
+
+        UBI images track the latest minor release of each RHEL major version:
+        - Latest Z-stream (e.g., rhel-9.8.z, not rhel-9.2.z)
+        - Next Y-stream only (e.g., rhel-9.9, not rhel-9.10)
+
+        Older EUS/AUS streams and future Y-streams do not get the UBI label.
 
         Looks the module up via ps_update_stream rather than the denormalized
         ps_module field, as ps_update_stream is a required field that is always set
         by the time this is called (even on an unsaved instance), whereas ps_module
         is only populated by save().
         """
-        return UbiPackage.objects.filter(
-            name=self.ps_component,
-            ps_module__in=PsUpdateStream.objects.filter(
-                name=self.ps_update_stream
-            ).values_list("ps_module__name", flat=True),
-        ).exists()
+        return (
+            PsUpdateStream.objects.filter(
+                name=self.ps_update_stream,
+            )
+            .annotate(
+                is_ubi_package=Exists(
+                    UbiPackage.objects.filter(
+                        name=self.ps_component,
+                        ps_module=OuterRef("ps_module__name"),
+                    )
+                ),
+                latest_z=Subquery(
+                    PsUpdateStream.objects.get_z_streams(OuterRef("ps_module")).values(
+                        "name"
+                    )[:1],
+                    output_field=CharField(),
+                ),
+                next_y=Subquery(
+                    PsUpdateStream.objects.get_y_streams(OuterRef("ps_module")).values(
+                        "name"
+                    )[:1],
+                    output_field=CharField(),
+                ),
+            )
+            .filter(
+                is_ubi_package=True,
+            )
+            .filter(Q(name=F("latest_z")) | Q(name=F("next_y")))
+            .exists()
+        )
 
     @property
     def is_notaffected(self) -> bool:

--- a/osidb/models/ps_module.py
+++ b/osidb/models/ps_module.py
@@ -6,7 +6,6 @@ from django.db import models
 from django.utils import timezone
 
 from apps.bbsync.constants import RHSCL_BTS_KEY
-from osidb.helpers import ps_update_stream_natural_keys
 from osidb.mixins import NullStrFieldsMixin, ValidateMixin
 
 from .ps_product import PsProduct
@@ -96,18 +95,16 @@ class PsModule(NullStrFieldsMixin, ValidateMixin):
     @property
     def y_streams(self):
         """Current Y-stream(s) - it can be more of them"""
+        from .ps_update_stream import PsUpdateStream
 
-        return list(self.active_ps_update_streams.exclude(name__endswith="z"))
+        return list(PsUpdateStream.objects.get_y_streams(self))
 
     @property
     def z_stream(self):
         """Current Z-stream"""
-        z_streams = self.active_ps_update_streams.filter(name__endswith="z")
-        return (
-            max(list(z_streams), key=ps_update_stream_natural_keys)
-            if z_streams
-            else None
-        )
+        from .ps_update_stream import PsUpdateStream
+
+        return PsUpdateStream.objects.get_z_streams(self).first()
 
     def subcomponent(self, component) -> Union[str, None]:
         """

--- a/osidb/models/ps_update_stream.py
+++ b/osidb/models/ps_update_stream.py
@@ -1,16 +1,61 @@
+from __future__ import annotations
+
 import uuid
 
 from django.contrib.postgres import fields
 from django.db import models
+from django.db.models import OuterRef
+from django.db.models.functions import Collate
 
 from osidb.mixins import NullStrFieldsMixin, ValidateMixin
 
 from .ps_module import PsModule
 
 
+class PsUpdateStreamManager(models.Manager):
+    """Custom manager for PsUpdateStream with UBI stream helpers"""
+
+    def get_z_streams(
+        self, ps_module: PsModule | OuterRef
+    ) -> models.QuerySet[PsUpdateStream]:
+        """
+        Returns a queryset of active Z-streams for the given module,
+        ordered by natural version sorting (descending, latest first).
+
+        Args:
+            ps_module: Either a PsModule instance or OuterRef("ps_module")
+                      for use in subqueries
+        """
+        return self.filter(
+            active_to_ps_module=ps_module,
+            name__endswith="z",
+        ).order_by(Collate("name", "natural").desc())
+
+    def get_y_streams(
+        self, ps_module: PsModule | OuterRef
+    ) -> models.QuerySet[PsUpdateStream]:
+        """
+        Returns a queryset of active Y-streams for the given module,
+        ordered by natural version sorting (ascending, next/lowest first).
+
+        Args:
+            ps_module: Either a PsModule instance or OuterRef("ps_module")
+                      for use in subqueries
+        """
+        return (
+            self.filter(
+                active_to_ps_module=ps_module,
+            )
+            .exclude(name__endswith="z")
+            .order_by(Collate("name", "natural").asc())
+        )
+
+
 class PsUpdateStream(NullStrFieldsMixin, ValidateMixin):
     # internal primary key
     uuid = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+
+    objects = PsUpdateStreamManager()
 
     name = models.CharField(max_length=100, unique=True)
     version = models.CharField(max_length=50, blank=True)

--- a/osidb/models/tests/test_affect.py
+++ b/osidb/models/tests/test_affect.py
@@ -690,3 +690,190 @@ class TestAutoResolve:
         affect.auto_resolve()
         assert affect.affectedness == Affect.AffectAffectedness.AFFECTED
         assert affect.resolution == Affect.AffectResolution.DEFER
+
+
+@pytest.mark.django_db
+class TestAffectIsUbi:
+    """Test UBI label logic for affects"""
+
+    @pytest.mark.enable_signals
+    def test_ubi_latest_z_stream(self):
+        """Latest Z-stream with UBI component should get UBI label"""
+        ps_module = PsModuleFactory(name="rhel-9")
+
+        # Old EUS stream (not active)
+        PsUpdateStreamFactory(
+            name="rhel-9.2.z",
+            ps_module=ps_module,
+            eus_to_ps_module=ps_module,
+            active_to_ps_module=None,
+        )
+        # Latest Z-stream (active)
+        PsUpdateStreamFactory(
+            name="rhel-9.8.z",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+
+        # Create UBI package
+        UbiPackage.objects.create(name="curl", ps_module="rhel-9")
+
+        affect = AffectFactory(
+            ps_update_stream="rhel-9.8.z",
+            ps_component="curl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+
+        assert affect.is_ubi() is True
+        assert "ubi" in affect.labels
+
+    @pytest.mark.enable_signals
+    def test_no_ubi_old_eus_stream(self):
+        """Old EUS stream should NOT get UBI label even with UBI component"""
+        ps_module = PsModuleFactory(name="rhel-9")
+
+        # Old EUS stream (not active)
+        PsUpdateStreamFactory(
+            name="rhel-9.2.z",
+            ps_module=ps_module,
+            eus_to_ps_module=ps_module,
+            active_to_ps_module=None,
+        )
+        # Latest Z-stream (active)
+        PsUpdateStreamFactory(
+            name="rhel-9.8.z",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+
+        # Create UBI package
+        UbiPackage.objects.create(name="curl", ps_module="rhel-9")
+
+        affect = AffectFactory(
+            ps_update_stream="rhel-9.2.z",
+            ps_component="curl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+
+        assert affect.is_ubi() is False
+        assert "ubi" not in affect.labels
+
+    @pytest.mark.enable_signals
+    def test_ubi_next_y_stream(self):
+        """Next Y-stream (lowest active Y) should get UBI label"""
+        ps_module = PsModuleFactory(name="rhel-9")
+
+        # Both active Y-streams
+        PsUpdateStreamFactory(
+            name="rhel-9.9",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+        PsUpdateStreamFactory(
+            name="rhel-9.10",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+
+        # Create UBI package
+        UbiPackage.objects.create(name="curl", ps_module="rhel-9")
+
+        affect = AffectFactory(
+            ps_update_stream="rhel-9.9",
+            ps_component="curl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+
+        assert affect.is_ubi() is True
+        assert "ubi" in affect.labels
+
+    @pytest.mark.enable_signals
+    def test_no_ubi_future_y_stream(self):
+        """Future Y-stream beyond next should NOT get UBI label"""
+        ps_module = PsModuleFactory(name="rhel-9")
+
+        # Both active Y-streams
+        PsUpdateStreamFactory(
+            name="rhel-9.9",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+        PsUpdateStreamFactory(
+            name="rhel-9.10",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+
+        # Create UBI package
+        UbiPackage.objects.create(name="curl", ps_module="rhel-9")
+
+        affect = AffectFactory(
+            ps_update_stream="rhel-9.10",  # Future Y, not next
+            ps_component="curl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+
+        assert affect.is_ubi() is False
+        assert "ubi" not in affect.labels
+
+    @pytest.mark.enable_signals
+    def test_no_ubi_non_ubi_component(self):
+        """Active stream with non-UBI component should NOT get UBI label"""
+        ps_module = PsModuleFactory(name="rhel-9")
+
+        PsUpdateStreamFactory(
+            name="rhel-9.8.z",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+
+        affect = AffectFactory(
+            ps_update_stream="rhel-9.8.z",
+            ps_component="non-ubi-package",  # Not in UbiPackage table
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+
+        assert affect.is_ubi() is False
+        assert "ubi" not in affect.labels
+
+    @pytest.mark.enable_signals
+    def test_natural_sort_9_vs_10(self):
+        """Verify natural sorting: 9.9 < 9.10 (not 9.10 < 9.9)"""
+        ps_module = PsModuleFactory(name="rhel-9")
+
+        # Both active Y-streams
+        PsUpdateStreamFactory(
+            name="rhel-9.9",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+        PsUpdateStreamFactory(
+            name="rhel-9.10",
+            ps_module=ps_module,
+            active_to_ps_module=ps_module,
+        )
+
+        # Create UBI package
+        UbiPackage.objects.create(name="curl", ps_module="rhel-9")
+
+        # Only 9.9 (min) should get UBI, not 9.10
+        affect_9_9 = AffectFactory(
+            ps_update_stream="rhel-9.9",
+            ps_component="curl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+        affect_9_10 = AffectFactory(
+            ps_update_stream="rhel-9.10",
+            ps_component="curl",
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+        )
+
+        assert affect_9_9.is_ubi() is True
+        assert affect_9_10.is_ubi() is False

--- a/osidb/models/tests/test_ps_module.py
+++ b/osidb/models/tests/test_ps_module.py
@@ -3,7 +3,8 @@ from datetime import datetime, timezone
 import pytest
 from freezegun import freeze_time
 
-from osidb.models import PsModule
+from osidb.models import PsModule, PsUpdateStream
+from osidb.tests.factories import PsModuleFactory, PsUpdateStreamFactory
 
 
 class TestPsModule:
@@ -48,3 +49,53 @@ class TestPsModule:
             ).is_prodsec_supported
             == is_prodsec_supported
         )
+
+    @pytest.mark.django_db
+    def test_z_stream_property(self):
+        """Test PsModule.z_stream property returns latest Z-stream"""
+        ps_module = PsModuleFactory(name="rhel-9")
+        PsUpdateStreamFactory(
+            name="rhel-9.8.z", ps_module=ps_module, active_to_ps_module=ps_module
+        )
+        PsUpdateStreamFactory(
+            name="rhel-9.9.z", ps_module=ps_module, active_to_ps_module=ps_module
+        )
+
+        # Should return latest (natural sort desc)
+        assert ps_module.z_stream.name == "rhel-9.9.z"
+
+    @pytest.mark.django_db
+    def test_get_z_streams_with_instance(self):
+        """Test PsUpdateStreamManager.get_z_streams accepts PsModule instance"""
+        ps_module = PsModuleFactory(name="rhel-9")
+        PsUpdateStreamFactory(
+            name="rhel-9.8.z", ps_module=ps_module, active_to_ps_module=ps_module
+        )
+        PsUpdateStreamFactory(
+            name="rhel-9.9.z", ps_module=ps_module, active_to_ps_module=ps_module
+        )
+
+        result = PsUpdateStream.objects.get_z_streams(ps_module)
+        names = list(result.values_list("name", flat=True))
+
+        assert len(names) == 2
+        # Should be ordered desc (latest first) using natural sort
+        assert names == ["rhel-9.9.z", "rhel-9.8.z"]
+
+    @pytest.mark.django_db
+    def test_get_y_streams_with_instance(self):
+        """Test PsUpdateStreamManager.get_y_streams accepts PsModule instance"""
+        ps_module = PsModuleFactory(name="rhel-9")
+        PsUpdateStreamFactory(
+            name="rhel-9.9", ps_module=ps_module, active_to_ps_module=ps_module
+        )
+        PsUpdateStreamFactory(
+            name="rhel-9.10", ps_module=ps_module, active_to_ps_module=ps_module
+        )
+
+        result = PsUpdateStream.objects.get_y_streams(ps_module)
+        names = list(result.values_list("name", flat=True))
+
+        assert len(names) == 2
+        # Should be ordered asc (next/lowest first) using natural sort
+        assert names == ["rhel-9.9", "rhel-9.10"]


### PR DESCRIPTION
This commit installs a special collation which allows natural order of char fields (e.g. 3.10 > 3.2) which makes finding the latest z-stream and the next y-stream trivial and efficient (done by the database), creates the necessary helpers and applies it to Affect.is_ubi(), as well as some existing helper properties / methods for retrieving z-streams and y-streams

This fix avoids false positives when marking the "ubi" label to affects, as well as bypassing the mod7 check for affects that don't meet the criteria.