### PR TITLE
feat: Add quantifiers (any/all) for label subfields

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - make sure that the flaw impact is always at or above any affect override (OSIDB-5389)
 - Provide insights into chosen affectedness/resolution by automation (OSIDB-5345)
+- Support `labels.any.<field>` / `labels.all.<field>` DjangoQL quantifiers for
+  `contributor`, `state` and `relevant` label properties (OSIDB-5212)
 
 ### Changed
 - exclude pre-Argus and already done flaws from workflow re-classification (OSIDB-5406)

--- a/osidb/djangoql.py
+++ b/osidb/djangoql.py
@@ -1,5 +1,8 @@
+from functools import reduce
+from operator import and_, or_
+
 from django.db import models
-from django.db.models import Q
+from django.db.models import Exists, OuterRef, Q
 from django.utils import timezone
 from djangoql.exceptions import DjangoQLSchemaError
 from djangoql.schema import (
@@ -129,6 +132,16 @@ class FlawQLSchema(DjangoQLSchema):
             if field:
                 return field
 
+        if (
+            len(name.parts) == 3
+            and name.parts[0] == "labels"
+            and name.parts[1] in ("any", "all")
+        ):
+            by_field = FLAW_LABEL_QUANTIFIED_FIELDS.get(name.parts[1], {})
+            field = by_field.get(name.parts[2])
+            if field:
+                return field
+
         return super().resolve_name(name)
 
     def get_fields(self, model):
@@ -189,8 +202,6 @@ class FlawNonCommunityAffectsNoTrackersField(BoolField):
     name = "flaw_has_no_non_community_affects_trackers"
 
     def get_lookup(self, path, operator, value):
-        from django.db.models import Exists, OuterRef
-
         from osidb.models import Affect
         from osidb.models.ps_module import PsModule
 
@@ -270,7 +281,10 @@ class FlawLabelsField(StrField):
 class FlawLabelPropertyField:
     """
     Mixin for fields that only exist on FlawLabel subclasses, reachable via
-    dotted access on the flat "labels" field, e.g. "labels.contributor".
+    dotted access on the flat "labels" field, e.g. "labels.contributor", or,
+    for the quantifier-parametrized instances registered in
+    FLAW_LABEL_QUANTIFIED_FIELDS, "labels.any.contributor" /
+    "labels.all.contributor".
 
     Plain mixin (not a DjangoQLField subclass) so the concrete field's own
     base (StrField/BoolField) decides its "type" for value validation.
@@ -279,8 +293,11 @@ class FlawLabelPropertyField:
     model = FlawLabel
     subclasses = ()
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, quantifier=None, **kwargs):
         super().__init__(*args, **kwargs)
+        # None -> bare "labels.<field>" behavior (unchanged).
+        # "any"/"all" -> quantified behavior, see _get_quantified_lookup.
+        self.quantifier = quantifier
         if not self.subclasses:
             # Fail loudly at import time rather than silently matching
             # everything (positive comparison) or nothing (negated) below.
@@ -288,8 +305,20 @@ class FlawLabelPropertyField:
                 f"{type(self).__name__} has no FlawLabel subclasses defining "
                 f"{self.name!r}; check the field name."
             )
+        # self.subclasses and FlawLabel.TYPE_TO_MODEL are both fixed at
+        # import time and these field instances are module-level
+        # singletons, so resolve the actual model classes once here rather
+        # than on every _get_quantified_lookup call.
+        self.subclass_models = [
+            model
+            for model in FlawLabel.TYPE_TO_MODEL.values()
+            if model._meta.model_name in self.subclasses
+        ]
 
     def get_lookup(self, path, operator, value):
+        if self.quantifier is not None:
+            return self._get_quantified_lookup(operator, value)
+
         op, invert = self.get_operator(operator)
         lookup_value = self.get_lookup_value(value)
         q = Q()
@@ -297,6 +326,71 @@ class FlawLabelPropertyField:
             search = "__".join(path + [subclass, self.name])
             q |= Q(**{f"{search}{op}": lookup_value})
         return ~q if invert else q
+
+    def _get_quantified_lookup(self, operator, value):
+        """
+        ANY/ALL over the FlawLabel subclasses that define this property.
+        Built on the same Exists/OuterRef primitive as
+        FlawNonCommunityAffectsNoTrackersField above.
+
+        The "path" djangoql normally passes to get_lookup is deliberately
+        ignored here: djangoql.queryset.build_filter computes it directly
+        from the AST node (expr.left.parts[:-1]), so for
+        "labels.any.contributor" it would be ["labels", "any"] - not a valid
+        join string, since "any"/"all" aren't real relations. These fields
+        are only ever reached through FlawQLSchema.resolve_name's
+        "labels.any.<x>"/"labels.all.<x>" whitelist though, never nested any
+        deeper, so we don't need path at all: each subclass joins straight
+        back to Flaw via its own flawlabel_ptr__flaw parent link.
+        """
+        op, invert = self.get_operator(operator)
+        lookup_value = self.get_lookup_value(value)
+
+        # The user's predicate exactly as written (operator's natural sign
+        # folded in), used as-is for ANY and negated for ALL below.
+        predicate = Q(**{f"{self.name}{op}": lookup_value})
+        if invert:
+            predicate = ~predicate
+
+        if self.quantifier == "any":
+            return reduce(
+                or_,
+                (
+                    Exists(
+                        subclass.objects.filter(
+                            predicate, flawlabel_ptr__flaw=OuterRef("pk")
+                        )
+                    )
+                    for subclass in self.subclass_models
+                ),
+            )
+
+        # ALL: structurally, "no row violates the predicate" - the
+        # inversion here is part of ALL's own definition, independent of
+        # whether the user wrote =/in or !=/not in.
+        violates = ~predicate
+        no_violation = reduce(
+            and_,
+            (
+                ~Exists(
+                    subclass.objects.filter(
+                        violates, flawlabel_ptr__flaw=OuterRef("pk")
+                    )
+                )
+                for subclass in self.subclass_models
+            ),
+        )
+        # ALL over zero qualifying rows (e.g. a flaw with no labels, or
+        # only labels of a subclass that doesn't define this property at
+        # all) is intentionally False here, not vacuously True.
+        has_rows = reduce(
+            or_,
+            (
+                Exists(subclass.objects.filter(flawlabel_ptr__flaw=OuterRef("pk")))
+                for subclass in self.subclass_models
+            ),
+        )
+        return no_violation & has_rows
 
 
 def _label_subclasses_with_field(field_name):
@@ -325,6 +419,24 @@ class FlawLabelStateField(FlawLabelPropertyField, StrField):
 class FlawLabelRelevantField(FlawLabelPropertyField, BoolField):
     name = "relevant"
     subclasses = _label_subclasses_with_field("relevant")
+
+
+# labels.any.<field> / labels.all.<field> - same three classes above,
+# reused with a quantifier instead of one bespoke subclass per
+# (quantifier, property) pair. See resolve_name() and
+# FlawLabelPropertyField._get_quantified_lookup().
+FLAW_LABEL_QUANTIFIED_FIELDS = {
+    "any": {
+        "contributor": FlawLabelContributorField(quantifier="any"),
+        "state": FlawLabelStateField(quantifier="any"),
+        "relevant": FlawLabelRelevantField(quantifier="any"),
+    },
+    "all": {
+        "contributor": FlawLabelContributorField(quantifier="all"),
+        "state": FlawLabelStateField(quantifier="all"),
+        "relevant": FlawLabelRelevantField(quantifier="all"),
+    },
+}
 
 
 class FlawLabelUuidField(StrField):

--- a/osidb/tests/test_search.py
+++ b/osidb/tests/test_search.py
@@ -12,6 +12,7 @@ from osidb.models import (
     FlawSource,
     Impact,
     ProductFamilyLabel,
+    WorkflowLabel,
 )
 
 from .factories import AffectFactory, FlawFactory
@@ -20,6 +21,17 @@ pytestmark = pytest.mark.unit
 
 
 class TestSearch:
+    def _assert_query_results(self, auth_client, test_api_uri, cases):
+        for query, expected_cve_ids in cases:
+            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
+            assert response.status_code == 200, (query, response.json())
+            body = response.json()
+            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
+                query,
+                body,
+            )
+            assert body["count"] == len(expected_cve_ids), (query, body)
+
     def test_search_flaws_on_create(self, auth_client, test_api_uri):
         """Test Flaw text-search vectors for each text field are created when Flaw is inserted"""
         response = auth_client().get(f"{test_api_uri}/flaws")
@@ -543,14 +555,7 @@ class TestSearch:
             ('labels.type != "alias"', {flaw1.cve_id}),
             (f'labels.uuid = "{alias_label.uuid}"', {flaw2.cve_id}),
         ]
-        for query, expected_cve_ids in cases:
-            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
-            assert response.status_code == 200, (query, response.json())
-            body = response.json()
-            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
-                query,
-                body,
-            )
+        self._assert_query_results(auth_client, test_api_uri, cases)
 
         # Values outside the LabelType enum are rejected rather than
         # silently matching nothing.
@@ -591,14 +596,7 @@ class TestSearch:
             ('labels endswith "fix"', {flaw1.cve_id}),
             ('labels not endswith "fix"', {flaw2.cve_id}),
         ]
-        for query, expected_cve_ids in cases:
-            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
-            assert response.status_code == 200, (query, response.json())
-            body = response.json()
-            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
-                query,
-                body,
-            )
+        self._assert_query_results(auth_client, test_api_uri, cases)
 
     def test_search_flaws_by_label_properties(self, auth_client, test_api_uri):
         """
@@ -679,17 +677,534 @@ class TestSearch:
             ('labels.state != "DONE"', {flaw1.cve_id, flaw3.cve_id}),
             ("labels.relevant != True", {flaw2.cve_id}),
         ]
