### PR TITLE
fix: avoid race condition in ACE trigger (OSIDB-5473)

### DIFF
--- a/apps/ace/signals.py
+++ b/apps/ace/signals.py
@@ -2,16 +2,42 @@ from django.db import transaction
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
+from apps.workflows.signals import classification_changed
 from osidb.models import Flaw
 from osidb.models.affect import AffectSettings
+
+
+def _is_eligible(workflow_name, workflow_state):
+    """Check if a workflow position qualifies for ACE triggering."""
+    return workflow_name == "DEFAULT" and workflow_state not in ("", "NEW", "DONE")
+
+
+def _has_nonempty_components(components):
+    """Check if at least one non-empty component exists."""
+    return any(c and str(c).strip() for c in (components or []))
+
+
+def _enqueue_ace(flaw_id):
+    """Enqueue the ACE Celery task via transaction.on_commit."""
+
+    def enqueue_sync():
+        from apps.ace.tasks import sync_flaw_affects_from_newcli
+
+        # Celery adds .delay at import time; static checkers do not see it
+        sync_flaw_affects_from_newcli.delay(flaw_id)  # type: ignore[attr-defined]
+
+    transaction.on_commit(enqueue_sync)
 
 
 @receiver(pre_save, sender=Flaw)
 def schedule_sync_flaw_affects_on_components_change(sender, instance, **kwargs) -> None:
     """
-    When :attr:`Flaw.components` is set or updated and the flaw has at least one
-    non-empty component, register :func:`apps.ace.tasks.sync_flaw_affects_from_newcli`
-    to run after the current DB transaction commits (via :func:`django.db.transaction.on_commit`).
+    Trigger ACE when components change on a flaw that is already in an eligible workflow state.
+
+    This handler checks the DB flaw's eligibility (not the instance's) to avoid race conditions
+    with the workflow pre_save signal that updates workflow_state. When both components and
+    workflow change in one save, the DB flaw is still in the old (ineligible) state, so this
+    handler skips and the classification_changed handler picks it up.
 
     Gated by :attr:`osidb.models.affect.AffectSettings.auto_create`
     (``OSIDB_AFFECTS_AUTO_CREATE``, default false).
@@ -22,47 +48,62 @@ def schedule_sync_flaw_affects_on_components_change(sender, instance, **kwargs) 
     if kwargs.get("raw"):
         return
 
-    new_list = list(instance.components or [])
-
     if instance._state.adding:
         return
 
     update_fields = kwargs.get("update_fields")
-    if (
-        update_fields is not None
-        and "components" not in update_fields
-        and "workflow_state" not in update_fields
-        and "workflow_name" not in update_fields
-    ):
+    if update_fields is not None and "components" not in update_fields:
         return
 
     db_flaw = Flaw.objects.get(pk=instance.pk)
 
-    if instance.workflow_name != "DEFAULT" or instance.workflow_state in (
-        "",
-        "NEW",
-        "DONE",
-    ):
+    # Check eligibility using DB flaw's state to avoid pre_save ordering race
+    if not _is_eligible(db_flaw.workflow_name, db_flaw.workflow_state):
         return
 
+    # Check if components changed
     old_list = list(db_flaw.components or [])
-    components_changed = old_list != new_list
-    workflow_state_became_eligible = (
-        db_flaw.workflow_name != "DEFAULT" or db_flaw.workflow_state in ("", "NEW")
-    ) and instance.workflow_state not in ("", "NEW", "DONE")
-
-    if not (components_changed or workflow_state_became_eligible):
+    new_list = list(instance.components or [])
+    if old_list == new_list:
         return
 
-    if not any(c and str(c).strip() for c in new_list):
+    if not _has_nonempty_components(new_list):
         return
 
-    flaw_id = str(instance.uuid)
+    _enqueue_ace(str(instance.uuid))
 
-    def enqueue_sync() -> None:
-        from apps.ace.tasks import sync_flaw_affects_from_newcli
 
-        # Celery adds .delay at import time; static checkers do not see it
-        sync_flaw_affects_from_newcli.delay(flaw_id)  # type: ignore[attr-defined]
+@receiver(classification_changed, sender=Flaw)
+def schedule_sync_flaw_affects_on_classification_change(
+    sender, instance, old_classification, new_classification, **kwargs
+) -> None:
+    """
+    Trigger ACE when a flaw transitions into an eligible workflow state.
 
