### PR TITLE
feat: Expose manual_completion_notes via API

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -19767,6 +19767,9 @@ components:
           type: string
           description: Source of the designated CSIRT coordinator
           maxLength: 255
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
         created_dt:
           type: string
           format: date-time
@@ -19859,6 +19862,9 @@ components:
           type: string
           description: Source of the designated CSIRT coordinator
           maxLength: 255
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
         created_dt:
           type: string
           format: date-time
@@ -19940,6 +19946,9 @@ components:
           type: string
           description: Source of the designated CSIRT coordinator
           maxLength: 255
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
       required:
       - evidence
       - flaw_id
@@ -19997,6 +20006,9 @@ components:
           type: string
           description: Owner of this milestone
           maxLength: 60
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
         created_dt:
           type: string
           format: date-time
@@ -20109,6 +20121,9 @@ components:
           type: string
           description: Owner of this milestone
           maxLength: 60
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
         created_dt:
           type: string
           format: date-time
@@ -20206,6 +20221,9 @@ components:
           type: string
           description: Owner of this milestone
           maxLength: 60
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
     SRPReportMilestoneRequest:
       type: object
       description: |-
@@ -20245,6 +20263,9 @@ components:
           type: string
           description: Owner of this milestone
           maxLength: 60
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
         updated_dt:
           type: string
           format: date-time
@@ -20321,6 +20342,9 @@ components:
           type: string
           description: Source of the designated CSIRT coordinator
           maxLength: 255
+        manual_completion_notes:
+          type: string
+          description: Manual completion notes
         updated_dt:
           type: string
           format: date-time

--- a/regulatory_reporting/serializers/srp_serializers.py
+++ b/regulatory_reporting/serializers/srp_serializers.py
@@ -87,6 +87,7 @@ class SRPReportMilestoneSerializer(
                 "request_text",
                 "submitted_at",
                 "owner",
+                "manual_completion_notes",
                 # Tracking fields
                 "created_dt",
                 "updated_dt",
@@ -243,6 +244,7 @@ class SRPReportSerializer(
             "member_states_available",
             "designated_csirt_country",
             "designated_csirt_source",
+            "manual_completion_notes",
             # Tracking fields
             "created_dt",
             "updated_dt",

--- a/regulatory_reporting/tests/test_api_srp_milestones.py
+++ b/regulatory_reporting/tests/test_api_srp_milestones.py
@@ -337,6 +337,25 @@ class TestSRPMilestoneUpdate:
         milestone.refresh_from_db()
         assert milestone.submitted_at == correction
 
+    def test_update_manual_completion_notes(
+        self, authenticated_client, create_flaw_report
+    ):
+        """Can update manual_completion_notes and value is returned in response."""
+        milestones_report = create_flaw_report()
+        milestone = milestones_report.milestones.get(
+            milestone_type=SRPReportMilestone.MilestoneType.LEVEL_24H
+        )
+        response = self._put_milestone(
+            authenticated_client,
+            milestones_report,
+            milestone,
+            manual_completion_notes="some notes",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["manual_completion_notes"] == "some notes"
+        milestone.refresh_from_db()
+        assert milestone.manual_completion_notes == "some notes"
+
 
 @pytest.mark.django_db
 @pytest.mark.enable_signals

--- a/regulatory_reporting/tests/test_api_srp_reports.py
+++ b/regulatory_reporting/tests/test_api_srp_reports.py
@@ -436,6 +436,21 @@ class TestSRPReportUpdate:
         assert report.status == SRPReport.SRPReportStatus.SUBMITTED
         assert report.srp_reference_id == "SRP-2026-001"
 
+    def test_update_manual_completion_notes(
+        self, authenticated_client, create_flaw_report
+    ):
+        """Can update manual_completion_notes and value is returned in response."""
+        report = create_flaw_report()
+        response = self._put_report(
+            authenticated_client,
+            report,
+            manual_completion_notes="some notes",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["manual_completion_notes"] == "some notes"
+        report.refresh_from_db()
+        assert report.manual_completion_notes == "some notes"
+
 
 @pytest.mark.django_db
 class TestSRPReportFiltering:


### PR DESCRIPTION
## What

Exposes the `manual_completion_notes` field (already present in the DB via `SRPReportBase`) through the API for both `SRPReport` and `SRPReportMilestone`.

## Why

The field existed in the database but was not included in either serializer's `fields` list, making it invisible to API consumers.

## Changes

- `regulatory_reporting/serializers/srp_serializers.py`: added `manual_completion_notes` to `SRPReportMilestoneSerializer` and `SRPReportSerializer` field lists
- `regulatory_reporting/tests/test_api_srp_reports.py`: added `test_update_manual_completion_notes`
- `regulatory_reporting/tests/test_api_srp_milestones.py`: added `test_update_manual_completion_notes`
- `openapi.yml`: updated schema (auto-generated)