### PR TITLE
refactor: remove obsolete FIFO queue infrastructure (OSIDB-5512)

### DIFF
--- a/config/celery.py
+++ b/config/celery.py
@@ -3,52 +3,10 @@ import logging
 from celery import Celery, signals
 from django.conf import settings
 from kombu import Queue
-from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from osidb.telemetry import OtelSettings, configure_telemetry, safe_instrument
 
 logger = logging.getLogger(__name__)
-
-
-class CelerySettings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="OSIDB_CELERY_")
-
-    enable_fifo: bool = False
-    fifo_pool_size: int = 2
-
-
-class FIFORouter:
-    """
-    A router to send tasks with a specific 'object_id' kwarg to a dedicated
-    FIFO queue.
-
-    This router guarantees order of operations for operations on the same
-    object, however operations on different objects is not guaranteed.
-
-    E.g. Flaw1 needs to perform update1, update2, update3 and then Flaw2
-    performs a single update. update1, update2 and update3 are guaranteed
-    to be in FIFO order, however it's possible that Flaw2's update will be
-    executed anywhere in between.
-
-    The order is guaranteed by hashing the given object's UUID and assigning it
-    to one of the fifo queues in the pool, the assigned queue will always be
-    the same for a given object, and since the queue is handled by a single
-    worker, tasks for said object will be executed in order.
-    """
-
-    def route_for_task(self, task, args=None, kwargs=None):
-        settings = CelerySettings()
-        if kwargs and "object_id" in kwargs and settings.enable_fifo:
-            object_id = str(kwargs["object_id"])
-            queue_index = hash(object_id) % settings.fifo_pool_size
-            queue_name = f"fifo.{queue_index}"
-
-            return {
-                "queue": queue_name,
-                "routing_key": queue_name,
-            }
-        # Return None to use the default routing for all other tasks
-        return None
 
 
 app = Celery("celery")
@@ -61,13 +19,8 @@ app.conf.task_queues = [
     # sync/transition) waiting on the "default" queue behind long-running
     # imports.
     Queue("collectors", routing_key="collectors"),
-    *[
-        Queue(f"fifo.{i}", routing_key=f"fifo.{i}")
-        for i in range(CelerySettings().fifo_pool_size)
-    ],
 ]
 app.conf.task_default_queue = "default"
-app.conf.task_routes = ("config.celery.FIFORouter",)
 
 
 @signals.worker_process_init.connect

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -220,30 +220,6 @@ services:
       environment: *celery-env
       depends_on: ["osidb-data", "osidb-service", "redis"]
 
-    # WARNING: The amount of instances of celery-fifo pods must be equal or greater
-    # than the environment variable OSIDB_CELERY_FIFO_POOL_SIZE, this is because
-    # each of these pods listens to a single queue and if the application spawns 3
-    # queues but there's only 2 pods, none of the tasks in the third queue will be
-    # worked on. This limitation only applies locally.
-    celery-fifo-1: &celery-fifo
-      image: localhost/osidb-service
-      pull_policy: never
-      container_name: celery-fifo-1
-      hostname: celery-fifo-1
-      command:
-        celery -A config worker --pidfile /tmp/celery_worker.pid -f celery.log --loglevel DEBUG -Q fifo.0 --concurrency=1 -E
-      volumes:
-        - ${PWD}:/opt/app-root/src:z
-      environment: *celery-env
-      depends_on: ["osidb-data", "osidb-service", "redis"]
-
-    celery-fifo-2:
-      <<: *celery-fifo
-      container_name: celery-fifo-2
-      hostname: celery-fifo-2
-      command:
-        celery -A config worker --pidfile /tmp/celery_worker.pid -f celery.log --loglevel DEBUG -Q fifo.1 --concurrency=1 -E
-
     celery_beat:
       container_name: celery_beat
       hostname: celery_beat

--- a/osidb/sync_manager.py
+++ b/osidb/sync_manager.py
@@ -845,12 +845,12 @@ class JiraTaskSyncManager(SyncManager):
         #
         # Contention is dropped, not retried: LockableTaskWithArgs rejects
         # outright (Reject, no requeue) rather than retrying, since a