-    transaction.on_commit(enqueue_sync)
+    This handler listens to the classification_changed signal emitted by
+    adjust_classification() after the workflow state has been updated in memory.
+    It only triggers when moving FROM an ineligible state TO an eligible state
+    (e.g., NEW -> TRIAGE).
+
+    Gated by :attr:`osidb.models.affect.AffectSettings.auto_create`
+    (``OSIDB_AFFECTS_AUTO_CREATE``, default false).
+    """
+    if not AffectSettings().auto_create:
+        return
+
+    old_workflow = old_classification.get("workflow", "")
+    old_state = old_classification.get("state", "")
+    new_workflow = new_classification.get("workflow", "")
+    new_state = new_classification.get("state", "")
+
+    was_eligible = _is_eligible(old_workflow, old_state)
+    now_eligible = _is_eligible(new_workflow, new_state)
+
+    # Only trigger when transitioning INTO an eligible state
+    if not now_eligible or was_eligible:
+        return
+
+    if not _has_nonempty_components(instance.components):
+        return
+
+    _enqueue_ace(str(instance.uuid))

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -27,6 +27,7 @@ from apps.ace.tasks import (
     _resolve_component,
     sync_flaw_affects_from_newcli,
 )
+from osidb.models import Flaw
 from osidb.models.affect import Affect
 from osidb.tests.factories import (
     FlawFactory,
@@ -1689,13 +1690,19 @@ def test_signal_enqueues_on_triage_promotion_with_existing_components(
     monkeypatch, signal_ace_enabled
 ):
     """Promoting a flaw from NEW to TRIAGE must enqueue ACE even if components didn't change."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="DEFAULT", workflow_state="NEW"
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_state = "TRIAGE"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "DEFAULT", "state": "NEW"},
+        new_classification={"workflow": "DEFAULT", "state": "TRIAGE"},
+    )
 
     assert len(calls) == 1
 
@@ -1705,11 +1712,17 @@ def test_signal_does_not_enqueue_on_triage_promotion_without_components(
     monkeypatch, signal_ace_enabled
 ):
     """Promoting to TRIAGE with no components must not enqueue ACE."""
-    flaw = FlawFactory(components=[], workflow_name="DEFAULT", workflow_state="NEW")
+    from apps.workflows.signals import classification_changed
+
+    flaw = FlawFactory(components=[], workflow_name="DEFAULT", workflow_state="TRIAGE")
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_state = "TRIAGE"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "DEFAULT", "state": "NEW"},
+        new_classification={"workflow": "DEFAULT", "state": "TRIAGE"},
+    )
 
     assert len(calls) == 0
 
@@ -1761,13 +1774,19 @@ def test_signal_does_not_enqueue_for_done_state(monkeypatch, signal_ace_enabled)
 @pytest.mark.enable_signals
 def test_signal_enqueues_on_empty_to_triage_promotion(monkeypatch, signal_ace_enabled):
     """Legacy flaw (empty workflow) promoted straight to TRIAGE must enqueue ACE."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="DEFAULT", workflow_state=""
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_state = "TRIAGE"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "DEFAULT", "state": ""},
+        new_classification={"workflow": "DEFAULT", "state": "TRIAGE"},
+    )
 
     assert len(calls) == 1
 
@@ -1777,13 +1796,19 @@ def test_signal_does_not_enqueue_on_empty_to_new_transition(
     monkeypatch, signal_ace_enabled
 ):
     """Transitioning from empty to NEW must not enqueue ACE — NEW is still a blocked state."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="DEFAULT", workflow_state=""
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="NEW"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_state = "NEW"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "DEFAULT", "state": ""},
+        new_classification={"workflow": "DEFAULT", "state": "NEW"},
+    )
 
     assert len(calls) == 0
 
@@ -1793,13 +1818,19 @@ def test_signal_does_not_enqueue_on_new_to_done_transition(
     monkeypatch, signal_ace_enabled
 ):
     """Transitioning from NEW to DONE (skipping triage) must not enqueue ACE."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="DEFAULT", workflow_state="NEW"
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="DONE"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_state = "DONE"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "DEFAULT", "state": "NEW"},
+        new_classification={"workflow": "DEFAULT", "state": "DONE"},
+    )
 
     assert len(calls) == 0
 
@@ -1809,13 +1840,19 @@ def test_signal_does_not_enqueue_on_within_eligible_state_change(
     monkeypatch, signal_ace_enabled
 ):
     """Moving between eligible states (TRIAGE→ANALYSIS) without component changes must not re-enqueue ACE."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="ANALYSIS"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_state = "ANALYSIS"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "DEFAULT", "state": "TRIAGE"},
