### PR TITLE
lock related entities on unembargoing cascaded entities

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -434,7 +434,7 @@
         "filename": "osidb/tests/endpoints/flaws/test_unembargo.py",
         "hashed_secret": "3c3b274d119ff5a5ec6c1e215c1cb794d9973ac1",
         "is_verified": false,
-        "line_number": 75,
+        "line_number": 80,
         "is_secret": false
       }
     ],
@@ -517,5 +517,5 @@
       }
     ]
   },
-  "generated_at": "2026-08-24T13:27:57Z"
+  "generated_at": "2026-08-31T14:06:48Z"
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+### Fixed
+- Fixed unembargo deadlocks by locking related affects and trackers before applying
+  flaw updates that cascade visibility changes. (OSIDB-5456)
+
 ## [5.17.1] - 2026-08-31
 ### Added
 - make sure that the flaw impact is always at or above any affect override (OSIDB-5389)

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -11,6 +11,7 @@ import pghistory
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import BadRequest, ValidationError
+from django.db import connection
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
@@ -2468,6 +2469,10 @@ class FlawSerializer(
         # 1) pre-update actions #
         #########################
 
+        if self._needs_related_update_lock(new_flaw, validated_data):
+            if self._lock_related_update_rows(new_flaw):
+                new_flaw.refresh_from_db()
+
         # store the old flaw for the later comparison
         old_flaw = Flaw.objects.get(uuid=new_flaw.uuid)
 
@@ -2507,30 +2512,79 @@ class FlawSerializer(
 
         return new_flaw
 
+    def _needs_related_update_lock(self, flaw, validated_data):
+        """
+        Check whether the flaw update can cascade into affect or tracker saves.
+        """
+        if validated_data.get("embargoed") is False and flaw.is_embargoed:
+            return True
+
+        return bool(
+            validated_data.keys()
+            & {
+                "components",
+                "cve_id",
+                "impact",
+                "major_incident_state",
+                "unembargo_dt",
+            }
+        )
+
+    def _major_incident_update_affects_trackers(self, old_state, new_state):
+        """
+        Check whether the MI transition affects tracker update behavior.
+        """
+        return old_state != new_state and bool(
+            {old_state, new_state}
+            & {
+                Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
+                Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
+                # Flaw.FlawMajorIncident.MINOR_INCIDENT_APPROVED is not included as it
+                # has no engineering impact.
+            }
+        )
+
+    def _lock_related_update_rows(self, flaw):
+        """
+        Serialize flaw updates which may save related affects and trackers later.
+        """
+        if not connection.in_atomic_block:
+            return False
+
+        list(
+            Affect.objects.select_for_update()
+            .filter(flaw=flaw)
+            .order_by("uuid")
+            .values_list("uuid", flat=True)
+        )
+
+        tracker_ids = Affect.objects.filter(
+            flaw=flaw,
+            tracker__isnull=False,
+        ).values_list("tracker_id", flat=True)
+
+        list(
+            Tracker.objects.select_for_update()
+            .filter(uuid__in=tracker_ids)
+            .order_by("uuid")
+            .values_list("uuid", flat=True)
+        )
+        return True
+
     def update_trackers(self, old_flaw, new_flaw):
         """
         update the related trackers if needed
         """
 
-        def mi_differ(flaw1, flaw2):
-            """
-            boolean check whether the given flaws
-            differ in MI value in an important way
-            """
-            if not differ(flaw1, flaw2, ["major_incident_state"]):
-                return False
-
-            # we only care for a change from or to some of the approved states
-            return bool(
-                {flaw1.major_incident_state, flaw2.major_incident_state}.intersection(
-                    [
-                        Flaw.FlawMajorIncident.MAJOR_INCIDENT_APPROVED,
-                        Flaw.FlawMajorIncident.EXPLOITS_KEV_APPROVED,
-                        # Flaw.FlawMajorIncident.MINOR_INCIDENT_APPROVED is not
-                        # included as it has no engineering impact
-                    ]
-                )
-            )
+        component_fields_changed = differ(old_flaw, new_flaw, ("components",))
+        general_fields_changed = differ(
+            old_flaw, new_flaw, ("cve_id", "is_embargoed", "unembargo_dt")
+        )
+        mi_changed = self._major_incident_update_affects_trackers(
+            old_flaw.major_incident_state,
+            new_flaw.major_incident_state,
+        )
+        impact_changed = Impact(old_flaw.impact) != Impact(new_flaw.impact)
 
         # we only need to sync the trackers when crucial attributes change
         # plus in the case of the MI we care for specific changes only
@@ -2541,14 +2595,11 @@ class FlawSerializer(
         # changes the tracker aggregated impact (in cases of multi-flaw trackers)
         # but that drastically increases the code complexity and brings only a little
         # value - would prevent a rare extra update attempt without any real effect
-        if (
-            not differ(
-                old_flaw,
-                new_flaw,
-                ["components", "cve_id", "is_embargoed", "unembargo_dt"],
-            )
-            and not mi_differ(old_flaw, new_flaw)
-            and Impact(old_flaw.impact) == Impact(new_flaw.impact)
+        if not (
+            component_fields_changed
+            or general_fields_changed
+            or mi_changed
+            or impact_changed
         ):
             return
 
@@ -2571,13 +2622,7 @@ class FlawSerializer(
             if (
                 tracker.meta_attr.get("jira_issuetype") != "Vulnerability"
                 or tracker.type != Tracker.TrackerType.JIRA
-            ) and (
-                not differ(
-                    old_flaw, new_flaw, ["cve_id", "is_embargoed", "unembargo_dt"]
-                )
-                and not mi_differ(old_flaw, new_flaw)
-                and Impact(old_flaw.impact) == Impact(new_flaw.impact)
-            ):
+            ) and not (general_fields_changed or mi_changed or impact_changed):
                 # If the non-components attributes are unchanged, a tracker update is
                 # necessary only for Vulnerability issuetype Jira trackers because only
                 # those contain components. And this tracker is not Vuln. issuetype.

--- a/osidb/tests/endpoints/flaws/test_unembargo.py
+++ b/osidb/tests/endpoints/flaws/test_unembargo.py
@@ -1,10 +1,14 @@
+import threading
 from datetime import datetime, timezone
 from itertools import chain
 
 import pytest
+from django.conf import settings
+from django.db import OperationalError, close_old_connections, transaction
 from freezegun import freeze_time
 from rest_framework import status
 
+from osidb.core import set_user_acls
 from osidb.models import (
     Affect,
     AffectCVSS,
@@ -13,6 +17,7 @@ from osidb.models import (
     FlawComment,
     FlawCVSS,
     FlawReference,
+    Impact,
     Package,
     Tracker,
 )
@@ -272,3 +277,256 @@ class TestEndpointsFlawsUnembargo:
             assert not any(instance.is_embargoed for instance in Affect.objects.all())
             assert not any(instance.is_embargoed for instance in Flaw.objects.all())
             assert not any(instance.is_embargoed for instance in Tracker.objects.all())
+
+    @pytest.mark.enable_signals
+    @pytest.mark.django_db(transaction=True)
+    @freeze_time(datetime(2030, 10, 10, tzinfo=timezone.utc))
+    def test_concurrent_shared_tracker_unembargo_does_not_deadlock(
+        self, monkeypatch, auth_client, test_api_uri, bugzilla_token, jira_token
+    ):
+        set_user_acls(settings.ALL_GROUPS)
+
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+
+        flaw1 = FlawFactory(
+            cve_id="CVE-2030-1111",
+            embargoed=True,
+            unembargo_dt=datetime(2030, 10, 10, tzinfo=timezone.utc),
+        )
+        flaw2 = FlawFactory(
+            cve_id="CVE-2030-2222",
+            embargoed=True,
+            unembargo_dt=datetime(2030, 10, 10, tzinfo=timezone.utc),
+        )
+        affect1 = AffectFactory(
+            flaw=flaw1,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_update_stream=ps_update_stream.name,
+            ps_component="component",
+        )
+        affect2 = AffectFactory(
+            flaw=flaw2,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_update_stream=ps_update_stream.name,
+            ps_component="component",
+        )
+        tracker = TrackerFactory(
+            affects=[affect1, affect2],
+            embargoed=True,
+            ps_update_stream=ps_update_stream.name,
+            type=Tracker.TrackerType.BUGZILLA,
+        )
+
+        original_save = Tracker.save
+        wait_timeout = 10
+        requests_started = threading.Barrier(2)
+        barrier = threading.Barrier(2)
+        tracker_unembargo_save_threads = []
+        tracker_barrier_completed = threading.Event()
+        tracker_barrier_broken = threading.Event()
+        thread_state = threading.local()
+
+        def save_with_barrier(self, *args, **kwargs):
+            if (
+                getattr(thread_state, "flaw_update", False)
+                and self.uuid == tracker.uuid
+                and kwargs.get("auto_timestamps") is False
+            ):
+                tracker_unembargo_save_threads.append(thread_state.index)
+                try:
+                    barrier.wait(timeout=wait_timeout)
+                except threading.BrokenBarrierError:
+                    tracker_barrier_broken.set()
+                else:
+                    tracker_barrier_completed.set()
+            return original_save(self, *args, **kwargs)
+
+        monkeypatch.setattr(Tracker, "save", save_with_barrier)
+
+        clients = {1: auth_client(), 2: auth_client()}
+        responses = {}
+        exceptions = {}
+
+        def update_flaw(index, flaw_uuid, updated_dt):
+            close_old_connections()
+            set_user_acls(settings.ALL_GROUPS)
+            thread_state.flaw_update = True
+            thread_state.index = index
+            try:
+                requests_started.wait(timeout=wait_timeout)
+                flaw = Flaw.objects.get(uuid=flaw_uuid)
+                responses[index] = clients[index].put(
+                    f"{test_api_uri}/flaws/{flaw_uuid}",
+                    {
+                        "title": flaw.title,
+                        "comment_zero": flaw.comment_zero,
+                        "embargoed": False,
+                        "updated_dt": updated_dt,
+                    },
+                    format="json",
+                    HTTP_BUGZILLA_API_KEY=bugzilla_token,
+                    HTTP_JIRA_API_KEY=jira_token,
+                )
+            except Exception as exc:
+                exceptions[index] = exc
+            finally:
+                if (
+                    index not in tracker_unembargo_save_threads
+                    and not tracker_barrier_completed.is_set()
+                ):
+                    barrier.abort()
+                thread_state.flaw_update = False
+                thread_state.index = None
+                close_old_connections()
+
+        thread1 = threading.Thread(
+            target=update_flaw, args=(1, flaw1.uuid, flaw1.updated_dt)
+        )
+        thread2 = threading.Thread(
+            target=update_flaw, args=(2, flaw2.uuid, flaw2.updated_dt)
+        )
+
+        thread1.start()
+        thread2.start()
+        thread1.join(timeout=20)
+        thread2.join(timeout=20)
+
+        set_user_acls(settings.ALL_GROUPS)
+        assert not thread1.is_alive()
+        assert not thread2.is_alive()
+        assert not exceptions, [str(exc) for exc in exceptions.values()]
+        assert tracker_unembargo_save_threads
+        assert tracker_barrier_completed.is_set() or tracker_barrier_broken.is_set()
+        if not tracker_barrier_completed.is_set():
+            assert len(set(tracker_unembargo_save_threads)) == 1
+        assert len(responses) == 2
+        assert all(
+            response.status_code == status.HTTP_200_OK
+            for response in responses.values()
+        )
+        assert not any(instance.is_embargoed for instance in Affect.objects.all())
+        assert not any(instance.is_embargoed for instance in Flaw.objects.all())
+        assert not any(instance.is_embargoed for instance in Tracker.objects.all())
+
+    @pytest.mark.enable_signals
+    @pytest.mark.django_db(transaction=True)
+    @freeze_time(datetime(2030, 10, 10, tzinfo=timezone.utc))
+    def test_concurrent_affect_save_unembargo_does_not_deadlock(
+        self, monkeypatch, auth_client, test_api_uri, bugzilla_token, jira_token
+    ):
+        set_user_acls(settings.ALL_GROUPS)
+
+        ps_module = PsModuleFactory(bts_name="bugzilla")
+        ps_update_stream = PsUpdateStreamFactory(ps_module=ps_module)
+        flaw = FlawFactory(
+            embargoed=True,
+            unembargo_dt=datetime(2030, 10, 10, tzinfo=timezone.utc),
+        )
+        affect = AffectFactory(
+            flaw=flaw,
+            affectedness=Affect.AffectAffectedness.AFFECTED,
+            resolution=Affect.AffectResolution.DELEGATED,
+            ps_update_stream=ps_update_stream.name,
+            ps_component="component",
+        )
+
+        original_affect_save = Affect.save
+        unembargo_saving_affect = threading.Event()
+        affect_update_checked_affect_lock = threading.Event()
+        unembargo_finished = threading.Event()
+        thread_state = threading.local()
+
+        def save_affect_with_pause(self, *args, **kwargs):
+            if getattr(thread_state, "unembargo", False) and self.uuid == affect.uuid:
+                unembargo_saving_affect.set()
+                assert affect_update_checked_affect_lock.wait(timeout=10)
+            return original_affect_save(self, *args, **kwargs)
+
+        monkeypatch.setattr(Affect, "save", save_affect_with_pause)
+
+        client = auth_client()
+        response = None
+        exceptions = {}
+
+        def unembargo_flaw():
+            nonlocal response
+            close_old_connections()
+            set_user_acls(settings.ALL_GROUPS)
+            thread_state.unembargo = True
+            try:
+                response = client.put(
+                    f"{test_api_uri}/flaws/{flaw.uuid}",
+                    {
+                        "title": flaw.title,
+                        "comment_zero": flaw.comment_zero,
+                        "embargoed": False,
+                        "updated_dt": flaw.updated_dt,
+                    },
+                    format="json",
+                    HTTP_BUGZILLA_API_KEY=bugzilla_token,
+                    HTTP_JIRA_API_KEY=jira_token,
+                )
+            except Exception as exc:
+                exceptions["unembargo"] = exc
+            finally:
+                thread_state.unembargo = False
+                unembargo_finished.set()
+                close_old_connections()
+
+        def update_affect():
+            close_old_connections()
+            set_user_acls(settings.ALL_GROUPS)
+            thread_state.affect_update = True
+            try:
+                assert unembargo_saving_affect.wait(timeout=10)
+                try:
+                    with transaction.atomic():
+                        affect_to_update = Affect.objects.select_for_update(
+                            nowait=True
+                        ).get(uuid=affect.uuid)
+                        affect_update_checked_affect_lock.set()
+                        affect_to_update.impact = Impact.LOW
+                        affect_to_update.save(
+                            auto_timestamps=False,
+                            raise_validation_error=False,
+                            update_fields=["impact"],
+                        )
+                except OperationalError as exc:
+                    if "could not obtain lock on row" not in str(exc):
+                        raise
+                    affect_update_checked_affect_lock.set()
+                    assert unembargo_finished.wait(timeout=10)
+                    with transaction.atomic():
+                        affect_to_update = Affect.objects.select_for_update().get(
+                            uuid=affect.uuid
+                        )
+                        affect_to_update.impact = Impact.LOW
+                        affect_to_update.save(
+                            auto_timestamps=False,
+                            raise_validation_error=False,
+                            update_fields=["impact"],
+                        )
+            except Exception as exc:
+                exceptions["affect_update"] = exc
+            finally:
+                thread_state.affect_update = False
+                close_old_connections()
+
+        thread1 = threading.Thread(target=unembargo_flaw)
+        thread2 = threading.Thread(target=update_affect)
+
+        thread1.start()
+        thread2.start()
+        thread1.join(timeout=20)
+        thread2.join(timeout=20)
+
+        set_user_acls(settings.ALL_GROUPS)
+        assert not thread1.is_alive()
+        assert not thread2.is_alive()
+        assert not exceptions, [str(exc) for exc in exceptions.values()]
+        assert response.status_code == status.HTTP_200_OK
+        assert not Flaw.objects.get(uuid=flaw.uuid).is_embargoed
+        assert not Affect.objects.get(uuid=affect.uuid).is_embargoed


### PR DESCRIPTION
This fixes REST unembargo deadlocks by locking related affects and trackers before flaw updates that can cascade into visibility/tracker saves.
I also added regression coverage for both deadlock shapes we found:
- concurrent unembargo of flaws sharing a tracker
- concurrent affect save while a flaw is being unembargoed

Closes OSIDB-5456.