### PR TITLE
fix: fallback to aegis ecosystem suggestion when unavailable (OSIDB-5353)

### DIFF
--- a/apps/ace/constants.py
+++ b/apps/ace/constants.py
@@ -1,3 +1,7 @@
+NEWTOPIA_ECOSYSTEMS = frozenset(
+    {"cargo", "gem", "generic", "golang", "maven", "npm", "nuget", "pypi", "upstream"}
+)
+
 # OSV ecosystem strings to normalized ecosystem identifiers
 OSV_ECOSYSTEM_MAP: dict[str, str] = {
     "maven": "maven",

--- a/apps/ace/tasks.py
+++ b/apps/ace/tasks.py
@@ -19,6 +19,7 @@ from apps.ace.constants import (
     LABEL_AUTO_REJECTED,
     LABEL_MANUAL_TRIAGE,
     LABEL_POTENTIAL_REJECTION,
+    NEWTOPIA_ECOSYSTEMS,
 )
 from apps.ace.osv_ranges import OsvPackageInfo, match_component_to_upstream
 from apps.ace.version import (
@@ -53,6 +54,32 @@ try:
 except ImportError:
     NewtopiaQuerier = None  # type: ignore[assignment,misc]
     HAS_LIB_NEWTOPIA = False
+
+
+def _aegis_ecosystems(flaw: Flaw) -> list[str]:
+    """
+    Extract ecosystem suggestions from aegis_meta._ecosystems.
+
+    AEGIS populates this field early in the flaw lifecycle — typically before
+    OSV upstream_data is available — so it serves as a fallback when
+    component_ecosystems (derived from UpstreamData) is empty.
+
+    Multiple entries may exist (e.g. from different AEGIS runs); their values
+    are combined.
+    """
+    ecosystems = []
+    entries = (flaw.aegis_meta or {}).get("_ecosystems", [])
+    if not isinstance(entries, list):
+        return ecosystems
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        value = entry.get("value")
+        if isinstance(value, list):
+            ecosystems.extend(
+                v.strip().lower() for v in value if isinstance(v, str) and v.strip()
+            )
+    return ecosystems
 
 
 def _flaw_components(flaw: Flaw) -> list[str]:
@@ -864,12 +891,20 @@ def sync_flaw_affects_from_newcli(flaw_id: str) -> dict[str, Any]:
     osv_data = flaw.upstream_data.filter(source=UpstreamData.Source.OSV).first()
     upstream_purls: list[dict] = osv_data.upstream_purls if osv_data else []
     component_ecosystems = osv_data.component_ecosystems if osv_data else {}
+    aegis_ecosystems = _aegis_ecosystems(flaw)
 
     # Pre-filter all components first. If any component triggers a skip
     # (e.g. blocklist), the entire flaw is skipped — matching vulncli behavior.
     pre_filter_results: list[tuple[str, str, PreFilterResult]] = []
     for flaw_component in components:
-        ecosystems = component_ecosystems.get(flaw_component.strip().lower(), [""])
+        ecosystems = component_ecosystems.get(flaw_component.strip().lower())
+        if not ecosystems and aegis_ecosystems:
+            ecosystems = aegis_ecosystems
+        if not ecosystems:
+            ecosystems = [""]
+        ecosystems = list(
+            set(e if e in NEWTOPIA_ECOSYSTEMS else "" for e in ecosystems)
+        )
         for ecosystem in ecosystems:
             pf = _pre_filter_component(flaw, flaw_component, ecosystem)
             pre_filter_results.append((flaw_component, ecosystem, pf))

--- a/apps/ace/tests/test_tasks.py
+++ b/apps/ace/tests/test_tasks.py
@@ -22,6 +22,7 @@ from apps.ace.constants import (
 from apps.ace.tasks import (
     PreFilterAction,
     SpecialWorkflow,
+    _aegis_ecosystems,
     _is_go_stdlib_component,
     _pre_filter_component,
     _resolve_component,
@@ -826,9 +827,196 @@ def test_sync_queries_each_ecosystem_for_component(monkeypatch, ace_enabled):
     stats = sync_flaw_affects_from_newcli(str(flaw.uuid))
 
     assert len(search_kwargs) == 2
-    assert search_kwargs[0]["ecosystem"] == "npm"
-    assert search_kwargs[1]["ecosystem"] == "pypi"
+    searched_ecosystems = [kw["ecosystem"] for kw in search_kwargs]
+    assert "npm" in searched_ecosystems
+    assert "pypi" in searched_ecosystems
     assert stats["created"] == 2
+
+
+# ── AEGIS ecosystem fallback tests ───────────────────────────────────────────
+
+
+def test_aegis_ecosystems_extracts_values():
+    """_aegis_ecosystems combines values from all entries."""
+    flaw = SimpleNamespace(
+        aegis_meta={
+            "_ecosystems": [
+                {"type": "AI-Bot", "value": ["npm"], "timestamp": "2026-01-01"},
+                {"type": "AI-Bot", "value": ["npm", "pypi"], "timestamp": "2026-01-02"},
+            ]
+        }
+    )
+    result = _aegis_ecosystems(flaw)
+    assert sorted(result) == ["npm", "npm", "pypi"]
+
+
+def test_aegis_ecosystems_empty_when_no_aegis_meta():
+    flaw = SimpleNamespace(aegis_meta={})
+    assert _aegis_ecosystems(flaw) == []
+
+
+def test_aegis_ecosystems_empty_when_no_ecosystems_key():
+    flaw = SimpleNamespace(aegis_meta={"components": [{"value": ["foo"]}]})
+    assert _aegis_ecosystems(flaw) == []
+
+
+def test_aegis_ecosystems_lowercases():
+    flaw = SimpleNamespace(
+        aegis_meta={"_ecosystems": [{"type": "AI-Bot", "value": ["NPM"]}]}
+    )
+    assert _aegis_ecosystems(flaw) == ["npm"]
+
+
+def test_aegis_ecosystems_passes_all_values():
+    """_aegis_ecosystems returns raw values; canonical filtering happens downstream."""
+    flaw = SimpleNamespace(
+        aegis_meta={
+            "_ecosystems": [
+                {
+                    "type": "AI-Bot",
+                    "value": ["npm", "unknown_eco", "crates.io", "golang"],
+                }
+            ]
+        }
+    )
+    result = _aegis_ecosystems(flaw)
+    assert sorted(result) == ["crates.io", "golang", "npm", "unknown_eco"]
+
+
+@pytest.mark.django_db
+def test_sync_falls_back_to_aegis_ecosystem_when_no_osv(monkeypatch, ace_enabled):
+    """When no UpstreamData exists but aegis_meta has ecosystem info,
+    the AEGIS ecosystem is used as fallback."""
+    flaw = FlawFactory(
+        components=["ip-address"],
+        workflow_name="DEFAULT",
+        workflow_state="TRIAGE",
+        aegis_meta={
+            "_ecosystems": [
+                {"type": "AI-Bot", "value": ["npm"], "timestamp": "2026-01-01"}
+            ]
+        },
+    )
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = []
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == "npm"
+
+
+@pytest.mark.django_db
+def test_sync_osv_ecosystem_takes_precedence_over_aegis(monkeypatch, ace_enabled):
+    """When both OSV component_ecosystems and aegis_meta have ecosystem info,
+    the OSV ecosystem takes precedence."""
+    flaw = FlawFactory(
+        components=["redis"],
+        workflow_name="DEFAULT",
+        workflow_state="TRIAGE",
+        aegis_meta={
+            "_ecosystems": [
+                {"type": "AI-Bot", "value": ["pypi"], "timestamp": "2026-01-01"}
+            ]
+        },
+    )
+    UpstreamDataFactory(
+        flaw=flaw,
+        upstream_purls=[
+            {
+                "purl": "pkg:npm/redis",
+                "name": "redis",
+                "ecosystem": "npm",
+                "ranges": [],
+                "versions": [],
+            }
+        ],
+    )
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = []
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == "npm"
+
+
+@pytest.mark.django_db
+def test_sync_no_ecosystem_when_neither_osv_nor_aegis(monkeypatch, ace_enabled):
+    """Without UpstreamData and without aegis_meta ecosystems, falls back to empty."""
+    flaw = FlawFactory(
+        components=["curl"],
+        workflow_name="DEFAULT",
+        workflow_state="TRIAGE",
+        aegis_meta={},
+    )
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = []
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == ""
+
+
+@pytest.mark.django_db
+def test_sync_non_canonical_ecosystem_treated_as_empty(monkeypatch, ace_enabled):
+    """Non-canonical ecosystem values (from any source) are converted to empty string."""
+    flaw = FlawFactory(
+        components=["foo"],
+        workflow_name="DEFAULT",
+        workflow_state="TRIAGE",
+        aegis_meta={
+            "_ecosystems": [{"type": "AI-Bot", "value": ["not-a-real-ecosystem"]}]
+        },
+    )
+
+    search_kwargs = []
+
+    def _search(terms, **kwargs):
+        search_kwargs.append(kwargs)
+        qs = MagicMock()
+        qs.filter.return_value.all.return_value = []
+        return qs
+
+    mock_nq = MagicMock()
+    mock_nq.return_value.search.side_effect = _search
+    monkeypatch.setattr("apps.ace.tasks.NewtopiaQuerier", mock_nq)
+
+    sync_flaw_affects_from_newcli(str(flaw.uuid))
+
+    assert len(search_kwargs) == 1
+    assert search_kwargs[0]["ecosystem"] == ""
 
 
 # ── Pre-filter tests ──────────────────────────────────────────────────────────

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - prefer relevant trackers over duplicates (OSIDB-5449)
 
+### Fixed
+- Fallback to Aegis' suggested ecosystem if not available in OSIDB (OSIDB-5353)
+
 ## [5.17.1] - 2026-08-31
 ### Added
 - make sure that the flaw impact is always at or above any affect override (OSIDB-5389)


### PR DESCRIPTION
When upstream data (OSV) ecosystem information is unavailable, fallback to aegis' ecosystem suggestions. This should prevent some false positives if e.g. OSV processing is backed up / not up-to-date.