-        # bounded Celery-retry-on-lock-contention policy re-enqueued into
-        # the fifo.* queues faster than the concurrency-1 workers could
-        # drain them (OSIDB-5189 revert). Recovery for a dropped run is
-        # left to check_for_reschedules()'s periodic sweep, on the
-        # MAX_RUN_LENGTH timescale (see the scheduled_not_started bucket
-        # there), not the longer MAX_SCHEDULE_DELAY.
+        # bounded Celery-retry-on-lock-contention policy would re-enqueue
+        # tasks faster than workers could drain them (OSIDB-5189 revert).
+        # Recovery for a dropped run is left to check_for_reschedules()'s
+        # periodic sweep, on the MAX_RUN_LENGTH timescale (see the
+        # scheduled_not_started bucket there), not the longer
+        # MAX_SCHEDULE_DELAY.
         lock_ttl=int(SyncManager.MAX_RUN_LENGTH.total_seconds()),
     )
     def sync_task(task, flaw_id, **kwargs):

--- a/osidb/tests/test_celery_routing.py
+++ b/osidb/tests/test_celery_routing.py
@@ -4,8 +4,8 @@ Tests for Celery queue routing.
 These exercise the exact routing pipeline Celery uses at apply_async() time
 (app.amqp.router.route) without needing a running broker/worker, so they
 work as a red/green check for queue-topology changes: change where a task
-is routed and these fail until config/celery.py + the task's `queue=`/
-`task_routes` are updated to match.
+is routed and these fail until config/celery.py + the task's `queue=`
+default are updated to match.
 """
 
 import pytest
@@ -54,20 +54,3 @@ class TestCeleryRouting:
         """
         options = _route(task_name)
         assert options["queue"].name == "default"
-
-    def test_object_id_tasks_use_fifo_queue_when_enabled(self, monkeypatch):
-        """
-        The per-object FIFO pool routing (used for ordering guarantees) must
-        keep taking precedence over any per-task default queue.
-        """
-        from config.celery import CelerySettings
-
-        monkeypatch.setattr(
-            "config.celery.CelerySettings",
-            lambda: CelerySettings(enable_fifo=True, fifo_pool_size=2),
-        )
-
-        options = _route(
-            "sync_manager.jira_task_sync", kwargs={"object_id": "some-uuid"}
-        )
-        assert options["queue"].name.startswith("fifo.")

--- a/osidb/tests/test_sync_manager.py
+++ b/osidb/tests/test_sync_manager.py
@@ -382,11 +382,10 @@ class TestCheckForReschedules(TestCase):
 class TestJiraTaskSyncManagerLockContention:
     """
     RetryOnLockContention turned lock contention into Celery-level
-    retries every 30s (up to ~130/task), re-enqueuing into the fifo.*
-    queues faster than the two concurrency-1 workers could drain them.
-    JiraTaskSyncManager.sync_task must not use any such
-    retry-on-contention wrapper: lock contention must be dropped
-    (LockableTaskWithArgs' plain behaviour), not retried.
+    retries every 30s (up to ~130/task), re-enqueuing tasks faster
+    than workers could drain them (OSIDB-5189). JiraTaskSyncManager.sync_task
+    must not use any such retry-on-contention wrapper: lock contention must
+    be dropped (LockableTaskWithArgs' plain behaviour), not retried.
     """
 
     def test_sync_task_uses_plain_lockable_task_with_args(self):


### PR DESCRIPTION
The FIFO queue routing (FIFORouter, CelerySettings, fifo.* queues, celery-fifo-1/2 docker services) is disabled in production and superseded by LockableTaskWithArgs exclusive locks and BZSyncManager.schedule() dedup logic.

Remove all FIFO-related code and configuration:
- CelerySettings class and FIFORouter class from config/celery.py
- fifo.* queue definitions and task_routes assignment
- celery-fifo-1 and celery-fifo-2 services from docker-compose.yml
- FIFO routing test from test_celery_routing.py
- Stale FIFO references in code comments