+        new_classification={"workflow": "DEFAULT", "state": "ANALYSIS"},
+    )
 
     assert len(calls) == 0
 
@@ -1825,14 +1862,19 @@ def test_signal_enqueues_on_workflow_transition_to_default(
     monkeypatch, signal_ace_enabled
 ):
     """Transitioning from REJECTED/DONE to DEFAULT/TRIAGE must enqueue ACE."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="REJECTED", workflow_state="DONE"
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_name = "DEFAULT"
-    flaw.workflow_state = "TRIAGE"
-    flaw.save()
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "REJECTED", "state": "DONE"},
+        new_classification={"workflow": "DEFAULT", "state": "TRIAGE"},
+    )
 
     assert len(calls) == 1
 
@@ -1841,17 +1883,59 @@ def test_signal_enqueues_on_workflow_transition_to_default(
 def test_signal_enqueues_on_workflow_transition_partial_save(
     monkeypatch, signal_ace_enabled
 ):
-    """Partial save updating only workflow_name and workflow_state must still enqueue ACE."""
+    """Classification change signal fires regardless of partial save semantics."""
+    from apps.workflows.signals import classification_changed
+
     flaw = FlawFactory(
-        components=["openssl"], workflow_name="REJECTED", workflow_state="DONE"
+        components=["openssl"], workflow_name="DEFAULT", workflow_state="TRIAGE"
     )
     calls = _count_enqueues(monkeypatch)
 
-    flaw.workflow_name = "DEFAULT"
-    flaw.workflow_state = "TRIAGE"
-    flaw.save(update_fields=["workflow_name", "workflow_state"])
+    classification_changed.send(
+        sender=Flaw,
+        instance=flaw,
+        old_classification={"workflow": "REJECTED", "state": "DONE"},
+        new_classification={"workflow": "DEFAULT", "state": "TRIAGE"},
+    )
 
     assert len(calls) == 1
+
+
+@pytest.mark.enable_signals
+def test_ace_triggers_when_workflow_changes_on_same_save(
+    monkeypatch, signal_ace_enabled
+):
+    """
+    Regression test for CVE-2026-47850: when components are set and workflow
+    transitions to TRIAGE in the same save (e.g. AEGIS submission), ACE must
+    trigger regardless of pre_save signal execution order.
+
+    Previously, ACE used a pre_save handler that could fire before the workflow
+    pre_save handler updated workflow_state, causing ACE to see the old state
+    ("NEW") and skip.
+    """
+    flaw = FlawFactory(
+        components=["openssl"],
+        workflow_name="DEFAULT",
+        workflow_state="NEW",
+        task_key="OSIM-12345",  # Required for adjust_classification to run
+    )
+    calls = _count_enqueues(monkeypatch)
+
+    # Mock classify() to return TRIAGE so adjust_classification detects a change
+    def mock_classify(self):
+        return {"workflow": "DEFAULT", "state": "TRIAGE"}
+
+    monkeypatch.setattr("apps.workflows.workflow.WorkflowModel.classify", mock_classify)
+
+    # Simulate what happens during a save: components change
+    flaw.components = ["org.springframework.data/spring-data-rest-webmvc"]
+    flaw.save()
+
+    assert len(calls) == 1, (
+        "ACE must be triggered when workflow transitions to TRIAGE "
+        "in the same save as a component change"
+    )
 
 
 def test_apply_label_persists_reason():

--- a/apps/workflows/signals.py
+++ b/apps/workflows/signals.py
@@ -1,7 +1,11 @@
 from django.db.models.signals import pre_save
-from django.dispatch import receiver
+from django.dispatch import Signal, receiver
 
 from apps.workflows.workflow import WorkflowModel
+
+# Custom signal emitted when workflow classification changes.
+# Arguments: sender (model class), instance, old_classification (dict), new_classification (dict)
+classification_changed = Signal()
 
 
 @receiver(pre_save)

--- a/apps/workflows/workflow.py
+++ b/apps/workflows/workflow.py
@@ -271,6 +271,17 @@ class WorkflowModel(models.Model):
         self.classification = classification
         self.adjust_acls()  # possibly adjust ACLs too
 
+        # Notify listeners that classification changed (e.g. ACE).
+        # Import here to avoid circular import: signals.py imports WorkflowModel.
+        from apps.workflows.signals import classification_changed
+
+        classification_changed.send(
+            sender=type(self),
+            instance=self,
+            old_classification=old_classification,
+            new_classification=classification,
+        )
+
         if not save:
             return
 

--- a/config/settings.py
+++ b/config/settings.py
@@ -37,45 +37,56 @@ BLACKLISTED_HTTP_METHODS = ("patch",)
 READONLY_MODE: bool = get_env("OSIDB_READONLY_MODE", default="False", is_bool=True)
 
 # Application definition
+# WARNING: Do not sort alphabetically — this list is ordered by dependency.
+# Apps are loaded and their ready() methods called in this order, which
+# determines signal registration order and migration execution order.
+# When adding a new app, place it after all apps it depends on.
 INSTALLED_APPS = [
-    "apps.ace",
+    # --- Django core ---
+    "django.contrib.contenttypes",
+    "django.contrib.auth",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.postgres",
+    "django.contrib.staticfiles",
+    # --- Third-party ---
+    "corsheaders",
+    "django_extensions",
+    "django_filters",
+    "djangoql",
+    "drf_spectacular",
+    "psqlextra",
+    "pgtrigger",
+    "pghistory",
+    "polymorphic",
+    "rest_framework",
+    "rest_framework_simplejwt",
+    # --- Foundation ---
+    "osidb",
+    # --- Business logic (no cross-app deps beyond osidb) ---
+    "apps.workflows",
     "apps.bbsync",
     "apps.exploits",
     "apps.sla",
+    # --- Business logic (depends on tier above) ---
     "apps.trackers",
-    "apps.workflows",
-    "collectors.bzimport",
+    "apps.ace",
+    # --- Collector infrastructure ---
+    "collectors.framework",
     "collectors.component_mapping",
+    # --- Collectors ---
+    "collectors.bzimport",
     "collectors.cveorg",
     "collectors.epss",
     "collectors.exploits_cisa",
     "collectors.exploits_exploitdb",
     "collectors.exploits_metasploit",
     "collectors.flaw_labels",
-    "collectors.framework",
     "collectors.jiraffe",
     "collectors.nvd",
     "collectors.osv",
     "collectors.product_definitions",
     "collectors.ps_constants",
-    "corsheaders",
-    "django_extensions",
-    "django_filters",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.messages",
-    "django.contrib.postgres",
-    "django.contrib.sessions",
-    "django.contrib.staticfiles",
-    "djangoql",
-    "drf_spectacular",
-    "osidb",
-    "pghistory",
-    "pgtrigger",
-    "polymorphic",
-    "psqlextra",
-    "rest_framework_simplejwt",
-    "rest_framework",
 ]
 
 MIDDLEWARE = [

--- a/conftest.py
+++ b/conftest.py
@@ -15,6 +15,7 @@ from dotenv import dotenv_values
 from rest_framework.test import APIClient
 
 from apps.trackers.models import JiraBugIssuetype, JiraProjectFields
+from apps.workflows.signals import classification_changed
 from osidb.constants import OSIDB_API_VERSION
 from osidb.core import generate_acls, set_user_acls
 from osidb.exceptions import InvalidTestEnvironmentException
@@ -218,7 +219,14 @@ def mute_signals(request):
     if "enable_signals" in request.keywords:
         return
 
-    signals = [pre_save, post_save, pre_delete, post_delete, m2m_changed]
+    signals = [
+        pre_save,
+        post_save,
+        pre_delete,
+        post_delete,
+        m2m_changed,
+        classification_changed,
+    ]
     restore = {}
     for signal in signals:
         # Temporally remove the signal's receivers (a.k.a attached functions)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix UBI label incorrectly applied to older EUS/AUS RHEL streams — now only
   applies to latest Z-stream and next Y-stream (e.g., rhel-9.8.z and rhel-9.9,
   not rhel-9.2.z or rhel-9.10) (OSIDB-5459)
+- Fix a race condition which prevented ACE triggering (OSIDB-5473)
 
 ## [5.17.0] - 2026-08-26
 ### Added


### PR DESCRIPTION
The ACE trigger depends on a pre_save signal but also depends on an
adjust_classification call which is itself triggered by the same
pre_save signal.

When two signal handlers depend on the same Django signal, the order of
execution is expected to be based on import order (which can be
non-deterministic), due to this it was possible for the ACE signal
handler to run before the workflow signal handler, meaning that in some
cases ACE wouldn't process a Flaw at all.

This commit fixes the issue by changing adjust_classification to
explicitly emit its own signal and splitting the ACE trigger logic into
two signal handlers: one for when the component is updated (via
pre_save) and another when a workflow name/state is changed (via the
aforementioned custom signal), this guarantees that the ACE trigger will
be executed _after_ the workflow signal handler is triggered.