### PR TITLE
OSIDB-5332: Fix flaw component not syncing to Bugzilla

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fallback to Aegis' suggested ecosystem if not available in OSIDB (OSIDB-5353)
+- Fix Bugzilla flaw bug not in sync with the flaw (OSIDB-5332)
 
 ## [5.17.1] - 2026-08-31
 ### Added

--- a/openapi.yml
+++ b/openapi.yml
@@ -18462,9 +18462,10 @@ components:
         sync_to_bz:
           type: boolean
           writeOnly: true
-          description: Setting sync_to_bz to false disables flaw sync with Bugzilla
-            after this operation. Use only as part of bulk actions and trigger a flaw
-            bugzilla sync afterwards. Does nothing if BZ is disabled.
+          description: Setting sync_to_bz to false skips the tracker's own Bugzilla
+            sync during this operation. For Jira trackers, the related flaw is still
+            synced to Bugzilla automatically, deduplicated per flaw. Bugzilla trackers
+            do not go through this sync. Does nothing if BZ is disabled.
       required:
       - affects
       - embargoed
@@ -18512,9 +18513,10 @@ components:
         sync_to_bz:
           type: boolean
           writeOnly: true
-          description: Setting sync_to_bz to false disables flaw sync with Bugzilla
-            after this operation. Use only as part of bulk actions and trigger a flaw
-            bugzilla sync afterwards. Does nothing if BZ is disabled.
+          description: Setting sync_to_bz to false skips the tracker's own Bugzilla
+            sync during this operation. For Jira trackers, the related flaw is still
+            synced to Bugzilla automatically, deduplicated per flaw. Bugzilla trackers
+            do not go through this sync. Does nothing if BZ is disabled.
       required:
       - affects
       - embargoed

--- a/osidb/serializer.py
+++ b/osidb/serializer.py
@@ -267,12 +267,13 @@ class TrackingMixinSerializer(serializers.ModelSerializer):
 
 class SyncToBzBulkEnablementMixinSerializer(serializers.ModelSerializer):
     """
-    Provides parameter "sync_to_bz" that when set to False disables sync
-    with Bugzilla for the given request. This is to be used by clients
-    during bulk actions that are carried out by repeated single-instance
-    calls (e.g. creating Trackers). The reason is that the final flaw bz
-    sync that happens after e.g. creating a tracker can take minutes for
-    huge flaws.
+    Provides parameter "sync_to_bz" that when set to False skips the
+    tracker-level Bugzilla sync for the given request. For Jira trackers,
+    the related flaws are still synced to Bugzilla automatically as part of the
+    operation, deduplicated per flaw, regardless of this flag.
+    This is to be used by clients during bulk actions that
+    are carried out by repeated single-instance calls (e.g. creating
+    Trackers). Bugzilla trackers do not go through this related-flaw sync path.
 
     The parameter does nothing if BZ sync is not enabled in the OSIDB instance.
     """
@@ -281,10 +282,11 @@ class SyncToBzBulkEnablementMixinSerializer(serializers.ModelSerializer):
         required=False,
         write_only=True,
         help_text=(
-            "Setting sync_to_bz to false disables flaw sync with Bugzilla "
-            "after this operation. Use only as part of bulk actions and "
-            "trigger a flaw bugzilla sync afterwards. Does nothing if BZ "
-            "is disabled."
+            "Setting sync_to_bz to false skips the tracker's own Bugzilla "
+            "sync during this operation. For Jira trackers, the related "
+            "flaw is still synced to Bugzilla automatically, deduplicated "
+            "per flaw. Bugzilla trackers do not go through this sync. "
+            "Does nothing if BZ is disabled."
         ),
     )
 
@@ -731,6 +733,28 @@ class TrackerSerializer(
             "resolved_dt",
         ]
 
+    def _sync_related_flaws_to_bz(self, affects):
+        synced_flaw_ids = set()
+        for affect in affects:
+            if affect.flaw_id in synced_flaw_ids:
+                continue
+            synced_flaw_ids.add(affect.flaw_id)
+            affect.flaw.save(
+                bz_api_key=self.get_bz_api_key(),
+                no_alerts=True,
+                raise_validation_error=False,
+            )
+
+    def _schedule_related_flaws_bz_sync(self, affects):
+        from osidb.sync_manager import BZSyncManager
+
+        synced_flaw_ids = set()
+        for affect in affects:
+            if affect.flaw_id in synced_flaw_ids:
+                continue
+            synced_flaw_ids.add(affect.flaw_id)
+            BZSyncManager.schedule(str(affect.flaw_id))
+
     def create(self, validated_data):
         """
         perform the tracker instance creation
@@ -793,22 +817,16 @@ class TrackerSerializer(
         # 4) post-create actions #
         ##########################
 
-        if self.sync_to_bz_helper:
+        if tracker.type == Tracker.TrackerType.JIRA:
             # related flaws need to be saved to Bugzilla in order to update SRT notes with the new
             # Jira tracker ID (Bugzilla trackers are linked naturally through Bugzilla relations)
-            if tracker.type == Tracker.TrackerType.JIRA:
-                for affect in affects:
-                    # do not raise validation errors here as the flaw is not what the user touches
-                    # which would make the errors hard to understand and cause the tracker to orphan
-                    affect.flaw.save(
-                        bz_api_key=self.get_bz_api_key(),
-                        no_alerts=True,
-                        raise_validation_error=False,
-                    )
-        else:
-            # Special path for bulk tracker create. Works for Jira trackers only.
-            # Do not sync with BZ, as that can take a long time for large flaws.
-            pass
+            if self.sync_to_bz_helper:
+                self._sync_related_flaws_to_bz(affects)
+            else:
+                # Previously skipped the BZ sync entirely for performance, but that
+                # left the flaw's bz_component stale.Schedule an async sync instead,
+                # preserving the original intent of sync_to_bz=False.
+                self._schedule_related_flaws_bz_sync(affects)
 
         #####################
         # 5) return created #

--- a/osidb/tests/endpoints/test_trackers.py
+++ b/osidb/tests/endpoints/test_trackers.py
@@ -132,10 +132,11 @@ class TestEndpointsTrackers:
             assert tracker.affects.first().uuid == affect.uuid
 
             if sync_to_bz is False:
-                # Flaw was not synced but affect was
+                # sync_to_bz=False now schedules an async BZ sync instead of
+                # syncing synchronously, so no additional Flaw.save() call happen here
                 assert len(shared_state["runs"]) == 3
             else:
-                # Flaw was synced.
+                # Flaw is synced synchronously when sync_to_bz is True or None (default)
                 assert len(shared_state["runs"]) == 4
                 assert shared_state["runs"][-1] == (Flaw, {"success": True})
 


### PR DESCRIPTION
Flaws were getting stuck with the wrong Bugzilla component after leaving the NEW state.
-When a tracker was created with `sync_to_bz=false`, the code skipped the Bugzilla sync entirely including the component field instead of just skipping what `sync_to_bz` was meant to skip. Tested it on staging the BZ component stayed empty after creating a tracker this way.
-`serializers.py` now calls `affect.flaw.save()` for each affect same as the `sync_to_bz=true` path already does.
-In `test_trackers.py` updated `test_tracker_create_jira_bulk_enablement` to check the flaw is always synced now.
Closes: OSIDB - 5332