### PR TITLE
OSIDB-5487: Add top-level SRP status filtering to Advanced Search

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add report payloads in milestones (OSIDB-5070)
 - Add manual POST create for SRP reports with PRE_REQUIRED status and evidence field (OSIDB-5284)
 - Add owner and submitted_at fields to SRP report milestones (OSIDB-5439)
+- Add Top-Level SRP Report Status Filtering to Advanced Search (OSIDB-5487)
 
 ### Changed
 - Remove additional information from report type (OSIDB-5437)

--- a/openapi.yml
+++ b/openapi.yml
@@ -14822,6 +14822,13 @@ paths:
         name: status
         schema:
           type: string
+          enum:
+          - empty
+          - in_progress
+          - submitted
+        description: |+
+          Current status of the SRP report
+
       - in: query
         name: timer_started_at__gte
         schema:

--- a/regulatory_reporting/filters.py
+++ b/regulatory_reporting/filters.py
@@ -62,7 +62,12 @@ class SRPReportFilter(FilterSet):
 
     uuid = UUIDFilter(field_name="uuid", lookup_expr="exact")
     flaw_id = UUIDFilter(field_name="flaw_id", lookup_expr="exact")
-    status = CharFilter(field_name="status", lookup_expr="exact")
+    STATUS_FILTER_CHOICES = (
+        (SRPReport.SRPReportStatus.EMPTY, "None"),
+        (SRPReport.SRPReportStatus.IN_PROGRESS, "In Progress"),
+        (SRPReport.SRPReportStatus.SUBMITTED, "Done"),
+    )
+    status = ChoiceFilter(field_name="status", choices=STATUS_FILTER_CHOICES)
     reportable_event_type = CharFilter(
         field_name="reportable_event_type", lookup_expr="exact"
     )

--- a/regulatory_reporting/tests/test_api_srp_reports.py
+++ b/regulatory_reporting/tests/test_api_srp_reports.py
@@ -11,7 +11,6 @@ from freezegun import freeze_time
 from rest_framework import status
 
 from regulatory_reporting.models import SRPReport, SRPReportMilestone
-from regulatory_reporting.models.abstracts import SRPReportBase
 from regulatory_reporting.tests.factories import (
     NonReportableFlawFactory,
     SRPReportFactory,
@@ -455,6 +454,38 @@ class TestSRPReportFiltering:
             response.data["results"][0]["status"]
             == SRPReport.SRPReportStatus.IN_PROGRESS
         )
+
+    def test_filter_by_status_choices(self, api_client):
+        """Filter accepts all three top-level status values."""
+        SRPReportFactory(status=SRPReport.SRPReportStatus.EMPTY)
+        SRPReportFactory(
+            status=SRPReport.SRPReportStatus.IN_PROGRESS,
+            timer_started_at=timezone.now(),
+        )
+        SRPReportFactory(
+            status=SRPReport.SRPReportStatus.SUBMITTED,
+            timer_started_at=timezone.now(),
+            srp_reference_id="SRP-2026-TEST",
+        )
+
+        for value in [
+            SRPReport.SRPReportStatus.EMPTY,
+            SRPReport.SRPReportStatus.IN_PROGRESS,
+            SRPReport.SRPReportStatus.SUBMITTED,
+        ]:
+            response = api_client.get(
+                f"/regulatory-reporting/api/v1/srp-reports?status={value}"
+            )
+            assert response.status_code == status.HTTP_200_OK
+            assert len(response.data["results"]) == 1
+            assert response.data["results"][0]["status"] == value
+
+    def test_filter_by_status_rejects_unsupported_value(self, api_client):
+        """Filter rejects a status value outside the defined choices."""
+        response = api_client.get(
+            "/regulatory-reporting/api/v1/srp-reports?status=not_a_real_status"
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
 
     def test_filter_by_reportable_event_type(self, api_client):
         """Can filter by reportable_event_type."""


### PR DESCRIPTION
-Adds a `status` filter to `SRPReportFilter` for Advanced Search.
-Added tests in `test_api_srp_reports.py`.
-Generated openapi.yml
-Entry in CHANGELOG.md
Closes: OSIDB-5487