-        for query, expected_cve_ids in cases:
-            response = auth_client().get(f"{test_api_uri}/flaws?query={query}")
-            assert response.status_code == 200, (query, response.json())
-            body = response.json()
-            assert {flaw["cve_id"] for flaw in body["results"]} == expected_cve_ids, (
-                query,
-                body,
-            )
-            # flaw1 has two matching labels for some of these queries; make
-            # sure the fan-out join is deduplicated before pagination.
-            assert body["count"] == len(expected_cve_ids), (query, body)
+        # flaw1 has two matching labels for some of these queries; make
+        # sure the fan-out join is deduplicated before pagination.
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_parity(self, auth_client, test_api_uri):
+        """
+        "labels.any.<field>" and "labels.all.<field>" are new dotted-name
+        quantifiers for the FlawLabelPropertyField family (contributor,
+        state, relevant only - name/uuid/type stay bare-only). Unlike the
+        bare 2-part "labels.<field>" form (which ORs matching rows and then
+        negates the whole OR for "!="), the quantifiers evaluate the
+        operator literally per row:
+
+            labels.any.<field> <op> <value> - True if at least one
+                qualifying label row satisfies the condition as written.
+            labels.all.<field> <op> <value> - True only if every qualifying
+                label row satisfies the condition as written, and False (not
+                vacuously True) when there are zero qualifying rows.
+
+        Each scenario in this test group uses its own isolated flaw
+        fixtures: a query like "labels.all.contributor != <value>" is
+        legitimately true for any flaw whose labels never contain that
+        value, so sharing fixtures across scenarios would let unrelated
+        flaws satisfy each other's assertions.
+
+        This one: labels.any.<field> behaves like bare labels.<field> for a
+        positive operator.
+        """
+        CollaboratorLabelDefinition.objects.create(name="solo")
+
+        flaw = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw)
+        CollaboratorLabel.objects.create(
+            flaw=flaw,
+            name="solo",
+            contributor="alice-parity@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            ('labels.any.contributor = "alice-parity@example.com"', {flaw.cve_id}),
+            ('labels.contributor = "alice-parity@example.com"', {flaw.cve_id}),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_all_positive_operator(
+        self, auth_client, test_api_uri
+    ):
+        """
+        ALL with a positive operator: matches only when every qualifying
+        row satisfies it. Isolated fixtures - see
+        test_search_flaws_by_label_any_parity for why.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        CollaboratorLabelDefinition.objects.create(name="collab-b")
+
+        flaw_match = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_match)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_match,
+            name="collab-a",
+            contributor="alice-allpos@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_match,
+            name="collab-b",
+            contributor="alice-allpos@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        flaw_nomatch = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_nomatch)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_nomatch,
+            name="collab-a",
+            contributor="carol-allpos@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_nomatch,
+            name="collab-b",
+            contributor="dave-allpos@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            (
+                'labels.all.contributor = "alice-allpos@example.com"',
+                {flaw_match.cve_id},
+            ),
+            ('labels.all.contributor = "carol-allpos@example.com"', set()),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_all_negative_operator(
+        self, auth_client, test_api_uri
+    ):
+        """
+        ALL with a negative operator. Isolated fixtures - see
+        test_search_flaws_by_label_any_parity for why.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        CollaboratorLabelDefinition.objects.create(name="collab-b")
+
+        flaw_match = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_match)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_match,
+            name="collab-a",
+            contributor="eve-allneg@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_match,
+            name="collab-b",
+            contributor="frank-allneg@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        flaw_nomatch = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_nomatch)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_nomatch,
+            name="collab-a",
+            contributor="zack-excluded@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_nomatch,
+            name="collab-b",
+            contributor="yara-allneg@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            # Neither flaw has this exact contributor anywhere, so every row
+            # of both flaws satisfies "!= <value>" -> both match.
+            (
+                'labels.all.contributor != "analyst-does-not-exist@example.com"',
+                {flaw_match.cve_id, flaw_nomatch.cve_id},
+            ),
+            # flaw_nomatch has a row whose contributor *is*
+            # "zack-excluded@example.com", so that row violates "!= zack" ->
+            # only flaw_match, which has no such row, matches.
+            (
+                'labels.all.contributor != "zack-excluded@example.com"',
+                {flaw_match.cve_id},
+            ),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_all_zero_qualifying_rows(
+        self, auth_client, test_api_uri
+    ):
+        """
+        Zero qualifying rows: False for both ANY and ALL, regardless of
+        operator sign, on a label-less flaw and on a flaw whose only labels
+        (Workflow/Alias) don't define "contributor" at all. Isolated
+        fixtures - see test_search_flaws_by_label_any_parity for why (a
+        query like "contributor != x" for an "x" that appears nowhere would
+        otherwise also match any *other* flaw's qualifying rows sharing the
+        same test).
+        """
+        flaw_empty = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_empty)
+
+        flaw_no_contrib_subclass = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_no_contrib_subclass)
+        WorkflowLabel.objects.create(flaw=flaw_no_contrib_subclass, name="wf-a")
+        AliasLabel.objects.create(flaw=flaw_no_contrib_subclass, name="CVE-9999-ALIAS")
+
+        cases = [
+            ('labels.all.contributor = "x"', set()),
+            ('labels.all.contributor != "x"', set()),
+            ('labels.any.contributor = "x"', set()),
+            ('labels.any.contributor != "x"', set()),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_all_polymorphic_subclass_spread(
+        self, auth_client, test_api_uri
+    ):
+        """
+        .any/.all OR/AND across subclass tables (BULabel + CollaboratorLabel
+        both define "contributor"), not just within one. Isolated fixtures -
+        see test_search_flaws_by_label_any_parity for why.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        BULabelDefinition.objects.create(name="bu-a")
+
+        flaw_bu_only = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_bu_only)
+        BULabel.objects.create(
+            flaw=flaw_bu_only,
+            name="bu-a",
+            contributor="grace-poly@example.com",
+            state=BULabel.State.REQ,
+            relevant=True,
+        )
+
+        flaw_and_match = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_and_match)
+        BULabel.objects.create(
+            flaw=flaw_and_match,
+            name="bu-a",
+            contributor="henry-poly@example.com",
+            state=BULabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_and_match,
+            name="collab-a",
+            contributor="henry-poly@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        flaw_and_nomatch = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_and_nomatch)
+        BULabel.objects.create(
+            flaw=flaw_and_nomatch,
+            name="bu-a",
+            contributor="ian-poly@example.com",
+            state=BULabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_and_nomatch,
+            name="collab-a",
+            contributor="jane-poly@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            (
+                'labels.any.contributor = "grace-poly@example.com"',
+                {flaw_bu_only.cve_id},
+            ),
+            (
+                'labels.all.contributor = "grace-poly@example.com"',
+                {flaw_bu_only.cve_id},
+            ),
+            (
+                'labels.all.contributor = "henry-poly@example.com"',
+                {flaw_and_match.cve_id},
+            ),
+            (
+                'labels.any.contributor = "ian-poly@example.com"',
+                {flaw_and_nomatch.cve_id},
+            ),
+            ('labels.all.contributor = "ian-poly@example.com"', set()),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_all_in_not_in_operator(
+        self, auth_client, test_api_uri
+    ):
+        """
+        Operator breadth: in/not in on contributor. Isolated fixtures - see
+        test_search_flaws_by_label_any_parity for why.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        CollaboratorLabelDefinition.objects.create(name="collab-b")
+
+        flaw_in_match = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_in_match)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_in_match,
+            name="collab-a",
+            contributor="kevin-in@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_in_match,
+            name="collab-b",
+            contributor="laura-in@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        flaw_in_nomatch = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_in_nomatch)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_in_nomatch,
+            name="collab-a",
+            contributor="kevin-in@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_in_nomatch,
+            name="collab-b",
+            contributor="mia-in@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        flaw_notin_match = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_notin_match)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_notin_match,
+            name="collab-a",
+            contributor="nora-notin@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_notin_match,
+            name="collab-b",
+            contributor="oscar-notin@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            (
+                'labels.any.contributor in ("kevin-in@example.com", "laura-in@example.com")',
+                {flaw_in_match.cve_id, flaw_in_nomatch.cve_id},
+            ),
+            (
+                'labels.all.contributor in ("kevin-in@example.com", "laura-in@example.com")',
+                {flaw_in_match.cve_id},
+            ),
+            (
+                'labels.any.contributor not in ("kevin-in@example.com", "laura-in@example.com")',
+                {flaw_in_nomatch.cve_id, flaw_notin_match.cve_id},
+            ),
+            (
+                'labels.all.contributor not in ("kevin-in@example.com", "laura-in@example.com")',
+                {flaw_notin_match.cve_id},
+            ),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_all_state(self, auth_client, test_api_uri):
+        """
+        .any.state / .all.state with =/!=. Isolated fixtures - see
+        test_search_flaws_by_label_any_parity for why.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        CollaboratorLabelDefinition.objects.create(name="collab-b")
+
+        flaw_mixed = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_mixed)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_mixed,
+            name="collab-a",
+            contributor="p-state@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_mixed,
+            name="collab-b",
+            contributor="q-state@example.com",
+            state=CollaboratorLabel.State.DONE,
+            relevant=True,
+        )
+
+        flaw_alldone = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_alldone)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_alldone,
+            name="collab-a",
+            contributor="r-state@example.com",
+            state=CollaboratorLabel.State.DONE,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_alldone,
+            name="collab-b",
+            contributor="s-state@example.com",
+            state=CollaboratorLabel.State.DONE,
+            relevant=True,
+        )
+
+        cases = [
+            ('labels.any.state = "DONE"', {flaw_mixed.cve_id, flaw_alldone.cve_id}),
+            ('labels.all.state = "DONE"', {flaw_alldone.cve_id}),
+            ('labels.any.state != "DONE"', {flaw_mixed.cve_id}),
+            ('labels.all.state != "DONE"', set()),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_all_relevant(self, auth_client, test_api_uri):
+        """
+        .any.relevant / .all.relevant (BoolField) with =/!=. Isolated
+        fixtures - see test_search_flaws_by_label_any_parity for why.
+        """
+        CollaboratorLabelDefinition.objects.create(name="collab-a")
+        CollaboratorLabelDefinition.objects.create(name="collab-b")
+
+        flaw_mixed = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_mixed)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_mixed,
+            name="collab-a",
+            contributor="t-rel@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_mixed,
+            name="collab-b",
+            contributor="u-rel@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=False,
+        )
+
+        flaw_alltrue = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw_alltrue)
+        CollaboratorLabel.objects.create(
+            flaw=flaw_alltrue,
+            name="collab-a",
+            contributor="v-rel@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        CollaboratorLabel.objects.create(
+            flaw=flaw_alltrue,
+            name="collab-b",
+            contributor="w-rel@example.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            (
+                "labels.any.relevant = True",
+                {flaw_mixed.cve_id, flaw_alltrue.cve_id},
+            ),
+            ("labels.all.relevant = True", {flaw_alltrue.cve_id}),
+            ("labels.any.relevant = False", {flaw_mixed.cve_id}),
+            ("labels.all.relevant = False", set()),
+            ("labels.any.relevant != True", {flaw_mixed.cve_id}),
+            ("labels.all.relevant != True", set()),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
+
+    def test_search_flaws_by_label_any_all_validation(self, auth_client, test_api_uri):
+        """
+        Unknown quantifier segment, and quantifier applied to a field
+        outside the whitelisted three (contributor/state/relevant) both fall
+        through to the same "Unknown field" 400 as any other unresolvable
+        dotted name.
+        """
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=labels.every.contributor = "x"'
+        )
+        assert response.status_code == 400
+        assert "Unknown field" in response.json()["detail"]
+
+        response = auth_client().get(
+            f'{test_api_uri}/flaws?query=labels.any.name = "x"'
+        )
+        assert response.status_code == 400
+        assert "Unknown field" in response.json()["detail"]
+
+    def test_search_flaws_by_label_contributor_bug_regression(
+        self, auth_client, test_api_uri
+    ):
+        """
+        Regression test for the original bug report: a team wants to find
+        flaws that have an "unclaimed" label of theirs (contributor not the
+        team's own address), but the bare 2-part "labels.contributor not in
+        (...)" form ORs across all matching rows and then negates the whole
+        thing, so it means "no row has this contributor" rather than "some
+        row lacks this contributor" - it can't express the latter. That's
+        exactly what "labels.any.contributor" is for.
+        """
+        CollaboratorLabelDefinition.objects.create(name="middleware_bu")
+        CollaboratorLabelDefinition.objects.create(name="openshift_bu")
+
+        flaw = FlawFactory(embargoed=False)
+        AffectFactory(flaw=flaw)
+        CollaboratorLabel.objects.create(
+            flaw=flaw,
+            name="middleware_bu",
+            contributor="analyst@redhat.com",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+        # "unclaimed" - no contributor set for this team's label.
+        CollaboratorLabel.objects.create(
+            flaw=flaw,
+            name="openshift_bu",
+            contributor="",
+            state=CollaboratorLabel.State.NEW,
+            relevant=True,
+        )
+
+        cases = [
+            # The bare "labels.contributor not in (...)" half is evaluated
+            # independently across all label rows (it means "no row has
+            # this contributor"), not correlated to the "middleware_bu" row
+            # matched by labels.name. Expected result is still empty here
+            # because analyst@redhat.com *is* a contributor on a label
+            # (middleware_bu) - pure regression guard, must stay green
+            # independently of the any/all work.
+            (
+                'labels.name = "middleware_bu" and labels.contributor not in ("analyst@redhat.com")',
+                set(),
+            ),
+            # New capability: "is any label unclaimed by this team" - the
+            # openshift_bu row (contributor "") satisfies it.
+            ('labels.any.contributor not in ("analyst@redhat.com")', {flaw.cve_id}),
+            # ALL requires every row to be unclaimed; middleware_bu violates
+            # it.
+            ('labels.all.contributor not in ("analyst@redhat.com")', set()),
+            # Same contrast with "!=": any is a new capability, bare is
+            # unaffected (means "no row equals this", which is false here
+            # since middleware_bu does).
+            ('labels.any.contributor != "analyst@redhat.com"', {flaw.cve_id}),
+            ('labels.contributor != "analyst@redhat.com"', set()),
+        ]
+        self._assert_query_results(auth_client, test_api_uri, cases)
 
     def test_search_websearch_exclusion(self, auth_client, test_api_uri):
         """websearch_to_tsquery supports -exclusion, verify it works after query refactor."""


### PR DESCRIPTION
## Summary

Add support for `labels.any.<field>` and `labels.all.<field>` DjangoQL quantifiers for label subclass properties (`contributor`, `state`, `relevant`). These allow precise filtering over polymorphic label rows that the existing bare 2-part `labels.<field>` syntax cannot express.

## Problem

The bare form `labels.contributor = X` ORs across all matching rows then negates the whole result for `!=`, making it impossible to express "find flaws with at least one unclaimed label" or "find flaws where all labels are in state Y". It always means "no label has this value" rather than "some label lacks this value".

## Solution

- `labels.any.contributor = X`: matches flaws with at least one label row satisfying the condition
- `labels.all.contributor = X`: matches flaws where every qualifying label row satisfies the condition
- Same for `.state` and `.relevant`
- Both return False (not vacuously True) for zero qualifying rows

Built on `Exists()`/`OuterRef()` subqueries across the polymorphic label subclass tables (BULabel, CollaboratorLabel, etc.).

## Test Coverage

Added 10 new test cases covering:
- Parity with bare form for positive operators
- ALL with positive/negative operators
- Zero qualifying rows behavior
- Polymorphic subclass spread (multiple label types defining the same property)
- `in`/`not in` operators
- State and relevant field types
- Validation of invalid quantifiers/fields
- Original regression case (unclaimed labels)

Changelog updated for Unreleased/Added section.

🤖 Assisted-by: Claude Haiku/Sonnet/Opus