### PR TITLE
Remove OSSM from Go stdlib builder-container auto-affects

### DIFF
--- a/apps/ace/constants.py
+++ b/apps/ace/constants.py
@@ -101,7 +101,7 @@ CHROMIUM_STREAMS = [
 ]
 
 # Go stdlib workflow constants
-GO_STDLIB_BUILDER_PRODUCTS = ["openshift-4", "cnv-4", "ossm-2", "ossm-3"]
+GO_STDLIB_BUILDER_PRODUCTS = ["openshift-4", "cnv-4"]
 GO_STDLIB_BUILDER_PURL = (
     "pkg:oci/openshift-golang-builder-container"
     "?repository_url=registry.redhat.io/openshift-golang-builder-container"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - prefer relevant trackers over duplicates (OSIDB-5449)
+- ACE: stop auto-creating `openshift-golang-builder-container` affects for OSSM
+  streams in the Go stdlib workflow
 
 ## [5.17.1] - 2026-08-31
 ### Added


### PR DESCRIPTION
## Summary
- Remove `ossm-2` and `ossm-3` from `GO_STDLIB_BUILDER_PRODUCTS` in ACE's Go stdlib workflow
- Stops Phase 4 from auto-creating `openshift-golang-builder-container` affects for OSSM streams

OSSM container images (e.g. `openshift-service-mesh/kiali-rhel9`) are already discovered and version-checked via the standard lib-newtopia search path. The synthetic builder-container affects were redundant for OSSM and produced duplicate/incorrect offerings (see CVE-2026-56862).

## Test plan
- [ ] `pytest apps/ace/tests/test_tasks.py::test_handle_go_stdlib_phase4_creates_builder_affects` still passes (uses `openshift-4`, unaffected by this change)
- [ ] On a Go stdlib flaw, ACE Phase 4 still creates builder-container affects for `openshift-4` and `cnv-4` active streams
- [ ] OSSM streams no longer receive synthetic `openshift-golang-builder-container` affects from Phase 4


Made with [Cursor](https://cursor.com)